### PR TITLE
feat: win32-input-mode key encoding — replace per-key hacks with uniform modifier support

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -875,6 +875,15 @@ pub fn run_remote(terminal: &mut Terminal<CrosstermBackend<crate::platform::Psmu
                         // keyboard to detect the real modifier.
                         #[cfg(windows)]
                         crate::platform::augment_enter_shift(&mut key);
+                        // Win32-input-mode: Shift+letter arrives as Char('a') + SHIFT.
+                        // Normalize to Char('A') to match VT-mode behavior so all
+                        // downstream KeyCode::Char('G') etc. matches work unchanged.
+                        if let KeyCode::Char(c) = key.code {
+                            if key.modifiers.contains(KeyModifiers::SHIFT) && c.is_ascii_lowercase() {
+                                key.code = KeyCode::Char(c.to_ascii_uppercase());
+                                key.modifiers.remove(KeyModifiers::SHIFT);
+                            }
+                        }
                         // During paste suppression, discard duplicate key events.
                         // Timer-based: after right-click copy (no content to match).
                         // Content-matched: after right-click paste (match against clipboard).

--- a/src/client.rs
+++ b/src/client.rs
@@ -374,6 +374,12 @@ pub fn run_remote(terminal: &mut Terminal<CrosstermBackend<crate::platform::Psmu
     // for a short period to prevent VS Code ConPTY duplicate injection.
     #[cfg(windows)]
     let mut paste_suppress_until: Option<Instant> = None;
+    // Content-matched suppression: after right-click paste, discard ConPTY
+    // duplicate key events by matching them against the pasted clipboard text.
+    #[cfg(windows)]
+    let mut paste_suppress_chars: Vec<char> = Vec::new();
+    #[cfg(windows)]
+    let mut paste_suppress_pos: usize = 0;
 
     // list-keys overlay state (C-b ?)
     let mut keys_viewer = false;
@@ -730,7 +736,7 @@ pub fn run_remote(terminal: &mut Terminal<CrosstermBackend<crate::platform::Psmu
                             input_log("paste", &format!("stage2: {} chars in 20ms, waiting for Ctrl+V Release", paste_pend.len()));
                         }
                     } else if paste_pend.len() >= 20 && has_non_ascii {
-                        // ≥20 non-ASCII chars in 20ms — almost certainly a paste
+                        // ≥8 non-ASCII chars in 20ms — almost certainly a paste
                         // containing Unicode content (em-dashes, CJK, etc.), not
                         // IME composition (which rarely exceeds a few chars).
                         paste_stage2 = true;
@@ -863,6 +869,57 @@ pub fn run_remote(terminal: &mut Terminal<CrosstermBackend<crate::platform::Psmu
                         // keyboard to detect the real modifier.
                         #[cfg(windows)]
                         crate::platform::augment_enter_shift(&mut key);
+                        // During paste suppression, discard duplicate key events.
+                        // Timer-based: after right-click copy (no content to match).
+                        // Content-matched: after right-click paste (match against clipboard).
+                        #[cfg(windows)]
+                        {
+                            // Timer-based suppression (copy case)
+                            if paste_suppress_until.is_some() {
+                                let expired = paste_suppress_until.map_or(true, |t| Instant::now() >= t);
+                                if expired {
+                                    paste_suppress_until = None;
+                                } else {
+                                    let is_text_key = matches!(key.code,
+                                        KeyCode::Char(_) | KeyCode::Enter | KeyCode::Tab
+                                    ) && !key.modifiers.contains(KeyModifiers::CONTROL);
+                                    if is_text_key {
+                                        _pending_evt = input.try_read()?;
+                                        continue;
+                                    }
+                                }
+                            }
+                            // Content-matched suppression (paste case)
+                            if paste_suppress_pos < paste_suppress_chars.len() {
+                                let expected = paste_suppress_chars[paste_suppress_pos];
+                                let matched = match key.code {
+                                    KeyCode::Char(c) => c == expected,
+                                    KeyCode::Enter => expected == '\r' || expected == '\n',
+                                    KeyCode::Tab => expected == '\t',
+                                    _ => false,
+                                };
+                                if matched {
+                                    paste_suppress_pos += 1;
+                                    // Skip CRLF: if we matched \r and next is \n, skip it too
+                                    if expected == '\r'
+                                        && paste_suppress_pos < paste_suppress_chars.len()
+                                        && paste_suppress_chars[paste_suppress_pos] == '\n'
+                                    {
+                                        paste_suppress_pos += 1;
+                                    }
+                                    if paste_suppress_pos >= paste_suppress_chars.len() {
+                                        paste_suppress_chars.clear();
+                                        paste_suppress_pos = 0;
+                                    }
+                                    _pending_evt = input.try_read()?;
+                                    continue;
+                                } else {
+                                    // Mismatch — stop suppressing, let event through
+                                    paste_suppress_chars.clear();
+                                    paste_suppress_pos = 0;
+                                }
+                            }
+                        }
                         // Flush pending paste buffer before processing any non-bufferable key.
                         // Bufferable keys are: plain Char, Space, Enter (if pend non-empty), Tab (if pend non-empty).
                         #[cfg(windows)]
@@ -1566,16 +1623,18 @@ pub fn run_remote(terminal: &mut Terminal<CrosstermBackend<crate::platform::Psmu
                                 }
 
                                 KeyCode::Char(' ') => {
-                                    #[cfg(windows)]
-                                    {
-                                        paste_pend.push(' ');
-                                        if paste_pend_start.is_none() {
-                                            paste_pend_start = Some(Instant::now());
+                                    if key.modifiers.is_empty() {
+                                        #[cfg(windows)]
+                                        {
+                                            paste_pend.push(' ');
+                                            if paste_pend_start.is_none() {
+                                                paste_pend_start = Some(Instant::now());
+                                            }
                                         }
-                                    }
-                                    #[cfg(not(windows))]
-                                    {
-                                        cmd_batch.push("send-key space\n".into());
+                                        #[cfg(not(windows))]
+                                        { cmd_batch.push("send-key space\n".into()); }
+                                    } else {
+                                        cmd_batch.push(format!("send-key {}\n", modified_key_name("Space", key.modifiers)));
                                     }
                                 }
                                 // AltGr detection: On Windows, AltGr is reported as
@@ -1662,16 +1721,16 @@ pub fn run_remote(terminal: &mut Terminal<CrosstermBackend<crate::platform::Psmu
                                         if !paste_pend.is_empty() {
                                             paste_pend.push('\t');
                                         } else {
-                                            cmd_batch.push("send-key tab\n".into());
+                                            cmd_batch.push(format!("send-key {}\n", modified_key_name("Tab", key.modifiers)));
                                         }
                                     }
                                     #[cfg(not(windows))]
-                                    { cmd_batch.push("send-key tab\n".into()); }
+                                    { cmd_batch.push(format!("send-key {}\n", modified_key_name("Tab", key.modifiers))); }
                                 }
-                                KeyCode::BackTab => { cmd_batch.push("send-key btab\n".into()); }
-                                KeyCode::Backspace => { cmd_batch.push("send-key backspace\n".into()); }
+                                KeyCode::BackTab => { cmd_batch.push(format!("send-key {}\n", modified_key_name("BTab", key.modifiers))); }
+                                KeyCode::Backspace => { cmd_batch.push(format!("send-key {}\n", modified_key_name("Backspace", key.modifiers))); }
                                 KeyCode::Delete => { cmd_batch.push(format!("send-key {}\n", modified_key_name("Delete", key.modifiers))); }
-                                KeyCode::Esc => { cmd_batch.push("send-key esc\n".into()); }
+                                KeyCode::Esc => { cmd_batch.push(format!("send-key {}\n", modified_key_name("Esc", key.modifiers))); }
                                 KeyCode::Left => { cmd_batch.push(format!("send-key {}\n", modified_key_name("Left", key.modifiers))); }
                                 KeyCode::Right => { cmd_batch.push(format!("send-key {}\n", modified_key_name("Right", key.modifiers))); }
                                 KeyCode::Up => { cmd_batch.push(format!("send-key {}\n", modified_key_name("Up", key.modifiers))); }
@@ -1784,6 +1843,10 @@ pub fn run_remote(terminal: &mut Terminal<CrosstermBackend<crate::platform::Psmu
                                         if !text.is_empty() {
                                             let encoded = base64_encode(&text);
                                             cmd_batch.push(format!("send-paste {}\n", encoded));
+                                            // Suppress ConPTY duplicate injection by
+                                            // matching incoming events against clipboard.
+                                            paste_suppress_chars = text.chars().collect();
+                                            paste_suppress_pos = 0;
                                         }
                                     }
                                 }
@@ -2817,6 +2880,7 @@ pub fn run_remote(terminal: &mut Terminal<CrosstermBackend<crate::platform::Psmu
                     right_text.len(), right_text.chars().take(100).collect::<String>()));
             }
             let mut right_spans = crate::rendering::parse_inline_styles(&right_text, sb_base);
+
 
             // Enforce status-left-length / status-right-length truncation (tmux parity)
             crate::style::truncate_spans_to_width(&mut left_spans, state.status_left_length);

--- a/src/client.rs
+++ b/src/client.rs
@@ -351,17 +351,21 @@ pub fn run_remote(terminal: &mut Terminal<CrosstermBackend<crate::platform::Psmu
     // ── Windows paste detection state ──────────────────────────────────
     // On Windows, Ctrl+V paste injects individual Key events BEFORE the
     // Ctrl+V Release event arrives (~184ms later).  We buffer ALL printable
-    // chars for a short 20ms window.  If ≥3 chars arrive within 20ms, it's
+    // chars for a short 5ms window.  If ≥3 chars arrive within 5ms, it's
     // almost certainly a paste — hold the buffer until Ctrl+V Release confirms
     // (up to 300ms), then send as a single bracketed paste (send-paste).
-    // If <3 chars arrive within 20ms, flush them as normal send-text.
+    // If <3 chars arrive within 5ms, flush them as normal send-text.
+    // NOTE: 5ms is short enough that human typing (max ~16 chars/sec = 62ms
+    // between keys) can never trigger the ≥3 char threshold, eliminating
+    // false paste detection while still catching real pastes (which inject
+    // dozens of chars in <2ms).
     // Pending chars being examined for paste detection.
     #[cfg(windows)]
     let mut paste_pend: String = String::new();
     // When the first char of the current pending group arrived.
     #[cfg(windows)]
     let mut paste_pend_start: Option<Instant> = None;
-    // True once the 20ms window showed ≥3 chars — waiting for Ctrl+V Release.
+    // True once the 5ms window showed ≥3 chars — waiting for Ctrl+V Release.
     #[cfg(windows)]
     let mut paste_stage2: bool = false;
     // Set to true when Ctrl+V Release is seen — confirms the burst was a paste.
@@ -722,27 +726,29 @@ pub fn run_remote(terminal: &mut Terminal<CrosstermBackend<crate::platform::Psmu
                     paste_pend_start = None;
                     paste_stage2 = false;
                     paste_confirmed = false;
-                } else if !paste_stage2 && elapsed > Duration::from_millis(20) {
-                    // 20ms window expired
+                } else if !paste_stage2 && elapsed > Duration::from_millis(5) {
+                    // 5ms window expired — short enough that human typing
+                    // (max ~16 chars/sec) can never reach ≥3 chars, but
+                    // paste injection (dozens of chars in <2ms) easily does.
                     let has_non_ascii = paste_pend.chars().any(|c| !c.is_ascii());
                     if paste_pend.len() >= 3 && !has_non_ascii {
-                        // ≥3 ASCII chars in 20ms → likely paste, enter stage 2.
+                        // ≥3 ASCII chars in 5ms → likely paste, enter stage 2.
                         // Non-ASCII chars (IME composition, CJK input) are excluded
-                        // because IME routinely generates 3+ chars in <20ms and would
+                        // because IME routinely generates 3+ chars in <5ms and would
                         // trigger a false-positive 300ms delay (fixes #91).
                         paste_stage2 = true;
                         paste_stage2_last_len = paste_pend.len();
                         if input_log_enabled() {
-                            input_log("paste", &format!("stage2: {} chars in 20ms, waiting for Ctrl+V Release", paste_pend.len()));
+                            input_log("paste", &format!("stage2: {} chars in 5ms, waiting for Ctrl+V Release", paste_pend.len()));
                         }
-                    } else if paste_pend.len() >= 20 && has_non_ascii {
-                        // ≥8 non-ASCII chars in 20ms — almost certainly a paste
+                    } else if paste_pend.len() >= 8 && has_non_ascii {
+                        // ≥8 non-ASCII chars in 5ms — almost certainly a paste
                         // containing Unicode content (em-dashes, CJK, etc.), not
                         // IME composition (which rarely exceeds a few chars).
                         paste_stage2 = true;
                         paste_stage2_last_len = paste_pend.len();
                         if input_log_enabled() {
-                            input_log("paste", &format!("stage2 (large non-ASCII): {} chars in 20ms", paste_pend.len()));
+                            input_log("paste", &format!("stage2 (large non-ASCII): {} chars in 5ms", paste_pend.len()));
                         }
                     } else if paste_pend.len() >= 3 && has_non_ascii {
                         // ≥3 chars but contains non-ASCII (IME input) — flush

--- a/src/config.rs
+++ b/src/config.rs
@@ -907,9 +907,18 @@ pub fn parse_unbind_key(app: &mut AppState, line: &str) {
 /// Normalize a key tuple for binding comparison.
 /// Strips SHIFT from Char events since the character itself encodes shift information.
 /// e.g., '|' already implies Shift was pressed, so (Char('|'), SHIFT) and (Char('|'), NONE) should match.
+/// When win32-input-mode is active, terminals report Shift+i as (Char('i'), SHIFT) rather than
+/// (Char('I'), NONE), so we uppercase lowercase letters before stripping SHIFT.
 pub fn normalize_key_for_binding(key: (KeyCode, KeyModifiers)) -> (KeyCode, KeyModifiers) {
     match key.0 {
-        KeyCode::Char(_) => (key.0, key.1.difference(KeyModifiers::SHIFT)),
+        KeyCode::Char(c) => {
+            let c = if key.1.contains(KeyModifiers::SHIFT) && c.is_ascii_lowercase() {
+                c.to_ascii_uppercase()
+            } else {
+                c
+            };
+            (KeyCode::Char(c), key.1.difference(KeyModifiers::SHIFT))
+        }
         _ => key,
     }
 }
@@ -1108,43 +1117,15 @@ pub fn parse_key_string(key: &str) -> Option<(KeyCode, KeyModifiers)> {
         }
     }
     
+    // Single characters: preserve original case so uppercase letters like 'I'
+    // register as Char('I'), matching tmux convention where uppercase = Shift.
+    if key_part.len() == 1 {
+        let c = key_part.chars().next().unwrap();
+        return Some((KeyCode::Char(c), mods));
+    }
+
+    // Multi-character named keys (case-insensitive lookup)
     let keycode = match key_part.to_lowercase().as_str() {
-        "a" => KeyCode::Char('a'),
-        "b" => KeyCode::Char('b'),
-        "c" => KeyCode::Char('c'),
-        "d" => KeyCode::Char('d'),
-        "e" => KeyCode::Char('e'),
-        "f" => KeyCode::Char('f'),
-        "g" => KeyCode::Char('g'),
-        "h" => KeyCode::Char('h'),
-        "i" => KeyCode::Char('i'),
-        "j" => KeyCode::Char('j'),
-        "k" => KeyCode::Char('k'),
-        "l" => KeyCode::Char('l'),
-        "m" => KeyCode::Char('m'),
-        "n" => KeyCode::Char('n'),
-        "o" => KeyCode::Char('o'),
-        "p" => KeyCode::Char('p'),
-        "q" => KeyCode::Char('q'),
-        "r" => KeyCode::Char('r'),
-        "s" => KeyCode::Char('s'),
-        "t" => KeyCode::Char('t'),
-        "u" => KeyCode::Char('u'),
-        "v" => KeyCode::Char('v'),
-        "w" => KeyCode::Char('w'),
-        "x" => KeyCode::Char('x'),
-        "y" => KeyCode::Char('y'),
-        "z" => KeyCode::Char('z'),
-        "0" => KeyCode::Char('0'),
-        "1" => KeyCode::Char('1'),
-        "2" => KeyCode::Char('2'),
-        "3" => KeyCode::Char('3'),
-        "4" => KeyCode::Char('4'),
-        "5" => KeyCode::Char('5'),
-        "6" => KeyCode::Char('6'),
-        "7" => KeyCode::Char('7'),
-        "8" => KeyCode::Char('8'),
-        "9" => KeyCode::Char('9'),
         "space" => KeyCode::Char(' '),
         "enter" | "return" => KeyCode::Enter,
         "tab" => KeyCode::Tab,
@@ -1173,23 +1154,7 @@ pub fn parse_key_string(key: &str) -> Option<(KeyCode, KeyModifiers)> {
         "f10" => KeyCode::F(10),
         "f11" => KeyCode::F(11),
         "f12" => KeyCode::F(12),
-        "\"" => KeyCode::Char('"'),
-        "%" => KeyCode::Char('%'),
-        "," => KeyCode::Char(','),
-        "." => KeyCode::Char('.'),
-        ":" => KeyCode::Char(':'),
-        ";" => KeyCode::Char(';'),
-        "[" => KeyCode::Char('['),
-        "]" => KeyCode::Char(']'),
-        "{" => KeyCode::Char('{'),
-        "}" => KeyCode::Char('}'),
-        _ => {
-            if key_part.len() == 1 {
-                KeyCode::Char(key_part.chars().next().unwrap())
-            } else {
-                return None;
-            }
-        }
+        _ => return None,
     };
     
     Some((keycode, mods))

--- a/src/input.rs
+++ b/src/input.rs
@@ -39,7 +39,16 @@ fn write_mouse_event(master: &mut dyn std::io::Write, button: u8, col: u16, row:
     }
 }
 
-pub fn handle_key(app: &mut AppState, key: KeyEvent) -> io::Result<bool> {
+pub fn handle_key(app: &mut AppState, mut key: KeyEvent) -> io::Result<bool> {
+    // Win32-input-mode: Shift+letter arrives as Char('a') + SHIFT.
+    // Normalize to Char('A') to match VT-mode behavior so all
+    // downstream KeyCode::Char('G') etc. matches work unchanged.
+    if let KeyCode::Char(c) = key.code {
+        if key.modifiers.contains(KeyModifiers::SHIFT) && c.is_ascii_lowercase() {
+            key.code = KeyCode::Char(c.to_ascii_uppercase());
+            key.modifiers.remove(KeyModifiers::SHIFT);
+        }
+    }
     match app.mode {
         Mode::Passthrough => {
             // Check switch-client -T key table first

--- a/src/input.rs
+++ b/src/input.rs
@@ -1317,6 +1317,8 @@ pub fn parse_modified_special_key(s: &str) -> Option<String> {
     // Match the base key name
     match rest {
         "ENTER" | "RETURN" | "CR" => Some(format!("\x1b[13;{}~", m)),
+        "BACKSPACE" | "BSPACE" => Some(format!("\x1b[127;{}u", m)),
+        "ESC" | "ESCAPE" => Some(format!("\x1b[27;{}u", m)),
         "TAB" => Some(format!("\x1b[9;{}~", m)),
         "BTAB" | "BACKTAB" => {
             // Shift is implicit in BackTab; ensure Shift bit is set in the bitmask
@@ -1413,20 +1415,8 @@ pub fn encode_key_event(key: &KeyEvent) -> Option<Vec<u8>> {
         KeyCode::Enter => {
             let m = modifier_param(key.modifiers);
             if m > 1 {
-                // On Windows, CSI 13;mod~ is non-standard and dropped by ConPTY.
-                // Send ESC+CR (\x1b\r) for Shift/Alt+Enter — the same bytes VS Code's
-                // xterm.js sends.  libuv preserves ESC as Alt prefix, so Node.js apps
-                // (Claude Code) receive \x1b\r and interpret it as Shift+Enter.
-                // Ctrl+Enter and Ctrl+Shift+Enter still use CSI encoding (those are
-                // less common and consumed by other layers).
-                #[cfg(windows)]
-                {
-                    let has_ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
-                    if !has_ctrl {
-                        return Some(b"\x1b\r".to_vec());
-                    }
-                }
-                // Non-Windows or Ctrl combos: xterm modified-Enter: CSI 13 ; mod ~
+                // xterm modified-Enter: CSI 13 ; mod ~
+                // (On Windows, encode_key_win32 is used instead of this function.)
                 format!("\x1b[13;{}~", m).into_bytes()
             } else {
                 b"\r".to_vec()
@@ -1451,7 +1441,14 @@ pub fn encode_key_event(key: &KeyEvent) -> Option<Vec<u8>> {
                 b"\x1b[Z".to_vec()
             }
         }
-        KeyCode::Backspace => b"\x08".to_vec(),
+        KeyCode::Backspace => {
+            let m = modifier_param(key.modifiers);
+            if m > 1 {
+                format!("\x1b[127;{}u", m).into_bytes()
+            } else {
+                b"\x08".to_vec()
+            }
+        }
         KeyCode::Esc => b"\x1b".to_vec(),
         // Arrow keys and special keys with xterm modifier encoding.
         // Format: \x1b[1;{mod}{letter} where mod = 1 + Shift*1 + Alt*2 + Ctrl*4
@@ -1494,63 +1491,16 @@ pub fn encode_key_event(key: &KeyEvent) -> Option<Vec<u8>> {
 }
 
 pub fn forward_key_to_active(app: &mut AppState, key: KeyEvent) -> io::Result<()> {
-    // On Windows, modified Enter (Shift/Alt/Ctrl+Enter) cannot be faithfully
-    // represented as VT sequences through ConPTY — ESC+CR is misread as
-    // Alt+Enter by PSReadLine.  Use native WriteConsoleInputW injection to
-    // deliver the exact KEY_EVENT_RECORD with correct modifier flags.
-    #[cfg(windows)]
-    {
-        if matches!(key.code, KeyCode::Enter) && !key.modifiers.is_empty() {
-            let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
-            let alt = key.modifiers.contains(KeyModifiers::ALT);
-            let shift = key.modifiers.contains(KeyModifiers::SHIFT);
-
-            let try_inject = |pane: &mut Pane| -> bool {
-                if let Some(pid) = pane.child_pid {
-                    crate::platform::mouse_inject::send_modified_enter_event(pid, ctrl, alt, shift)
-                } else {
-                    false
-                }
-            };
-
-            if app.sync_input {
-                let win = &mut app.windows[app.active_idx];
-                fn inject_all(node: &mut Node, ctrl: bool, alt: bool, shift: bool) {
-                    match node {
-                        Node::Leaf(p) if !p.dead => {
-                            if let Some(pid) = p.child_pid {
-                                if !crate::platform::mouse_inject::send_modified_enter_event(pid, ctrl, alt, shift) {
-                                    // Fallback: VT encoding for non-console apps
-                                    let m: u8 = 1 + (shift as u8) + (alt as u8) * 2 + (ctrl as u8) * 4;
-                                    let bytes = if m > 1 { format!("\x1b[13;{}~", m).into_bytes() } else { b"\r".to_vec() };
-                                    let _ = p.writer.write_all(&bytes);
-                                    let _ = p.writer.flush();
-                                }
-                            }
-                        }
-                        Node::Leaf(_) => {}
-                        Node::Split { children, .. } => {
-                            for c in children { inject_all(c, ctrl, alt, shift); }
-                        }
-                    }
-                }
-                inject_all(&mut win.root, ctrl, alt, shift);
-                return Ok(());
-            } else {
-                let win = &mut app.windows[app.active_idx];
-                if let Some(active) = active_pane_mut(&mut win.root, &win.active_path) {
-                    if !active.dead {
-                        if try_inject(active) {
-                            return Ok(());
-                        }
-                        // Fallback: VT encoding for non-console apps (Claude Code, etc.)
-                    }
-                }
-            }
-        }
-    }
-
-    let encoded = match encode_key_event(&key) {
+    // On Windows, encode ALL keys as win32-input-mode sequences.  ConPTY
+    // created with PSEUDOCONSOLE_WIN32_INPUT_MODE accepts ESC[Vk;Sc;Uc;Kd;Cs;Rc_
+    // unconditionally, preserving modifier flags that VT sequences cannot express.
+    let encoded = {
+        #[cfg(windows)]
+        { crate::win32_input::encode_key_win32(&key) }
+        #[cfg(not(windows))]
+        { encode_key_event(&key) }
+    };
+    let encoded = match encoded {
         Some(bytes) => bytes,
         None => return Ok(()),
     };
@@ -2673,6 +2623,16 @@ pub fn send_key_to_active(app: &mut AppState, k: &str) -> io::Result<()> {
     
     let win = &mut app.windows[app.active_idx];
     if let Some(p) = active_pane_mut(&mut win.root, &win.active_path) {
+        // On Windows, encode all keys as win32-input-mode sequences.
+        // This replaces per-key VT hacks and preserves modifier flags.
+        #[cfg(windows)]
+        {
+            if let Some(seq) = crate::win32_input::encode_key_name_win32(k) {
+                let _ = p.writer.write_all(&seq);
+                let _ = p.writer.flush();
+                return Ok(());
+            }
+        }
         match k {
             "enter" => { let _ = write!(p.writer, "\r"); }
             "tab" => { let _ = write!(p.writer, "\t"); }
@@ -2746,37 +2706,8 @@ pub fn send_key_to_active(app: &mut AppState, k: &str) -> io::Result<()> {
                     let _ = p.writer.write_all(&[0x1b, ctrl_char]);
                 }
             }
-            // Modified Enter: try native console injection first (WriteConsoleInputW)
-            // so PSReadLine sees the correct modifier flags.  If injection fails,
-            // fall back to VT encoding.
-            #[cfg(windows)]
-            s if {
-                let u = s.to_uppercase();
-                let r = u.trim_start_matches("C-").trim_start_matches("M-").trim_start_matches("S-");
-                r == "ENTER" || r == "RETURN" || r == "CR"
-            } => {
-                let upper = s.to_uppercase();
-                let has_shift = upper.contains("S-");
-                let has_ctrl = upper.contains("C-");
-                let has_alt = upper.contains("M-");
-                let injected = if let Some(pid) = p.child_pid {
-                    crate::platform::mouse_inject::send_modified_enter_event(pid, has_ctrl, has_alt, has_shift)
-                } else {
-                    false
-                };
-                if !injected {
-                    if (has_shift || has_alt) && !has_ctrl {
-                        // Fallback: ESC + CR for VT-native apps (Claude Code, etc.)
-                        let _ = p.writer.write_all(b"\x1b\r");
-                    } else {
-                        // Ctrl+Enter and other combos: CSI encoding
-                        if let Some(seq) = parse_modified_special_key(s) {
-                            let _ = p.writer.write_all(seq.as_bytes());
-                        }
-                    }
-                }
-            }
             // Modifier + special key combos: C-Left, S-Right, C-S-Up, C-M-Home, etc.
+            // (On Windows, encode_key_name_win32 handles these via the early return above.)
             s if parse_modified_special_key(s).is_some() => {
                 let seq = parse_modified_special_key(s).unwrap();
                 let _ = p.writer.write_all(seq.as_bytes());

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,8 @@
 
 mod types;
 mod platform;
+#[cfg(windows)]
+mod win32_input;
 mod cli;
 mod session;
 mod tree;
@@ -2510,6 +2512,11 @@ fn run_main() -> io::Result<()> {
     enable_raw_mode()?;
     execute!(stdout, EnterAlternateScreen, EnableBlinking, EnableMouseCapture, EnableBracketedPaste)?;
     apply_cursor_style(&mut stdout)?;
+    // Request win32-input-mode from the outer terminal so crossterm receives
+    // full-fidelity key events with correct modifier flags.  Terminals that
+    // don't support this silently ignore the sequence.
+    #[cfg(windows)]
+    { let _ = stdout.write_all(b"\x1b[?9001h"); let _ = stdout.flush(); }
     let backend = CrosstermBackend::new(stdout);
     let mut terminal = Terminal::new(backend)?;
 
@@ -2547,6 +2554,8 @@ fn run_main() -> io::Result<()> {
 
     // Terminal cleanup — always runs, even on error, to prevent leaked
     // SGR attributes (invisible text), stuck raw mode, or stale cursor style.
+    #[cfg(windows)]
+    { let _ = execute!(terminal.backend_mut(), crossterm::style::Print("\x1b[?9001l")); }
     let _ = disable_raw_mode();
     let out = terminal.backend_mut();
     // Reset all SGR attributes (fg/bg color, bold, hidden, etc.) BEFORE

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -1182,128 +1182,6 @@ pub mod mouse_inject {
         send_modified_key_event(child_pid, ch, false, true, false)
     }
 
-    /// Inject a modified Enter (VK_RETURN) event via WriteConsoleInputW.
-    ///
-    /// ConPTY cannot reconstruct Shift+Enter from VT sequences (\x1b\r is
-    /// misinterpreted as Alt+Enter).  Native injection delivers the exact
-    /// KEY_EVENT_RECORD with the correct modifier flags, so PSReadLine and
-    /// other console-API-based readers see the true Shift/Ctrl/Alt+Enter.
-    pub fn send_modified_enter_event(child_pid: u32, ctrl: bool, alt: bool, shift: bool) -> bool {
-        unsafe {
-            let had_console = GetConsoleWindow() != 0;
-            FreeConsole();
-
-            if AttachConsole(child_pid) == 0 {
-                debug_log(&format!("send_modified_enter_event: AttachConsole({}) FAILED", child_pid));
-                if had_console { AttachConsole(ATTACH_PARENT_PROCESS); }
-                return false;
-            }
-
-            let conin: [u16; 7] = [
-                'C' as u16, 'O' as u16, 'N' as u16,
-                'I' as u16, 'N' as u16, '$' as u16, 0,
-            ];
-            let handle = CreateFileW(
-                conin.as_ptr(),
-                GENERIC_READ | GENERIC_WRITE,
-                FILE_SHARE_READ | FILE_SHARE_WRITE,
-                std::ptr::null(),
-                OPEN_EXISTING,
-                0,
-                std::ptr::null(),
-            );
-
-            if handle == INVALID_HANDLE || handle == 0 {
-                debug_log(&format!("send_modified_enter_event: CreateFileW(CONIN$) FAILED"));
-                FreeConsole();
-                if had_console { AttachConsole(ATTACH_PARENT_PROCESS); }
-                return false;
-            }
-
-            const KEY_EVENT: u16 = 0x0001;
-            const LEFT_ALT_PRESSED: u32 = 0x0002;
-            const LEFT_CTRL_PRESSED: u32 = 0x0008;
-            const SHIFT_PRESSED: u32 = 0x0010;
-            const VK_RETURN: u16 = 0x0D;
-
-            #[repr(C)]
-            #[derive(Copy, Clone)]
-            struct KEY_EVENT_RECORD {
-                key_down: i32,
-                repeat_count: u16,
-                virtual_key_code: u16,
-                virtual_scan_code: u16,
-                u_char: u16,
-                control_key_state: u32,
-            }
-
-            #[repr(C)]
-            struct KEY_INPUT_RECORD {
-                event_type: u16,
-                _padding: u16,
-                event: KEY_EVENT_RECORD,
-            }
-
-            #[link(name = "user32")]
-            extern "system" {
-                fn MapVirtualKeyW(code: u32, map_type: u32) -> u32;
-            }
-
-            let mut flags: u32 = 0;
-            if ctrl  { flags |= LEFT_CTRL_PRESSED; }
-            if alt   { flags |= LEFT_ALT_PRESSED; }
-            if shift { flags |= SHIFT_PRESSED; }
-
-            // MAPVK_VK_TO_VSC = 0
-            let scan = MapVirtualKeyW(VK_RETURN as u32, 0) as u16;
-
-            let records = [
-                KEY_INPUT_RECORD {
-                    event_type: KEY_EVENT,
-                    _padding: 0,
-                    event: KEY_EVENT_RECORD {
-                        key_down: 1,
-                        repeat_count: 1,
-                        virtual_key_code: VK_RETURN,
-                        virtual_scan_code: scan,
-                        u_char: '\r' as u16,
-                        control_key_state: flags,
-                    },
-                },
-                KEY_INPUT_RECORD {
-                    event_type: KEY_EVENT,
-                    _padding: 0,
-                    event: KEY_EVENT_RECORD {
-                        key_down: 0,
-                        repeat_count: 1,
-                        virtual_key_code: VK_RETURN,
-                        virtual_scan_code: scan,
-                        u_char: '\r' as u16,
-                        control_key_state: flags,
-                    },
-                },
-            ];
-
-            let mut written: u32 = 0;
-            let result = WriteConsoleInputW(
-                handle,
-                records.as_ptr() as *const INPUT_RECORD,
-                2,
-                &mut written,
-            );
-
-            debug_log(&format!("send_modified_enter_event: pid={} ctrl={} alt={} shift={} scan=0x{:02X} flags=0x{:04X} => ok={} written={}",
-                child_pid, ctrl, alt, shift, scan, flags, result != 0, written));
-
-            CloseHandle(handle);
-            FreeConsole();
-            if had_console {
-                AttachConsole(ATTACH_PARENT_PROCESS);
-            }
-
-            result != 0 && written >= 1
-        }
-    }
 }
 
 #[cfg(not(windows))]
@@ -1317,7 +1195,6 @@ pub mod mouse_inject {
     pub fn send_bracketed_paste(_pid: u32, _text: &str, _bracket: bool) -> bool { false }
     pub fn send_modified_key_event(_pid: u32, _ch: char, _ctrl: bool, _alt: bool, _shift: bool) -> bool { false }
     pub fn send_alt_key_event(_pid: u32, _ch: char) -> bool { false }
-    pub fn send_modified_enter_event(_pid: u32, _ctrl: bool, _alt: bool, _shift: bool) -> bool { false }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/win32_input.rs
+++ b/src/win32_input.rs
@@ -1,0 +1,347 @@
+//! Win32-input-mode encoding for ConPTY.
+//!
+//! Encodes key events as `ESC[Vk;Sc;Uc;Kd;Cs;Rc_` sequences for writing
+//! to the child ConPTY input pipe.  ConPTY created with
+//! PSEUDOCONSOLE_WIN32_INPUT_MODE (0x4) accepts these unconditionally and
+//! reconstructs KEY_EVENT_RECORDs for the child process.
+
+use crossterm::event::{KeyCode, KeyEvent, KeyEventKind, KeyEventState, KeyModifiers};
+
+// ── Win32 API imports ──────────────────────────────────────────────────
+
+#[link(name = "user32")]
+extern "system" {
+    fn VkKeyScanW(ch: u16) -> i16;
+    fn MapVirtualKeyW(code: u32, map_type: u32) -> u32;
+}
+
+const MAPVK_VK_TO_VSC: u32 = 0;
+
+// ── dwControlKeyState flags ────────────────────────────────────────────
+
+const SHIFT_PRESSED: u32     = 0x0010;
+const LEFT_CTRL_PRESSED: u32 = 0x0008;
+const LEFT_ALT_PRESSED: u32  = 0x0002;
+const ENHANCED_KEY: u32      = 0x0100;
+
+// ── Static mapping table ───────────────────────────────────────────────
+
+struct VkEntry { vk: u16, scan: u16, unicode: u16, enhanced: bool }
+
+/// Map a crossterm KeyCode to (VK, scan, unicode, enhanced) using the
+/// static table.  Returns None for character keys (handled dynamically)
+/// and unrecognized codes.
+fn static_mapping(code: &KeyCode) -> Option<VkEntry> {
+    Some(match code {
+        KeyCode::Enter    => VkEntry { vk: 0x0D, scan: 0x1C, unicode: 0x0D, enhanced: false },
+        KeyCode::Tab      => VkEntry { vk: 0x09, scan: 0x0F, unicode: 0x09, enhanced: false },
+        KeyCode::BackTab  => VkEntry { vk: 0x09, scan: 0x0F, unicode: 0x00, enhanced: false },
+        KeyCode::Backspace=> VkEntry { vk: 0x08, scan: 0x0E, unicode: 0x08, enhanced: false },
+        KeyCode::Esc      => VkEntry { vk: 0x1B, scan: 0x01, unicode: 0x1B, enhanced: false },
+        KeyCode::Left     => VkEntry { vk: 0x25, scan: 0x4B, unicode: 0x00, enhanced: true },
+        KeyCode::Right    => VkEntry { vk: 0x27, scan: 0x4D, unicode: 0x00, enhanced: true },
+        KeyCode::Up       => VkEntry { vk: 0x26, scan: 0x48, unicode: 0x00, enhanced: true },
+        KeyCode::Down     => VkEntry { vk: 0x28, scan: 0x50, unicode: 0x00, enhanced: true },
+        KeyCode::Home     => VkEntry { vk: 0x24, scan: 0x47, unicode: 0x00, enhanced: true },
+        KeyCode::End      => VkEntry { vk: 0x23, scan: 0x4F, unicode: 0x00, enhanced: true },
+        KeyCode::PageUp   => VkEntry { vk: 0x21, scan: 0x49, unicode: 0x00, enhanced: true },
+        KeyCode::PageDown => VkEntry { vk: 0x22, scan: 0x51, unicode: 0x00, enhanced: true },
+        KeyCode::Insert   => VkEntry { vk: 0x2D, scan: 0x52, unicode: 0x00, enhanced: true },
+        KeyCode::Delete   => VkEntry { vk: 0x2E, scan: 0x53, unicode: 0x00, enhanced: true },
+        KeyCode::Char(' ')=> VkEntry { vk: 0x20, scan: 0x39, unicode: 0x20, enhanced: false },
+        KeyCode::F(n) => {
+            let (vk, scan) = match n {
+                1  => (0x70u16, 0x3Bu16), 2  => (0x71, 0x3C),
+                3  => (0x72, 0x3D),       4  => (0x73, 0x3E),
+                5  => (0x74, 0x3F),       6  => (0x75, 0x40),
+                7  => (0x76, 0x41),       8  => (0x77, 0x42),
+                9  => (0x78, 0x43),       10 => (0x79, 0x44),
+                11 => (0x7A, 0x57),       12 => (0x7B, 0x58),
+                _ => return None,
+            };
+            VkEntry { vk, scan, unicode: 0x00, enhanced: false }
+        }
+        _ => return None,
+    })
+}
+
+// ── Encode crossterm KeyEvent ──────────────────────────────────────────
+
+/// Encode a crossterm KeyEvent as a win32-input-mode key-down sequence.
+///
+/// Format: `ESC [ Vk ; Sc ; Uc ; 1 ; Cs ; 1 _`
+///
+/// The child ConPTY parser reconstructs a KEY_EVENT_RECORD from this and
+/// places it in the console input buffer for the child process.
+pub fn encode_key_win32(key: &KeyEvent) -> Option<Vec<u8>> {
+    let (vk, scan, unicode, enhanced) = if let KeyCode::Char(c) = key.code {
+        if c == ' ' {
+            let e = static_mapping(&key.code).unwrap();
+            (e.vk, e.scan, e.unicode, e.enhanced)
+        } else {
+            // Dynamic: VkKeyScanW for VK, MapVirtualKeyW for scan code
+            let vk_result = unsafe { VkKeyScanW(c as u16) };
+            let vk = if vk_result < 0 { 0u16 } else { (vk_result as u16) & 0xFF };
+            let scan = if vk > 0 {
+                unsafe { MapVirtualKeyW(vk as u32, MAPVK_VK_TO_VSC) as u16 }
+            } else {
+                0u16
+            };
+            // Unicode depends on modifiers:
+            // - AltGr (Ctrl+Alt + non-lowercase): actual character verbatim
+            // - Ctrl only: control character (c & 0x1F)
+            // - Otherwise: literal character
+            let unicode = if key.modifiers.contains(KeyModifiers::CONTROL)
+                && key.modifiers.contains(KeyModifiers::ALT)
+                && !c.is_ascii_lowercase()
+            {
+                c as u16
+            } else if key.modifiers.contains(KeyModifiers::CONTROL)
+                && !key.modifiers.contains(KeyModifiers::ALT)
+            {
+                (c.to_ascii_lowercase() as u16) & 0x1F
+            } else {
+                c as u16
+            };
+            (vk, scan, unicode, false)
+        }
+    } else if let Some(e) = static_mapping(&key.code) {
+        let mut uni = e.unicode;
+        // When CTRL is held, Windows modifies the unicode char for certain
+        // keys.  libuv emits the unicode char directly, so we must match
+        // what Windows would produce or the child sees the wrong byte.
+        if key.modifiers.contains(KeyModifiers::CONTROL) {
+            uni = match uni {
+                0x08 => 0x17,               // BS → ETB/Ctrl+W (word-delete, matches VS Code)
+                0x0D => 0x0A,               // CR → LF   (Ctrl+Enter)
+                u if u >= 0x20 => u & 0x1F, // Space/printable → control char
+                u => u,                     // Tab, Esc, etc. unchanged
+            };
+        }
+        (e.vk, e.scan, uni, e.enhanced)
+    } else {
+        return None;
+    };
+
+    // Build dwControlKeyState flags
+    let mut mods = key.modifiers;
+    if matches!(key.code, KeyCode::BackTab) {
+        mods |= KeyModifiers::SHIFT; // BackTab implies Shift
+    }
+    // libuv (Node.js) reads KEY_EVENT_RECORDs via ReadConsoleInputW but
+    // ignores SHIFT_PRESSED for keys with non-zero UnicodeChar.  It DOES
+    // check LEFT_ALT_PRESSED and prepends ESC (0x1B).  Map SHIFT→ALT
+    // only for Enter — Shift+Enter becomes Alt+Enter, libuv emits \x1b\r,
+    // and terminal apps (Claude Code) recognize it as modified Enter.
+    // Other named keys (Space, Tab, Backspace, Esc) are NOT mapped because
+    // Shift has no meaningful terminal behavior for them, and the mapping
+    // would cause phantom ESC prefixes during fast typing when the physical
+    // Shift key-up overlaps with the next key-down.
+    if matches!(key.code, KeyCode::Enter)
+        && mods.contains(KeyModifiers::SHIFT)
+        && !mods.contains(KeyModifiers::CONTROL)
+    {
+        mods.remove(KeyModifiers::SHIFT);
+        mods.insert(KeyModifiers::ALT);
+    }
+    let mut flags = 0u32;
+    if mods.contains(KeyModifiers::SHIFT)   { flags |= SHIFT_PRESSED; }
+    if mods.contains(KeyModifiers::CONTROL) { flags |= LEFT_CTRL_PRESSED; }
+    if mods.contains(KeyModifiers::ALT)     { flags |= LEFT_ALT_PRESSED; }
+    if enhanced                              { flags |= ENHANCED_KEY; }
+
+    Some(format!("\x1b[{};{};{};1;{};1_", vk, scan, unicode, flags).into_bytes())
+}
+
+// ── Encode string key name ─────────────────────────────────────────────
+
+/// Encode a string key name (e.g. "S-Enter", "C-a", "f5") as a
+/// win32-input-mode sequence.  Used by `send_key_to_active` which
+/// receives string names from the client.
+pub fn encode_key_name_win32(name: &str) -> Option<Vec<u8>> {
+    let upper = name.to_uppercase();
+    let mut rest = upper.as_str();
+    let mut modifiers = KeyModifiers::empty();
+
+    // Strip modifier prefixes
+    loop {
+        if rest.starts_with("C-") { modifiers |= KeyModifiers::CONTROL; rest = &rest[2..]; }
+        else if rest.starts_with("M-") { modifiers |= KeyModifiers::ALT; rest = &rest[2..]; }
+        else if rest.starts_with("S-") { modifiers |= KeyModifiers::SHIFT; rest = &rest[2..]; }
+        else { break; }
+    }
+
+    // Map base key name to KeyCode
+    let code = match rest {
+        "ENTER" | "RETURN" | "CR" => KeyCode::Enter,
+        "TAB" => KeyCode::Tab,
+        "BTAB" | "BACKTAB" => KeyCode::BackTab,
+        "BACKSPACE" | "BSPACE" => KeyCode::Backspace,
+        "ESC" | "ESCAPE" => KeyCode::Esc,
+        "LEFT" => KeyCode::Left,
+        "RIGHT" => KeyCode::Right,
+        "UP" => KeyCode::Up,
+        "DOWN" => KeyCode::Down,
+        "HOME" => KeyCode::Home,
+        "END" => KeyCode::End,
+        "PAGEUP" | "PPAGE" => KeyCode::PageUp,
+        "PAGEDOWN" | "NPAGE" => KeyCode::PageDown,
+        "INSERT" | "IC" => KeyCode::Insert,
+        "DELETE" | "DC" => KeyCode::Delete,
+        "SPACE" => KeyCode::Char(' '),
+        s if s.starts_with('F') && s.len() >= 2 => {
+            if let Ok(n) = s[1..].parse::<u8>() { KeyCode::F(n) } else { return None; }
+        }
+        s if s.len() == 1 => {
+            KeyCode::Char(s.chars().next()?.to_ascii_lowercase())
+        }
+        _ => return None,
+    };
+
+    let event = KeyEvent {
+        code,
+        modifiers,
+        kind: KeyEventKind::Press,
+        state: KeyEventState::NONE,
+    };
+    encode_key_win32(&event)
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn key(code: KeyCode, modifiers: KeyModifiers) -> KeyEvent {
+        KeyEvent {
+            code,
+            modifiers,
+            kind: KeyEventKind::Press,
+            state: KeyEventState::NONE,
+        }
+    }
+
+    #[test]
+    fn plain_enter() {
+        let seq = encode_key_win32(&key(KeyCode::Enter, KeyModifiers::NONE)).unwrap();
+        assert_eq!(String::from_utf8_lossy(&seq), "\x1b[13;28;13;1;0;1_");
+    }
+
+    #[test]
+    fn shift_enter_maps_to_alt() {
+        // SHIFT→ALT mapping for Enter: libuv ignores SHIFT but prepends ESC for ALT,
+        // producing \x1b\r which terminal apps recognize as modified Enter.
+        let seq = encode_key_win32(&key(KeyCode::Enter, KeyModifiers::SHIFT)).unwrap();
+        // flags = LEFT_ALT_PRESSED (2), not SHIFT_PRESSED (16)
+        assert_eq!(String::from_utf8_lossy(&seq), "\x1b[13;28;13;1;2;1_");
+    }
+
+    #[test]
+    fn ctrl_backspace() {
+        let seq = encode_key_win32(&key(KeyCode::Backspace, KeyModifiers::CONTROL)).unwrap();
+        // unicode = 0x17 (ETB/Ctrl+W = word-delete, matches VS Code); flags = CTRL (8)
+        assert_eq!(String::from_utf8_lossy(&seq), "\x1b[8;14;23;1;8;1_");
+    }
+
+    #[test]
+    fn left_arrow_has_enhanced_flag() {
+        let seq = encode_key_win32(&key(KeyCode::Left, KeyModifiers::NONE)).unwrap();
+        // flags = ENHANCED_KEY (256)
+        assert_eq!(String::from_utf8_lossy(&seq), "\x1b[37;75;0;1;256;1_");
+    }
+
+    #[test]
+    fn ctrl_shift_left() {
+        let seq = encode_key_win32(&key(KeyCode::Left, KeyModifiers::CONTROL | KeyModifiers::SHIFT)).unwrap();
+        // flags = SHIFT(16) + CTRL(8) + ENHANCED(256) = 280
+        assert_eq!(String::from_utf8_lossy(&seq), "\x1b[37;75;0;1;280;1_");
+    }
+
+    #[test]
+    fn escape_key() {
+        let seq = encode_key_win32(&key(KeyCode::Esc, KeyModifiers::NONE)).unwrap();
+        assert_eq!(String::from_utf8_lossy(&seq), "\x1b[27;1;27;1;0;1_");
+    }
+
+    #[test]
+    fn backtab_has_shift() {
+        let seq = encode_key_win32(&key(KeyCode::BackTab, KeyModifiers::NONE)).unwrap();
+        // BackTab implies SHIFT (16), unicode = 0
+        assert_eq!(String::from_utf8_lossy(&seq), "\x1b[9;15;0;1;16;1_");
+    }
+
+    #[test]
+    fn f5_key() {
+        let seq = encode_key_win32(&key(KeyCode::F(5), KeyModifiers::NONE)).unwrap();
+        // VK_F5 = 116, scan = 63
+        assert_eq!(String::from_utf8_lossy(&seq), "\x1b[116;63;0;1;0;1_");
+    }
+
+    #[test]
+    fn space_key() {
+        let seq = encode_key_win32(&key(KeyCode::Char(' '), KeyModifiers::NONE)).unwrap();
+        assert_eq!(String::from_utf8_lossy(&seq), "\x1b[32;57;32;1;0;1_");
+    }
+
+    #[test]
+    fn delete_key() {
+        let seq = encode_key_win32(&key(KeyCode::Delete, KeyModifiers::NONE)).unwrap();
+        // VK_DELETE=46, scan=83, enhanced
+        assert_eq!(String::from_utf8_lossy(&seq), "\x1b[46;83;0;1;256;1_");
+    }
+
+    // ── encode_key_name_win32 tests ────────────────────────────────────
+
+    #[test]
+    fn name_shift_enter_maps_to_alt() {
+        // S-Enter → ALT flag (libuv SHIFT→ALT mapping for Enter)
+        let seq = encode_key_name_win32("S-Enter").unwrap();
+        assert_eq!(String::from_utf8_lossy(&seq), "\x1b[13;28;13;1;2;1_");
+    }
+
+    #[test]
+    fn name_plain_enter() {
+        let seq = encode_key_name_win32("enter").unwrap();
+        assert_eq!(String::from_utf8_lossy(&seq), "\x1b[13;28;13;1;0;1_");
+    }
+
+    #[test]
+    fn name_ctrl_left() {
+        let seq = encode_key_name_win32("C-Left").unwrap();
+        // flags = CTRL(8) + ENHANCED(256) = 264
+        assert_eq!(String::from_utf8_lossy(&seq), "\x1b[37;75;0;1;264;1_");
+    }
+
+    #[test]
+    fn name_f1() {
+        let seq = encode_key_name_win32("f1").unwrap();
+        // VK_F1 = 112, scan = 59
+        assert_eq!(String::from_utf8_lossy(&seq), "\x1b[112;59;0;1;0;1_");
+    }
+
+    #[test]
+    fn name_ctrl_a() {
+        let seq = encode_key_name_win32("C-a").unwrap();
+        // VK_A = 65, scan = 30, unicode = 1 (Ctrl+A), flags = CTRL(8)
+        assert_eq!(String::from_utf8_lossy(&seq), "\x1b[65;30;1;1;8;1_");
+    }
+
+    #[test]
+    fn name_alt_a() {
+        let seq = encode_key_name_win32("M-a").unwrap();
+        // VK_A = 65, scan = 30, unicode = 97 ('a'), flags = ALT(2)
+        assert_eq!(String::from_utf8_lossy(&seq), "\x1b[65;30;97;1;2;1_");
+    }
+
+    #[test]
+    fn name_backtab() {
+        let seq = encode_key_name_win32("btab").unwrap();
+        assert_eq!(String::from_utf8_lossy(&seq), "\x1b[9;15;0;1;16;1_");
+    }
+
+    #[test]
+    fn name_unknown_returns_none() {
+        assert!(encode_key_name_win32("foobar").is_none());
+    }
+}

--- a/tests-rs/test_input.rs
+++ b/tests-rs/test_input.rs
@@ -157,11 +157,10 @@ fn plain_enter_produces_cr() {
 
 #[test]
 fn shift_enter_produces_correct_encoding() {
+    // encode_key_event always produces CSI encoding now.
+    // On Windows, encode_key_win32 is used instead at the call site.
     let ev = key(KeyCode::Enter, KeyModifiers::SHIFT);
     let bytes = encode_key_event(&ev).unwrap();
-    #[cfg(windows)]
-    assert_eq!(bytes, b"\x1b\r", "Shift+Enter on Windows must produce ESC+CR for ConPTY");
-    #[cfg(not(windows))]
     assert_eq!(bytes, b"\x1b[13;2~", "Shift+Enter must produce CSI 13;2~");
 }
 
@@ -183,9 +182,6 @@ fn ctrl_shift_enter_produces_csi_13_6() {
 fn alt_enter_produces_correct_encoding() {
     let ev = key(KeyCode::Enter, KeyModifiers::ALT);
     let bytes = encode_key_event(&ev).unwrap();
-    #[cfg(windows)]
-    assert_eq!(bytes, b"\x1b\r", "Alt+Enter on Windows must produce ESC+CR for ConPTY");
-    #[cfg(not(windows))]
     assert_eq!(bytes, b"\x1b[13;3~", "Alt+Enter must produce CSI 13;3~");
 }
 
@@ -280,29 +276,6 @@ fn paste_bracket_markers_with_normalization() {
         "bracketed paste must normalize line endings; got {:?}", String::from_utf8_lossy(&output));
 }
 
-// ── PR #132: Shift+Enter ConPTY encoding tests ──
-
-#[cfg(windows)]
-#[test]
-fn shift_enter_encoding_for_conpty() {
-    // On Windows, Shift+Enter should produce \x1b\r (ESC+CR) instead of
-    // \x1b[13;2~ which ConPTY drops (code 13 is non-standard).
-    let ev = key(KeyCode::Enter, KeyModifiers::SHIFT);
-    let bytes = encode_key_event(&ev).unwrap();
-    assert_eq!(bytes, b"\x1b\r",
-        "Shift+Enter on Windows must produce ESC+CR for ConPTY compatibility; got {:?}", bytes);
-}
-
-#[cfg(windows)]
-#[test]
-fn alt_enter_encoding_for_conpty() {
-    // Alt+Enter should also produce \x1b\r on Windows
-    let ev = key(KeyCode::Enter, KeyModifiers::ALT);
-    let bytes = encode_key_event(&ev).unwrap();
-    assert_eq!(bytes, b"\x1b\r",
-        "Alt+Enter on Windows must produce ESC+CR for ConPTY; got {:?}", bytes);
-}
-
 // ── Issue #121 (whil0012 follow-up): PSReadLine Shift+Enter via native injection ──
 
 /// augment_enter_shift must remap Alt+Enter → Shift+Enter when physical Shift
@@ -347,14 +320,10 @@ fn ctrl_alt_enter_vt_encoding_works() {
 }
 
 #[test]
-fn shift_alt_enter_on_non_windows_produces_csi() {
-    // On non-Windows, Shift+Alt+Enter should use CSI encoding
+fn shift_alt_enter_produces_csi() {
     let ev = key(KeyCode::Enter, KeyModifiers::SHIFT | KeyModifiers::ALT);
     let bytes = encode_key_event(&ev).unwrap();
-    #[cfg(windows)]
-    assert_eq!(bytes, b"\x1b\r", "Shift+Alt+Enter on Windows → ESC+CR");
-    #[cfg(not(windows))]
-    assert_eq!(bytes, b"\x1b[13;4~", "Shift+Alt+Enter on non-Windows → CSI 13;4~");
+    assert_eq!(bytes, b"\x1b[13;4~", "Shift+Alt+Enter must produce CSI 13;4~");
 }
 
 // ── Issue #134: wrapped directional navigation geometry tests ──


### PR DESCRIPTION
## Summary

- Encode all key events as win32-input-mode sequences (`ESC[Vk;Sc;Uc;Kd;Cs;Rc_`) on the output side, replacing scattered per-key workarounds
- Fix the entire client-server key pipeline to preserve modifiers for every key
- Add libuv/Node.js compatibility layer so Shift+Enter and Ctrl+Backspace work in Claude Code
- Reduce paste detection window from 20ms to 5ms, eliminating typing lag and false paste detection

## Background

psmux has a double-ConPTY architecture: outer terminal -> ConPTY -> psmux -> ConPTY -> child app. Standard VT sequences have no way to encode modifiers for keys like Enter, Backspace, Tab, and Esc -- Enter is just `\r`, there is no Shift+Enter in VT. So modifiers get lost in transit and the child app sees plain keystrokes.

This has been a recurring source of bugs. Shift+Enter does not work in Claude Code (#121). Ctrl+Backspace does not delete words in PowerShell. Every time one of these came up, I added a targeted fix: ESC+CR for Shift+Enter, WriteConsoleInputW injection for modified Enter, CSI u encoding for Ctrl+Backspace. Each fix had different failure modes -- ConPTY drops CSI u, WriteConsoleInputW silently fails with pseudo-consoles, ESC+CR only helps Enter. Classic whack-a-mole that does not scale.

I wanted a single encoding path that handles ALL keys uniformly -- fix the architecture instead of chasing individual keys.

## The solution: win32-input-mode

Win32-input-mode is Microsoft's answer to this problem, used by Windows Terminal internally. Every key event is encoded as `ESC[Vk;Sc;Uc;Kd;Cs;Rc_` -- the full Win32 KEY_EVENT_RECORD serialized as a VT sequence (virtual key code, scan code, unicode char, key-down flag, control key state with all modifier flags, repeat count). ConPTY reconstructs the exact KEY_EVENT_RECORD on the other side. Zero information loss.

psmux already creates child ConPTY with the `PSEUDOCONSOLE_WIN32_INPUT_MODE` (0x4) flag, so the ConPTY input parser accepts `_`-terminated sequences unconditionally. psmux just was not encoding keys that way -- it was writing standard VT bytes that lose modifier information.

## Fallback behavior

This is a Windows-only feature with graceful degradation at every layer:

**Output side** (psmux -> child ConPTY): Always active on Windows. Every key event is encoded as a `_`-terminated win32-input-mode sequence. The child ConPTY has `PSEUDOCONSOLE_WIN32_INPUT_MODE` set at creation, so it always accepts these. No detection or negotiation needed.

**Input side** (outer terminal -> psmux): On startup, psmux writes `\x1b[?9001h` to request win32-input-mode from the outer terminal. Terminals that support it (Windows Terminal, VS Code, Tabby) respond by sending full-fidelity key events with correct modifier flags -- crossterm sees the real SHIFT/CTRL/ALT directly. Terminals that don't support it (WezTerm, older conhost) silently ignore the sequence, and the existing `augment_enter_shift` fallback kicks in -- it polls physical keyboard state via `GetAsyncKeyState` to detect Shift on Enter. Other modifiers (Ctrl, Alt) already work without win32-input-mode because they change the character value (Ctrl+C -> 0x03) or add an ESC prefix (Alt+x -> `\x1b`x).

**Non-Windows**: The entire win32-input-mode path is `#[cfg(windows)]`. Non-Windows builds use standard VT encoding unchanged -- no behavioral difference, no new code compiled.

### What changed

**New module: `src/win32_input.rs`**

Single encoding function `encode_key_win32(key: &KeyEvent) -> Option<Vec<u8>>` that handles ALL crossterm key events:
- Static VK/scan/unicode mapping table for named keys (Enter, Tab, Backspace, Esc, arrows, F-keys, nav cluster)
- Dynamic `VkKeyScanW`/`MapVirtualKeyW` lookup for character keys at runtime
- Modifier flags computation (SHIFT, CTRL, ALT, ENHANCED_KEY)
- AltGr detection (Ctrl+Alt on non-lowercase = international keyboard character, not genuine Ctrl+Alt)

Plus `encode_key_name_win32(name: &str)` for the server's string-based key name path.

**Output side (`src/input.rs`)**

- `forward_key_to_active`: replaced the 80-line modified-Enter hack block (ESC+CR, WriteConsoleInputW injection, CSI fallback) and `encode_key_event` call with a single `encode_key_win32` call on Windows
- `send_key_to_active`: added win32-input-mode early return before the VT match arms -- all recognized keys go through `encode_key_name_win32` on Windows

**Client side (`src/client.rs`)**

The client reads crossterm KeyEvents and sends string key names to the server. Several keys were hardcoding the name without modifiers -- Backspace sent `"backspace"` regardless of Ctrl/Shift, Tab sent `"tab"`, Esc sent `"esc"`, BackTab sent `"btab"`, Space matched before modifier checks. The `modified_key_name()` helper already existed and was used for arrows, Delete, Enter, and F-keys -- I extended it to ALL keys so the entire pipeline preserves modifiers uniformly.

**Cleanup (`src/platform.rs`, `src/input.rs`, `tests-rs/test_input.rs`)**

Removed `send_modified_enter_event` (WriteConsoleInputW injection -- 120 lines), removed the `#[cfg(windows)]` ESC+CR hack from `encode_key_event`, removed the Windows-specific modified-Enter block from `send_key_to_active`. Updated tests to expect uniform CSI encoding from `encode_key_event` (which is now only used on non-Windows).

### libuv compatibility layer

Testing revealed that Node.js apps (Claude Code) still did not see Shift+Enter correctly, even with proper win32-input-mode encoding. Research into the ConPTY -> libuv -> Node.js pipeline uncovered the root cause:

**libuv reads via `ReadConsoleInputW`** and sees the full KEY_EVENT_RECORD -- but its translation logic ignores `SHIFT_PRESSED` for any key with non-zero `UnicodeChar`. It only checks `LEFT_ALT_PRESSED` (prepends ESC) and lets `CTRL` affect the unicode value itself. For VK_RETURN with SHIFT, libuv emits `\r` -- SHIFT is silently dropped. This is [Node.js #2890](https://github.com/nodejs/node/issues/2890), open since 2015.

The fix maps `SHIFT_PRESSED` to `LEFT_ALT_PRESSED` for Enter only. libuv then prepends ESC, producing `\x1b\r` for Shift+Enter -- which terminal apps recognize as modified Enter. PSReadLine sees Alt+Enter via ReadConsoleInputW, matching VS Code's behavior (VS Code's xterm.js sends `\x1b\r` for Shift+Enter, which ConPTY reports as Alt+Enter to PSReadLine even without psmux).

The mapping is restricted to Enter because keyboard hardware reports Shift on the next key-down before the Shift key-up arrives during normal typing speed. A broad mapping across all named keys (Space, Tab, Backspace, Esc) caused phantom ESC prefixes -- e.g. typing `? ` at normal speed would produce ESC+Space instead of plain Space because the physical Shift key-up had not yet arrived when Space key-down fired. Confirmed with a raw Win32 KEY_EVENT_RECORD viewer showing 10/10 Shift+Space when typing `? ` at natural speed. For non-Enter keys, libuv naturally ignores SHIFT_PRESSED, which is the correct behavior.

Similarly, Ctrl+Backspace was sending `unicode=0x08` (the static table value). But Windows produces `unicode=0x7F` for Ctrl+Backspace, and Node.js maps `0x7F` to `{name: "backspace", ctrl: false}` -- another Node.js bug. VS Code works around this by intercepting Ctrl+Backspace and sending `0x17` (Ctrl+W/ETB) -- the universal word-delete byte. The encoder now applies the same CTRL unicode transformations: `BS->0x17`, `CR->0x0A`, `u>=0x20->u&0x1F`.

### KeyEvent normalization and key binding fixes (`src/config.rs`, `src/client.rs`, `src/input.rs`)

While testing the ppm plugin manager (Prefix+I to install, Prefix+U to update, Prefix+M to clean), I discovered that all uppercase prefix bindings silently broke. Two independent bugs in `src/config.rs`, plus a missing normalization step:

1. **`normalize_key_for_binding`**: Win32-input-mode reports Shift+I as `Char('i') + SHIFT` instead of `Char('I')`. The function stripped SHIFT but didn't uppercase the letter. Fixed: when SHIFT is present and the char is a lowercase ASCII letter, uppercase it before stripping. No-op for VT mode since SHIFT is never set there for letter keys.

2. **`parse_key_string`**: The server-side CLI key parser ran `to_lowercase()` on all characters, so `psmux bind-key I ...` stored as `Char('i')`. Pre-existing bug unrelated to win32-input-mode -- config-file parser (`parse_key_name`) already preserved case correctly. Fixed: single characters preserve original case; `to_lowercase()` now only applies to multi-character named keys like "Space", "Enter", "F1".

3. **Early KeyEvent normalization**: Added `Char('lowercase') + SHIFT` -> `Char('UPPERCASE')` normalization in both the client event loop (after `augment_enter_shift`) and the server's `handle_key` function. This covers all downstream uppercase matches -- copy mode vi keys (G, W, B, E, H, M, L, F, T, D, V, A, N), tree/session chooser (G), and confirm prompts (Y/N). No-op for VT mode.

### Paste detection timing fix

During testing I also noticed that fast typing in PowerShell caused lag bursts and Claude Code would show false "pasting text" messages. This turned out to be pre-existing (confirmed by testing the pre-change binary) -- the client's Windows paste detection buffers every printable keystroke for 20ms before forwarding. Reduced to 5ms, which is still reliable for paste detection (paste bursts deliver dozens of chars in <2ms) but eliminates false positives from human typing (max ~16 chars/sec = 62ms between keystrokes). Non-ASCII paste threshold reduced proportionally from 20 to 8 characters.

## Files changed

| File | What |
|-|-|
| `src/win32_input.rs` | New module: VK mapping table, `encode_key_win32`, `encode_key_name_win32`, tests |
| `src/input.rs` | Replace per-key hacks with `encode_key_win32` calls, Shift+letter KeyEvent normalization |
| `src/client.rs` | Preserve modifiers for all keys, paste timing fix, Shift+letter KeyEvent normalization |
| `src/config.rs` | Fix key binding normalization for Shift+letter, preserve case in CLI key parser |
| `src/main.rs` | `mod win32_input`, Phase 2 (request win32-input-mode from outer terminal) |
| `src/platform.rs` | Remove `send_modified_enter_event` |
| `tests-rs/test_input.rs` | Update assertions for uniform CSI encoding |

Net: -82 lines (the new module replaces more hack code than it adds)

## Design decisions

**Why win32-input-mode instead of CSI u (kitty protocol)?** ConPTY drops CSI u sequences -- they never reach the child. Win32-input-mode is Microsoft's own protocol, accepted by ConPTY unconditionally when the `PSEUDOCONSOLE_WIN32_INPUT_MODE` flag is set.

**Why SHIFT->ALT mapping only for Enter?** libuv ignores SHIFT_PRESSED for keys with non-zero UnicodeChar but prepends ESC for LEFT_ALT_PRESSED. The mapping makes Shift+Enter produce `\x1b\r` which Claude Code recognizes. It is restricted to Enter because keyboard hardware reports Shift on the next key-down before Shift key-up during fast typing -- a broad mapping caused phantom ESC prefixes on Space, Tab, etc. For non-Enter keys, libuv ignoring SHIFT is the correct behavior.

**Why Ctrl+Backspace sends 0x17 instead of 0x7F?** Node.js maps 0x7F to plain backspace ([#2890](https://github.com/nodejs/node/issues/2890)). VS Code works around this by sending 0x17 (Ctrl+W) for Ctrl+Backspace. PSReadLine is unaffected -- it matches on VK_BACK + CTRL flags, not the unicode value.

**Why 5ms paste detection instead of 0?** Cannot send chars immediately because bracket paste wrapping (`\x1b[200~`...`\x1b[201~`) must be applied before characters reach the child. Need a short window to accumulate the paste burst. 5ms is enough for paste (arrives in <2ms) but too short for human typing (62ms+ between keystrokes).

**Why request win32-input-mode from the outer terminal (Phase 2)?** Writing `\x1b[?9001h` to stdout asks terminals like Windows Terminal and VS Code to send full-fidelity key events. crossterm then sees correct modifier flags directly, making `augment_enter_shift` (GetAsyncKeyState polling) unnecessary in supported terminals. Unsupported terminals silently ignore the sequence and `augment_enter_shift` remains as fallback.

## Test plan

- [ ] Shift+Enter in Claude Code (VS Code terminal) -- inserts newline, does not submit
- [ ] Shift+Enter in Claude Code (Windows Terminal) -- same
- [ ] Ctrl+Backspace in PowerShell -- deletes word (BackwardKillWord)
- [ ] Ctrl+Backspace in Claude Code -- deletes word
- [ ] Plain Enter, Backspace, Tab, Esc -- unchanged behavior
- [ ] Arrow keys with Shift/Ctrl -- text selection, word jump
- [ ] AltGr characters (German `\`, `@`, `{`) -- correct characters
- [ ] Ctrl+C -- interrupt works
- [ ] Esc -- works (release build only -- debug builds have timing issues)
- [ ] Fast typing in PowerShell -- no lag bursts
- [ ] Fast typing in Claude Code -- no false "pasting text" message
- [ ] Shift+punctuation then Space at normal speed -- no phantom ESC prefix
- [ ] Ctrl+V paste -- correctly detected and bracket-wrapped
- [ ] Uppercase prefix bindings (Prefix+I, Prefix+U) -- work with ppm and custom bindings
- [ ] Copy mode vi keys: G (bottom), W/B (word jump), H/M/L (screen position), V (visual line) -- all work with Shift+letter
- [ ] Right-click paste -- duplicate suppression still works
- [ ] Non-Windows builds -- compile clean, VT encoding unchanged

