### PR TITLE
feat(mouse): forward hover (Moved) events to child PTY

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1438,7 +1438,18 @@ pub fn run_remote(terminal: &mut Terminal<CrosstermBackend<crate::platform::Psmu
                             MouseEventKind::Up(MouseButton::Right) => {}
                             MouseEventKind::Up(MouseButton::Middle) => {}
                             MouseEventKind::Moved => {
-                                // Don't send bare mouse-move to server - wasteful and server ignores it
+                                // Forward bare mouse motion (hover) to server only when the
+                                // active pane is in alternate screen mode (real TUI app like
+                                // htop, vim, opencode).  At a shell prompt, hover is not sent
+                                // to avoid wasteful socket traffic.
+                                let tui_active = if !prev_dump_buf.is_empty() {
+                                    serde_json::from_str::<DumpState>(&prev_dump_buf)
+                                        .map(|s| active_pane_in_alt_screen(&s.layout))
+                                        .unwrap_or(false)
+                                } else { false };
+                                if tui_active {
+                                    cmd_batch.push(format!("mouse-move {} {}\n", me.column, me.row));
+                                }
                             }
                             MouseEventKind::ScrollUp => {
                                 // Clear client-side selection when scrolling — server may

--- a/src/input.rs
+++ b/src/input.rs
@@ -1582,8 +1582,27 @@ pub fn handle_mouse(app: &mut AppState, me: MouseEvent, window_area: Rect) -> io
             }
         }
         MouseEventKind::Moved => {
-            // Don't forward bare motion - only forward drag events
-            // Most TUI apps don't want constant mouse position updates
+            // Forward bare mouse motion (hover) to child PTY only when the
+            // active pane is in alternate screen mode (real TUI app like
+            // htop, vim, opencode).  Shell prompts are excluded — PSReadLine
+            // spuriously enables mouse tracking on ConPTY.
+            let child_in_alt = active_pane(&win.root, &win.active_path)
+                .map_or(false, |p| {
+                    if let Ok(parser) = p.term.lock() {
+                        return parser.screen().alternate_screen();
+                    }
+                    false
+                });
+            if child_in_alt {
+                if let Some(area) = active_area {
+                    if let Some(active) = active_pane_mut(&mut win.root, &win.active_path) {
+                        // SGR button 35 = bare motion (no button held)
+                        forward_mouse_to_pane_ex(active, area, me.column, me.row,
+                            0, crate::platform::mouse_inject::MOUSE_MOVED,
+                            35, true);
+                    }
+                }
+            }
         }
         MouseEventKind::ScrollUp => {
             if matches!(app.mode, Mode::CopyMode | Mode::CopySearch { .. }) {

--- a/src/window_ops.rs
+++ b/src/window_ops.rs
@@ -550,10 +550,37 @@ pub fn remote_mouse_button(app: &mut AppState, x: u16, y: u16, button: u8, press
     }
 }
 
-/// Forward mouse motion to the child PTY - currently disabled to avoid garbage.
-/// Most TUI apps don't want constant mouse position updates without button held.
-pub fn remote_mouse_motion(_app: &mut AppState, _x: u16, _y: u16) {
-    // Don't forward bare motion - only forward drag events
+/// Forward bare mouse motion (hover) to the child PTY.
+/// Only forwarded when the active pane is in alternate screen mode (real TUI
+/// apps like htop, vim, opencode).  Shell prompts (PSReadLine) are excluded
+/// because they spuriously enable mouse tracking on ConPTY.
+/// SGR button 35 = bare motion with no button held.
+pub fn remote_mouse_motion(app: &mut AppState, x: u16, y: u16) {
+    let win = &mut app.windows[app.active_idx];
+    let mut rects: Vec<(Vec<usize>, Rect)> = Vec::new();
+    compute_rects(&win.root, app.last_window_area, &mut rects);
+
+    // Only forward hover when the active pane is in alternate screen
+    // (reliable TUI detection — matches scroll-event gating logic).
+    let in_alt = active_pane(&win.root, &win.active_path)
+        .map_or(false, |p| {
+            if let Ok(parser) = p.term.lock() {
+                return parser.screen().alternate_screen();
+            }
+            false
+        });
+    if !in_alt {
+        return;
+    }
+
+    if let Some(area) = rects.iter().find(|(path, _)| *path == win.active_path).map(|(_, a)| *a) {
+        let (col, row) = pane_inner_cell_0based(area, x, y);
+        let win_name = win.name.clone();
+        if let Some(active) = active_pane_mut(&mut win.root, &win.active_path) {
+            inject_mouse_combined(active, col, row, 35, true,
+                0, mouse_inject::MOUSE_MOVED, &win_name);
+        }
+    }
 }
 
 fn wheel_cell_for_area(area: Rect, x: u16, y: u16) -> (u16, u16) {


### PR DESCRIPTION
## What

Mouse hover (`MouseEventKind::Moved`) events are received from the terminal but silently discarded in all three handling paths (standalone, client-server, and app dispatch).

## Why

TUI apps running inside psmux panes (htop, vim, opencode, etc.) expect SGR mouse motion events (button 35) for hover functionality. Without forwarding these events, hover-dependent features in child applications don't work.

## Fix

Forward `MouseEventKind::Moved` as SGR button 35 (`\x1b[<35;col;rowM`) to the child PTY, gated on `alternate_screen()` to avoid PSReadLine false positives at shell prompts. Changes span 3 files:

- **`src/window_ops.rs`** — Replaced `remote_mouse_motion()` no-op stub with real forwarding logic
- **`src/input.rs`** — Handle `Moved` in standalone mode
- **`src/client.rs`** — Handle `Moved` in client-server mode (sends `mouse-move` to server only when active pane is in alt screen)