### PR TITLE
Fix quoting of session/window names to prevent argument splitting

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1443,14 +1443,14 @@ pub fn run_remote(terminal: &mut Terminal<CrosstermBackend<crate::platform::Psmu
                                 KeyCode::Backspace if command_input => { let _ = command_buf.pop(); }
                                 KeyCode::Enter if renaming => {
                                     if session_renaming {
-                                        cmd_batch.push(format!("rename-session {}\n", rename_buf));
+                                        cmd_batch.push(format!("rename-session {}\n", crate::util::quote_arg(&rename_buf)));
                                         session_renaming = false;
                                     } else {
-                                        cmd_batch.push(format!("rename-window {}\n", rename_buf));
+                                        cmd_batch.push(format!("rename-window {}\n", crate::util::quote_arg(&rename_buf)));
                                     }
                                     renaming = false;
                                 }
-                                KeyCode::Enter if pane_renaming => { cmd_batch.push(format!("set-pane-title {}\n", pane_title_buf)); pane_renaming = false; }
+                                KeyCode::Enter if pane_renaming => { cmd_batch.push(format!("set-pane-title {}\n", crate::util::quote_arg(&pane_title_buf))); pane_renaming = false; }
                                 KeyCode::Enter if command_input => {
                                     let trimmed = command_buf.trim().to_string();
                                     if !trimmed.is_empty() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -552,14 +552,14 @@ fn run_main() -> io::Result<()> {
                                     if !warm_key.is_empty() {
                                         match crate::session::send_auth_cmd_response(
                                             &warm_addr, &warm_key,
-                                            format!("claim-session {}\n", name).as_bytes(),
+                                            format!("claim-session {}\n", crate::util::quote_arg(&name)).as_bytes(),
                                         ) {
                                             Ok(resp) if resp.contains("OK") => {
                                                 if let Some(ref wn) = window_name {
                                                     let new_key = crate::session::read_session_key(&port_file_base).unwrap_or_default();
                                                     let _ = crate::session::send_auth_cmd(
                                                         &warm_addr, &new_key,
-                                                        format!("rename-window {}\n", wn).as_bytes(),
+                                                        format!("rename-window {}\n", crate::util::quote_arg(wn)).as_bytes(),
                                                     );
                                                 }
                                                 true
@@ -1174,7 +1174,7 @@ fn run_main() -> io::Result<()> {
                     i += 1;
                 }
                 if let Some(name) = new_name {
-                    send_control(format!("rename-session {}\n", name))?;
+                    send_control(format!("rename-session {}\n", crate::util::quote_arg(&name)))?;
                 }
                 return Ok(());
             }
@@ -1563,7 +1563,7 @@ fn run_main() -> io::Result<()> {
                 // cmd_args[0] is the command, cmd_args[1] should be the new name
                 if let Some(name) = cmd_args.get(1) {
                     if !name.starts_with('-') {
-                        send_control(format!("rename-window {}\n", name))?;
+                        send_control(format!("rename-window {}\n", crate::util::quote_arg(name)))?;
                     }
                 }
                 return Ok(());
@@ -1603,7 +1603,7 @@ fn run_main() -> io::Result<()> {
                         }
                     } else {
                         // Send source-file command to server if attached
-                        send_control(format!("source-file {}\n", expanded))?;
+                        send_control(format!("source-file {}\n", crate::util::quote_arg(&expanded)))?;
                     }
                 }
                 return Ok(());
@@ -2408,7 +2408,7 @@ fn run_main() -> io::Result<()> {
                         let _ = stream.set_nodelay(true);
                         let _ = stream.set_read_timeout(Some(Duration::from_millis(3000)));
                         let _ = write!(stream, "AUTH {}\n", warm_key);
-                        let _ = write!(stream, "claim-session {}\n", session_name);
+                        let _ = write!(stream, "claim-session {}\n", crate::util::quote_arg(&session_name));
                         let _ = stream.flush();
                         // Use send_auth_cmd_response pattern: read AUTH
                         // "OK" line first, then read the claim-session

--- a/src/util.rs
+++ b/src/util.rs
@@ -145,6 +145,13 @@ pub fn base64_decode(encoded: &str) -> Option<String> {
     String::from_utf8(result).ok()
 }
 
+/// Quote an argument for sending over the control protocol.
+/// Wraps the string in double quotes and escapes any embedded double-quotes.
+pub fn quote_arg(s: &str) -> String {
+    let escaped = s.replace('"', "\\\"");
+    format!("\"{}\"", escaped)
+}
+
 /// Return color name as a string. Uses static strings for Default and
 /// the 256 indexed colors to avoid heap allocations on every cell.
 pub fn color_to_name(c: vt100::Color) -> std::borrow::Cow<'static, str> {

--- a/tests/test_cli_handlers.ps1
+++ b/tests/test_cli_handlers.ps1
@@ -60,6 +60,15 @@ Cleanup-All
 & $exe new-session -d -s test-cli 2>$null
 Start-Sleep -Seconds 2
 
+# TEST (warm start): new-session with spaces in session name
+& $exe new-session -d -s "space test session" 2>$null
+Start-Sleep -Seconds 1
+$infoOut = & $exe -t "space test session" server-info 2>&1
+$infoStr = ($infoOut | Out-String).Trim()
+Test-Assert "server-info shows full multi-word session name" ($infoStr -match 'session: space test session') "Got: '$infoStr'"
+& $exe kill-session -t "space test session" 2>$null
+Start-Sleep -Milliseconds 200
+
 # ============================================================
 # TEST GROUP 1: server-info / info
 # ============================================================


### PR DESCRIPTION

This pull request improves the safety and correctness of handling user-provided names and arguments in control protocol commands by introducing a new quoting utility. This ensures that names containing spaces or special characters are properly quoted and escaped before being sent, preventing parsing errors or injection issues. The changes are applied consistently across the codebase, and a new test verifies correct handling of session names with spaces.

**Argument quoting improvements:**

* Added a new utility function `quote_arg` in `src/util.rs` to wrap arguments in double quotes and escape embedded quotes for safe protocol transmission.
* Updated all instances where session, window, or pane names are sent as arguments in control protocol commands to use the new `quote_arg` function, including in `src/main.rs` (`claim-session`, `rename-session`, `rename-window`, `source-file`) and `src/client.rs` (`rename-session`, `rename-window`, `set-pane-title`). [[1]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL555-R562) [[2]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL1177-R1177) [[3]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL1566-R1566) [[4]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL1606-R1606) [[5]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL2411-R2411) [[6]](diffhunk://#diff-7f93c4e263c4e9ec748f804c7fd04a3b2fde86ffd741fb5516d67e1097bae4c1L1446-R1453)

**Testing:**

* Added a new test in `tests/test_cli_handlers.ps1` to verify that session names containing spaces are handled correctly and displayed as expected in `server-info`.…, causing the server's parse_command_line to split arguments incorrectly.

Creating a session with a multi-word name (e.g., "cc 123")  when running server exists. new-session failed,  but a trimmed session "cc" was created.

The server uses a quote-aware parser (parse_command_line) that preserves quoted tokens. The client constructed command lines without quoting/escaping user-provided strings, so multi-word names were split on whitespace before the server parsed them. Fix:

Escape and wrap session/window name arguments that may contain spaces using quote_arg() before sending control commands.