### PR TITLE
Remove duplicate Cargo installation section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,12 +72,6 @@ To uninstall:
 irm https://raw.githubusercontent.com/marlocarlo/psmux/master/scripts/uninstall.ps1 | iex
 ```
 
-### Using Cargo
-
-```powershell
-cargo install psmux
-```
-
 ### Using Scoop
 
 ```powershell


### PR DESCRIPTION
I removed the duplicate of the readme. Dumb but it bothered me. And I removed the first one because I think people will prefer to use their package manager rather than cargo itself.