### PR TITLE
feat: add support for environment variables in new-session command

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1564,11 +1564,12 @@ fn execute_command_string_single(app: &mut AppState, cmd: &str) -> io::Result<()
         }
         "new-session" | "new" => {
             // Issue #200: create a new session from inside a running session.
-            // Parse flags: -s name, -d (detached), -n windowname, -c startdir
+            // Parse flags: -s name, -d (detached), -n windowname, -c startdir, -e VAR=val
             let mut session_name: Option<String> = None;
             let mut detached = false;
             let mut window_name: Option<String> = None;
             let mut start_dir: Option<String> = None;
+            let mut session_env: Vec<(String, String)> = Vec::new();
             {
                 let mut i = 1;
                 while i < parts.len() {
@@ -1578,7 +1579,17 @@ fn execute_command_string_single(app: &mut AppState, cmd: &str) -> io::Result<()
                         "-c" => { i += 1; if i < parts.len() { start_dir = Some(parts[i].trim_matches('"').to_string()); } }
                         "-d" => { detached = true; }
                         "-A" | "-D" | "-E" | "-P" | "-X" => { /* compatibility flags, ignored */ }
-                        "-e" | "-F" | "-f" | "-t" | "-x" | "-y" => { i += 1; /* skip value */ }
+                        "-e" => {
+                            i += 1;
+                            match crate::util::parse_new_session_e_value_token(parts.get(i).copied()) {
+                                Ok(p) => session_env.push(p),
+                                Err(e) => {
+                                    app.status_message = Some((format!("psmux: {}", e), Instant::now()));
+                                    return Ok(());
+                                }
+                            }
+                        }
+                        "-F" | "-f" | "-t" | "-x" | "-y" => { i += 1; /* skip value */ }
                         _ => {}
                     }
                     i += 1;
@@ -1619,7 +1630,7 @@ fn execute_command_string_single(app: &mut AppState, cmd: &str) -> io::Result<()
             // Try to claim a warm server first (fast path)
             let warm_disabled = std::env::var("PSMUX_NO_WARM").map(|v| v == "1" || v == "true").unwrap_or(false)
                 || crate::config::is_warm_disabled_by_config();
-            let claimed_warm = if !warm_disabled && start_dir.is_none() {
+            let claimed_warm = if !warm_disabled && start_dir.is_none() && session_env.is_empty() {
                 let warm_base = if let Some(ref sn) = app.socket_name {
                     format!("{}____warm__", sn)
                 } else {
@@ -1683,6 +1694,10 @@ fn execute_command_string_single(app: &mut AppState, cmd: &str) -> io::Result<()
                     server_args.push(area.width.to_string());
                     server_args.push("-y".into());
                     server_args.push(area.height.to_string());
+                }
+                for (k, v) in &session_env {
+                    server_args.push("-e".into());
+                    server_args.push(format!("{}={}", k, v));
                 }
                 #[cfg(windows)]
                 { let _ = crate::platform::spawn_server_hidden(&exe, &server_args); }

--- a/src/main.rs
+++ b/src/main.rs
@@ -431,7 +431,10 @@ fn run_main() -> io::Result<()> {
                 let raw_cmd: Option<Vec<String>> = args.iter().position(|a| a == "--").map(|pos| {
                     args.iter().skip(pos + 1).cloned().collect()
                 }).filter(|v: &Vec<String>| !v.is_empty());
-                return run_server(name, server_socket_name, initial_cmd, raw_cmd, srv_start_dir, srv_window_name, srv_init_size, srv_group_target);
+                let session_env = crate::util::collect_server_session_env_args(&args).map_err(|e| {
+                    io::Error::new(io::ErrorKind::InvalidInput, e)
+                })?;
+                return run_server(name, server_socket_name, initial_cmd, raw_cmd, srv_start_dir, srv_window_name, srv_init_size, srv_group_target, session_env);
             }
             "new-session" | "new" => {
                 // Prevent nesting: block new-session inside an existing psmux session
@@ -462,6 +465,7 @@ fn run_main() -> io::Result<()> {
                 let mut group_target: Option<String> = None;
                 let mut positional_args: Vec<String> = Vec::new();
                 let mut raw_cmd_after_dd: Option<Vec<String>> = None;
+                let mut session_env: Vec<(String, String)> = Vec::new();
 
                 {
                     let mut i = 1; // skip command name (cmd_args[0])
@@ -502,7 +506,19 @@ fn run_main() -> io::Result<()> {
                             'c' => { i += 1; if i < cmd_args.len() { start_dir = Some(cmd_args[i].trim_matches('"').to_string()); } break; }
                             'x' => { i += 1; if i < cmd_args.len() { init_width = cmd_args[i].parse::<u16>().ok(); } break; }
                             'y' => { i += 1; if i < cmd_args.len() { init_height = cmd_args[i].parse::<u16>().ok(); } break; }
-                            'e' | 'f' => { i += 1; break; /* skip value */ }
+                            'e' => {
+                                i += 1;
+                                match crate::util::parse_new_session_e_value_token(
+                                    cmd_args.get(i).map(|s| s.as_str()),
+                                ) {
+                                    Ok(pair) => session_env.push(pair),
+                                    Err(msg) => {
+                                        return Err(io::Error::new(io::ErrorKind::InvalidInput, msg));
+                                    }
+                                }
+                                break;
+                            }
+                            'f' => { i += 1; break; /* skip value (client flags, ignored) */ }
                             't' => { i += 1; if i < cmd_args.len() { group_target = Some(cmd_args[i].to_string()); } break; }
                             // Boolean flags
                             'd' => { detached = true; }
@@ -579,7 +595,7 @@ fn run_main() -> io::Result<()> {
                 // Skipped when PSMUX_NO_WARM=1 is set or config has 'set -g warm off'.
                 let warm_disabled = std::env::var("PSMUX_NO_WARM").map(|v| v == "1" || v == "true").unwrap_or(false)
                     || crate::config::is_warm_disabled_by_config();
-                let claimed_warm = if !warm_disabled && initial_cmd.is_none() && raw_cmd_args.is_none() && start_dir.is_none() {
+                let claimed_warm = if !warm_disabled && initial_cmd.is_none() && raw_cmd_args.is_none() && start_dir.is_none() && session_env.is_empty() {
                     let warm_base = if let Some(ref l) = l_socket_name {
                         format!("{}____warm__", l)
                     } else {
@@ -667,6 +683,10 @@ fn run_main() -> io::Result<()> {
                 if let Some(ref gt) = group_target {
                     server_args.push("-g".into());
                     server_args.push(gt.clone());
+                }
+                for (k, v) in &session_env {
+                    server_args.push("-e".into());
+                    server_args.push(format!("{}={}", k, v));
                 }
                 // Pass raw command args (direct execution) if -- was used
                 if let Some(ref raw_args) = raw_cmd_args {

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -1799,6 +1799,8 @@ match cmd {
             let mut detached = false;
             let mut window_name: Option<String> = None;
             let mut start_dir: Option<String> = None;
+            let mut session_env: Vec<(String, String)> = Vec::new();
+            let mut session_env_parse_err: Option<String> = None;
             {
                 let mut i = 0;
                 while i < args.len() {
@@ -1808,12 +1810,33 @@ match cmd {
                         "-c" => { i += 1; if i < args.len() { start_dir = Some(args[i].trim_matches('"').to_string()); } }
                         "-d" => { detached = true; }
                         "-t" => { i += 1; /* already handled above */ }
-                        "-e" | "-F" | "-f" | "-x" | "-y" => { i += 1; /* skip value */ }
+                        "-e" => {
+                            i += 1;
+                            match crate::util::parse_new_session_e_value_token(args.get(i).copied()) {
+                                Ok(p) => session_env.push(p),
+                                Err(e) => {
+                                    session_env_parse_err = Some(e);
+                                    break;
+                                }
+                            }
+                        }
+                        "-F" | "-f" | "-x" | "-y" => { i += 1; /* skip value */ }
                         _ => {}
                     }
                     i += 1;
                 }
             }
+
+            if let Some(ref err) = session_env_parse_err {
+                let msg = format!("psmux: {}\n", err);
+                if persistent {
+                    let _ = tx.send(CtrlReq::StatusMessage(msg.trim().to_string()));
+                } else {
+                    let _ = write!(write_stream, "{}", msg);
+                    let _ = write_stream.flush();
+                }
+                if !persistent { break; }
+            } else {
 
             // Note: socket_name (from -L flag) is not directly available here;
             // the client-side handler in commands.rs has it via app.socket_name.
@@ -1854,6 +1877,10 @@ match cmd {
                     server_args.push("-n".into());
                     server_args.push(wn.clone());
                 }
+                for (k, v) in &session_env {
+                    server_args.push("-e".into());
+                    server_args.push(format!("{}={}", k, v));
+                }
                 #[cfg(windows)]
                 { let _ = crate::platform::spawn_server_hidden(&exe, &server_args); }
                 #[cfg(not(windows))]
@@ -1890,6 +1917,7 @@ match cmd {
                         let _ = write_stream.flush();
                     }
                 }
+            }
             }
         }
     }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -295,7 +295,7 @@ fn drain_plugin_req(
     }
 }
 
-pub fn run_server(session_name: String, socket_name: Option<String>, initial_command: Option<String>, raw_command: Option<Vec<String>>, start_dir: Option<String>, window_name: Option<String>, init_size: Option<(u16, u16)>, group_target: Option<String>) -> io::Result<()> {
+pub fn run_server(session_name: String, socket_name: Option<String>, initial_command: Option<String>, raw_command: Option<Vec<String>>, start_dir: Option<String>, window_name: Option<String>, init_size: Option<(u16, u16)>, group_target: Option<String>, session_env: Vec<(String, String)>) -> io::Result<()> {
     // Write crash info to a log file when stderr is unavailable (detached server)
     std::panic::set_hook(Box::new(|info| {
         let home = std::env::var("USERPROFILE").or_else(|_| std::env::var("HOME")).unwrap_or_default();
@@ -414,6 +414,8 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
 
     crate::config::populate_default_bindings(&mut app);
     load_config(&mut app);
+    // new-session -e: apply after config so CLI overrides set-environment from config
+    crate::util::merge_session_env_into_app(&mut app, &session_env);
 
     // Execute queued plugin .ps1 scripts (e.g. theme plugins that use
     // PowerShell variables and call back to psmux via CLI).  We spawn
@@ -4039,3 +4041,7 @@ mod test_pane_title;
 #[cfg(test)]
 #[path = "../../tests-rs/test_issue202_switch_client.rs"]
 mod test_issue202;
+
+#[cfg(test)]
+#[path = "../../tests-rs/test_new_session_env.rs"]
+mod test_new_session_env;

--- a/src/util.rs
+++ b/src/util.rs
@@ -192,10 +192,76 @@ pub fn quote_arg(s: &str) -> String {
     format!("\"{}\"", escaped)
 }
 
+/// Parse `VARIABLE=value` for tmux `new-session -e` / internal `server -e`
+/// (split on the first `=` so values may contain `=`).
+pub fn parse_env_assignment(s: &str) -> Result<(String, String), &'static str> {
+    let s = s.trim();
+    let eq = s.find('=').ok_or("expected VARIABLE=value")?;
+    if eq == 0 {
+        return Err("invalid environment variable name");
+    }
+    let name = &s[..eq];
+    let value = &s[eq + 1..];
+    if name.is_empty() || !is_valid_env_var_name(name) {
+        return Err("invalid environment variable name");
+    }
+    Ok((name.to_string(), value.to_string()))
+}
+
+/// Parse the token after `-e` on `new-session` or internal `server -e` (`VAR=value`).
+/// Shared by CLI short flags, control-protocol `new-session`, and [`collect_server_session_env_args`].
+pub fn parse_new_session_e_value_token(next_arg: Option<&str>) -> Result<(String, String), String> {
+    let Some(s) = next_arg else {
+        return Err("-e requires a value".to_string());
+    };
+    parse_env_assignment(s).map_err(|e| format!("invalid -e: {}", e))
+}
+
+fn is_valid_env_var_name(name: &str) -> bool {
+    let mut chars = name.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    if !(first.is_ascii_alphabetic() || first == '_') {
+        return false;
+    }
+    for c in chars {
+        if !(c.is_ascii_alphanumeric() || c == '_') {
+            return false;
+        }
+    }
+    true
+}
+
+/// Merge CLI `new-session -e` pairs into session environment (after `load_config`).
+pub fn merge_session_env_into_app(app: &mut AppState, session_env: &[(String, String)]) {
+    for (k, v) in session_env {
+        app.environment.insert(k.clone(), v.clone());
+    }
+}
+
+/// Collect `-e` flags from internal `server` argv (only before `--`).
+pub fn collect_server_session_env_args(args: &[String]) -> Result<Vec<(String, String)>, String> {
+    let limit = args.iter().position(|a| a == "--").unwrap_or(args.len());
+    let mut out = Vec::new();
+    let mut i = 0;
+    while i < limit {
+        if args[i] == "-e" {
+            let pair = parse_new_session_e_value_token(args.get(i + 1).map(|s| s.as_str()))?;
+            out.push(pair);
+            i += 2;
+        } else {
+            i += 1;
+        }
+    }
+    Ok(out)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::commands::parse_command_line;
+    use crate::types::AppState;
 
     #[test]
     fn test_quote_arg_simple() {
@@ -361,6 +427,98 @@ mod tests {
         let line = "send-keys \"cd 'C:\\Users\\foo\\project'\" Enter";
         let args = parse_command_line(line);
         assert_eq!(args[1], "cd 'C:\\Users\\foo\\project'");
+    }
+
+    #[test]
+    fn parse_env_assignment_basic() {
+        assert_eq!(
+            parse_env_assignment("FOO=bar").unwrap(),
+            ("FOO".to_string(), "bar".to_string())
+        );
+    }
+
+    #[test]
+    fn parse_env_assignment_empty_value() {
+        assert_eq!(
+            parse_env_assignment("VAR=").unwrap(),
+            ("VAR".to_string(), "".to_string())
+        );
+    }
+
+    #[test]
+    fn parse_env_assignment_value_with_equals() {
+        assert_eq!(
+            parse_env_assignment("FOO=a=b=c").unwrap(),
+            ("FOO".to_string(), "a=b=c".to_string())
+        );
+    }
+
+    #[test]
+    fn parse_env_assignment_rejects_no_equals() {
+        assert!(parse_env_assignment("FOO").is_err());
+    }
+
+    #[test]
+    fn parse_env_assignment_rejects_bad_name() {
+        assert!(parse_env_assignment("123=x").is_err());
+        assert!(parse_env_assignment("bad-name=x").is_err());
+    }
+
+    #[test]
+    fn parse_new_session_e_value_token_missing() {
+        assert_eq!(
+            parse_new_session_e_value_token(None).unwrap_err(),
+            "-e requires a value"
+        );
+    }
+
+    #[test]
+    fn parse_new_session_e_value_token_ok() {
+        let p = parse_new_session_e_value_token(Some("Z=1")).unwrap();
+        assert_eq!(p, ("Z".to_string(), "1".to_string()));
+    }
+
+    #[test]
+    fn collect_server_session_env_skips_after_dd() {
+        let args = vec![
+            "psmux".into(),
+            "server".into(),
+            "-s".into(),
+            "s1".into(),
+            "-e".into(),
+            "A=1".into(),
+            "--".into(),
+            "cmd".into(),
+            "-e".into(),
+            "IGNORE=me".into(),
+        ];
+        let v = collect_server_session_env_args(&args).unwrap();
+        assert_eq!(v, vec![("A".to_string(), "1".to_string())]);
+    }
+
+    #[test]
+    fn collect_server_session_env_duplicate_key_last_in_vec() {
+        let args = vec![
+            "psmux".into(),
+            "server".into(),
+            "-s".into(),
+            "s1".into(),
+            "-e".into(),
+            "FOO=first".into(),
+            "-e".into(),
+            "FOO=last".into(),
+        ];
+        let v = collect_server_session_env_args(&args).unwrap();
+        assert_eq!(
+            v,
+            vec![
+                ("FOO".to_string(), "first".to_string()),
+                ("FOO".to_string(), "last".to_string()),
+            ]
+        );
+        let mut app = AppState::new("t".to_string());
+        merge_session_env_into_app(&mut app, &v);
+        assert_eq!(app.environment.get("FOO").map(|s| s.as_str()), Some("last"));
     }
 }
 

--- a/tests-rs/test_new_session_env.rs
+++ b/tests-rs/test_new_session_env.rs
@@ -1,0 +1,33 @@
+//! new-session -e: session environment merges into app.environment and format expansion.
+
+use crate::types::AppState;
+use crate::config::parse_config_content;
+use crate::format::expand_format;
+
+#[test]
+fn session_env_merge_after_config_visible_in_expand_format() {
+    let mut app = AppState::new("sess_e".to_string());
+    parse_config_content(&mut app, "");
+    let env = vec![("PSMUX_NS_E_TEST".to_string(), "from_cli".to_string())];
+    crate::util::merge_session_env_into_app(&mut app, &env);
+    assert_eq!(
+        app.environment.get("PSMUX_NS_E_TEST").map(|s| s.as_str()),
+        Some("from_cli")
+    );
+    let out = expand_format("#{PSMUX_NS_E_TEST}", &app);
+    assert_eq!(out, "from_cli");
+}
+
+/// tmux: repeated `-e` for the same variable — last wins (HashMap insert order).
+#[test]
+fn session_env_merge_last_wins_duplicate_variable() {
+    let mut app = AppState::new("sess_e2".to_string());
+    parse_config_content(&mut app, "");
+    let env = vec![
+        ("PSMUX_DUP_E".to_string(), "first".to_string()),
+        ("PSMUX_DUP_E".to_string(), "last".to_string()),
+    ];
+    crate::util::merge_session_env_into_app(&mut app, &env);
+    assert_eq!(app.environment.get("PSMUX_DUP_E").map(|s| s.as_str()), Some("last"));
+    assert_eq!(expand_format("#{PSMUX_DUP_E}", &app), "last");
+}


### PR DESCRIPTION
Here is my attempt at adding this feature. I dont really code in Rust, so if there is any AI slop, please point it out.  I didn't like these big blocks added to the `-e` parsing in [main.rs](https://github.com/pbolduc/psmux/blob/9f9d59abc29ea70e76c3af2bdb25d5cf880eecdb/src/main.rs#L509-L520), [commands.rs](https://github.com/pbolduc/psmux/blob/9f9d59abc29ea70e76c3af2bdb25d5cf880eecdb/src/commands.rs#L1582-L1591) and [connection.rs](https://github.com/pbolduc/psmux/blob/9f9d59abc29ea70e76c3af2bdb25d5cf880eecdb/src/server/connection.rs#L1813-L1822). Please advise of any changes you would like to see.

- Enhanced the `new-session` command to accept `-e VAR=value` flags for setting environment variables.
- Implemented parsing for environment variable assignments and integrated them into the session environment.
- Updated relevant functions to handle the new session environment variables, ensuring they are applied after loading the configuration.
- Added tests for parsing and collecting environment variable arguments to ensure correctness.

Fixes #205 