### PR TITLE
fix: restore ConPTY functionality on Windows 11 Build 26200+

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,21 +3,6 @@
 version = 4
 
 [[package]]
-name = "addr2line"
-version = "0.25.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
-dependencies = [
- "gimli",
-]
-
-[[package]]
-name = "adler2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
-
-[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -33,6 +18,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+
+[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -43,21 +34,6 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
-
-[[package]]
-name = "backtrace"
-version = "0.3.76"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
-dependencies = [
- "addr2line",
- "cfg-if",
- "libc",
- "miniz_oxide",
- "object",
- "rustc-demangle",
- "windows-link",
-]
 
 [[package]]
 name = "bitflags"
@@ -107,6 +83,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
 name = "chrono"
@@ -182,6 +164,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -204,36 +192,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "failure"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d32e9bd16cc02eae7db7ef620b392808b89f6a5e16bb3497d159c6b92a0f4f86"
-dependencies = [
- "backtrace",
- "failure_derive",
-]
-
-[[package]]
-name = "failure_derive"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "synstructure",
-]
-
-[[package]]
 name = "filedescriptor"
-version = "0.5.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08a671f85e14920b1d7d79b19b699c061967fd2771d482aac613f0f4aacda256"
+checksum = "e40758ed24c9b2eeb76c35fb0aebc66c626084edd827e07e1552279814c6682d"
 dependencies = [
- "failure",
- "failure_derive",
  "libc",
+ "thiserror",
  "winapi",
 ]
 
@@ -248,18 +213,6 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
-
-[[package]]
-name = "fuchsia-cprng"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
-
-[[package]]
-name = "gimli"
-version = "0.32.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "hashbrown"
@@ -309,15 +262,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
  "cc",
-]
-
-[[package]]
-name = "ioctl-rs"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7970510895cee30b3e9128319f2cefd4bde883a39f38baa279567ba3a7eb97d"
-dependencies = [
- "libc",
 ]
 
 [[package]]
@@ -403,15 +347,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
-name = "miniz_oxide"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
-dependencies = [
- "adler2",
-]
-
-[[package]]
 name = "mio"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -436,21 +371,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
+dependencies = [
+ "bitflags 2.10.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
-]
-
-[[package]]
-name = "object"
-version = "0.37.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -490,22 +428,23 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "portable-pty"
-version = "0.2.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d29d0e3700207ba6ba86693f0b5302138a59a42744e1c2e0d830b24f90886f"
+checksum = "b4a596a2b3d2752d94f51fac2d4a96737b8705dddd311a32b9af47211f08671e"
 dependencies = [
+ "anyhow",
  "bitflags 1.3.2",
- "failure",
- "failure_derive",
+ "downcast-rs",
  "filedescriptor",
  "lazy_static",
  "libc",
  "log",
- "serial",
+ "nix",
+ "serial2",
  "shared_library",
  "shell-words",
- "uds_windows",
  "winapi",
+ "winreg",
 ]
 
 [[package]]
@@ -543,34 +482,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
-dependencies = [
- "fuchsia-cprng",
- "libc",
- "rand_core 0.3.1",
- "rdrand",
- "winapi",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
-dependencies = [
- "rand_core 0.4.2",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
-
-[[package]]
 name = "ratatui"
 version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -591,15 +502,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rdrand"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
-dependencies = [
- "rand_core 0.3.1",
-]
-
-[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -607,21 +509,6 @@ checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags 2.10.0",
 ]
-
-[[package]]
-name = "remove_dir_all"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
-dependencies = [
- "winapi",
-]
-
-[[package]]
-name = "rustc-demangle"
-version = "0.1.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
 
 [[package]]
 name = "rustix"
@@ -681,7 +568,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn",
 ]
 
 [[package]]
@@ -698,45 +585,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "serial"
-version = "0.4.0"
+name = "serial2"
+version = "0.2.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1237a96570fc377c13baa1b88c7589ab66edced652e43ffb17088f003db3e86"
+checksum = "8cc76fa68e25e771492ca1e3c53d447ef0be3093e05cd3b47f4b712ba10c6f3c"
 dependencies = [
- "serial-core",
- "serial-unix",
- "serial-windows",
-]
-
-[[package]]
-name = "serial-core"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f46209b345401737ae2125fe5b19a77acce90cd53e1658cda928e4fe9a64581"
-dependencies = [
+ "cfg-if",
  "libc",
-]
-
-[[package]]
-name = "serial-unix"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f03fbca4c9d866e24a459cbca71283f545a37f8e3e002ad8c70593871453cab7"
-dependencies = [
- "ioctl-rs",
- "libc",
- "serial-core",
- "termios",
-]
-
-[[package]]
-name = "serial-windows"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15c6d3b776267a75d31bbdfd5d36c0ca051251caafc285827052bc53bcdc8162"
-dependencies = [
- "libc",
- "serial-core",
+ "winapi",
 ]
 
 [[package]]
@@ -751,9 +607,9 @@ dependencies = [
 
 [[package]]
 name = "shell-words"
-version = "0.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39acde55a154c4cd3ae048ac78cc21c25f3a0145e44111b523279113dce0d94a"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
 name = "shlex"
@@ -805,7 +661,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d904e7009df136af5297832a3ace3370cd14ff1546a232f4f185036c2736fcac"
 dependencies = [
  "quote",
- "syn 2.0.110",
+ "syn",
 ]
 
 [[package]]
@@ -833,18 +689,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.110",
-]
-
-[[package]]
-name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
+ "syn",
 ]
 
 [[package]]
@@ -859,44 +704,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "synstructure"
-version = "0.12.6"
+name = "thiserror"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
- "unicode-xid",
-]
-
-[[package]]
-name = "tempdir"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
-dependencies = [
- "rand",
- "remove_dir_all",
-]
-
-[[package]]
-name = "termios"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5d9cf598a6d7ce700a4e6a9199da127e6819a61e64b68609683cc9a01b5683a"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "uds_windows"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09b22bf5f590ee6a2892e134e18482e63361319cc62ed108eb236803284cefec"
-dependencies = [
- "tempdir",
- "winapi",
+ "syn",
 ]
 
 [[package]]
@@ -933,12 +757,6 @@ name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "vt100"
@@ -999,7 +817,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -1090,7 +908,7 @@ checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn",
 ]
 
 [[package]]
@@ -1101,7 +919,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn",
 ]
 
 [[package]]
@@ -1112,7 +930,7 @@ checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn",
 ]
 
 [[package]]
@@ -1123,7 +941,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn",
 ]
 
 [[package]]
@@ -1316,6 +1134,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "winsafe"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,10 +24,14 @@ path = "src/main.rs"
 name = "tmux"
 path = "src/main.rs"
 
+[[bin]]
+name = "pty_test"
+path = "src/bin/pty_test.rs"
+
 [dependencies]
 ratatui = "0.26"
 crossterm = "0.28"
-portable-pty = "0.2"
+portable-pty = "0.9"
 which = "6"
 chrono = "0.4"
 vt100 = "0.16"

--- a/src/bin/pty_test.rs
+++ b/src/bin/pty_test.rs
@@ -1,0 +1,90 @@
+// Simple test to verify PTY behavior with portable-pty 0.9
+use portable_pty::{native_pty_system, CommandBuilder, PtySize, PtySystem};
+use std::io::Read;
+use std::thread;
+use std::time::Duration;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    println!("Creating PTY system...");
+    let pty_system = native_pty_system();
+
+    let size = PtySize {
+        rows: 24,
+        cols: 80,
+        pixel_width: 0,
+        pixel_height: 0,
+    };
+
+    println!("Opening PTY with size {}x{}...", size.cols, size.rows);
+    let pair = pty_system.openpty(size)?;
+
+    println!("Creating shell command...");
+    let mut cmd = CommandBuilder::new("powershell.exe");
+    cmd.args(["-NoLogo", "-NoProfile"]);
+
+    println!("Spawning shell...");
+    let mut child = pair.slave.spawn_command(cmd)?;
+    println!("Shell spawned! PID: {:?}", child.process_id());
+
+    // Get reader
+    let mut reader = pair.master.try_clone_reader()?;
+    println!("Got PTY reader");
+
+    // Read in a thread
+    let handle = thread::spawn(move || {
+        let mut buf = [0u8; 4096];
+        let mut total = 0;
+        println!("Reader thread started, waiting for data...");
+        loop {
+            match reader.read(&mut buf) {
+                Ok(n) if n > 0 => {
+                    total += n;
+                    let text = String::from_utf8_lossy(&buf[..n]);
+                    println!("Read {} bytes (total: {}): {:?}", n, total, text);
+                }
+                Ok(_) => {
+                    thread::sleep(Duration::from_millis(10));
+                }
+                Err(e) => {
+                    println!("Reader error: {:?}", e);
+                    break;
+                }
+            }
+        }
+        println!("Reader thread exiting, total bytes: {}", total);
+    });
+
+    // Check child status periodically
+    for i in 0..50 {  // 5 seconds
+        thread::sleep(Duration::from_millis(100));
+        match child.try_wait() {
+            Ok(Some(status)) => {
+                println!("Child exited with status: {:?} (after {}ms)", status, (i+1)*100);
+                break;
+            }
+            Ok(None) => {
+                if i % 10 == 0 {
+                    println!("Child still running ({}ms)...", (i+1)*100);
+                }
+            }
+            Err(e) => {
+                println!("Error checking child: {:?}", e);
+                break;
+            }
+        }
+    }
+
+    // Final check
+    match child.try_wait() {
+        Ok(Some(status)) => println!("Final: Child exited with status: {:?}", status),
+        Ok(None) => println!("Final: Child still running after 5 seconds"),
+        Err(e) => println!("Final: Error checking child: {:?}", e),
+    }
+
+    // Kill child if still running
+    let _ = child.kill();
+    let _ = handle.join();
+
+    println!("Test complete.");
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ use std::io::Read as _;
 use std::io::BufRead as _;
 
 use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
-use portable_pty::{CommandBuilder, MasterPty, PtySize, PtySystemSelection};
+use portable_pty::{native_pty_system, CommandBuilder, MasterPty, PtySize, PtySystem};
 use ratatui::{prelude::*, widgets::*};
 use ratatui::backend::CrosstermBackend;
 use ratatui::Terminal;
@@ -23,6 +23,7 @@ use serde::{Serialize, Deserialize};
 
 struct Pane {
     master: Box<dyn MasterPty>,
+    writer: Arc<Mutex<Box<dyn Write + Send>>>,
     child: Box<dyn portable_pty::Child>,
     term: Arc<Mutex<vt100::Parser>>,
     last_rows: u16,
@@ -362,8 +363,36 @@ fn cleanup_stale_sessions() {
 }
 
 fn main() -> io::Result<()> {
+    // Set DLL search path to include executable directory for sideloaded conpty.dll
+    #[cfg(windows)]
+    {
+        use std::os::windows::ffi::OsStrExt;
+        if let Some(exe_dir) = std::env::current_exe().ok().and_then(|p| p.parent().map(|p| p.to_path_buf())) {
+            let wide: Vec<u16> = exe_dir.as_os_str().encode_wide().chain(std::iter::once(0)).collect();
+            unsafe {
+                #[link(name = "kernel32")]
+                extern "system" {
+                    fn SetDllDirectoryW(lpPathName: *const u16) -> i32;
+                }
+                SetDllDirectoryW(wide.as_ptr());
+            }
+        }
+    }
+
     let args: Vec<String> = env::args().collect();
-    
+
+    // Debug: check ConPTY DLL status
+    if args.get(1).map(|s| s.as_str()) == Some("--check-conpty") {
+        let exe_dir = std::env::current_exe().ok().and_then(|p| p.parent().map(|p| p.to_path_buf()));
+        println!("Executable directory: {:?}", exe_dir);
+        if let Some(dir) = &exe_dir {
+            println!("Sideloaded conpty.dll: {}", dir.join("conpty.dll").exists());
+            println!("Sideloaded OpenConsole.exe: {}", dir.join("OpenConsole.exe").exists());
+        }
+        println!("System conpty.dll: {}", std::path::Path::new(r"C:\Windows\System32\conpty.dll").exists());
+        return Ok(());
+    }
+
     // Clean up any stale sessions at startup
     cleanup_stale_sessions();
     
@@ -1670,18 +1699,34 @@ fn main() -> io::Result<()> {
             }
         }
     
+    // Debug helper - writes to file if PSMUX_DEBUG is set
+    fn debug_log(msg: &str) {
+        if std::env::var("PSMUX_DEBUG").is_ok() {
+            use std::io::Write;
+            let log_path = std::env::current_dir().unwrap_or_default().join("psmux_debug.log");
+            if let Ok(mut f) = std::fs::OpenOptions::new().create(true).append(true).open(&log_path) {
+                let _ = writeln!(f, "[CLIENT {}] {}", std::process::id(), msg);
+            }
+        }
+    }
+
+    debug_log("main() starting");
+
     // Default behavior: If no PSMUX_REMOTE_ATTACH is set and no specific command matched,
     // we need to either attach to an existing session or create a new one.
     // This ensures sessions persist after detach.
     if env::var("PSMUX_REMOTE_ATTACH").ok().as_deref() != Some("1") {
         let session_name = env::var("PSMUX_SESSION_NAME").unwrap_or_else(|_| "default".to_string());
+        debug_log(&format!("session_name={}", session_name));
 
         // Check if server is running via named pipe
         let server_alive = pipe_exists(&session_name);
+        debug_log(&format!("server_alive={}", server_alive));
 
         if !server_alive {
             // No existing session - create one in background
             let exe = std::env::current_exe().unwrap_or_else(|_| std::path::PathBuf::from("psmux"));
+            debug_log(&format!("spawning server: {:?}", exe));
             let mut cmd = std::process::Command::new(&exe);
             cmd.arg("server").arg("-s").arg(&session_name);
             #[cfg(windows)]
@@ -1691,37 +1736,50 @@ fn main() -> io::Result<()> {
                 const CREATE_NO_WINDOW: u32 = 0x08000000;
                 cmd.creation_flags(CREATE_NEW_PROCESS_GROUP | CREATE_NO_WINDOW);
             }
-            let _child = cmd.spawn().map_err(|e| io::Error::new(io::ErrorKind::Other, format!("failed to spawn server: {e}")))?;
+            let child_result = cmd.spawn();
+            debug_log(&format!("spawn result: {:?}", child_result.as_ref().map(|c| c.id())));
+            let _child = child_result.map_err(|e| io::Error::new(io::ErrorKind::Other, format!("failed to spawn server: {e}")))?;
 
             // Wait for server to start by checking for named pipe
-            for _ in 0..20 {
+            for i in 0..20 {
                 if pipe_exists(&session_name) {
+                    debug_log(&format!("pipe exists after {} iterations", i));
                     break;
                 }
                 std::thread::sleep(Duration::from_millis(100));
             }
+            if !pipe_exists(&session_name) {
+                debug_log("WARNING: pipe never appeared after 2 seconds!");
+            }
         }
-        
+
         // Now attach to the session
         env::set_var("PSMUX_SESSION_NAME", &session_name);
         env::set_var("PSMUX_REMOTE_ATTACH", "1");
+        debug_log("set PSMUX_REMOTE_ATTACH=1");
     }
     
+    debug_log("checking PSMUX_ACTIVE");
     if env::var("PSMUX_ACTIVE").ok().as_deref() == Some("1") {
+        debug_log("nested session detected, exiting");
         eprintln!("psmux: nested sessions are not allowed");
         return Ok(());
     }
     env::set_var("PSMUX_ACTIVE", "1");
+    debug_log("enabling raw mode and alternate screen");
     let mut stdout = io::stdout();
     enable_raw_mode()?;
     execute!(stdout, EnterAlternateScreen, EnableBlinking, EnableMouseCapture, EnableBracketedPaste)?;
     apply_cursor_style(&mut stdout)?;
     let backend = CrosstermBackend::new(stdout);
     let mut terminal = Terminal::new(backend)?;
-    
+    debug_log("terminal created, entering main loop");
+
     // Loop to handle session switching without spawning new processes
     loop {
+        debug_log("calling run_remote");
         let result = run_remote(&mut terminal);
+        debug_log(&format!("run_remote returned: {:?}", result.as_ref().err()));
         
         // Check if we should switch to another session
         if let Ok(switch_to) = env::var("PSMUX_SWITCH_TO") {
@@ -1744,13 +1802,28 @@ fn main() -> io::Result<()> {
 }
 
 fn run_remote(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>) -> io::Result<()> {
+    // Debug helper for run_remote
+    fn rlog(msg: &str) {
+        if std::env::var("PSMUX_DEBUG").is_ok() {
+            use std::io::Write;
+            let log_path = std::env::current_dir().unwrap_or_default().join("psmux_debug.log");
+            if let Ok(mut f) = std::fs::OpenOptions::new().create(true).append(true).open(&log_path) {
+                let _ = writeln!(f, "[REMOTE {}] {}", std::process::id(), msg);
+            }
+        }
+    }
+
     let name = env::var("PSMUX_SESSION_NAME").unwrap_or_else(|_| "default".to_string());
     let home = env::var("USERPROFILE").or_else(|_| env::var("HOME")).unwrap_or_default();
+    rlog(&format!("run_remote started, session={}", name));
 
     // Connect to named pipe and send client-attach
+    rlog("connecting to pipe");
     let pipe = connect_to_pipe(&name, 1000)?;
+    rlog("connected, sending client-attach");
     pipe_write(pipe, b"client-attach\n")?;
     close_pipe(pipe);
+    rlog("client-attach sent");
 
     let last_path = format!("{}\\.psmux\\last_session", home);
     let _ = std::fs::write(&last_path, &name);
@@ -1772,24 +1845,39 @@ fn run_remote(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>) -> io::Resu
     let current_session = name.clone();
 
     // Helper to send command to server via named pipe - returns response if any
+    // Includes retry logic to handle race conditions with pipe recreation
+    // Uses larger buffer and multiple reads to handle large responses
     let pipe_command = |cmd: &[u8]| -> Option<String> {
-        if let Ok(pipe) = connect_to_pipe(&name, 100) {
-            let _ = pipe_write(pipe, cmd);
-            let mut buf = [0u8; 65536];
-            let response = if let Ok(n) = pipe_read(pipe, &mut buf) {
-                if n > 0 {
-                    Some(String::from_utf8_lossy(&buf[..n]).to_string())
-                } else {
-                    None
+        for attempt in 0..5 {
+            if let Ok(pipe) = connect_to_pipe(&name, 100) {
+                let _ = pipe_write(pipe, cmd);
+                // Read in a loop to get all data
+                let mut result = Vec::new();
+                let mut buf = [0u8; 65536];
+                loop {
+                    match pipe_read(pipe, &mut buf) {
+                        Ok(n) if n > 0 => {
+                            result.extend_from_slice(&buf[..n]);
+                            if n < buf.len() {
+                                // Got less than buffer size, likely done
+                                break;
+                            }
+                        }
+                        _ => break,
+                    }
                 }
-            } else {
-                None
-            };
-            close_pipe(pipe);
-            response
-        } else {
-            None
+                close_pipe(pipe);
+                if !result.is_empty() {
+                    return Some(String::from_utf8_lossy(&result).to_string());
+                }
+                return None;
+            }
+            // Wait briefly before retrying
+            if attempt < 4 {
+                thread::sleep(Duration::from_millis(10));
+            }
         }
+        None
     };
 
     // Helper to send command without expecting response
@@ -1807,17 +1895,25 @@ fn run_remote(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>) -> io::Resu
     #[derive(serde::Deserialize, Default)]
     struct WinStatus { id: usize, name: String, active: bool }
 
+    rlog("entering main loop");
+    let mut loop_count = 0;
     loop {
+        loop_count += 1;
+        if loop_count <= 3 { rlog(&format!("loop iteration {}", loop_count)); }
+
         // Fetch layout BEFORE draw - this also serves as liveness check
         let root: LayoutJson = if let Some(buf) = pipe_command(b"dump-layout\n") {
+            if loop_count <= 3 { rlog(&format!("dump-layout response len={}", buf.len())); }
             if !buf.is_empty() {
                 serde_json::from_str(&buf).unwrap_or(LayoutJson::Leaf { id: 0, rows: 0, cols: 0, cursor_row: 0, cursor_col: 0, active: true, copy_mode: false, scroll_offset: 0, content: Vec::new() })
             } else {
                 // Server closed connection or sent no data - exit
+                rlog("dump-layout returned empty, breaking");
                 break;
             }
         } else {
             // Server connection failed - exit immediately
+            rlog("dump-layout failed to connect, breaking");
             break;
         };
 
@@ -2377,12 +2473,19 @@ fn pipe_exists(session_name: &str) -> bool {
     }
 }
 
-/// Write data to pipe and optionally read response
+/// Write data to pipe - handles large writes by looping
 fn pipe_write(pipe: HANDLE, data: &[u8]) -> io::Result<()> {
     unsafe {
-        let mut written = 0u32;
-        WriteFile(pipe, Some(data), Some(&mut written), None)
-            .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("WriteFile failed: {}", e)))?;
+        let mut offset = 0usize;
+        while offset < data.len() {
+            let mut written = 0u32;
+            WriteFile(pipe, Some(&data[offset..]), Some(&mut written), None)
+                .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("WriteFile failed: {}", e)))?;
+            if written == 0 {
+                return Err(io::Error::new(io::ErrorKind::WriteZero, "pipe write returned 0"));
+            }
+            offset += written as usize;
+        }
         let _ = FlushFileBuffers(pipe);
         Ok(())
     }
@@ -2477,9 +2580,7 @@ fn send_control_with_response(line: String) -> io::Result<String> {
 }
 
 fn run(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>) -> io::Result<()> {
-    let pty_system = PtySystemSelection::default()
-        .get()
-        .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("pty system error: {e}")))?;
+    let pty_system = native_pty_system();
 
     let mut app = AppState {
         windows: Vec::new(),
@@ -2811,7 +2912,7 @@ fn run(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>) -> io::Result<()> 
             let Some(req) = req else { break; };
             match req {
                 CtrlReq::NewWindow => {
-                    let pty_system = PtySystemSelection::default().get().map_err(|e| io::Error::new(io::ErrorKind::Other, format!("pty system error: {e}")))?;
+                    let pty_system = native_pty_system();
                     create_window(&*pty_system, &mut app)?;
                     resize_all_panes(&mut app);
                 }
@@ -2898,10 +2999,26 @@ fn create_window(pty_system: &dyn portable_pty::PtySystem, app: &mut AppState) -
         .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("openpty error: {e}")))?;
 
     let shell_cmd = detect_shell();
+    // Log what shell we're spawning
+    if std::env::var("PSMUX_DEBUG").is_ok() {
+        use std::io::Write;
+        let log_path = std::env::current_dir().unwrap_or_default().join("psmux_debug.log");
+        if let Ok(mut f) = std::fs::OpenOptions::new().create(true).append(true).open(&log_path) {
+            let _ = writeln!(f, "[SERVER {}] spawning shell command", std::process::id());
+        }
+    }
     let child = pair
         .slave
         .spawn_command(shell_cmd)
         .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("spawn shell error: {e}")))?;
+    // Log child process info
+    if std::env::var("PSMUX_DEBUG").is_ok() {
+        use std::io::Write;
+        let log_path = std::env::current_dir().unwrap_or_default().join("psmux_debug.log");
+        if let Ok(mut f) = std::fs::OpenOptions::new().create(true).append(true).open(&log_path) {
+            let _ = writeln!(f, "[SERVER {}] shell spawned, child pid: {:?}", std::process::id(), child.process_id());
+        }
+    }
 
     let term: Arc<Mutex<vt100::Parser>> = Arc::new(Mutex::new(vt100::Parser::new(size.rows, size.cols, 1000)));
     let term_reader = term.clone();
@@ -2909,22 +3026,73 @@ fn create_window(pty_system: &dyn portable_pty::PtySystem, app: &mut AppState) -
         .master
         .try_clone_reader()
         .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("clone reader error: {e}")))?;
+    let writer = pair
+        .master
+        .take_writer()
+        .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("clone writer error: {e}")))?;
 
+    // Wrap writer in Arc<Mutex<>> so it can be shared with reader thread for DSR responses
+    let writer = Arc::new(Mutex::new(writer));
+    let writer_for_reader = writer.clone();
+
+    let debug_pty = std::env::var("PSMUX_DEBUG").is_ok();
     thread::spawn(move || {
+        // PTY reader debug logging helper
+        fn pty_log(msg: &str) {
+            use std::io::Write;
+            let log_path = std::env::current_dir().unwrap_or_default().join("psmux_debug.log");
+            if let Ok(mut f) = std::fs::OpenOptions::new().create(true).append(true).open(&log_path) {
+                let _ = writeln!(f, "[PTY-READER {}] {}", std::process::id(), msg);
+            }
+        }
+
+        if debug_pty { pty_log("reader thread started"); }
         let mut local = [0u8; 8192];
+        let mut total_bytes = 0usize;
+        let mut read_count = 0usize;
         loop {
             match reader.read(&mut local) {
                 Ok(n) if n > 0 => {
+                    total_bytes += n;
+                    read_count += 1;
+                    if debug_pty && read_count <= 5 {
+                        pty_log(&format!("read {} bytes (total: {})", n, total_bytes));
+                    }
+
+                    // Check for DSR (Device Status Report) cursor position query: ESC [ 6 n
+                    // PowerShell sends this and waits for response before showing prompt
+                    let data = &local[..n];
+                    if let Some(pos) = data.windows(4).position(|w| w == b"\x1b[6n") {
+                        if debug_pty { pty_log("detected DSR cursor query, sending response"); }
+                        // Get cursor position from parser and send response
+                        let (row, col) = {
+                            let parser = term_reader.lock().unwrap();
+                            let screen = parser.screen();
+                            let (r, c) = screen.cursor_position();
+                            (r + 1, c + 1)  // Convert to 1-based
+                        };
+                        // Send cursor position report: ESC [ row ; col R
+                        let response = format!("\x1b[{};{}R", row, col);
+                        if let Ok(mut w) = writer_for_reader.lock() {
+                            let _ = w.write_all(response.as_bytes());
+                            let _ = w.flush();
+                        }
+                    }
+
                     let mut parser = term_reader.lock().unwrap();
                     parser.process(&local[..n]);
                 }
                 Ok(_) => thread::sleep(Duration::from_millis(5)),
-                Err(_) => break,
+                Err(e) => {
+                    if debug_pty { pty_log(&format!("reader error: {:?}, total bytes: {}", e, total_bytes)); }
+                    break;
+                }
             }
         }
+        if debug_pty { pty_log(&format!("reader thread exiting, total bytes read: {}", total_bytes)); }
     });
 
-    let pane = Pane { master: pair.master, child, term, last_rows: size.rows, last_cols: size.cols, id: app.next_pane_id, title: format!("pane %{}", app.next_pane_id) };
+    let pane = Pane { master: pair.master, writer, child, term, last_rows: size.rows, last_cols: size.cols, id: app.next_pane_id, title: format!("pane %{}", app.next_pane_id) };
     app.next_pane_id += 1;
     app.windows.push(Window { root: Node::Leaf(pane), active_path: vec![], name: format!("win {}", app.windows.len()+1), id: app.next_win_id });
     app.next_win_id += 1;
@@ -2961,9 +3129,7 @@ fn handle_key(app: &mut AppState, key: KeyEvent) -> io::Result<bool> {
                     true
                 }
                 KeyCode::Char('c') => {
-                    let pty_system = PtySystemSelection::default()
-                        .get()
-                        .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("pty system error: {e}")))?;
+                    let pty_system = native_pty_system();
                     create_window(&*pty_system, app)?;
                     true
                 }
@@ -3261,30 +3427,31 @@ fn move_focus(app: &mut AppState, dir: FocusDir) {
 fn forward_key_to_active(app: &mut AppState, key: KeyEvent) -> io::Result<()> {
     let win = &mut app.windows[app.active_idx];
     let Some(active) = active_pane_mut(&mut win.root, &win.active_path) else { return Ok(()); };
+    let Ok(mut writer) = active.writer.lock() else { return Ok(()); };
     match key.code {
         KeyCode::Char(c) if key.modifiers.contains(KeyModifiers::CONTROL) => {
             // Send control character (Ctrl+C = 0x03, Ctrl+D = 0x04, etc.)
             let ctrl_char = (c.to_ascii_lowercase() as u8).wrapping_sub(b'a' - 1);
-            let _ = active.master.write_all(&[ctrl_char]);
+            let _ = writer.write_all(&[ctrl_char]);
         }
         KeyCode::Char(c) => {
-            let _ = write!(active.master, "{}", c);
+            let _ = write!(writer, "{}", c);
         }
-        KeyCode::Enter => { let _ = write!(active.master, "\r"); }
-        KeyCode::Tab => { let _ = write!(active.master, "\t"); }
-        KeyCode::Backspace => { let _ = write!(active.master, "\x08"); }
-        KeyCode::Esc => { let _ = write!(active.master, "\x1b"); }
-        KeyCode::Left => { let _ = write!(active.master, "\x1b[D"); }
-        KeyCode::Right => { let _ = write!(active.master, "\x1b[C"); }
-        KeyCode::Up => { let _ = write!(active.master, "\x1b[A"); }
-        KeyCode::Down => { let _ = write!(active.master, "\x1b[B"); }
+        KeyCode::Enter => { let _ = write!(writer, "\r"); }
+        KeyCode::Tab => { let _ = write!(writer, "\t"); }
+        KeyCode::Backspace => { let _ = write!(writer, "\x08"); }
+        KeyCode::Esc => { let _ = write!(writer, "\x1b"); }
+        KeyCode::Left => { let _ = write!(writer, "\x1b[D"); }
+        KeyCode::Right => { let _ = write!(writer, "\x1b[C"); }
+        KeyCode::Up => { let _ = write!(writer, "\x1b[A"); }
+        KeyCode::Down => { let _ = write!(writer, "\x1b[B"); }
         _ => {}
     }
     Ok(())
 }
 
 fn split_active(app: &mut AppState, kind: LayoutKind) -> io::Result<()> {
-    let pty_system = PtySystemSelection::default().get().map_err(|e| io::Error::new(io::ErrorKind::Other, format!("pty system error: {e}")))?;
+    let pty_system = native_pty_system();
     let size = PtySize { rows: 30, cols: 120, pixel_width: 0, pixel_height: 0 };
     let pair = pty_system.openpty(size).map_err(|e| io::Error::new(io::ErrorKind::Other, format!("openpty error: {e}")))?;
     let shell_cmd = detect_shell();
@@ -3292,17 +3459,41 @@ fn split_active(app: &mut AppState, kind: LayoutKind) -> io::Result<()> {
     let term: Arc<Mutex<vt100::Parser>> = Arc::new(Mutex::new(vt100::Parser::new(size.rows, size.cols, 1000)));
     let term_reader = term.clone();
     let mut reader = pair.master.try_clone_reader().map_err(|e| io::Error::new(io::ErrorKind::Other, format!("clone reader error: {e}")))?;
+    let writer = pair.master.take_writer().map_err(|e| io::Error::new(io::ErrorKind::Other, format!("clone writer error: {e}")))?;
+
+    // Wrap writer in Arc<Mutex<>> so it can be shared with reader thread for DSR responses
+    let writer = Arc::new(Mutex::new(writer));
+    let writer_for_reader = writer.clone();
+
     thread::spawn(move || {
         let mut local = [0u8; 8192];
         loop {
             match reader.read(&mut local) {
-                Ok(n) if n > 0 => { let mut parser = term_reader.lock().unwrap(); parser.process(&local[..n]); }
+                Ok(n) if n > 0 => {
+                    // Check for DSR (Device Status Report) cursor position query: ESC [ 6 n
+                    let data = &local[..n];
+                    if data.windows(4).any(|w| w == b"\x1b[6n") {
+                        let (row, col) = {
+                            let parser = term_reader.lock().unwrap();
+                            let screen = parser.screen();
+                            let (r, c) = screen.cursor_position();
+                            (r + 1, c + 1)
+                        };
+                        let response = format!("\x1b[{};{}R", row, col);
+                        if let Ok(mut w) = writer_for_reader.lock() {
+                            let _ = w.write_all(response.as_bytes());
+                            let _ = w.flush();
+                        }
+                    }
+                    let mut parser = term_reader.lock().unwrap();
+                    parser.process(&local[..n]);
+                }
                 Ok(_) => thread::sleep(Duration::from_millis(5)),
                 Err(_) => break,
             }
         }
     });
-    let new_leaf = Node::Leaf(Pane { master: pair.master, child, term, last_rows: size.rows, last_cols: size.cols, id: app.next_pane_id, title: format!("pane %{}", app.next_pane_id) });
+    let new_leaf = Node::Leaf(Pane { master: pair.master, writer, child, term, last_rows: size.rows, last_cols: size.cols, id: app.next_pane_id, title: format!("pane %{}", app.next_pane_id) });
     app.next_pane_id += 1;
     let win = &mut app.windows[app.active_idx];
     replace_leaf_with_split(&mut win.root, &win.active_path, kind, new_leaf);
@@ -3360,10 +3551,10 @@ fn handle_mouse(app: &mut AppState, me: crossterm::event::MouseEvent, window_are
         }
         MouseEventKind::Up(MouseButton::Left) => { app.drag = None; }
         MouseEventKind::ScrollUp => {
-            if let Some(active) = active_pane_mut(&mut win.root, &win.active_path) { let _ = write!(active.master, "\x1b[A"); }
+            if let Some(active) = active_pane_mut(&mut win.root, &win.active_path) { if let Ok(mut w) = active.writer.lock() { let _ = write!(w, "\x1b[A"); } }
         }
         MouseEventKind::ScrollDown => {
-            if let Some(active) = active_pane_mut(&mut win.root, &win.active_path) { let _ = write!(active.master, "\x1b[B"); }
+            if let Some(active) = active_pane_mut(&mut win.root, &win.active_path) { if let Ok(mut w) = active.writer.lock() { let _ = write!(w, "\x1b[B"); } }
         }
         _ => {}
     }
@@ -3379,6 +3570,13 @@ fn kill_active_pane(app: &mut AppState) -> io::Result<()> {
 }
 
 fn detect_shell() -> CommandBuilder {
+    // DEBUG: Test with a simple long-running command to verify PTY works
+    if std::env::var("PSMUX_TEST_PTY").is_ok() {
+        let mut builder = CommandBuilder::new("cmd.exe");
+        builder.args(["/k", "echo PTY TEST && ping -t localhost"]);
+        return builder;
+    }
+
     let pwsh = which::which("pwsh").ok().map(|p| p.to_string_lossy().into_owned());
     let cmd = which::which("cmd").ok().map(|p| p.to_string_lossy().into_owned());
     match pwsh.or(cmd) {
@@ -3387,7 +3585,7 @@ fn detect_shell() -> CommandBuilder {
             // If it's PowerShell, disable inline predictions (ghost text) which doesn't render well in PTY
             if path.to_lowercase().contains("pwsh") {
                 // Use -NoExit with a command to disable predictions, then continue interactive
-                builder.args(["-NoLogo", "-NoExit", "-Command", 
+                builder.args(["-NoLogo", "-NoExit", "-Command",
                     "Set-PSReadLineOption -PredictionSource None -ErrorAction SilentlyContinue"]);
             }
             builder
@@ -3403,7 +3601,7 @@ fn execute_command_prompt(app: &mut AppState) -> io::Result<()> {
     if parts.is_empty() { return Ok(()); }
     match parts[0] {
         "new-window" => {
-            let pty_system = PtySystemSelection::default().get().map_err(|e| io::Error::new(io::ErrorKind::Other, format!("pty system error: {e}")))?;
+            let pty_system = native_pty_system();
             create_window(&*pty_system, app)?;
         }
         "split-window" => {
@@ -3671,6 +3869,8 @@ fn get_active_pane_id(node: &Node, path: &[usize]) -> Option<usize> {
 }
 
 fn reap_children(app: &mut AppState) -> io::Result<bool> {
+    let debug = std::env::var("PSMUX_DEBUG").is_ok();
+    let initial_count = app.windows.len();
     // Transform each window's split tree by pruning exited leaves.
     for i in (0..app.windows.len()).rev() {
         let root = std::mem::replace(&mut app.windows[i].root, Node::Split { kind: LayoutKind::Horizontal, sizes: vec![], children: vec![] });
@@ -3682,7 +3882,29 @@ fn reap_children(app: &mut AppState) -> io::Result<bool> {
                     app.windows[i].active_path = first_leaf_path(&app.windows[i].root);
                 }
             }
-            None => { app.windows.remove(i); }
+            None => {
+                if debug {
+                    use std::io::Write;
+                    let log_path = std::env::current_dir().unwrap_or_default().join("psmux_debug.log");
+                    if let Ok(mut f) = std::fs::OpenOptions::new().create(true).append(true).open(&log_path) {
+                        let _ = writeln!(f, "[SERVER {}] reap_children: removing window {} (prune_exited returned None)", std::process::id(), i);
+                    }
+                }
+                app.windows.remove(i);
+                // Adjust active_idx if needed
+                if !app.windows.is_empty() {
+                    if app.active_idx >= app.windows.len() {
+                        app.active_idx = app.windows.len() - 1;
+                    }
+                }
+            }
+        }
+    }
+    if debug && app.windows.is_empty() && initial_count > 0 {
+        use std::io::Write;
+        let log_path = std::env::current_dir().unwrap_or_default().join("psmux_debug.log");
+        if let Ok(mut f) = std::fs::OpenOptions::new().create(true).append(true).open(&log_path) {
+            let _ = writeln!(f, "[SERVER {}] reap_children: all {} windows removed, server will exit", std::process::id(), initial_count);
         }
     }
     Ok(app.windows.is_empty())
@@ -4063,7 +4285,18 @@ fn prune_exited(n: Node) -> Option<Node> {
     match n {
         Node::Leaf(mut p) => {
             match p.child.try_wait() {
-                Ok(Some(_)) => None,
+                Ok(Some(status)) => {
+                    // Only log when a child actually exits
+                    if std::env::var("PSMUX_DEBUG").is_ok() {
+                        use std::io::Write;
+                        let log_path = std::env::current_dir().unwrap_or_default().join("psmux_debug.log");
+                        if let Ok(mut f) = std::fs::OpenOptions::new().create(true).append(true).open(&log_path) {
+                            let _ = writeln!(f, "[SERVER {}] Child process pane {} (pid {:?}) exited with status: {:?}",
+                                std::process::id(), p.id, p.child.process_id(), status);
+                        }
+                    }
+                    None
+                }
                 _ => Some(Node::Leaf(p)),
             }
         }
@@ -4651,6 +4884,22 @@ fn parse_status(fmt: &str, app: &AppState, time_str: &str) -> Vec<Span<'static>>
 }
 
 fn map_color(name: &str) -> Color {
+    // Handle indexed colors: "idx:N"
+    if let Some(idx_str) = name.strip_prefix("idx:") {
+        if let Ok(idx) = idx_str.parse::<u8>() {
+            return Color::Indexed(idx);
+        }
+    }
+    // Handle RGB colors: "rgb:R,G,B"
+    if let Some(rgb_str) = name.strip_prefix("rgb:") {
+        let parts: Vec<&str> = rgb_str.split(',').collect();
+        if parts.len() == 3 {
+            if let (Ok(r), Ok(g), Ok(b)) = (parts[0].parse::<u8>(), parts[1].parse::<u8>(), parts[2].parse::<u8>()) {
+                return Color::Rgb(r, g, b);
+            }
+        }
+    }
+    // Handle named colors
     match name.to_lowercase().as_str() {
         "black" => Color::Black,
         "red" => Color::Red,
@@ -4743,7 +4992,7 @@ fn yank_selection(app: &mut AppState) -> io::Result<()> {
 fn paste_latest(app: &mut AppState) -> io::Result<()> {
     if let Some(buf) = app.paste_buffers.last() {
         let win = &mut app.windows[app.active_idx];
-        if let Some(p) = active_pane_mut(&mut win.root, &win.active_path) { let _ = write!(p.master, "{}", buf); }
+        if let Some(p) = active_pane_mut(&mut win.root, &win.active_path) { if let Ok(mut w) = p.writer.lock() { let _ = write!(w, "{}", buf); } }
     }
     Ok(())
 }
@@ -4934,9 +5183,21 @@ fn focus_pane_by_id(app: &mut AppState, pid: usize) {
     if let Some(p) = found { win.active_path = p; }
 }
 fn run_server(session_name: String) -> io::Result<()> {
-    let pty_system = PtySystemSelection::default()
-        .get()
-        .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("pty system error: {e}")))?;
+    // Server debug helper - writes to file
+    fn slog(msg: &str) {
+        if std::env::var("PSMUX_DEBUG").is_ok() {
+            use std::io::Write;
+            let log_path = std::env::current_dir().unwrap_or_default().join("psmux_debug.log");
+            if let Ok(mut f) = std::fs::OpenOptions::new().create(true).append(true).open(&log_path) {
+                let _ = writeln!(f, "[SERVER {}] {}", std::process::id(), msg);
+            }
+        }
+    }
+
+    slog(&format!("run_server started, session={}", session_name));
+    slog("calling native_pty_system()");
+    let pty_system = native_pty_system();
+    slog("native_pty_system() returned");
 
     let mut app = AppState {
         windows: Vec::new(),
@@ -4970,20 +5231,42 @@ fn run_server(session_name: String) -> io::Result<()> {
         last_window_idx: 0,
         last_pane_path: Vec::new(),
     };
-    create_window(&*pty_system, &mut app)?;
+    slog("AppState created, calling create_window");
+    if let Err(e) = create_window(&*pty_system, &mut app) {
+        slog(&format!("create_window FAILED: {:?}", e));
+        return Err(e);
+    }
+    slog("create_window succeeded");
     let (tx, rx) = mpsc::channel::<CtrlReq>();
     app.control_rx = Some(rx);
 
     // Create named pipe server with user-only security
     let session_name_for_pipe = app.session_name.clone();
+    slog(&format!("registering session: {}", &app.session_name));
     let _ = register_session(&app.session_name);
+    slog("starting named pipe server thread");
 
+    let debug_pipe = std::env::var("PSMUX_DEBUG").is_ok();
     thread::spawn(move || {
+        // Pipe thread logging helper
+        fn plog(msg: &str) {
+            use std::io::Write;
+            let log_path = std::env::current_dir().unwrap_or_default().join("psmux_debug.log");
+            if let Ok(mut f) = std::fs::OpenOptions::new().create(true).append(true).open(&log_path) {
+                let _ = writeln!(f, "[PIPE {}] {}", std::process::id(), msg);
+            }
+        }
+
+        let mut conn_count = 0u32;
         loop {
             // Create a new pipe instance for each connection
             let pipe = match create_named_pipe_server(&session_name_for_pipe) {
                 Ok(p) => p,
-                Err(_) => { thread::sleep(Duration::from_millis(100)); continue; }
+                Err(e) => {
+                    if debug_pipe { plog(&format!("create_named_pipe_server error: {:?}", e)); }
+                    thread::sleep(Duration::from_millis(100));
+                    continue;
+                }
             };
 
             // Wait for client connection
@@ -4991,17 +5274,23 @@ fn run_server(session_name: String) -> io::Result<()> {
                 close_pipe(pipe);
                 continue;
             }
+            conn_count += 1;
+            if debug_pipe { plog(&format!("connection #{}", conn_count)); }
 
             // Read command from pipe
             let mut buf = [0u8; 4096];
             let n = match pipe_read(pipe, &mut buf) {
                 Ok(n) if n > 0 => n,
-                _ => { disconnect_pipe(pipe); close_pipe(pipe); continue; }
+                _ => {
+                    if debug_pipe { plog(&format!("conn #{}: read failed or empty", conn_count)); }
+                    disconnect_pipe(pipe); close_pipe(pipe); continue;
+                }
             };
 
             let line = String::from_utf8_lossy(&buf[..n]).to_string();
             let mut parts = line.split_whitespace();
             let cmd = parts.next().unwrap_or("");
+            if debug_pipe { plog(&format!("conn #{}: cmd={}", conn_count, cmd)); }
             let args: Vec<&str> = parts.by_ref().collect();
             let mut target_win: Option<usize> = None;
             let mut target_pane: Option<usize> = None;
@@ -5400,6 +5689,7 @@ fn run_server(session_name: String) -> io::Result<()> {
                 }
                 _ => {}
             }
+            if debug_pipe { plog(&format!("conn #{}: done", conn_count)); }
             disconnect_pipe(pipe);
             close_pipe(pipe);
         }
@@ -6054,11 +6344,13 @@ fn run_server(session_name: String) -> io::Result<()> {
         // Check if all windows/panes have exited
         if reap_children(&mut app)? {
             // All windows are gone - unregister session and exit server
+            slog("all windows gone, exiting server");
             unregister_session(&app.session_name);
             break;
         }
         thread::sleep(Duration::from_millis(5));  // Faster response, lower latency
     }
+    slog("server main loop ended");
     Ok(())
 }
 
@@ -6109,7 +6401,9 @@ fn dump_layout_json(app: &mut AppState) -> io::Result<String> {
                         if let Some(cell) = screen.cell(r, c) {
                             let fg = color_to_name(cell.fgcolor());
                             let bg = color_to_name(cell.bgcolor());
-                            let text = cell.contents().to_string();
+                            // Treat empty cells as spaces (important for tab stops)
+                            let contents = cell.contents();
+                            let text = if contents.is_empty() { " ".to_string() } else { contents.to_string() };
                             row.push(CellJson { text, fg, bg, bold: cell.bold(), italic: cell.italic(), underline: cell.underline(), inverse: cell.inverse(), dim: cell.dim() });
                         } else {
                             row.push(CellJson { text: " ".to_string(), fg: "default".to_string(), bg: "default".to_string(), bold: false, italic: false, underline: false, inverse: false, dim: false });
@@ -6300,7 +6594,7 @@ fn color_to_name(c: vt100::Color) -> String {
 
 fn send_text_to_active(app: &mut AppState, text: &str) -> io::Result<()> {
     let win = &mut app.windows[app.active_idx];
-    if let Some(p) = active_pane_mut(&mut win.root, &win.active_path) { let _ = write!(p.master, "{}", text); }
+    if let Some(p) = active_pane_mut(&mut win.root, &win.active_path) { if let Ok(mut w) = p.writer.lock() { let _ = write!(w, "{}", text); } }
     Ok(())
 }
 
@@ -6334,25 +6628,27 @@ fn send_key_to_active(app: &mut AppState, k: &str) -> io::Result<()> {
     
     let win = &mut app.windows[app.active_idx];
     if let Some(p) = active_pane_mut(&mut win.root, &win.active_path) {
-        match k {
-            "enter" => { let _ = write!(p.master, "\r"); }
-            "tab" => { let _ = write!(p.master, "\t"); }
-            "backspace" => { let _ = write!(p.master, "\x08"); }
-            "esc" => { let _ = write!(p.master, "\x1b"); }
-            "left" => { let _ = write!(p.master, "\x1b[D"); }
-            "right" => { let _ = write!(p.master, "\x1b[C"); }
-            "up" => { let _ = write!(p.master, "\x1b[A"); }
-            "down" => { let _ = write!(p.master, "\x1b[B"); }
-            "pageup" => { let _ = write!(p.master, "\x1b[5~"); }
-            "pagedown" => { let _ = write!(p.master, "\x1b[6~"); }
-            "space" => { let _ = write!(p.master, " "); }
-            // Control keys: C-c, C-d, C-z, etc.
-            s if s.starts_with("C-") && s.len() == 3 => {
-                let c = s.chars().nth(2).unwrap_or('c');
-                let ctrl_char = (c.to_ascii_lowercase() as u8).wrapping_sub(b'a' - 1);
-                let _ = p.master.write_all(&[ctrl_char]);
+        if let Ok(mut w) = p.writer.lock() {
+            match k {
+                "enter" => { let _ = write!(w, "\r"); }
+                "tab" => { let _ = write!(w, "\t"); }
+                "backspace" => { let _ = write!(w, "\x08"); }
+                "esc" => { let _ = write!(w, "\x1b"); }
+                "left" => { let _ = write!(w, "\x1b[D"); }
+                "right" => { let _ = write!(w, "\x1b[C"); }
+                "up" => { let _ = write!(w, "\x1b[A"); }
+                "down" => { let _ = write!(w, "\x1b[B"); }
+                "pageup" => { let _ = write!(w, "\x1b[5~"); }
+                "pagedown" => { let _ = write!(w, "\x1b[6~"); }
+                "space" => { let _ = write!(w, " "); }
+                // Control keys: C-c, C-d, C-z, etc.
+                s if s.starts_with("C-") && s.len() == 3 => {
+                    let c = s.chars().nth(2).unwrap_or('c');
+                    let ctrl_char = (c.to_ascii_lowercase() as u8).wrapping_sub(b'a' - 1);
+                    let _ = w.write_all(&[ctrl_char]);
+                }
+                _ => {}
             }
-            _ => {}
         }
     }
     Ok(())
@@ -6513,8 +6809,8 @@ fn remote_mouse_down(app: &mut AppState, x: u16, y: u16) {
 
 fn remote_mouse_drag(app: &mut AppState, x: u16, y: u16) { let win = &mut app.windows[app.active_idx]; if let Some(d) = &app.drag { adjust_split_sizes(&mut win.root, d, x, y); } }
 
-fn remote_scroll_up(app: &mut AppState) { let win = &mut app.windows[app.active_idx]; if let Some(p) = active_pane_mut(&mut win.root, &win.active_path) { let _ = write!(p.master, "\x1b[A"); } }
-fn remote_scroll_down(app: &mut AppState) { let win = &mut app.windows[app.active_idx]; if let Some(p) = active_pane_mut(&mut win.root, &win.active_path) { let _ = write!(p.master, "\x1b[B"); } }
+fn remote_scroll_up(app: &mut AppState) { let win = &mut app.windows[app.active_idx]; if let Some(p) = active_pane_mut(&mut win.root, &win.active_path) { if let Ok(mut w) = p.writer.lock() { let _ = write!(w, "\x1b[A"); } } }
+fn remote_scroll_down(app: &mut AppState) { let win = &mut app.windows[app.active_idx]; if let Some(p) = active_pane_mut(&mut win.root, &win.active_path) { if let Ok(mut w) = p.writer.lock() { let _ = write!(w, "\x1b[B"); } } }
 
 // New helper functions for tmux compatibility
 
@@ -6621,16 +6917,13 @@ fn rotate_panes(app: &mut AppState, _reverse: bool) {
 fn break_pane_to_window(app: &mut AppState) {
     // This would require extracting the current pane from its split and creating a new window
     // For now, just create a new window
-    let pty_system = match PtySystemSelection::default().get() {
-        Ok(p) => p,
-        Err(_) => return,
-    };
+    let pty_system = native_pty_system();
     let _ = create_window(&*pty_system, app);
 }
 
 fn respawn_active_pane(app: &mut AppState) -> io::Result<()> {
     // Respawn the shell in the active pane
-    let pty_system = PtySystemSelection::default().get().map_err(|e| io::Error::new(io::ErrorKind::Other, format!("pty system error: {e}")))?;
+    let pty_system = native_pty_system();
     let win = &mut app.windows[app.active_idx];
     let Some(pane) = active_pane_mut(&mut win.root, &win.active_path) else { return Ok(()); };
     


### PR DESCRIPTION
## Summary
- Fixes psmux on Windows 11 Build 26200+ where ConPTY behavior changed
- Enables sideloading ConPTY binaries (conpty.dll, OpenConsole.exe) from executable directory
- Fixes DSR cursor position query response so PowerShell prompt appears
- Fixes large response handling, color rendering, tab spacing, and window exit handling

## Changes
- Upgrade portable-pty from 0.2 to 0.9 for sideloading support
- Add SetDllDirectory to search executable directory for DLLs
- Add DSR (Device Status Report) response - PowerShell sends ESC[6n and waits for reply
- Share PTY writer between reader thread and main code using Arc<Mutex>
- Fix pipe read/write to handle large JSON responses (was truncating at 64KB)
- Fix color mapping for indexed (idx:N) and RGB (rgb:R,G,B) colors
- Fix tab rendering by treating empty cells as spaces
- Fix window exit handling to adjust active_idx when a window is removed
- Add --check-conpty flag to verify sideloaded DLLs

## Test plan
- [x] Start psmux and verify shell prompt appears
- [x] Verify colors render correctly
- [x] Verify tab spacing works (e.g., `ls` output alignment)
- [x] Create multiple windows (Ctrl+B, c), exit one, verify others remain
- [x] Run `psmux --check-conpty` to verify sideloaded DLLs are detected

🤖 Generated with [Claude Code](https://claude.com/claude-code)