### PR TITLE
feat: add pwsh-mouse-selection option

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -35,73 +35,99 @@ fn modified_key_name(base: &str, mods: KeyModifiers) -> String {
 /// Extract selected text from the layout tree given absolute terminal coordinates.
 /// Computes pane areas via the same Layout splitting render_json uses, then reads
 /// characters from the run-length-encoded rows_v2 data.
-fn extract_selection_text(
-    layout: &LayoutJson,
-    term_width: u16,
-    content_height: u16, // excluding status bar
-    start: (u16, u16),   // (col, row)
-    end: (u16, u16),
-) -> String {
-    // Normalise so (r0,c0) <= (r1,c1) in reading order
-    let (r0, c0, r1, c1) = if (start.1, start.0) <= (end.1, end.0) {
-        (start.1, start.0, end.1, end.0)
-    } else {
-        (end.1, end.0, start.1, start.0)
-    };
+struct PaneLeaf<'a> {
+    inner: Rect,
+    rows_v2: &'a [RowRunsJson],
+}
 
-    // Collect leaf panes with their inner areas and content
-    struct PaneLeaf<'a> {
-        inner: Rect,
-        rows_v2: &'a [RowRunsJson],
-    }
-
-    fn collect_leaves<'a>(node: &'a LayoutJson, area: Rect, out: &mut Vec<PaneLeaf<'a>>) {
-        match node {
-            LayoutJson::Leaf { rows_v2, .. } => {
-                // No borders — content fills entire area (tmux-style)
-                out.push(PaneLeaf { inner: area, rows_v2 });
-            }
-            LayoutJson::Split { kind, sizes, children } => {
-                let effective_sizes: Vec<u16> = if sizes.len() == children.len() {
-                    sizes.clone()
-                } else {
-                    vec![(100 / children.len().max(1)) as u16; children.len()]
-                };
-                let is_horizontal = kind == "Horizontal";
-                let rects = split_with_gaps(is_horizontal, &effective_sizes, area);
-                for (i, child) in children.iter().enumerate() {
-                    if i < rects.len() {
-                        collect_leaves(child, rects[i], out);
-                    }
+fn collect_leaves<'a>(node: &'a LayoutJson, area: Rect, out: &mut Vec<PaneLeaf<'a>>) {
+    match node {
+        LayoutJson::Leaf { rows_v2, .. } => {
+            out.push(PaneLeaf { inner: area, rows_v2 });
+        }
+        LayoutJson::Split { kind, sizes, children } => {
+            let effective_sizes: Vec<u16> = if sizes.len() == children.len() {
+                sizes.clone()
+            } else {
+                vec![(100 / children.len().max(1)) as u16; children.len()]
+            };
+            let is_horizontal = kind == "Horizontal";
+            let rects = split_with_gaps(is_horizontal, &effective_sizes, area);
+            for (i, child) in children.iter().enumerate() {
+                if i < rects.len() {
+                    collect_leaves(child, rects[i], out);
                 }
             }
         }
     }
+}
+
+/// Get the character at a column position within a row's runs.
+///
+/// `run.text` may be shorter than `run.width` (single repeated char) or
+/// multi-char (wide chars); pick the nth char if present.
+fn char_at_col(runs: &[crate::layout::CellRunJson], local_col: usize) -> char {
+    let mut cursor = 0usize;
+    for run in runs {
+        let run_width = run.width.max(1) as usize;
+        if local_col >= cursor && local_col < cursor + run_width {
+            let offset = local_col - cursor;
+            return run.text.chars().nth(offset).unwrap_or(' ');
+        }
+        cursor += run_width;
+    }
+    ' '
+}
+
+/// Expand a row's runs into a dense `Vec<char>` indexed by local column.
+/// Used by hot paths (word-boundary scan) that would otherwise call
+/// `char_at_col` O(width) times and pay O(width²) total.
+fn row_chars(runs: &[crate::layout::CellRunJson], width: usize) -> Vec<char> {
+    let mut out = vec![' '; width];
+    let mut cursor = 0usize;
+    for run in runs {
+        let run_width = run.width.max(1) as usize;
+        let chars: Vec<char> = run.text.chars().collect();
+        for i in 0..run_width {
+            let col = cursor + i;
+            if col >= width { break; }
+            out[col] = chars.get(i).copied().unwrap_or(' ');
+        }
+        cursor += run_width;
+        if cursor >= width { break; }
+    }
+    out
+}
+
+/// Normalise a selection (start, end) into reading-order or block-mode bounds.
+fn normalize_selection(start: (u16, u16), end: (u16, u16), block: bool) -> (u16, u16, u16, u16) {
+    if block {
+        (start.1.min(end.1), start.0.min(end.0), start.1.max(end.1), start.0.max(end.0))
+    } else if (start.1, start.0) <= (end.1, end.0) {
+        (start.1, start.0, end.1, end.0)
+    } else {
+        (end.1, end.0, start.1, start.0)
+    }
+}
+
+fn extract_selection_text(
+    layout: &LayoutJson,
+    term_width: u16,
+    content_height: u16,
+    start: (u16, u16),
+    end: (u16, u16),
+    block: bool,
+) -> String {
+    let (r0, c0, r1, c1) = normalize_selection(start, end, block);
 
     let content_area = Rect { x: 0, y: 0, width: term_width, height: content_height };
     let mut leaves: Vec<PaneLeaf> = Vec::new();
     collect_leaves(layout, content_area, &mut leaves);
 
-    // Helper: get character at a local column position within a row's runs
-    fn char_at_col(runs: &[crate::layout::CellRunJson], local_col: usize) -> char {
-        let mut cursor = 0usize;
-        for run in runs {
-            let run_width = run.width.max(1) as usize;
-            if local_col >= cursor && local_col < cursor + run_width {
-                let offset = local_col - cursor;
-                // Run text may be shorter than run_width (e.g. single char repeated)
-                // or multi-char for wide chars. Pick the nth char if available.
-                return run.text.chars().nth(offset).unwrap_or(' ');
-            }
-            cursor += run_width;
-        }
-        ' '
-    }
-
     let mut result = String::new();
     for row in r0..=r1 {
-        let col_start = if row == r0 { c0 } else { 0 };
-        let col_end = if row == r1 { c1 } else { term_width.saturating_sub(1) };
+        let col_start = if block || row == r0 { c0 } else { 0 };
+        let col_end = if block || row == r1 { c1 } else { term_width.saturating_sub(1) };
 
         let mut line = String::new();
         for col in col_start..=col_end {
@@ -121,7 +147,6 @@ fn extract_selection_text(
             }
             line.push(ch);
         }
-        // Trim trailing whitespace per line
         let trimmed = line.trim_end();
         result.push_str(trimmed);
         if row < r1 {
@@ -150,6 +175,51 @@ fn active_pane_in_copy_mode(layout: &LayoutJson) -> bool {
         LayoutJson::Leaf { active, copy_mode, .. } => *active && *copy_mode,
         LayoutJson::Split { children, .. } => children.iter().any(|c| active_pane_in_copy_mode(c)),
     }
+}
+
+fn is_word_char(c: char) -> bool {
+    c.is_alphanumeric() || c == '_'
+}
+
+/// Find the (start_col, end_col) of the word at `(col, row)` inside the
+/// given pane. Returns None when the cell is not a word character.
+///
+/// `layout` is walked to resolve the clicked leaf's `rows_v2` — the caller
+/// already knows `pane_rect`, but it does not have a handle to the raw
+/// content, so we do a single targeted descent.
+fn word_bounds_at(
+    layout: &LayoutJson,
+    term_width: u16,
+    content_height: u16,
+    pane_rect: Rect,
+    col: u16,
+    row: u16,
+) -> Option<(u16, u16)> {
+    let content_area = Rect { x: 0, y: 0, width: term_width, height: content_height };
+    let mut leaves: Vec<PaneLeaf> = Vec::new();
+    collect_leaves(layout, content_area, &mut leaves);
+
+    let leaf = leaves.iter().find(|l| l.inner == pane_rect)?;
+
+    let local_row = row.checked_sub(leaf.inner.y)? as usize;
+    if local_row >= leaf.rows_v2.len() { return None; }
+    let width = leaf.inner.width as usize;
+    let chars = row_chars(&leaf.rows_v2[local_row].runs, width);
+
+    let local_col = col.checked_sub(leaf.inner.x)? as usize;
+    if local_col >= width { return None; }
+    if !is_word_char(chars[local_col]) { return None; }
+
+    let mut left = local_col;
+    while left > 0 && is_word_char(chars[left - 1]) {
+        left -= 1;
+    }
+    let mut right = local_col;
+    while right + 1 < width && is_word_char(chars[right + 1]) {
+        right += 1;
+    }
+
+    Some((leaf.inner.x + left as u16, leaf.inner.x + right as u16))
 }
 
 /// Check if screen coordinates (x, y) fall on a separator line in the layout.
@@ -621,6 +691,9 @@ pub fn run_remote(terminal: &mut Terminal<CrosstermBackend<crate::platform::Psmu
         /// When true, hardcoded default keybindings are suppressed (set by unbind-key -a)
         #[serde(default)]
         defaults_suppressed: bool,
+        /// pwsh-mouse-selection option (mirror of server-side AppState field)
+        #[serde(default)]
+        pwsh_mouse_selection: bool,
         /// status-left-length (max display width for left status)
         #[serde(default = "default_status_left_length")]
         status_left_length: usize,
@@ -741,7 +814,14 @@ pub fn run_remote(terminal: &mut Terminal<CrosstermBackend<crate::platform::Psmu
     // Text selection state (client-side only, left-click drag like pwsh)
     let mut rsel_start: Option<(u16, u16)> = None;  // (col, row) in terminal coords
     let mut rsel_end: Option<(u16, u16)> = None;
+    let mut rsel_pane_rect: Option<Rect> = None;    // clip bounds of the originating pane
     let mut rsel_dragged = false;
+    // Multi-click tracking for word/line selection.
+    let mut last_click: Option<(Instant, (u16, u16))> = None;
+    let mut click_count: u32 = 0;
+    // When true, the current rsel selection uses rectangular (block) mode
+    // instead of reading-order. Triggered by Alt held on MouseDown.
+    let mut rsel_block: bool = false;
     let mut selection_changed = false; // forces redraw for selection overlay
     let mut border_drag = false; // true when dragging a pane separator (resize)
     // Client-side tab position tracking for accurate mouse click detection.
@@ -754,6 +834,7 @@ pub fn run_remote(terminal: &mut Terminal<CrosstermBackend<crate::platform::Psmu
     let mut client_borders: Vec<(Vec<usize>, String, usize, u16, u16, Vec<u16>, Rect)> = Vec::new();
     let mut client_content_area: Rect = Rect::default();
     let mut client_copy_mode: bool = false;
+    let mut client_pwsh_selection: bool = false;
     let mut client_zoomed: bool = false;
     let mut client_drag: Option<ClientDragState> = None;
     // Border hover highlight: (position, kind, area) of the border under the cursor.
@@ -1907,6 +1988,81 @@ pub fn run_remote(terminal: &mut Terminal<CrosstermBackend<crate::platform::Psmu
                                 KeyCode::Char(c) if key.modifiers.contains(KeyModifiers::ALT) => {
                                     cmd_batch.push(format!("send-key M-{}\n", c));
                                 }
+                                // pwsh-mouse-selection: Ctrl+Shift+C / Ctrl+Shift+V
+                                // explicit copy/paste regardless of selection state.
+                                KeyCode::Char('C') if client_pwsh_selection
+                                    && key.kind == KeyEventKind::Press
+                                    && key.modifiers.contains(KeyModifiers::CONTROL)
+                                    && key.modifiers.contains(KeyModifiers::SHIFT) =>
+                                {
+                                    if let (Some(s), Some(e)) = (rsel_start, rsel_end) {
+                                        if rsel_dragged {
+                                            if let Ok(state) = serde_json::from_str::<DumpState>(&prev_dump_buf) {
+                                                let text = extract_selection_text(
+                                                    &state.layout,
+                                                    last_sent_size.0,
+                                                    last_sent_size.1,
+                                                    s, e,
+                                                    rsel_block,
+                                                );
+                                                if !text.is_empty() {
+                                                    copy_to_system_clipboard(&text);
+                                                    pending_osc52 = Some(text);
+                                                }
+                                            }
+                                        }
+                                    }
+                                    rsel_start = None;
+                                    rsel_end = None;
+                                    rsel_pane_rect = None;
+                                    rsel_block = false;
+                                    rsel_dragged = false;
+                                    selection_changed = true;
+                                }
+                                KeyCode::Char('V') if client_pwsh_selection
+                                    && key.kind == KeyEventKind::Press
+                                    && key.modifiers.contains(KeyModifiers::CONTROL)
+                                    && key.modifiers.contains(KeyModifiers::SHIFT) =>
+                                {
+                                    if let Some(text) = read_from_system_clipboard() {
+                                        if !text.is_empty() {
+                                            let encoded = base64_encode(&text);
+                                            cmd_batch.push(format!("send-paste {}\n", encoded));
+                                        }
+                                    }
+                                }
+                                // Ctrl+C smart: when a selection is active in
+                                // pwsh-mouse-selection mode, copy and clear.
+                                // Otherwise fall through to the generic Ctrl handler
+                                // which sends SIGINT to the shell.
+                                KeyCode::Char('c') if client_pwsh_selection
+                                    && key.kind == KeyEventKind::Press
+                                    && key.modifiers == KeyModifiers::CONTROL
+                                    && rsel_dragged
+                                    && rsel_start.is_some() =>
+                                {
+                                    if let (Some(s), Some(e)) = (rsel_start, rsel_end) {
+                                        if let Ok(state) = serde_json::from_str::<DumpState>(&prev_dump_buf) {
+                                            let text = extract_selection_text(
+                                                &state.layout,
+                                                last_sent_size.0,
+                                                last_sent_size.1,
+                                                s, e,
+                                                rsel_block,
+                                            );
+                                            if !text.is_empty() {
+                                                copy_to_system_clipboard(&text);
+                                                pending_osc52 = Some(text);
+                                            }
+                                        }
+                                    }
+                                    rsel_start = None;
+                                    rsel_end = None;
+                                    rsel_pane_rect = None;
+                                    rsel_block = false;
+                                    rsel_dragged = false;
+                                    selection_changed = true;
+                                }
                                 // On Windows, suppress Ctrl+V Press — the console host
                                 // already injected clipboard content as character events
                                 // and the paste mechanism handles them.  Forwarding C-v
@@ -2072,15 +2228,81 @@ pub fn run_remote(terminal: &mut Terminal<CrosstermBackend<crate::platform::Psmu
                                                     pane_id, rel_col, rel_row));
                                                 rsel_start = None;
                                                 rsel_end = None;
+                                                rsel_pane_rect = None;
+                                                rsel_block = false;
                                                 selection_changed = true;
                                             } else {
                                                 cmd_batch.push(format!("pane-mouse {} 0 {} {} M\n",
                                                     pane_id, rel_col, rel_row));
                                                 border_drag = false;
-                                                rsel_start = Some((me.column, me.row));
-                                                rsel_end = Some((me.column, me.row));
-                                                rsel_dragged = false;
-                                                selection_changed = true;
+
+                                                // Ctrl+click extends an existing selection to the click
+                                                // position without starting a new one. (Shift+click
+                                                // cannot be used on Windows Terminal — it is reserved
+                                                // for WT's native selection override.) Only active
+                                                // when pwsh-mouse-selection is on and a selection
+                                                // already exists in the same pane.
+                                                let ctrl_extend = client_pwsh_selection
+                                                    && me.modifiers.contains(KeyModifiers::CONTROL)
+                                                    && rsel_start.is_some()
+                                                    && rsel_pane_rect == Some(pane_rect);
+
+                                                if ctrl_extend {
+                                                    let r = pane_rect;
+                                                    let col = me.column.clamp(r.x, r.x + r.width.saturating_sub(1));
+                                                    let row = me.row.clamp(r.y, r.y + r.height.saturating_sub(1));
+                                                    rsel_end = Some((col, row));
+                                                    rsel_dragged = true;
+                                                    selection_changed = true;
+                                                } else if client_pwsh_selection {
+                                                    rsel_block = me.modifiers.contains(KeyModifiers::ALT);
+                                                    rsel_pane_rect = Some(pane_rect);
+                                                    rsel_dragged = false;
+                                                    selection_changed = true;
+
+                                                    let now = Instant::now();
+                                                    let is_multi = last_click.map_or(false, |(t, (c, r))| {
+                                                        now.duration_since(t) < Duration::from_millis(400)
+                                                            && c == me.column && r == me.row
+                                                    });
+                                                    click_count = if is_multi { click_count + 1 } else { 1 };
+                                                    last_click = Some((now, (me.column, me.row)));
+
+                                                    let word = if click_count == 2 {
+                                                        serde_json::from_str::<DumpState>(&prev_dump_buf).ok()
+                                                            .and_then(|s| word_bounds_at(
+                                                                &s.layout,
+                                                                last_sent_size.0,
+                                                                last_sent_size.1,
+                                                                pane_rect,
+                                                                me.column, me.row,
+                                                            ))
+                                                    } else {
+                                                        None
+                                                    };
+
+                                                    if let Some((ws, we)) = word {
+                                                        rsel_start = Some((ws, me.row));
+                                                        rsel_end = Some((we, me.row));
+                                                        rsel_dragged = true;
+                                                    } else if click_count >= 3 {
+                                                        let left = pane_rect.x;
+                                                        let right = pane_rect.x + pane_rect.width.saturating_sub(1);
+                                                        rsel_start = Some((left, me.row));
+                                                        rsel_end = Some((right, me.row));
+                                                        rsel_dragged = true;
+                                                    } else {
+                                                        rsel_start = Some((me.column, me.row));
+                                                        rsel_end = None;
+                                                    }
+                                                } else {
+                                                    // Legacy: start == end for 1-cell hint.
+                                                    rsel_start = Some((me.column, me.row));
+                                                    rsel_end = Some((me.column, me.row));
+                                                    rsel_pane_rect = Some(pane_rect);
+                                                    rsel_dragged = false;
+                                                    selection_changed = true;
+                                                }
                                             }
                                         } else {
                                             cmd_batch.push(format!("mouse-down {} {}\n", me.column, me.row));
@@ -2120,6 +2342,7 @@ pub fn run_remote(terminal: &mut Terminal<CrosstermBackend<crate::platform::Psmu
                                                 last_sent_size.0,
                                                 last_sent_size.1,
                                                 s, e,
+                                                rsel_block,
                                             );
                                             if !text.is_empty() {
                                                 copy_to_system_clipboard(&text);
@@ -2194,10 +2417,28 @@ pub fn run_remote(terminal: &mut Terminal<CrosstermBackend<crate::platform::Psmu
                                         cmd_batch.push(format!("mouse-drag {} {}\n", me.column, me.row));
                                     }
                                 } else {
-                                    if rsel_start.is_some() {
-                                        rsel_end = Some((me.column, me.row));
-                                        rsel_dragged = true;
-                                        selection_changed = true;
+                                    if let Some(start) = rsel_start {
+                                        let (col, row) = if client_pwsh_selection {
+                                            if let Some(r) = rsel_pane_rect {
+                                                (
+                                                    me.column.clamp(r.x, r.x + r.width.saturating_sub(1)),
+                                                    me.row.clamp(r.y, r.y + r.height.saturating_sub(1)),
+                                                )
+                                            } else {
+                                                (me.column, me.row)
+                                            }
+                                        } else {
+                                            (me.column, me.row)
+                                        };
+                                        // Ignore micro-drags that stay on the
+                                        // initial click cell (#199 parity).
+                                        if (col, row) == start && !rsel_dragged {
+                                            // no-op
+                                        } else {
+                                            rsel_end = Some((col, row));
+                                            rsel_dragged = true;
+                                            selection_changed = true;
+                                        }
                                     }
                                 }
                             }
@@ -2208,28 +2449,44 @@ pub fn run_remote(terminal: &mut Terminal<CrosstermBackend<crate::platform::Psmu
                                     border_drag = false;
                                     client_drag = None;
                                 } else if rsel_dragged {
-                                    rsel_end = Some((me.column, me.row));
-                                    if let (Some(s), Some(e)) = (rsel_start, rsel_end) {
-                                        if let Ok(state) = serde_json::from_str::<DumpState>(&prev_dump_buf) {
-                                            let text = extract_selection_text(
-                                                &state.layout,
-                                                last_sent_size.0,
-                                                last_sent_size.1,
-                                                s, e,
-                                            );
-                                            if !text.is_empty() {
-                                                copy_to_system_clipboard(&text);
-                                                pending_osc52 = Some(text);
+                                    if client_pwsh_selection {
+                                        // Windows 11 style: keep the selection
+                                        // visible until the user right-clicks to
+                                        // copy. Do not overwrite rsel_end here —
+                                        // the drag handler already tracks it,
+                                        // and double-click word bounds must not
+                                        // be replaced by the release-position.
+                                        selection_changed = true;
+                                    } else {
+                                        // Legacy: copy-on-release.
+                                        rsel_end = Some((me.column, me.row));
+                                        if let (Some(s), Some(e)) = (rsel_start, rsel_end) {
+                                            if let Ok(state) = serde_json::from_str::<DumpState>(&prev_dump_buf) {
+                                                let text = extract_selection_text(
+                                                    &state.layout,
+                                                    last_sent_size.0,
+                                                    last_sent_size.1,
+                                                    s, e,
+                                                    false,
+                                                );
+                                                if !text.is_empty() {
+                                                    copy_to_system_clipboard(&text);
+                                                    pending_osc52 = Some(text);
+                                                }
                                             }
                                         }
+                                        rsel_start = None;
+                                        rsel_end = None;
+                                        rsel_pane_rect = None;
+                                        rsel_block = false;
+                                        rsel_dragged = false;
+                                        selection_changed = true;
                                     }
-                                    rsel_start = None;
-                                    rsel_end = None;
-                                    rsel_dragged = false;
-                                    selection_changed = true;
                                 } else {
                                     rsel_start = None;
                                     rsel_end = None;
+                                    rsel_pane_rect = None;
+                                    rsel_block = false;
                                     selection_changed = true;
                                     if client_copy_mode {
                                         if let Some(&(pane_id, pane_rect)) = client_pane_rects.iter().find(|(_, r)| {
@@ -2473,6 +2730,7 @@ pub fn run_remote(terminal: &mut Terminal<CrosstermBackend<crate::platform::Psmu
         let base_index = state.base_index;
         client_base_index = base_index;
         client_copy_mode = active_pane_in_copy_mode(&root);
+        client_pwsh_selection = state.pwsh_mouse_selection;
         client_zoomed = state.zoomed;
         let dim_preds = state.prediction_dimming;
         clock_active = state.clock_mode;
@@ -2676,6 +2934,9 @@ pub fn run_remote(terminal: &mut Terminal<CrosstermBackend<crate::platform::Psmu
         // ── STEP 3: Render ───────────────────────────────────────────────
         let sel_s = rsel_start;
         let sel_e = rsel_end;
+        let sel_rect = rsel_pane_rect;
+        let sel_pwsh = client_pwsh_selection;
+        let sel_block = rsel_block;
         let status_at_top = status_position_str == "top";
         if client_log_enabled() {
             let sz = terminal.size().unwrap_or_default();
@@ -3183,23 +3444,40 @@ pub fn run_remote(terminal: &mut Terminal<CrosstermBackend<crate::platform::Psmu
             // selection and the blue overlay would hide everything.
             if let (Some(s), Some(e)) = (sel_s, sel_e) {
             if !active_pane_in_copy_mode(&root) {
-                // Normalise so (r0,c0) <= (r1,c1) in reading order
-                let (r0, c0, r1, c1) = if (s.1, s.0) <= (e.1, e.0) {
-                    (s.1, s.0, e.1, e.0)
+                let (r0, c0, r1, c1) = normalize_selection(s, e, sel_block);
+                // pwsh-mouse-selection: clip intermediate rows to the
+                // originating pane so they never bleed into neighbours.
+                // Legacy mode: full terminal width on intermediate rows.
+                let (pane_left, pane_right) = if sel_pwsh {
+                    if let Some(r) = sel_rect {
+                        (r.x, r.x + r.width.saturating_sub(1))
+                    } else {
+                        (0, area.width.saturating_sub(1))
+                    }
                 } else {
-                    (e.1, e.0, s.1, s.0)
+                    (0, area.width.saturating_sub(1))
                 };
                 let buf = f.buffer_mut();
                 let buf_area = buf.area;
                 for row in r0..=r1 {
-                    let col_start = if row == r0 { c0 } else { 0 };
-                    let col_end = if row == r1 { c1 } else { area.width.saturating_sub(1) };
+                    let col_start = if sel_block {
+                        c0.max(pane_left)
+                    } else if row == r0 { c0.max(pane_left) } else { pane_left };
+                    let col_end = if sel_block {
+                        c1.min(pane_right)
+                    } else if row == r1 { c1.min(pane_right) } else { pane_right };
+                    if col_start > col_end { continue; }
                     for col in col_start..=col_end {
                         if row < buf_area.height && col < buf_area.width {
                             let idx = (row - buf_area.y) as usize * buf_area.width as usize
                                 + (col - buf_area.x) as usize;
                             if idx < buf.content.len() {
-                                buf.content[idx].set_style(Style::default().fg(Color::Black).bg(Color::LightCyan));
+                                let style = if sel_pwsh {
+                                    Style::default().fg(Color::Black).bg(Color::White)
+                                } else {
+                                    Style::default().fg(Color::Black).bg(Color::LightCyan)
+                                };
+                                buf.content[idx].set_style(style);
                             }
                         }
                     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -510,6 +510,7 @@ pub fn parse_option_value(app: &mut AppState, rest: &str, _is_global: bool) {
         "status-right" => app.status_right = value.to_string(),
         "mouse" => app.mouse_enabled = matches!(value, "on" | "true" | "1"),
         "scroll-enter-copy-mode" => app.scroll_enter_copy_mode = matches!(value, "on" | "true" | "1"),
+        "pwsh-mouse-selection" => app.pwsh_mouse_selection = matches!(value, "on" | "true" | "1"),
         "prefix" => {
             if let Some(key) = parse_key_name(value) {
                 app.prefix_key = key;

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1272,7 +1272,7 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                     };
                     let cursor_style_code = crate::rendering::configured_cursor_code();
                     let _ = std::fmt::Write::write_fmt(&mut combined_buf, format_args!(
-                        "{{\"layout\":{},\"windows\":{},\"prefix\":\"{}\",\"prefix2\":\"{}\",\"tree\":{},\"base_index\":{},\"prediction_dimming\":{},\"status_style\":\"{}\",\"status_left\":\"{}\",\"status_right\":\"{}\",\"pane_border_style\":\"{}\",\"pane_active_border_style\":\"{}\",\"pane_border_hover_style\":\"{}\",\"wsf\":\"{}\",\"wscf\":\"{}\",\"wss\":\"{}\",\"ws_style\":\"{}\",\"wsc_style\":\"{}\",\"clock_mode\":{},\"bindings\":{},\"status_left_length\":{},\"status_right_length\":{},\"status_lines\":{},\"status_format\":{},\"mode_style\":\"{}\",\"status_position\":\"{}\",\"status_justify\":\"{}\",\"cursor_style_code\":{},\"status_visible\":{},\"repeat_time\":{},\"zoomed\":{},\"defaults_suppressed\":{}}}",
+                        "{{\"layout\":{},\"windows\":{},\"prefix\":\"{}\",\"prefix2\":\"{}\",\"tree\":{},\"base_index\":{},\"prediction_dimming\":{},\"status_style\":\"{}\",\"status_left\":\"{}\",\"status_right\":\"{}\",\"pane_border_style\":\"{}\",\"pane_active_border_style\":\"{}\",\"pane_border_hover_style\":\"{}\",\"wsf\":\"{}\",\"wscf\":\"{}\",\"wss\":\"{}\",\"ws_style\":\"{}\",\"wsc_style\":\"{}\",\"clock_mode\":{},\"bindings\":{},\"status_left_length\":{},\"status_right_length\":{},\"status_lines\":{},\"status_format\":{},\"mode_style\":\"{}\",\"status_position\":\"{}\",\"status_justify\":\"{}\",\"cursor_style_code\":{},\"status_visible\":{},\"repeat_time\":{},\"zoomed\":{},\"defaults_suppressed\":{},\"pwsh_mouse_selection\":{}}}",
                         layout_json, cached_windows_json, cached_prefix_str, cached_prefix2_str, cached_tree_json, cached_base_index, cached_pred_dim, ss_escaped, sl_expanded, sr_expanded, pbs_escaped, pabs_escaped, pbhs_escaped, wsf_escaped, wscf_escaped, wss_escaped, ws_style_escaped, wsc_style_escaped,
                         matches!(app.mode, Mode::ClockMode), cached_bindings_json,
                         app.status_left_length, app.status_right_length, app.status_lines, status_format_json,
@@ -1280,6 +1280,7 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                         cursor_style_code, app.status_visible, app.repeat_time_ms,
                         app.windows.get(app.active_idx).map_or(false, |w| w.zoom_saved.is_some()),
                         app.defaults_suppressed,
+                        app.pwsh_mouse_selection,
                     ));
                     // Inject overlay state (popup, menu, confirm, display_panes)
                     {
@@ -2478,6 +2479,7 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                             "status-right" => { app.status_right = "#{?window_bigger,[#{window_offset_x}#,#{window_offset_y}] ,}\"#{=21:pane_title}\" %H:%M %d-%b-%y".to_string(); }
                             "mouse" => { app.mouse_enabled = true; }
                             "scroll-enter-copy-mode" => { app.scroll_enter_copy_mode = true; }
+                            "pwsh-mouse-selection" => { app.pwsh_mouse_selection = false; }
                             "escape-time" => { app.escape_time_ms = 500; }
                             "history-limit" => { app.history_limit = 2000; }
                             "display-time" => { app.display_time_ms = 750; }
@@ -2532,6 +2534,7 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                     output.push_str(&format!("escape-time {}\n", app.escape_time_ms));
                     output.push_str(&format!("mouse {}\n", if app.mouse_enabled { "on" } else { "off" }));
                     output.push_str(&format!("scroll-enter-copy-mode {}\n", if app.scroll_enter_copy_mode { "on" } else { "off" }));
+                    output.push_str(&format!("pwsh-mouse-selection {}\n", if app.pwsh_mouse_selection { "on" } else { "off" }));
                     output.push_str(&format!("status {}\n", if app.status_visible { "on" } else { "off" }));
                     output.push_str(&format!("status-position {}\n", app.status_position));
                     output.push_str(&format!("status-left \"{}\"\n", app.status_left));
@@ -3842,13 +3845,14 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
             };
             let cursor_style_code = crate::rendering::configured_cursor_code();
             let _ = std::fmt::Write::write_fmt(&mut combined_buf, format_args!(
-                "{{\"layout\":{},\"windows\":{},\"prefix\":\"{}\",\"prefix2\":\"{}\",\"tree\":{},\"base_index\":{},\"prediction_dimming\":{},\"status_style\":\"{}\",\"status_left\":\"{}\",\"status_right\":\"{}\",\"pane_border_style\":\"{}\",\"pane_active_border_style\":\"{}\",\"pane_border_hover_style\":\"{}\",\"wsf\":\"{}\",\"wscf\":\"{}\",\"wss\":\"{}\",\"ws_style\":\"{}\",\"wsc_style\":\"{}\",\"clock_mode\":{},\"bindings\":{},\"status_left_length\":{},\"status_right_length\":{},\"status_lines\":{},\"status_format\":{},\"mode_style\":\"{}\",\"status_position\":\"{}\",\"status_justify\":\"{}\",\"cursor_style_code\":{},\"status_visible\":{},\"repeat_time\":{},\"zoomed\":{}}}",
+                "{{\"layout\":{},\"windows\":{},\"prefix\":\"{}\",\"prefix2\":\"{}\",\"tree\":{},\"base_index\":{},\"prediction_dimming\":{},\"status_style\":\"{}\",\"status_left\":\"{}\",\"status_right\":\"{}\",\"pane_border_style\":\"{}\",\"pane_active_border_style\":\"{}\",\"pane_border_hover_style\":\"{}\",\"wsf\":\"{}\",\"wscf\":\"{}\",\"wss\":\"{}\",\"ws_style\":\"{}\",\"wsc_style\":\"{}\",\"clock_mode\":{},\"bindings\":{},\"status_left_length\":{},\"status_right_length\":{},\"status_lines\":{},\"status_format\":{},\"mode_style\":\"{}\",\"status_position\":\"{}\",\"status_justify\":\"{}\",\"cursor_style_code\":{},\"status_visible\":{},\"repeat_time\":{},\"zoomed\":{},\"pwsh_mouse_selection\":{}}}",
                 layout_json, cached_windows_json, cached_prefix_str, cached_prefix2_str, cached_tree_json, cached_base_index, cached_pred_dim, ss_escaped, sl_expanded, sr_expanded, pbs_escaped, pabs_escaped, pbhs_escaped, wsf_escaped, wscf_escaped, wss_escaped, ws_style_escaped, wsc_style_escaped,
                 matches!(app.mode, Mode::ClockMode), cached_bindings_json,
                 app.status_left_length, app.status_right_length, app.status_lines, status_format_json,
                 mode_style_escaped, status_position_escaped, status_justify_escaped,
                 cursor_style_code, app.status_visible, app.repeat_time_ms,
                 app.windows.get(app.active_idx).map_or(false, |w| w.zoom_saved.is_some()),
+                app.pwsh_mouse_selection,
             ));
             // Inject overlay state (popup, menu, confirm, display_panes)
             {

--- a/src/server/option_catalog.rs
+++ b/src/server/option_catalog.rs
@@ -28,6 +28,7 @@ pub static OPTION_CATALOG: &[OptionDef] = &[
     OptionDef { name: "repeat-time", scope: "session", option_type: "number", default: "500", description: "Repeat timeout for prefix keys in ms" },
     OptionDef { name: "mouse", scope: "session", option_type: "boolean", default: "off", description: "Enable mouse support" },
     OptionDef { name: "scroll-enter-copy-mode", scope: "session", option_type: "boolean", default: "on", description: "Enter copy mode on mouse scroll up at shell prompt" },
+    OptionDef { name: "pwsh-mouse-selection", scope: "session", option_type: "boolean", default: "off", description: "Windows 11 PowerShell-style drag selection (pane-aware, right-click to copy, word/line multi-click)" },
     OptionDef { name: "mode-keys", scope: "session", option_type: "choice", default: "emacs", description: "Key bindings in copy mode (vi/emacs)" },
     OptionDef { name: "status", scope: "session", option_type: "boolean", default: "on", description: "Show/hide the status bar" },
     OptionDef { name: "status-position", scope: "session", option_type: "choice", default: "bottom", description: "Status bar position (top/bottom)" },

--- a/src/server/options.rs
+++ b/src/server/options.rs
@@ -31,6 +31,7 @@ pub(crate) fn get_option_value(app: &AppState, name: &str) -> String {
         "escape-time" => app.escape_time_ms.to_string(),
         "mouse" => if app.mouse_enabled { "on".into() } else { "off".into() },
         "scroll-enter-copy-mode" => if app.scroll_enter_copy_mode { "on".into() } else { "off".into() },
+        "pwsh-mouse-selection" => if app.pwsh_mouse_selection { "on".into() } else { "off".into() },
         "status" => {
             if !app.status_visible { "off".into() }
             else if app.status_lines >= 2 { app.status_lines.to_string() }
@@ -169,6 +170,7 @@ pub(crate) fn apply_set_option(app: &mut AppState, option: &str, value: &str, _q
         }
         "mouse" => { app.mouse_enabled = value == "on" || value == "true" || value == "1"; }
         "scroll-enter-copy-mode" => { app.scroll_enter_copy_mode = matches!(value, "on" | "true" | "1"); }
+        "pwsh-mouse-selection" => { app.pwsh_mouse_selection = matches!(value, "on" | "true" | "1"); }
         "prefix" => {
             if let Some(kc) = parse_key_string(value) {
                 app.prefix_key = kc;

--- a/src/types.rs
+++ b/src/types.rs
@@ -354,6 +354,11 @@ pub struct AppState {
     /// scroll-enter-copy-mode: when off, mouse scroll at a shell prompt does NOT
     /// auto-enter copy mode.  Default: on (tmux parity).
     pub scroll_enter_copy_mode: bool,
+    /// pwsh-mouse-selection: when on, client-side drag selection behaves like
+    /// Windows 11 PowerShell — pane-aware clipping, no copy-on-release (copy
+    /// only on right-click), word/line selection on double/triple-click.
+    /// Default: off (preserves the legacy pwsh-style copy-on-release).
+    pub pwsh_mouse_selection: bool,
     pub paste_buffers: Vec<String>,
     pub status_left: String,
     pub status_right: String,
@@ -628,6 +633,7 @@ impl AppState {
             last_window_area: Rect { x: 0, y: 0, width: 120, height: 30 },
             mouse_enabled: true,
             scroll_enter_copy_mode: true,
+            pwsh_mouse_selection: false,
             paste_buffers: Vec::new(),
             status_left: "[#S] ".to_string(),
             status_right: "#{?window_bigger,[#{window_offset_x}#,#{window_offset_y}] ,}\"#{=21:pane_title}\" %H:%M %d-%b-%y".to_string(),


### PR DESCRIPTION
## Summary

Adds a new `pwsh-mouse-selection` session option (boolean, default `off`) that opts into Windows 11 PowerShell-parity drag selection behaviour for the client-side `rsel` path.

Closes #211.

## When the option is on

- **Pane-aware overlay clipping** — fixes the latent bug where `rsel` paints the full terminal width on intermediate rows, bleeding into neighbouring panes.
- **Selection persists on mouse-up** — no implicit copy-on-release. Copy is explicit via right-click, `Ctrl+Shift+C`, or smart `Ctrl+C`.
- **Double-click / triple-click** — select word / whole line within the originating pane.
- **Ctrl+click** extends the existing selection to the click point. (Shift+click is reserved by Windows Terminal for its own native selection override and cannot be reclaimed.)
- **Alt+drag** produces a rectangular (block) selection.
- **Key bindings**: `Ctrl+Shift+C` (copy), `Ctrl+Shift+V` (paste from clipboard), and smart `Ctrl+C` (copy-if-selected, SIGINT otherwise).
- **Overlay colour** is white to more closely match Windows Terminal's native selection.

Default remains `off`, so existing behaviour is unchanged for anyone who does not opt in.

## Usage

```
# ~/.psmux.conf
set -g mouse on
set -g pwsh-mouse-selection on
```

## Changes

- `src/types.rs` — `AppState.pwsh_mouse_selection` field + default.
- `src/server/option_catalog.rs`, `src/server/options.rs`, `src/config.rs`, `src/server/mod.rs` — option plumbing parallel to `scroll-enter-copy-mode`, and `pwsh_mouse_selection` included in both dump JSON serialisation sites.
- `src/client.rs` — `DumpState.pwsh_mouse_selection` field, `client_pwsh_selection` local mirroring the dump, and gated drag/key handlers.
- **Refactor**: hoisted `PaneLeaf` / `collect_leaves` / `char_at_col` from inside `extract_selection_text` to module scope so `word_bounds_at` can share them; added `normalize_selection` helper used by `extract_selection_text` and the render path; added `row_chars` helper turning the double-click word scan from O(n²) to O(n).

## Notes

- **Shift+click** is not used because Windows Terminal reserves it as a native-selection override regardless of app-level mouse tracking; `Ctrl+click` is used instead.
- **Auto-scroll during drag at pane edges** is out of scope — `rsel` operates on visible content only, and scrolling the pane scrollback is copy mode's job.