### PR TITLE
fix: route switch-client CLI to source session server (#202)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -124,7 +124,14 @@ fn run_main() -> io::Result<()> {
             // directly. Otherwise (e.g. -t %2, -t :1.0) fall through to
             // the TMUX env var resolution below so we connect to the right
             // server when invoked from inside a psmux pane.
-            if has_explicit_session {
+            //
+            // Exception: for switch-client, -t is the DESTINATION session,
+            // not the server to route the command to. Skip setting
+            // PSMUX_TARGET_SESSION so the TMUX-based fallback below resolves
+            // the current (source) session for routing. PSMUX_TARGET_FULL
+            // still carries the destination for the server handler.
+            let is_switch_client = args.iter().any(|a| a == "switch-client" || a == "switchc");
+            if has_explicit_session && !is_switch_client {
                 env::set_var("PSMUX_TARGET_SESSION", &port_file_base);
             }
         }


### PR DESCRIPTION
## Summary

Fixes the remaining CLI path issue from #202: `psmux switch-client -t <session>` returns exit 0 but does not switch when invoked from the command line (works from `prefix + :`).

**Root cause:** The global `-t` parser in `main.rs` sets `PSMUX_TARGET_SESSION` for all commands, routing `send_control()` to the target session's server. But for `switch-client`, `-t` means "switch TO this session" (destination), not "route to this session's server" (source). The destination server receives the command and responds "already on that session" — doing nothing.

**Fix:** Skip setting `PSMUX_TARGET_SESSION` when the command is `switch-client` or `switchc`, so the existing TMUX-based fallback resolves the current (source) session for routing. `PSMUX_TARGET_FULL` still carries the destination for the server-side handler in `connection.rs`.

## Repro (before fix)

```powershell
# Inside a psmux pane (session "claude-watch"):
psmux switch-client -t convserv    # exit 0, no switch
# prefix + : → switch-client -t convserv  # works
```

## Test plan

- [ ] `psmux switch-client -t <other-session>` from CLI switches the terminal
- [ ] `psmux switch-client -n` / `-p` / `-l` from CLI still work
- [ ] `prefix + :` → `switch-client -t <session>` still works
- [ ] Other commands with `-t` (e.g. `select-window -t session:window`) still route correctly
- [ ] Existing Rust unit tests pass (`cargo test`)