### PR TITLE
Fix list-panes -s not iterating all windows when -F is used

### DIFF
--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -883,7 +883,7 @@ match cmd {
         let session_scope = args.iter().any(|a| *a == "-s");
         let (rtx, rrx) = mpsc::channel::<String>();
         if let Some(fmt_str) = fmt {
-            if all {
+            if all || session_scope {
                 let _ = tx.send(CtrlReq::ListAllPanesFormat(rtx, fmt_str));
             } else {
                 let _ = tx.send(CtrlReq::ListPanesFormat(rtx, fmt_str));
@@ -2180,9 +2180,10 @@ fn dispatch_control_command(
         }
         "list-panes" | "lsp" => {
             let all = args.iter().any(|a| *a == "-a");
+            let session_scope = args.iter().any(|a| *a == "-s");
             let format_str = args.windows(2).find(|w| w[0] == "-F").map(|w| w[1].to_string());
             let (rtx, rrx) = mpsc::channel::<String>();
-            if all {
+            if all || session_scope {
                 if let Some(fmt) = format_str {
                     let _ = tx.send(CtrlReq::ListAllPanesFormat(rtx, fmt));
                 } else {


### PR DESCRIPTION
## Summary

- `list-panes -s -t <session> -F "..."` only returned panes from one window instead of all windows in the session
- The `-s` (session scope) flag was handled correctly in the non-format code path but was missing from the `-F` (format) branch — only `-a` was checked there
- Fixed both handler locations in `connection.rs` to check `session_scope` alongside `all`

## Root Cause

In the first handler (~line 886), when `-F` is provided:
```rust
// Before: only -a triggers ListAllPanesFormat
if all { ... }

// After: -s also triggers it
if all || session_scope { ... }
```

The second handler (~line 2185) had the same issue and was also missing the `session_scope` variable entirely.

## Test Plan

- [ ] Create a session with multiple windows: `psmux new-session -d -s test && psmux new-window -t test && psmux new-window -t test`
- [ ] Run `psmux list-panes -s -t test -F "#{pane_pid} #{window_index}"` — should return panes from all 3 windows
- [ ] Run `psmux list-panes -s -t test` (no `-F`) — should also return all panes (was already working)
- [ ] Run `psmux list-panes -t test` (no `-s`) — should return panes from the current window only (unchanged behavior)

Fixes #218

🤖 Generated with [Claude Code](https://claude.com/claude-code)