### PR TITLE
fix: resolve Windows run-shell executables to absolute paths

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,5 +1,7 @@
 use std::io;
 use std::time::Instant;
+#[cfg(windows)]
+use std::path::PathBuf;
 
 use std::io::Write;
 use crate::types::{AppState, Mode, Action, FocusDir, LayoutKind, MenuItem, Menu, Node};
@@ -35,11 +37,31 @@ pub(crate) const DISPLAY_MESSAGE_DEFAULT_FMT: &str =
 pub fn resolve_run_shell() -> (String, Vec<String>) {
     #[cfg(windows)]
     {
-        if which::which("pwsh").is_ok() {
-            return ("pwsh".to_string(), vec!["-NoProfile".to_string(), "-Command".to_string()]);
+        if let Ok(path) = which::which("pwsh") {
+            return (path.to_string_lossy().into_owned(), vec!["-NoProfile".to_string(), "-Command".to_string()]);
         }
-        if which::which("powershell").is_ok() {
-            return ("powershell".to_string(), vec!["-NoProfile".to_string(), "-Command".to_string()]);
+        if let Ok(path) = which::which("powershell") {
+            return (path.to_string_lossy().into_owned(), vec!["-NoProfile".to_string(), "-Command".to_string()]);
+        }
+        if let Ok(system_root) = std::env::var("SystemRoot").or_else(|_| std::env::var("SYSTEMROOT")) {
+            let powershell = PathBuf::from(&system_root)
+                .join("System32")
+                .join("WindowsPowerShell")
+                .join("v1.0")
+                .join("powershell.exe");
+            if powershell.is_file() {
+                return (powershell.to_string_lossy().into_owned(), vec!["-NoProfile".to_string(), "-Command".to_string()]);
+            }
+            let cmd = PathBuf::from(&system_root).join("System32").join("cmd.exe");
+            if cmd.is_file() {
+                return (cmd.to_string_lossy().into_owned(), vec!["/c".to_string()]);
+            }
+        }
+        if let Ok(comspec) = std::env::var("ComSpec").or_else(|_| std::env::var("COMSPEC")) {
+            let trimmed = comspec.trim();
+            if !trimmed.is_empty() {
+                return (trimmed.to_string(), vec!["/c".to_string()]);
+            }
         }
         ("cmd".to_string(), vec!["/c".to_string()])
     }
@@ -1258,12 +1280,16 @@ pub fn execute_command_string(app: &mut AppState, cmd: &str) -> io::Result<()> {
                     } else if condition == "false" || condition == "0" {
                         false
                     } else {
-                        std::process::Command::new(if cfg!(windows) { "pwsh" } else { "sh" })
-                            .args(if cfg!(windows) { vec!["-NoProfile", "-Command", condition] } else { vec!["-c", condition] })
+                        {
+                            let (shell_prog, mut shell_args) = resolve_run_shell();
+                            shell_args.push(condition.to_string());
+                            std::process::Command::new(&shell_prog)
+                            .args(shell_args)
                             .stdout(std::process::Stdio::null())
                             .stderr(std::process::Stdio::null())
                             .status()
                             .map(|s| s.success()).unwrap_or(false)
+                        }
                     };
                     if let Some(chosen) = if success { Some(true_cmd) } else { false_cmd } {
                         execute_command_string(app, chosen)?;

--- a/tests-rs/test_commands_new.rs
+++ b/tests-rs/test_commands_new.rs
@@ -1995,3 +1995,21 @@ fn resolve_run_shell_returns_valid_shell() {
         prog
     );
 }
+
+#[cfg(windows)]
+#[test]
+fn resolve_run_shell_returns_absolute_windows_shell_path() {
+    let (prog, args) = resolve_run_shell();
+    let path = std::path::Path::new(&prog);
+    assert!(!args.is_empty(), "shell args should include at least one flag");
+    assert!(
+        path.is_absolute(),
+        "windows run-shell should resolve to an absolute executable path, got '{}'",
+        prog
+    );
+    assert!(
+        path.is_file(),
+        "resolved windows shell path should point to an existing file, got '{}'",
+        prog
+    );
+}


### PR DESCRIPTION
## Summary
- return absolute executable paths from `resolve_run_shell()` on Windows instead of bare `pwsh`/`powershell`/`cmd` command names
- add explicit fallbacks through `SystemRoot\System32\WindowsPowerShell\v1.0\powershell.exe`, `SystemRoot\System32\cmd.exe`, and `ComSpec`
- reuse the same resolver for local `if-shell` command execution on Windows
- add a Windows regression test that requires `resolve_run_shell()` to return an absolute executable path

## Verification
- `cargo +stable-x86_64-pc-windows-gnu test --target-dir target-test resolve_run_shell_returns_absolute_windows_shell_path -- --nocapture`
- `powershell -ExecutionPolicy Bypass -File tests/test_run_shell.ps1`
  - observed `TOTAL: 11 PASS, 0 FAIL out of 11 tests`