### PR TITLE
fix: reduce paste_suppress_until window from 2s to 200ms (closes #237)

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -960,7 +960,7 @@ pub fn run_remote(terminal: &mut Terminal<CrosstermBackend<crate::platform::Psmu
                         let encoded = base64_encode(&paste_pend);
                         cmd_batch.push(format!("send-paste {}\n", encoded));
                         // Suppress clipboard-read fallback
-                        paste_suppress_until = Some(Instant::now() + Duration::from_secs(2));
+                        paste_suppress_until = Some(Instant::now() + Duration::from_millis(200));
                     }
                     paste_pend.clear();
                     paste_pend_start = None;
@@ -1057,7 +1057,7 @@ pub fn run_remote(terminal: &mut Terminal<CrosstermBackend<crate::platform::Psmu
                         // Suppress the clipboard-read fallback that fires
                         // when Ctrl+V Release arrives later (the paste was
                         // already sent via stage2).
-                        paste_suppress_until = Some(Instant::now() + Duration::from_secs(2));
+                        paste_suppress_until = Some(Instant::now() + Duration::from_millis(200));
                     }
                 }
             }
@@ -2161,7 +2161,7 @@ pub fn run_remote(terminal: &mut Terminal<CrosstermBackend<crate::platform::Psmu
                             paste_pend_start = None;
                             paste_stage2 = false;
                             paste_confirmed = false;
-                            paste_suppress_until = Some(Instant::now() + Duration::from_secs(2));
+                            paste_suppress_until = Some(Instant::now() + Duration::from_millis(200));
                         }
                     }
                     Event::Mouse(me) => {
@@ -2358,7 +2358,7 @@ pub fn run_remote(terminal: &mut Terminal<CrosstermBackend<crate::platform::Psmu
                                     selection_changed = true;
                                     // Suppress text key events that VS Code's ConPTY
                                     // injects after a right-click copy action.
-                                    paste_suppress_until = Some(Instant::now() + Duration::from_secs(2));
+                                    paste_suppress_until = Some(Instant::now() + Duration::from_millis(200));
                                 } else {
                                     // No selection, no TUI — paste from clipboard (pwsh-style)
                                     rsel_start = None;
@@ -2602,7 +2602,7 @@ pub fn run_remote(terminal: &mut Terminal<CrosstermBackend<crate::platform::Psmu
                 paste_confirmed = false;
                 // Suppress subsequent char accumulation and clipboard-read
                 // fallback — the paste was already delivered.
-                paste_suppress_until = Some(Instant::now() + Duration::from_secs(2));
+                paste_suppress_until = Some(Instant::now() + Duration::from_millis(200));
             } else if paste_confirmed && paste_pend.is_empty() {
                 // Ctrl+V Release with no buffered chars.  If paste was
                 // already sent via stage2 timeout or Event::Paste, the
@@ -2621,7 +2621,7 @@ pub fn run_remote(terminal: &mut Terminal<CrosstermBackend<crate::platform::Psmu
                             // Suppress subsequent char accumulation — the
                             // clipboard chars may arrive later (async inject)
                             // and would cause a duplicate paste via stage2.
-                            paste_suppress_until = Some(Instant::now() + Duration::from_secs(2));
+                            paste_suppress_until = Some(Instant::now() + Duration::from_millis(200));
                         }
                     }
                 }


### PR DESCRIPTION
## Summary
- Reduces `paste_suppress_until` window in `src/client.rs` from 2 seconds to 200 milliseconds across all 6 call sites.
- Eliminates the silent 2-second typing freeze reported in #237 (regression from #197 / `3bf380d`).
- No behavior change for paste: the 200ms window still covers ConPTY's async clipboard-inject race (resolves <50ms) with a 4× margin.

## Why
`paste_suppress_until` blocks `KeyCode::Char(c)` events while the window is in the future (pre-existing check at `src/client.rs:2079–2107`). Commit `3bf380d` (#197) added five new call sites that set this window to `now + 2s`, including `STAGE2_TIMEOUT` — which fires when `paste_pend` accumulates typed chars without a Ctrl+V within 300ms. That is the exact pattern of normal fast typing, so fast typing trips the stage2 heuristic, sets a 2-second suppression window, and silently drops every subsequent keystroke for 2 seconds. See #237 for the full bisect and root-cause analysis.

The 2-second window is far longer than the race it guards. Original motivation (#197): ConPTY may inject clipboard characters asynchronously after a Ctrl+V Release event arrives, so a subsequent `Event::Paste` / stage2 burst could cause a double-send. This async inject completes in well under 50ms on tested Windows 11 systems. 200ms is a comfortable margin while staying below human-perceptible typing latency.

## Test plan
Tested on Windows 11 / pwsh 7 / Windows Terminal 1.23 / PSReadLine 2.4.5:

- [x] Fast typing no longer stalls. Verified by sustained typing in a psmux session — previously reproduced the 2s freeze every few seconds; with this change, no stalls observed.
- [x] Single-line Ctrl+V paste — `hello world` arrives exactly once.
- [x] Multi-line Ctrl+V paste — 3-line snippet arrives intact, no duplication.
- [x] Rapid sequential Ctrl+V (×3 in quick succession) — all three instances delivered, none duplicated.
- [x] Existing psmux test suite passes (no changes to compile or test harness).

## Risk / rollout
- Worst-case regression if 200ms proves insufficient on slower hardware: paste duplication under a specific timing window. Easy to tune upward if reports surface.
- Alternative minimal fix (if reviewers prefer): remove the `KeyCode::Char` suppression check entirely and rely on `paste_pend` timing plus bracketed-paste `Event::Paste` for dedup. Happy to switch to that approach.

Closes #237