### PR TITLE
fix: forward Shift+Enter and Ctrl+Enter to child process

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1512,11 +1512,11 @@ pub fn run_remote(terminal: &mut Terminal<CrosstermBackend<crate::platform::Psmu
                                         if !paste_pend.is_empty() {
                                             paste_pend.push('\n');
                                         } else {
-                                            cmd_batch.push("send-key enter\n".into());
+                                            cmd_batch.push(format!("send-key {}\n", modified_key_name("Enter", key.modifiers)));
                                         }
                                     }
                                     #[cfg(not(windows))]
-                                    { cmd_batch.push("send-key enter\n".into()); }
+                                    { cmd_batch.push(format!("send-key {}\n", modified_key_name("Enter", key.modifiers))); }
                                 }
                                 KeyCode::Tab => {
                                     #[cfg(windows)]

--- a/src/input.rs
+++ b/src/input.rs
@@ -1269,6 +1269,7 @@ pub fn parse_modified_special_key(s: &str) -> Option<String> {
     if m <= 1 { return None; } // no modifiers found
     // Match the base key name
     match rest {
+        "ENTER" | "RETURN" | "CR" => Some(format!("\x1b[13;{}~", m)),
         "TAB" => Some(format!("\x1b[9;{}~", m)),
         "BTAB" | "BACKTAB" => {
             // Shift is implicit in BackTab; ensure Shift bit is set
@@ -1362,7 +1363,15 @@ pub fn encode_key_event(key: &KeyEvent) -> Option<Vec<u8>> {
         KeyCode::Char(c) => {
             format!("{}", c).into_bytes()
         }
-        KeyCode::Enter => b"\r".to_vec(),
+        KeyCode::Enter => {
+            let m = modifier_param(key.modifiers);
+            if m > 1 {
+                // xterm modified-Enter: CSI 13 ; mod ~
+                format!("\x1b[13;{}~", m).into_bytes()
+            } else {
+                b"\r".to_vec()
+            }
+        }
         KeyCode::Tab => {
             let m = modifier_param(key.modifiers);
             if m > 1 {


### PR DESCRIPTION
Hi! Thanks for building psmux — it's been great for running persistent sessions on Windows.

I ran into an issue where Shift+Enter and Ctrl+Enter aren't being forwarded to child processes. For example, Claude Code uses Shift+Enter for multi-line input, and it doesn't work inside psmux because Enter always sends a plain `\r` regardless of modifiers.

I noticed that Tab (#108) and Arrow keys (#3) already handle modifiers correctly using `modifier_param()` and the xterm encoding pattern. Enter was just missing from those same code paths, so I followed the same approach:

## What this changes

- **`encode_key_event()`** — emits `CSI 13;{mod}~` when Enter has modifiers (e.g. `\x1b[13;2~` for Shift+Enter, `\x1b[13;5~` for Ctrl+Enter)
- **`parse_modified_special_key()`** — adds an `ENTER` arm so `send-keys S-Enter` and `send-keys C-Enter` work from the CLI
- **Client passthrough** — uses the existing `modified_key_name()` helper for Enter, same as Arrow keys already do

Plain Enter behavior is completely unchanged — this only kicks in when a modifier key is held.

Hope this is useful! Happy to adjust anything if you'd prefer a different approach.