### PR TITLE
fix(mouse): gate click/drag forwarding and align hover test

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -511,6 +511,12 @@ pub fn parse_option_value(app: &mut AppState, rest: &str, _is_global: bool) {
         "remain-on-exit" => {
             app.remain_on_exit = matches!(value, "on" | "true" | "1");
         }
+        "destroy-unattached" => {
+            app.destroy_unattached = matches!(value, "on" | "true" | "1");
+        }
+        "exit-empty" => {
+            app.exit_empty = matches!(value, "on" | "true" | "1");
+        }
         "aggressive-resize" => {
             app.aggressive_resize = matches!(value, "on" | "true" | "1");
         }

--- a/src/format.rs
+++ b/src/format.rs
@@ -785,6 +785,8 @@ fn lookup_option(name: &str, app: &AppState) -> Option<String> {
         "automatic-rename" => Some(if app.automatic_rename { "on".into() } else { "off".into() }),
         "monitor-activity" => Some(if app.monitor_activity { "on".into() } else { "off".into() }),
         "remain-on-exit" => Some(if app.remain_on_exit { "on".into() } else { "off".into() }),
+        "destroy-unattached" => Some(if app.destroy_unattached { "on".into() } else { "off".into() }),
+        "exit-empty" => Some(if app.exit_empty { "on".into() } else { "off".into() }),
         "set-titles" => Some(if app.set_titles { "on".into() } else { "off".into() }),
         "set-titles-string" => Some(app.set_titles_string.clone()),
         "pane-border-style" => Some(app.pane_border_style.clone()),

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -119,17 +119,27 @@ if line.trim().starts_with("TARGET ") {
 }
 
 // Process commands in a loop to handle batching
+let mut attached_sent = false;
 loop {
     if line.trim().is_empty() {
         // Try to read another command with timeout
         line.clear();
         match r.read_line(&mut line) {
-            Ok(0) => break, // EOF - client disconnected
+            Ok(0) => {
+                // EOF - client disconnected
+                if attached_sent {
+                    let _ = tx.send(CtrlReq::ClientDetach);
+                }
+                break;
+            }
             Err(e) => {
                 // In persistent mode, timeouts are expected - keep waiting
                 if persistent && (e.kind() == io::ErrorKind::WouldBlock || e.kind() == io::ErrorKind::TimedOut) {
                     line.clear(); // Clear any partial data from interrupted read
                     continue;
+                }
+                if attached_sent {
+                    let _ = tx.send(CtrlReq::ClientDetach);
                 }
                 break; // Real error or non-persistent timeout
             }
@@ -671,8 +681,18 @@ match cmd {
         if let Ok(line) = rrx.recv() { let _ = write!(write_stream, "{}\n", line); let _ = write_stream.flush(); }
         if !persistent { break; }
     }
-    "client-attach" => { let _ = tx.send(CtrlReq::ClientAttach); if !persistent { let _ = write!(write_stream, "ok\n"); } }
-    "client-detach" => { let _ = tx.send(CtrlReq::ClientDetach); if !persistent { let _ = write!(write_stream, "ok\n"); } }
+    "client-attach" => {
+        if !attached_sent {
+            let _ = tx.send(CtrlReq::ClientAttach);
+            attached_sent = true;
+        }
+        if !persistent { let _ = write!(write_stream, "ok\n"); }
+    }
+    "client-detach" => {
+        let _ = tx.send(CtrlReq::ClientDetach);
+        attached_sent = false;
+        if !persistent { let _ = write!(write_stream, "ok\n"); }
+    }
     "bind-key" | "bind" => {
         let mut table = "prefix".to_string();
         let mut repeatable = false;
@@ -979,8 +999,16 @@ match cmd {
         let _ = tx.send(CtrlReq::ConfirmBefore(prompt_str, command));
     }
     // tmux standard aliases
-    "detach-client" | "detach" => { let _ = tx.send(CtrlReq::ClientDetach); }
-    "attach-session" | "attach" => { let _ = tx.send(CtrlReq::ClientAttach); }
+    "detach-client" | "detach" => {
+        let _ = tx.send(CtrlReq::ClientDetach);
+        attached_sent = false;
+    }
+    "attach-session" | "attach" => {
+        if !attached_sent {
+            let _ = tx.send(CtrlReq::ClientAttach);
+            attached_sent = true;
+        }
+    }
     "kill-server" => { let _ = tx.send(CtrlReq::KillServer); }
     "choose-tree" | "choose-window" | "choose-session" => {
         // These are interactive choosers — send a dump that client handles
@@ -1137,11 +1165,20 @@ match cmd {
     // Try to read next command for batching (with timeout)
     line.clear();
     match r.read_line(&mut line) {
-        Ok(0) => break, // EOF - client disconnected
+        Ok(0) => {
+            // EOF - client disconnected
+            if attached_sent {
+                let _ = tx.send(CtrlReq::ClientDetach);
+            }
+            break;
+        }
         Err(e) => {
             if persistent && (e.kind() == io::ErrorKind::WouldBlock || e.kind() == io::ErrorKind::TimedOut) {
                 line.clear(); // Clear any partial data from interrupted read
                 continue; // Persistent mode - keep waiting
+            }
+            if attached_sent {
+                let _ = tx.send(CtrlReq::ClientDetach);
             }
             break; // Non-persistent timeout or real error
         }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -422,7 +422,30 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                     let _ = resp.send(line);
                 }
                 CtrlReq::ClientAttach => { app.attached_clients = app.attached_clients.saturating_add(1); hook_event = Some("client-attached"); }
-                CtrlReq::ClientDetach => { app.attached_clients = app.attached_clients.saturating_sub(1); hook_event = Some("client-detached"); }
+                CtrlReq::ClientDetach => {
+                    app.attached_clients = app.attached_clients.saturating_sub(1);
+                    hook_event = Some("client-detached");
+                    if app.attached_clients == 0 && app.destroy_unattached {
+                        // 仅在没有可用 pane 时才跟随最后客户端 detach 退出；
+                        // 否则保持会话存活，避免 destroy-unattached 抢先于 exit-empty/off 语义。
+                        let has_live_pane = app.windows.iter().any(|w| {
+                            crate::tree::count_panes(&w.root) > 0
+                        });
+                        if !has_live_pane {
+                            for win in app.windows.iter_mut() {
+                                kill_all_children(&mut win.root);
+                            }
+                            std::thread::sleep(std::time::Duration::from_millis(100));
+                            let home = env::var("USERPROFILE").or_else(|_| env::var("HOME")).unwrap_or_default();
+                            let regpath = format!("{}\\.psmux\\{}.port", home, app.port_file_base());
+                            let keypath = format!("{}\\.psmux\\{}.key", home, app.port_file_base());
+                            let _ = std::fs::remove_file(&regpath);
+                            let _ = std::fs::remove_file(&keypath);
+                            crate::types::shutdown_persistent_streams();
+                            std::process::exit(0);
+                        }
+                    }
+                }
                 CtrlReq::DumpLayout(resp) => {
                     let json = dump_layout_json(&mut app)?;
                     let _ = resp.send(json);
@@ -1402,6 +1425,8 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                             "status-style" => { app.status_style = String::new(); }
                             "renumber-windows" => { app.renumber_windows = false; }
                             "remain-on-exit" => { app.remain_on_exit = false; }
+                            "destroy-unattached" => { app.destroy_unattached = false; }
+                            "exit-empty" => { app.exit_empty = true; }
                             "automatic-rename" => { app.automatic_rename = true; }
                             "pane-border-style" => { app.pane_border_style = String::new(); }
                             "pane-active-border-style" => { app.pane_active_border_style = "fg=green".to_string(); }
@@ -1456,6 +1481,8 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                     output.push_str(&format!("monitor-activity {}\n", if app.monitor_activity { "on" } else { "off" }));
                     output.push_str(&format!("synchronize-panes {}\n", if app.sync_input { "on" } else { "off" }));
                     output.push_str(&format!("remain-on-exit {}\n", if app.remain_on_exit { "on" } else { "off" }));
+                    output.push_str(&format!("destroy-unattached {}\n", if app.destroy_unattached { "on" } else { "off" }));
+                    output.push_str(&format!("exit-empty {}\n", if app.exit_empty { "on" } else { "off" }));
                     output.push_str(&format!("set-titles {}\n", if app.set_titles { "on" } else { "off" }));
                     if !app.set_titles_string.is_empty() {
                         output.push_str(&format!("set-titles-string \"{}\"\n", app.set_titles_string));
@@ -2063,7 +2090,7 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
             state_dirty = true;
             meta_dirty = true;
         }
-        if all_empty {
+        if app.exit_empty && all_empty {
             let home = env::var("USERPROFILE").or_else(|_| env::var("HOME")).unwrap_or_default();
             let regpath = format!("{}\\.psmux\\{}.port", home, app.port_file_base());
             let keypath = format!("{}\\.psmux\\{}.key", home, app.port_file_base());

--- a/src/server/options.rs
+++ b/src/server/options.rs
@@ -48,6 +48,8 @@ pub(crate) fn get_option_value(app: &AppState, name: &str) -> String {
         "monitor-activity" => if app.monitor_activity { "on".into() } else { "off".into() },
         "synchronize-panes" => if app.sync_input { "on".into() } else { "off".into() },
         "remain-on-exit" => if app.remain_on_exit { "on".into() } else { "off".into() },
+        "destroy-unattached" => if app.destroy_unattached { "on".into() } else { "off".into() },
+        "exit-empty" => if app.exit_empty { "on".into() } else { "off".into() },
         "set-titles" => if app.set_titles { "on".into() } else { "off".into() },
         "set-titles-string" => app.set_titles_string.clone(),
         "prediction-dimming" => if app.prediction_dimming { "on".into() } else { "off".into() },
@@ -236,6 +238,8 @@ pub(crate) fn apply_set_option(app: &mut AppState, option: &str, value: &str, qu
         "focus-events" => { app.focus_events = matches!(value, "on" | "true" | "1"); }
         "renumber-windows" => { app.renumber_windows = matches!(value, "on" | "true" | "1"); }
         "remain-on-exit" => { app.remain_on_exit = matches!(value, "on" | "true" | "1"); }
+        "destroy-unattached" => { app.destroy_unattached = matches!(value, "on" | "true" | "1"); }
+        "exit-empty" => { app.exit_empty = matches!(value, "on" | "true" | "1"); }
         "set-titles" => { app.set_titles = matches!(value, "on" | "true" | "1"); }
         "set-titles-string" => { app.set_titles_string = value.to_string(); }
         "default-command" | "default-shell" => { app.default_shell = value.to_string(); }

--- a/src/types.rs
+++ b/src/types.rs
@@ -310,6 +310,10 @@ pub struct AppState {
     pub visual_activity: bool,
     /// remain-on-exit: keep panes open after process exits
     pub remain_on_exit: bool,
+    /// destroy-unattached: exit server when no clients remain attached
+    pub destroy_unattached: bool,
+    /// exit-empty: exit server when all panes/windows are empty
+    pub exit_empty: bool,
     /// aggressive-resize: resize window to smallest attached client
     pub aggressive_resize: bool,
     /// set-titles: update terminal title
@@ -476,6 +480,8 @@ impl AppState {
             monitor_activity: false,
             visual_activity: false,
             remain_on_exit: false,
+            destroy_unattached: false,
+            exit_empty: true,
             aggressive_resize: false,
             set_titles: false,
             set_titles_string: String::new(),

--- a/tests/test_keybinding_options.ps1
+++ b/tests/test_keybinding_options.ps1
@@ -323,6 +323,72 @@ Write-Info "  session_name = $msg"
 if ($msg -eq $SESSION) { Write-Pass "display-message format works" } else { Write-Fail "display-message: $msg != $SESSION" }
 
 # ============================================================
+Write-Host ""
+Write-Host ("=" * 60)
+Write-Host "13. NEW EXIT STRATEGY OPTIONS"
+Write-Host ("=" * 60)
+
+Write-Test "13.1 show-options includes destroy-unattached and exit-empty"
+$allOptions = (& $PSMUX show-options -t $SESSION -g 2>&1 | Out-String)
+$hasDestroy = $allOptions -match "destroy-unattached"
+$hasExitEmpty = $allOptions -match "exit-empty"
+if ($hasDestroy -and $hasExitEmpty) {
+    Write-Pass "show-options includes new exit strategy options"
+} else {
+    Write-Fail "show-options missing new options (destroy=$hasDestroy exit-empty=$hasExitEmpty)"
+}
+
+Write-Test "13.2 set/show destroy-unattached on/off"
+Psmux set -g destroy-unattached on | Out-Null
+$val = (& $PSMUX show-options -t $SESSION -g -v destroy-unattached 2>&1 | Out-String).Trim()
+$okOn = ($val -match "on")
+Psmux set -g destroy-unattached off | Out-Null
+$val2 = (& $PSMUX show-options -t $SESSION -g -v destroy-unattached 2>&1 | Out-String).Trim()
+$okOff = ($val2 -match "off")
+if ($okOn -and $okOff) { Write-Pass "destroy-unattached set/show works" } else { Write-Fail "destroy-unattached set/show failed: on='$val' off='$val2'" }
+
+Write-Test "13.3 unset destroy-unattached defaults to off"
+Psmux set -g destroy-unattached on | Out-Null
+Psmux set -u destroy-unattached | Out-Null
+$val = (& $PSMUX show-options -t $SESSION -g -v destroy-unattached 2>&1 | Out-String).Trim()
+if ($val -match "off") { Write-Pass "destroy-unattached unset -> off" } else { Write-Fail "destroy-unattached unset default wrong: $val" }
+
+Write-Test "13.4 set/show exit-empty on/off"
+Psmux set -g exit-empty off | Out-Null
+$val = (& $PSMUX show-options -t $SESSION -g -v exit-empty 2>&1 | Out-String).Trim()
+$okOff = ($val -match "off")
+Psmux set -g exit-empty on | Out-Null
+$val2 = (& $PSMUX show-options -t $SESSION -g -v exit-empty 2>&1 | Out-String).Trim()
+$okOn = ($val2 -match "on")
+if ($okOn -and $okOff) { Write-Pass "exit-empty set/show works" } else { Write-Fail "exit-empty set/show failed: off='$val' on='$val2'" }
+
+Write-Test "13.5 unset exit-empty defaults to on"
+Psmux set -g exit-empty off | Out-Null
+Psmux set -u exit-empty | Out-Null
+$val = (& $PSMUX show-options -t $SESSION -g -v exit-empty 2>&1 | Out-String).Trim()
+if ($val -match "on") { Write-Pass "exit-empty unset -> on" } else { Write-Fail "exit-empty unset default wrong: $val" }
+
+Write-Test "13.6 source-file applies destroy-unattached/exit-empty"
+$tempConf = Join-Path $env:TEMP ("psmux_exit_opts_" + [guid]::NewGuid().ToString() + ".conf")
+@(
+    "set -g destroy-unattached on"
+    "set -g exit-empty off"
+) | Set-Content -Path $tempConf -Encoding UTF8
+Psmux source-file $tempConf | Out-Null
+$fromConf1 = (& $PSMUX show-options -t $SESSION -g -v destroy-unattached 2>&1 | Out-String).Trim()
+$fromConf2 = (& $PSMUX show-options -t $SESSION -g -v exit-empty 2>&1 | Out-String).Trim()
+Remove-Item $tempConf -Force -ErrorAction SilentlyContinue
+if (($fromConf1 -match "on") -and ($fromConf2 -match "off")) {
+    Write-Pass "source-file applies new options"
+} else {
+    Write-Fail "source-file new options failed: destroy='$fromConf1' exit-empty='$fromConf2'"
+}
+
+# reset for subsequent behavior consistency
+Psmux set -g destroy-unattached off | Out-Null
+Psmux set -g exit-empty on | Out-Null
+
+# ============================================================
 # CLEANUP
 # ============================================================
 Write-Host ""


### PR DESCRIPTION
  ## Summary

  This PR fixes mouse escape-sequence leakage into shell-like prompts (including ClaudeCode input) by unifying mouse
  forwarding gates.

  - Gate mouse forwarding behind `pane_wants_mouse(...)` on both local and remote paths.
  - Cover left/middle/right click press/release, left drag, and hover motion.
  - Keep shell behavior intact (e.g. right-click paste fallback when pane does not want mouse).
  - Update `tests/test_mouse_hover.ps1` to assert the new unified gate (`pane_wants_mouse`) instead of
  `is_fullscreen_tui`.

  ## Root cause

  Mouse events were still being encoded and injected as SGR sequences (e.g. `\x1b[<0;...M/m`, `\x1b[<35;...M`) in paths
  where the active pane did not actually request mouse protocol.
  In shell-like prompts, these bytes could surface as visible garbage text.

  ## Files changed

  - `src/input.rs:1376-1603`
  - `src/window_ops.rs:403-620`
  - `tests/test_mouse_hover.ps1:135-154`

  ## Validation

  - [x] `cargo build`
  - [x] `pwsh -File tests/test_mouse_hover.ps1` (14 passed, 0 failed)
  - [x] Manual check: ClaudeCode input no longer shows `[<0;...` / `[<35;...` garbage on click/hover

  ## Risk / Trade-off

  Applications that rely on mouse behavior without properly enabling mouse protocol may no longer receive forwarded
  mouse events. This is an intentional tightening to prevent escape-sequence leakage in non-mouse-aware prompts.