### PR TITLE
docs: note WinGet release lag vs git builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,15 @@ psmux is a **native Windows terminal multiplexer** built from the ground up in R
 winget install psmux
 ```
 
+WinGet installs the latest published release, not the current `master` branch.
+If you are comparing behavior against a source build from git, the versions may
+be significantly different. Check with:
+
+```powershell
+psmux -V
+tmux -V
+```
+
 ### Using Cargo
 
 ```powershell

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -18,6 +18,9 @@ A: Yes. psmux supports 14 style options with 24-bit true color, 256 indexed colo
 **Q: Can I use tmux commands with psmux?**
 A: Yes! psmux includes a `tmux` alias. Commands like `tmux new-session`, `tmux attach`, `tmux ls`, `tmux split-window` all work. 76 commands in total.
 
+**Q: Why does the WinGet build behave differently from a git/source build?**
+A: WinGet installs the latest published release. A local build from git uses whatever commit you have checked out, which can be much newer than the packaged release. If you're comparing behavior, check `psmux -V` and `tmux -V` first.
+
 **Q: How fast is psmux?**
 A: Session creation takes < 100ms. New windows/panes add < 80ms overhead. The bottleneck is your shell's startup time, not psmux. Compiled with opt-level 3 and full LTO.
 


### PR DESCRIPTION
## Summary
  - document that `winget install psmux` installs the latest published release, not the current `master` branch
  - add a short version-check reminder to the README install section
  - add an FAQ entry for cases where WinGet and git/source builds behave differently

  ## Why
  This came up while investigating a Korean input / IME issue in `psmux` + `codex`.

  At first the behavior looked like a live Korean input bug, but reproduction was inconsistent because the WinGet-
  installed build and the local git/source build were far apart in version and behavior.

  In my case:
  - WinGet build resolved to `psmux 0.4.10`
  - local git/source build resolved to `psmux 3.1`

  That version gap was large enough to completely change the reproduction result, so this PR adds a version/source check
  to the docs before deeper debugging.

  ## Scope
  This PR does **not** include a Korean IME/input fix itself.
  It only documents the version-gap trap that can make Korean input issues look reproducible on one install path and
  disappear on another.

  ## Verification
  - reviewed the updated install docs in `README.md`
  - reviewed the new FAQ entry in `docs/faq.md`
  - confirmed locally that WinGet and git/source installs can resolve to different binaries and versions

  ## Changed files
  - `README.md`
  - `docs/faq.md`

  ## Simplifications made
  - kept the guidance focused on version/source identification
  - avoided adding package-manager-specific troubleshooting beyond the minimal commands needed to compare installs

  ## Remaining risks
  - this explains one major source of confusion during Korean input debugging
  - it does not change WinGet publishing cadence or fix any actual IME behavior in code