### PR TITLE
fix: preserve main pane focus when killing targeted panes

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -17,7 +17,7 @@ use chrono::Local;
 use crate::types::{AppState, CtrlReq, LayoutKind, Mode};
 use crate::tree::{active_pane_mut, compute_rects, resize_all_panes, kill_all_children,
     find_window_index_by_id, focus_pane_by_id, focus_pane_by_index, reap_children};
-use crate::pane::{create_window, split_active_with_command, kill_active_pane};
+use crate::pane::{create_window, split_active_with_command, kill_active_pane, kill_pane_by_id};
 use crate::input::{handle_key, handle_mouse, send_text_to_active, send_key_to_active, send_paste_to_active};
 use crate::rendering::{render_window, parse_status, centered_rect};
 use crate::style::{parse_tmux_style, parse_inline_styles, spans_visual_width};
@@ -423,18 +423,25 @@ pub fn run(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>) -> io::Result<
                         let _ = tx.send(CtrlReq::FocusWindowTemp(wid));
                     }
                 }
-                if let Some(pid) = target_pane {
-                    if is_focus_cmd {
-                        if pane_is_id {
-                            let _ = tx.send(CtrlReq::FocusPane(pid));
+                let targeted_kill_pane_id = if matches!(cmd, "kill-pane") && pane_is_id {
+                    target_pane
+                } else {
+                    None
+                };
+                if targeted_kill_pane_id.is_none() {
+                    if let Some(pid) = target_pane {
+                        if is_focus_cmd {
+                            if pane_is_id {
+                                let _ = tx.send(CtrlReq::FocusPane(pid));
+                            } else {
+                                let _ = tx.send(CtrlReq::FocusPaneByIndex(pid));
+                            }
                         } else {
-                            let _ = tx.send(CtrlReq::FocusPaneByIndex(pid));
-                        }
-                    } else {
-                        if pane_is_id {
-                            let _ = tx.send(CtrlReq::FocusPaneTemp(pid));
-                        } else {
-                            let _ = tx.send(CtrlReq::FocusPaneByIndexTemp(pid));
+                            if pane_is_id {
+                                let _ = tx.send(CtrlReq::FocusPaneTemp(pid));
+                            } else {
+                                let _ = tx.send(CtrlReq::FocusPaneByIndexTemp(pid));
+                            }
                         }
                     }
                 }
@@ -461,7 +468,15 @@ pub fn run(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>) -> io::Result<
                         let _ = write!(stream, "OK\n");
                         let _ = stream.flush();
                     }
-                    "kill-pane" => { let _ = tx.send(CtrlReq::KillPane); let _ = write!(stream, "OK\n"); let _ = stream.flush(); }
+                    "kill-pane" => {
+                        if let Some(pid) = targeted_kill_pane_id {
+                            let _ = tx.send(CtrlReq::KillPaneById(pid));
+                        } else {
+                            let _ = tx.send(CtrlReq::KillPane);
+                        }
+                        let _ = write!(stream, "OK\n");
+                        let _ = stream.flush();
+                    }
                     "capture-pane" => {
                         let escape_seqs = args.iter().any(|a| *a == "-e");
                         let (rtx, rrx) = mpsc::channel::<String>();
@@ -1096,6 +1111,7 @@ pub fn run(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>) -> io::Result<
                 }
                 CtrlReq::SplitWindow(k, cmd, _detached, _start_dir, _size_pct, resp) => { let _ = resp.send(if let Err(e) = split_active_with_command(&mut app, k, cmd.as_deref(), Some(&*pty_system)) { format!("{e}") } else { String::new() }); resize_all_panes(&mut app); }
                 CtrlReq::KillPane => { let _ = kill_active_pane(&mut app); resize_all_panes(&mut app); }
+                CtrlReq::KillPaneById(pid) => { let _ = kill_pane_by_id(&mut app, pid); resize_all_panes(&mut app); }
                 CtrlReq::CapturePane(resp) => {
                     if let Some(text) = capture_active_pane_text(&mut app)? { let _ = resp.send(text); } else { let _ = resp.send(String::new()); }
                 }

--- a/src/pane.rs
+++ b/src/pane.rs
@@ -386,22 +386,57 @@ pub fn split_active_with_command(app: &mut AppState, kind: LayoutKind, command: 
     Ok(())
 }
 
-pub fn kill_active_pane(app: &mut AppState) -> io::Result<()> {
-    let win = &mut app.windows[app.active_idx];
-    // Find the neighbor pane's ID BEFORE removing the active one.
-    let neighbor_id = crate::tree::next_leaf_path(&win.root, &win.active_path)
+fn kill_pane_at_path(win: &mut Window, path: &Vec<usize>) {
+    let neighbor_id = crate::tree::next_leaf_path(&win.root, path)
         .and_then(|p| crate::tree::get_active_pane_id(&win.root, &p));
-    // Explicitly kill the active pane's process tree FIRST.
+    // Explicitly kill the target pane's process tree FIRST.
     // remove_node() doesn't call kill_node() when the root is a single Leaf,
     // so we must do it here to ensure no orphaned processes.
-    if let Some(p) = active_pane_mut(&mut win.root, &win.active_path) {
+    if let Some(p) = active_pane_mut(&mut win.root, path) {
         crate::platform::process_kill::kill_process_tree(&mut p.child);
     }
-    kill_leaf(&mut win.root, &win.active_path);
+    kill_leaf(&mut win.root, path);
     // Focus the neighbor by ID (tree structure may have shifted).
     win.active_path = neighbor_id
         .and_then(|id| crate::tree::find_path_by_id(&win.root, id))
         .unwrap_or_else(|| crate::tree::first_leaf_path(&win.root));
+}
+
+pub fn kill_active_pane(app: &mut AppState) -> io::Result<()> {
+    let win = &mut app.windows[app.active_idx];
+    let active_path = win.active_path.clone();
+    kill_pane_at_path(win, &active_path);
+    Ok(())
+}
+
+pub fn kill_pane_by_id(app: &mut AppState, pane_id: usize) -> io::Result<()> {
+    let restore_idx = app.active_idx;
+    let restore_path = app.windows[restore_idx].active_path.clone();
+    let restore_pane_id = crate::tree::get_active_pane_id(&app.windows[restore_idx].root, &restore_path);
+
+    let target = app.windows.iter().enumerate().find_map(|(wi, win)| {
+        crate::tree::find_path_by_id(&win.root, pane_id).map(|path| (wi, path))
+    });
+
+    let Some((target_idx, target_path)) = target else {
+        return Ok(());
+    };
+
+    {
+        let win = &mut app.windows[target_idx];
+        kill_pane_at_path(win, &target_path);
+    }
+
+    if restore_idx < app.windows.len() {
+        app.active_idx = restore_idx;
+        let restore_win = &mut app.windows[restore_idx];
+        let resolved_restore_path = restore_pane_id
+            .and_then(|id| crate::tree::find_path_by_id(&restore_win.root, id))
+            .or_else(|| crate::tree::path_exists(&restore_win.root, &restore_path).then_some(restore_path.clone()))
+            .unwrap_or_else(|| crate::tree::first_leaf_path(&restore_win.root));
+        restore_win.active_path = resolved_restore_path;
+    }
+
     Ok(())
 }
 

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -226,18 +226,25 @@ if let Some(wid) = target_win {
         let _ = tx.send(CtrlReq::FocusWindowTemp(wid));
     }
 }
-if let Some(pid) = target_pane {
-    if is_focus_cmd {
-        if pane_is_id {
-            let _ = tx.send(CtrlReq::FocusPane(pid));
+let targeted_kill_pane_id = if matches!(cmd, "kill-pane" | "killp") && pane_is_id {
+    target_pane
+} else {
+    None
+};
+if targeted_kill_pane_id.is_none() {
+    if let Some(pid) = target_pane {
+        if is_focus_cmd {
+            if pane_is_id {
+                let _ = tx.send(CtrlReq::FocusPane(pid));
+            } else {
+                let _ = tx.send(CtrlReq::FocusPaneByIndex(pid));
+            }
         } else {
-            let _ = tx.send(CtrlReq::FocusPaneByIndex(pid));
-        }
-    } else {
-        if pane_is_id {
-            let _ = tx.send(CtrlReq::FocusPaneTemp(pid));
-        } else {
-            let _ = tx.send(CtrlReq::FocusPaneByIndexTemp(pid));
+            if pane_is_id {
+                let _ = tx.send(CtrlReq::FocusPaneTemp(pid));
+            } else {
+                let _ = tx.send(CtrlReq::FocusPaneByIndexTemp(pid));
+            }
         }
     }
 }
@@ -296,7 +303,13 @@ match cmd {
             }
         }
     }
-    "kill-pane" | "killp" => { let _ = tx.send(CtrlReq::KillPane); }
+    "kill-pane" | "killp" => {
+        if let Some(pid) = targeted_kill_pane_id {
+            let _ = tx.send(CtrlReq::KillPaneById(pid));
+        } else {
+            let _ = tx.send(CtrlReq::KillPane);
+        }
+    }
     "capture-pane" | "capturep" => {
         let print_stdout = args.iter().any(|a| *a == "-p");
         let join_lines = args.iter().any(|a| *a == "-J");
@@ -517,7 +530,9 @@ match cmd {
         if let Some(style) = pane_style {
             let _ = tx.send(CtrlReq::SetPaneStyle(style));
         }
-        let _ = tx.send(CtrlReq::SelectPane(dir.to_string()));
+        if !dir.is_empty() {
+            let _ = tx.send(CtrlReq::SelectPane(dir.to_string()));
+        }
     }
     "select-window" | "selectw" => {
         let idx = args.iter().find(|a| !a.starts_with('-')).and_then(|s| s.parse::<usize>().ok())

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -15,7 +15,7 @@ use ratatui::prelude::Rect;
 use crate::types::{AppState, CtrlReq, Mode, FocusDir, LayoutKind, PipePaneState, VERSION,
     WaitChannel, WaitForOp, Node, Action, Bind, PopupPty};
 use crate::platform::install_console_ctrl_handler;
-use crate::pane::{create_window, create_window_raw, split_active_with_command, kill_active_pane, spawn_warm_pane};
+use crate::pane::{create_window, create_window_raw, split_active_with_command, kill_active_pane, kill_pane_by_id, spawn_warm_pane};
 use crate::tree::{self, active_pane, active_pane_mut, resize_all_panes, kill_all_children,
     find_window_index_by_id, focus_pane_by_id, focus_pane_by_index, get_active_pane_id,
     get_split_mut, path_exists};
@@ -543,6 +543,7 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                         CtrlReq::NewWindow(..) => "NewWindow",
                         CtrlReq::KillWindow => "KillWindow",
                         CtrlReq::KillPane => "KillPane",
+                        CtrlReq::KillPaneById(_) => "KillPaneById",
                         CtrlReq::BreakPane => "BreakPane",
                         CtrlReq::JoinPane(_) => "JoinPane",
                         CtrlReq::MoveWindow(..) => "MoveWindow",
@@ -675,6 +676,7 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                     resize_all_panes(&mut app); meta_dirty = true; hook_event = Some("after-split-window");
                 }
                 CtrlReq::KillPane => { let _ = kill_active_pane(&mut app); resize_all_panes(&mut app); meta_dirty = true; hook_event = Some("after-kill-pane"); }
+                CtrlReq::KillPaneById(pid) => { let _ = kill_pane_by_id(&mut app, pid); resize_all_panes(&mut app); meta_dirty = true; hook_event = Some("after-kill-pane"); }
                 CtrlReq::CapturePane(resp) => {
                     if let Some(text) = capture_active_pane_text(&mut app)? { let _ = resp.send(text); } else { let _ = resp.send(String::new()); }
                 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -632,6 +632,7 @@ pub enum CtrlReq {
     SplitWindow(LayoutKind, Option<String>, bool, Option<String>, Option<u16>, mpsc::Sender<String>),  // kind, cmd, detached, start_dir, size_percent, error_resp
     SplitWindowPrint(LayoutKind, Option<String>, bool, Option<String>, Option<u16>, Option<String>, mpsc::Sender<String>),  // kind, cmd, detached, start_dir, size_percent, format, resp
     KillPane,
+    KillPaneById(usize),
     CapturePane(mpsc::Sender<String>),
     CapturePaneStyled(mpsc::Sender<String>, Option<i32>, Option<i32>),
     FocusWindow(usize),


### PR DESCRIPTION
## Summary

  - add a targeted `kill-pane` path for pane-id targets so pane removal does not depend on temporary focus switching
  - restore the original main pane by pane id after removing the target pane, including same-window close flows
  - prevent style-only `select-pane -P` updates from sending an empty pane selection request

  ## Problem

  Closing a child/sub-agent pane could leave the main pane visible but effectively unresponsive.

  The root issue was that targeted pane killing still went through the temporary focus-switch / restore chain. After the target pane was
   removed, the restore step could leave the main pane with a stale active path. In same-window cases, the pane could still render, but
  input/focus behavior was broken.

  ## Solution

  This change narrows the fix to the targeted close-pane flow instead of changing the global focus restore behavior:

  - introduce `KillPaneById(usize)` and route `kill-pane -t %pane` through a direct targeted kill path
  - add `kill_pane_by_id()` to remove the target pane and then restore the previously active main pane by pane id, with path fallback
  only when needed
  - extract shared pane-removal logic into a helper to keep active-pane and targeted-pane deletion consistent
  - guard style-only `select-pane -P` handling so it does not emit `SelectPane("")`

  ## Validation

  - built successfully with:
    - `cargo build --bin psmux`

  ## Notes

  - this intentionally avoids broader refactors in the global temp-focus restore pipeline
  - pane-index-targeted `kill-pane -t` behavior was not expanded in this change; the fix focuses on pane-id-targeted child pane closing
