### PR TITLE
fix: bind-key new-window -c drops -c flag, losing start directory (#111)

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -187,7 +187,16 @@ pub fn parse_command_to_action(cmd: &str) -> Option<Action> {
     
     match parts[0] {
         "display-panes" | "displayp" => Some(Action::DisplayPanes),
-        "new-window" | "neww" => Some(Action::NewWindow),
+        "new-window" | "neww" => {
+            // If extra flags like -c, -d, -n, -F, -e or a shell command are present,
+            // store as Command to preserve the full argument string (esp. -c for start dir).
+            let has_extra = parts.len() > 1;
+            if has_extra {
+                Some(Action::Command(cmd.to_string()))
+            } else {
+                Some(Action::NewWindow)
+            }
+        }
         "split-window" | "splitw" => {
             // If extra flags like -c, -d, -p, -F, or a shell command are present,
             // store as Command to preserve the full argument string.

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -2114,21 +2114,25 @@ fn dispatch_control_command(
             true
         }
         "bind-key" | "bind" => {
-            // Simplified bind: bind [-n] [-T table] key command
-            let no_prefix = args.iter().any(|a| *a == "-n");
-            let table_name = args.windows(2).find(|w| w[0] == "-T")
-                .map(|w| w[1].to_string())
-                .unwrap_or_else(|| if no_prefix { "root".to_string() } else { "prefix".to_string() });
-            let repeat = args.iter().any(|a| *a == "-r");
-            let positional: Vec<&str> = args.iter()
-                .filter(|a| !a.starts_with('-') && {
-                    let pos = args.iter().position(|x| x == *a).unwrap_or(0);
-                    !(pos > 0 && args[pos-1] == "-T")
-                })
-                .copied().collect();
-            if positional.len() >= 2 {
-                let key = positional[0].to_string();
-                let command = positional[1..].join(" ");
+            // Parse bind-key's own flags, then treat everything after
+            // the key name as the verbatim command (preserving flags like -c).
+            let mut table_name = "prefix".to_string();
+            let mut repeat = false;
+            let mut i = 0;
+            while i < args.len() {
+                match args[i] {
+                    "-T" if i + 1 < args.len() => {
+                        table_name = args[i + 1].to_string();
+                        i += 2; continue;
+                    }
+                    "-n" => { table_name = "root".to_string(); i += 1; continue; }
+                    "-r" => { repeat = true; i += 1; continue; }
+                    _ => break,
+                }
+            }
+            if i < args.len() && i + 1 < args.len() {
+                let key = args[i].to_string();
+                let command = args[i + 1..].join(" ");
                 let _ = tx.send(CtrlReq::BindKey(table_name, key, command, repeat));
             }
             let _ = resp_tx.send(String::new());

--- a/tests-rs/test_commands_new.rs
+++ b/tests-rs/test_commands_new.rs
@@ -1878,3 +1878,48 @@ fn display_popup_d_flag_with_percent_dims() {
         other => panic!("expected PopupMode, got {:?}", std::mem::discriminant(other)),
     }
 }
+
+// ── Issue #111 follow-up: new-window -c must preserve -c flag in bind-key ──
+
+#[test]
+fn new_window_bare_returns_action_new_window() {
+    // Bare new-window with no args should still return the simple Action::NewWindow
+    assert!(matches!(parse_command_to_action("new-window"), Some(Action::NewWindow)));
+    assert!(matches!(parse_command_to_action("neww"), Some(Action::NewWindow)));
+}
+
+#[test]
+fn new_window_with_c_flag_returns_command_preserving_args() {
+    // new-window -c <dir> must NOT be reduced to Action::NewWindow — the -c flag
+    // must be preserved so the server can expand #{pane_current_path}. (Issue #111)
+    match parse_command_to_action("new-window -c #{pane_current_path}") {
+        Some(Action::Command(cmd)) => {
+            assert!(cmd.contains("-c"), "expected -c in command, got: {}", cmd);
+            assert!(cmd.contains("#{pane_current_path}"), "expected format var in command, got: {}", cmd);
+        }
+        _ => panic!("expected Action::Command preserving -c"),
+    }
+}
+
+#[test]
+fn new_window_with_name_flag_returns_command() {
+    // new-window -n myname should also be preserved as Command
+    match parse_command_to_action("new-window -n myname") {
+        Some(Action::Command(cmd)) => {
+            assert!(cmd.contains("-n"), "expected -n in command, got: {}", cmd);
+            assert!(cmd.contains("myname"), "expected window name in command, got: {}", cmd);
+        }
+        _ => panic!("expected Action::Command"),
+    }
+}
+
+#[test]
+fn new_window_with_shell_command_returns_command() {
+    // new-window -- python3 should also be preserved
+    match parse_command_to_action("new-window -- python3") {
+        Some(Action::Command(cmd)) => {
+            assert!(cmd.contains("python3"), "expected shell command in command, got: {}", cmd);
+        }
+        _ => panic!("expected Action::Command"),
+    }
+}


### PR DESCRIPTION
`bind-key c new-window -c "#{pane_current_path}"` silently dropped the `-c` argument, causing new windows to always open in the default directory instead of the current pane's working directory.

The #111 fix (ff9898c) correctly added `expand_format()` to the server-side NewWindow handler, but two client-side code paths still discarded the `-c` flag before it could reach the server:

1. `parse_command_to_action()` in commands.rs mapped `new-window ...` to the bare `Action::NewWindow` enum variant regardless of arguments, discarding `-c`, `-n`, and any other flags. This affected both config file parsing and server-side BindKey handling. The fix mirrors the existing `split-window` pattern: when arguments are present, preserve the full command string as `Action::Command(cmd)`.

2. `dispatch_control_command()` in connection.rs (persistent connection bind-key handler) filtered out all `-` prefixed tokens as bind-key's own flags, which stripped `-c` from the command. The fix replaces the greedy filter with explicit flag parsing that only consumes `-T`, `-n`, `-r` as bind-key flags, then passes everything after the key name through verbatim.

Bare `new-window` (no arguments) still returns `Action::NewWindow` as before.

Added 4 unit tests verifying new-window argument preservation for `-c`, `-n`, shell commands, and the bare case. All 649 tests pass.