### PR TITLE
Fix Shift+Enter for VS Code terminal with Node.js apps (Claude Code)

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -838,7 +838,13 @@ pub fn run_remote(terminal: &mut Terminal<CrosstermBackend<crate::platform::Psmu
                         }
                         paste_confirmed = true;
                     }
-                    Event::Key(key) if key.kind == KeyEventKind::Press || key.kind == KeyEventKind::Repeat => {
+                    Event::Key(mut key) if key.kind == KeyEventKind::Press || key.kind == KeyEventKind::Repeat => {
+                        // On Windows, VS Code's xterm.js sends ESC+CR for
+                        // Shift+Enter.  ConPTY interprets the ESC as Alt, so
+                        // crossterm reports Alt+Enter.  Poll the physical
+                        // keyboard to detect the real modifier.
+                        #[cfg(windows)]
+                        crate::platform::augment_enter_shift(&mut key);
                         // Flush pending paste buffer before processing any non-bufferable key.
                         // Bufferable keys are: plain Char, Space, Enter (if pend non-empty), Tab (if pend non-empty).
                         #[cfg(windows)]

--- a/src/input.rs
+++ b/src/input.rs
@@ -2609,6 +2609,40 @@ pub fn send_key_to_active(app: &mut AppState, k: &str) -> io::Result<()> {
                     let _ = p.writer.write_all(&[0x1b, ctrl_char]);
                 }
             }
+            // Modified Enter: send ESC + CR (\x1b\r) for Shift/Alt+Enter.
+            //
+            // This matches what VS Code's xterm.js sends for Shift+Enter.
+            // The round-trip is: \x1b\r → ConPTY interprets ESC as Alt →
+            // KEY_EVENT_RECORD(VK_RETURN, LEFT_ALT_PRESSED) → libuv
+            // translates Alt back to ESC prefix → child gets \x1b\r.
+            // Claude Code (and other Node.js apps) interpret \x1b\r as
+            // Shift+Enter.  PSReadLine also handles this correctly when
+            // Alt+Enter is bound to AddLine.
+            //
+            // The CSI \x1b[13;2~ encoding (from parse_modified_special_key)
+            // is dropped by ConPTY — it doesn't recognize code 13 in ~
+            // format.  Win32-input-mode doesn't work for Node.js because
+            // libuv's uv_tty_read_raw ignores SHIFT on VK_RETURN.
+            #[cfg(windows)]
+            s if {
+                let u = s.to_uppercase();
+                let r = u.trim_start_matches("C-").trim_start_matches("M-").trim_start_matches("S-");
+                r == "ENTER" || r == "RETURN" || r == "CR"
+            } => {
+                let upper = s.to_uppercase();
+                let has_shift = upper.contains("S-");
+                let has_ctrl = upper.contains("C-");
+                let has_alt = upper.contains("M-");
+                if (has_shift || has_alt) && !has_ctrl {
+                    // Shift+Enter or Alt+Enter: ESC + CR, same as xterm.js
+                    let _ = p.writer.write_all(b"\x1b\r");
+                } else {
+                    // Ctrl+Enter and other combos: fall through to CSI encoding
+                    if let Some(seq) = parse_modified_special_key(s) {
+                        let _ = p.writer.write_all(seq.as_bytes());
+                    }
+                }
+            }
             // Modifier + special key combos: C-Left, S-Right, C-S-Up, C-M-Home, etc.
             s if parse_modified_special_key(s).is_some() => {
                 let seq = parse_modified_special_key(s).unwrap();

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -2071,3 +2071,45 @@ pub mod caret {
     pub fn update(_col: u16, _row: u16) {}
     pub fn destroy() {}
 }
+
+/// On Windows ConPTY, Shift+Enter is misreported by crossterm:
+///
+/// VS Code's xterm.js sends `\x1b\r` (ESC + CR) for Shift+Enter.
+/// ConPTY interprets the ESC prefix as Alt, so crossterm reports
+/// `KeyModifiers::ALT` instead of `KeyModifiers::SHIFT`.
+///
+/// This function polls the physical keyboard state to detect the real
+/// modifiers and remaps accordingly.
+///
+/// See: <https://github.com/crossterm-rs/crossterm/issues/773>
+#[cfg(windows)]
+pub fn augment_enter_shift(key: &mut crossterm::event::KeyEvent) {
+    use crossterm::event::{KeyCode, KeyModifiers};
+
+    if !matches!(key.code, KeyCode::Enter) {
+        return;
+    }
+    if key.modifiers.contains(KeyModifiers::SHIFT) {
+        return;
+    }
+
+    #[link(name = "user32")]
+    extern "system" {
+        fn GetAsyncKeyState(vKey: i32) -> i16;
+    }
+
+    const VK_SHIFT: i32 = 0x10;
+    const VK_MENU: i32 = 0x12; // Alt
+
+    unsafe {
+        let shift_down = GetAsyncKeyState(VK_SHIFT) < 0;
+        let alt_down = GetAsyncKeyState(VK_MENU) < 0;
+
+        if shift_down && !alt_down {
+            key.modifiers.remove(KeyModifiers::ALT);
+            key.modifiers.insert(KeyModifiers::SHIFT);
+        } else if shift_down {
+            key.modifiers.insert(KeyModifiers::SHIFT);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Shift+Enter doesn't work for Node.js apps (like Claude Code) running inside psmux in VS Code's terminal. The existing CSI `\x1b[13;2~` encoding from `a761f3e` is dropped by ConPTY (it doesn't recognize code 13 in `~` format), so the keypress never reaches the child process.

This PR fixes both the client-side detection and server-side delivery for the VS Code + ConPTY + Node.js case.

## Root cause

Two separate issues in the VS Code terminal path:

**Client:** VS Code's xterm.js sends `\x1b\r` (ESC + CR) for Shift+Enter. ConPTY interprets the ESC prefix as Alt, so crossterm reports Alt+Enter instead of Shift+Enter.

**Server:** Node.js apps use libuv's `uv_tty_read_raw`, which translates `VK_RETURN` to `\r` regardless of modifier flags. Both the CSI `\x1b[13;2~` encoding (dropped by ConPTY) and win32-input-mode `KEY_EVENT_RECORD` with `SHIFT_PRESSED` (libuv ignores shift on Enter) fail to deliver the modifier.

## Fix

**Client (`platform.rs`):** `augment_enter_shift` polls `GetAsyncKeyState(VK_SHIFT)` to detect the physical Shift key and remaps crossterm's misreported Alt+Enter back to Shift+Enter.

**Server (`input.rs`):** Sends `\x1b\r` (ESC + CR) for Shift+Enter — the same bytes VS Code's xterm.js sends. The round-trip works because libuv *does* preserve Alt as an ESC prefix:

```
\x1b\r → ConPTY: Alt+Enter → libuv: \x1b\r → app interprets as Shift+Enter
```

## Trade-offs

- `GetAsyncKeyState` is a heuristic — there's a small race window between keypress and event processing. In practice this is reliable for interactive use.
- ConPTY delivers the key as Alt+Enter, not Shift+Enter. PSReadLine users need to add a keybinding to map Alt+Enter to the same AddLine action (see User Setup below).
- This is the same limitation that exists in VS Code's terminal without psmux — xterm.js always sends `\x1b\r` for Shift+Enter, which ConPTY interprets as Alt+Enter.

## User setup

For full Shift+Enter support in VS Code, users also need:

**VS Code keybindings.json** — ensures VS Code sends `\x1b\r` for Shift+Enter in terminal:
```json
{
    "key": "shift+enter",
    "command": "workbench.action.terminal.sendSequence",
    "args": {
        "text": "\u001b\r"
    },
    "when": "terminalFocus && terminalShellType != 'pwsh'"
}
```

**PowerShell profile** (`$PROFILE`) — maps Alt+Enter to AddLine since ConPTY delivers the key as Alt+Enter:
```powershell
Set-PSReadLineKeyHandler -Chord 'Alt+Enter' -Function AddLine
```

## Test plan
- [ ] Press Shift+Enter in Claude Code inside psmux (VS Code terminal) — should insert newline
- [ ] Press Shift+Enter in PowerShell with the PSReadLine keybinding — should insert newline
- [ ] Plain Enter still works normally in all apps
- [ ] Alt+char shortcuts (Alt+F, Alt+B) still work in PSReadLine