### PR TITLE
fix: fire pane-died/pane-exited hooks with remain-on-exit

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -4023,15 +4023,18 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
         // Check if all windows/panes have exited (throttled to every 250ms)
         if last_reap.elapsed() >= Duration::from_millis(100) {
             last_reap = Instant::now();
-            let (all_empty, any_pruned) = tree::reap_children(&mut app)?;
+            let (all_empty, any_pruned, any_newly_dead) = tree::reap_children(&mut app)?;
             if any_pruned {
-                // A pane exited naturally - resize remaining panes to fill the space
+                // A pane was removed from the tree - resize remaining panes to fill the space
                 resize_all_panes(&mut app);
+            }
+            if any_pruned || any_newly_dead {
+                // A pane exited — fire hooks whether it was removed (remain-on-exit off)
+                // or just marked dead (remain-on-exit on).  Fixes #227.
                 state_dirty = true;
                 meta_dirty = true;
-                // Fire pane-died / pane-exited hooks
-                if let Some(cmds) = app.hooks.get("pane-died") { let cmds = cmds.clone(); for cmd in &cmds { let _ = execute_command_string(&mut app, cmd); } }
-                if let Some(cmds) = app.hooks.get("pane-exited") { let cmds = cmds.clone(); for cmd in &cmds { let _ = execute_command_string(&mut app, cmd); } }
+                crate::commands::fire_hooks(&mut app, "pane-died");
+                crate::commands::fire_hooks(&mut app, "pane-exited");
             }
             if app.exit_empty && all_empty {
                 let home = env::var("USERPROFILE").or_else(|_| env::var("HOME")).unwrap_or_default();

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -363,33 +363,40 @@ pub fn get_split_mut<'a>(node: &'a mut Node, path: &Vec<usize>) -> Option<&'a mu
     Some(cur)
 }
 
-pub fn prune_exited(n: Node, remain_on_exit: bool) -> Option<Node> {
+/// Prune exited panes from the tree.  Returns `(Option<Node>, newly_dead_count)`:
+/// - `newly_dead_count` tracks panes that transitioned alive→dead in this call
+///   (remain-on-exit case), so callers can fire hooks even when the tree shape
+///   doesn't change.
+pub fn prune_exited(n: Node, remain_on_exit: bool) -> (Option<Node>, usize) {
     match n {
         Node::Leaf(mut p) => {
-            if p.dead { return Some(Node::Leaf(p)); }
+            if p.dead { return (Some(Node::Leaf(p)), 0); }
             match p.child.try_wait() {
                 Ok(Some(_)) => {
                     if remain_on_exit {
                         p.dead = true;
-                        Some(Node::Leaf(p))
+                        (Some(Node::Leaf(p)), 1)
                     } else {
-                        None
+                        (None, 0)
                     }
                 }
-                _ => Some(Node::Leaf(p)),
+                _ => (Some(Node::Leaf(p)), 0),
             }
         }
         Node::Split { kind, sizes, children } => {
             let mut new_children: Vec<Node> = Vec::new();
             let mut new_sizes: Vec<u16> = Vec::new();
+            let mut newly_dead = 0;
             for (i, child) in children.into_iter().enumerate() {
-                if let Some(c) = prune_exited(child, remain_on_exit) {
+                let (pruned, dead_count) = prune_exited(child, remain_on_exit);
+                newly_dead += dead_count;
+                if let Some(c) = pruned {
                     new_children.push(c);
                     new_sizes.push(sizes.get(i).copied().unwrap_or(0));
                 }
             }
-            if new_children.is_empty() { None }
-            else if new_children.len() == 1 { Some(new_children.remove(0)) }
+            if new_children.is_empty() { (None, newly_dead) }
+            else if new_children.len() == 1 { (Some(new_children.remove(0)), newly_dead) }
             else {
                 // Redistribute removed pane's percentage proportionally among survivors
                 let total: u16 = new_sizes.iter().sum();
@@ -407,7 +414,7 @@ pub fn prune_exited(n: Node, remain_on_exit: bool) -> Option<Node> {
                     if let Some(last) = scaled.last_mut() { *last += rem; }
                     new_sizes = scaled;
                 }
-                Some(Node::Split { kind, sizes: new_sizes, children: new_children })
+                (Some(Node::Split { kind, sizes: new_sizes, children: new_children }), newly_dead)
             }
         }
     }
@@ -679,7 +686,14 @@ pub fn pane_index_in_window(node: &Node, path: &[usize]) -> Option<usize> {
     if walk(node, target_id, &mut idx) { Some(idx) } else { None }
 }
 
-/// Reap exited children from the app. Returns (all_empty, any_pruned).
+/// Reap exited children from the app.
+/// Returns `(all_empty, any_pruned, any_newly_dead)`:
+/// - `any_pruned`: at least one pane was removed from the tree (remain-on-exit off)
+/// - `any_newly_dead`: at least one pane transitioned alive→dead (remain-on-exit on)
+///
+/// Callers should fire pane-died/pane-exited hooks when either flag is true,
+/// and only resize the layout when `any_pruned` is true.
+///
 /// Fast check: does any pane in this node tree have an exited child?
 /// Uses try_wait() but avoids the full tree rebuild if nothing has exited.
 fn has_any_exited(node: &mut Node) -> bool {
@@ -694,9 +708,10 @@ fn has_any_exited(node: &mut Node) -> bool {
     }
 }
 
-pub fn reap_children(app: &mut AppState) -> io::Result<(bool, bool)> {
+pub fn reap_children(app: &mut AppState) -> io::Result<(bool, bool, bool)> {
     let remain = app.remain_on_exit;
     let mut any_pruned = false;
+    let mut any_newly_dead = false;
     for i in (0..app.windows.len()).rev() {
         // Fast path: skip full tree rebuild if no panes have exited
         if !has_any_exited(&mut app.windows[i].root) {
@@ -705,7 +720,11 @@ pub fn reap_children(app: &mut AppState) -> io::Result<(bool, bool)> {
         let leaves_before = count_panes(&app.windows[i].root);
         let active_pane_id = get_active_pane_id(&app.windows[i].root, &app.windows[i].active_path);
         let root = std::mem::replace(&mut app.windows[i].root, Node::Split { kind: LayoutKind::Horizontal, sizes: vec![], children: vec![] });
-        match prune_exited(root, remain) {
+        let (pruned_result, newly_dead_count) = prune_exited(root, remain);
+        if newly_dead_count > 0 {
+            any_newly_dead = true;
+        }
+        match pruned_result {
             Some(new_root) => {
                 let leaves_after = count_panes(&new_root);
                 if leaves_after < leaves_before {
@@ -749,7 +768,7 @@ pub fn reap_children(app: &mut AppState) -> io::Result<(bool, bool)> {
             }
         }
     }
-    Ok((app.windows.is_empty(), any_pruned))
+    Ok((app.windows.is_empty(), any_pruned, any_newly_dead))
 }
 
 /// Collect all leaf (Pane) nodes from the tree, consuming it.


### PR DESCRIPTION
## Summary

- Fixes `pane-died` and `pane-exited` hooks not firing when `remain-on-exit` is enabled
- Hooks now fire when a pane's child process exits, regardless of whether the pane is retained or removed from the tree
- Layout resize only happens when panes are actually removed (not when they transition to dead state)

## Root cause

When `remain-on-exit` is on, `prune_exited()` marks panes as `dead` but keeps them in the tree. The hook-firing logic only checked whether the tree leaf count decreased (`leaves_after < leaves_before`), which **never** happens in the remain-on-exit case since dead panes are still counted as leaves. So hooks never fired.

## What changed

**`src/tree.rs`**:
- `prune_exited()` now returns `(Option<Node>, newly_dead_count)` — the second value tracks panes that transitioned alive→dead in each call
- `reap_children()` returns `(all_empty, any_pruned, any_newly_dead)` — separating "pane removed from tree" from "pane became dead"

**`src/server/mod.rs`**:
- Hooks fire when `any_pruned || any_newly_dead` (either a pane was removed OR became dead)
- Layout resize only runs when `any_pruned` (actual tree structure change)
- Uses `fire_hooks()` helper instead of inline hook execution

## Why hooks don't fire repeatedly

The `has_any_exited()` fast-path check (line 688) returns `false` for already-dead panes (`if p.dead { return false; }`), so once a pane transitions to dead state and hooks fire, subsequent reap ticks skip it entirely.

Fixes #227

## Test plan

- [ ] With `remain-on-exit on`: start a pane with a short-lived process, set `pane-died` hook — verify hook fires when process exits
- [ ] With `remain-on-exit off`: same test — verify existing behavior (hooks fire, pane is removed) still works
- [ ] Verify hooks fire exactly once per pane death, not on every reap tick
- [ ] `respawn-pane` after death should reset the pane; if it dies again, hooks should fire again

🤖 Generated with [Claude Code](https://claude.com/claude-code)