### PR TITLE
fix: select-pane -Z loses its -Z flag when used in bind-key

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -503,7 +503,9 @@ pub fn parse_command_to_action(cmd: &str) -> Option<Action> {
         "resize-pane" | "resizep" if parts.iter().any(|p| *p == "-Z") => Some(Action::ZoomPane),
         "zoom-pane" => Some(Action::ZoomPane),
         "select-pane" | "selectp" => {
-            if parts.iter().any(|p| *p == "-U") {
+            if parts.iter().any(|p| *p == "-Z") {
+                Some(Action::Command(cmd.to_string()))
+            } else if parts.iter().any(|p| *p == "-U") {
                 Some(Action::MoveFocus(FocusDir::Up))
             } else if parts.iter().any(|p| *p == "-D") {
                 Some(Action::MoveFocus(FocusDir::Down))
@@ -1010,16 +1012,23 @@ fn execute_command_string_single(app: &mut AppState, cmd: &str) -> io::Result<()
                 });
                 return Ok(());
             }
+            let keep_zoom = parts.iter().any(|p| *p == "-Z");
             let dir = if parts.iter().any(|p| *p == "-U") { FocusDir::Up }
                 else if parts.iter().any(|p| *p == "-D") { FocusDir::Down }
                 else if parts.iter().any(|p| *p == "-L") { FocusDir::Left }
                 else if parts.iter().any(|p| *p == "-R") { FocusDir::Right }
                 else { return Ok(()); };
-            // Zoom-aware directional navigation (tmux parity #134):
-            // If zoomed, check if there's a direct neighbor OR a wrap target.
-            // If yes: cancel zoom and navigate to it.
-            // If no (single-pane window): no-op — stay zoomed.
-            if app.windows[app.active_idx].zoom_saved.is_some() {
+            if keep_zoom {
+                switch_with_copy_save(app, |app| {
+                    let win = &app.windows[app.active_idx];
+                    app.last_pane_path = win.active_path.clone();
+                    crate::input::move_focus_preserving_zoom(app, dir);
+                });
+            } else if app.windows[app.active_idx].zoom_saved.is_some() {
+                // Zoom-aware directional navigation (tmux parity #134):
+                // If zoomed, check if there's a direct neighbor OR a wrap target.
+                // If yes: cancel zoom and navigate to it.
+                // If no (single-pane window): no-op — stay zoomed.
                 // Temporarily unzoom to compute real geometry
                 let saved = app.windows[app.active_idx].zoom_saved.take();
                 if let Some(ref s) = saved {

--- a/src/input.rs
+++ b/src/input.rs
@@ -1388,6 +1388,20 @@ pub fn move_focus(app: &mut AppState, dir: FocusDir) {
     }
 }
 
+pub fn move_focus_preserving_zoom(app: &mut AppState, dir: FocusDir) {
+    if app.windows.get(app.active_idx).map_or(false, |w| w.zoom_saved.is_some()) {
+        let old_path = app.windows[app.active_idx].active_path.clone();
+        toggle_zoom(app);
+        move_focus(app, dir);
+        toggle_zoom(app);
+        if app.windows[app.active_idx].active_path == old_path {
+            app.last_pane_path = old_path;
+        }
+    } else {
+        move_focus(app, dir);
+    }
+}
+
 /// Spatial pane navigation: find the best pane in the given direction.
 /// Prefers panes that overlap on the perpendicular axis (visually adjacent),
 /// then picks the closest by primary-axis gap, tie-broken by MRU recency

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -874,7 +874,8 @@ match cmd {
             let _ = tx.send(CtrlReq::SetPaneStyle(style));
         }
         if !dir.is_empty() {
-            let _ = tx.send(CtrlReq::SelectPane(dir.to_string()));
+            let keep_zoom = args.iter().any(|a| *a == "-Z");
+            let _ = tx.send(CtrlReq::SelectPane(dir.to_string(), keep_zoom));
         }
     }
     "select-window" | "selectw" => {

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -25,7 +25,7 @@ use helpers::{collect_pane_paths_server, serialize_bindings_json, json_escape_st
     list_windows_json_with_tabs, combined_data_version, TMUX_COMMANDS};
 use options::{get_option_value, get_window_option_value, render_window_options, apply_set_option};
 
-use crate::input::{send_text_to_active, send_key_to_active, send_paste_to_active, move_focus, find_best_pane_in_direction, find_wrap_target};
+use crate::input::{send_text_to_active, send_key_to_active, send_paste_to_active, move_focus, move_focus_preserving_zoom, find_best_pane_in_direction, find_wrap_target};
 use crate::copy_mode::{enter_copy_mode, exit_copy_mode, move_copy_cursor, current_prompt_pos,
     yank_selection, scroll_copy_up, scroll_copy_down, switch_with_copy_save,
     capture_active_pane_text, capture_active_pane_range, capture_active_pane_styled};
@@ -1889,7 +1889,7 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                         _ => {} // ignore unknown copy-mode commands
                     }
                 }
-                CtrlReq::SelectPane(dir) => {
+                CtrlReq::SelectPane(dir, keep_zoom) => {
                     if let Some(cmds) = app.hooks.get("before-select-pane") { let cmds = cmds.clone(); for cmd in &cmds { let _ = execute_command_string(&mut app, cmd); } }
                     // Auto-unzoom when navigating to another pane (tmux behavior).
                     // For directional nav: unzoom first so compute_rects uses
@@ -1902,36 +1902,47 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                                 "U" => FocusDir::Up, "D" => FocusDir::Down,
                                 "L" => FocusDir::Left, _ => FocusDir::Right,
                             };
-                            let was_zoomed = unzoom_if_zoomed(&mut app);
-                            if was_zoomed {
+                            if keep_zoom {
+                                let old_path = app.windows[app.active_idx].active_path.clone();
+                                switch_with_copy_save(&mut app, |app| {
+                                    move_focus_preserving_zoom(app, focus_dir);
+                                });
+                                if app.windows[app.active_idx].active_path != old_path {
+                                    app.last_pane_path = old_path;
+                                }
+                            } else {
+                                let was_zoomed = unzoom_if_zoomed(&mut app);
+                                if was_zoomed {
                                 // Zoom-aware: check direct neighbor or wrap target (tmux parity: unzoom+wrap).
                                 let win = &app.windows[app.active_idx];
                                 let mut rects: Vec<(Vec<usize>, ratatui::layout::Rect)> = Vec::new();
                                 crate::tree::compute_rects(&win.root, app.last_window_area, &mut rects);
                                 let active_idx = rects.iter().position(|(path, _)| *path == win.active_path);
-                                let has_target = if let Some(ai) = active_idx {
-                                    let (_, arect) = &rects[ai];
-                                    find_best_pane_in_direction(&rects, ai, arect, focus_dir, &[], &[])
-                                        .or_else(|| find_wrap_target(&rects, ai, arect, focus_dir, &[], &[]))
-                                        .is_some()
-                                } else { false };
-                                if has_target {
+                                let has_target = 
+                                    if let Some(ai) = active_idx {
+                                        let (_, arect) = &rects[ai];
+                                        find_best_pane_in_direction(&rects, ai, arect, focus_dir, &[], &[])
+                                            .or_else(|| find_wrap_target(&rects, ai, arect, focus_dir, &[], &[]))
+                                            .is_some()
+                                    } else { false };
+                                    if has_target {
+                                        let old_path = app.windows[app.active_idx].active_path.clone();
+                                        switch_with_copy_save(&mut app, |app| {
+                                            move_focus(app, focus_dir);
+                                        });
+                                        app.last_pane_path = old_path;
+                                    } else {
+                                        // No reachable pane (single-pane window) — re-zoom
+                                        toggle_zoom(&mut app);
+                                    }
+                                } else {
                                     let old_path = app.windows[app.active_idx].active_path.clone();
                                     switch_with_copy_save(&mut app, |app| {
                                         move_focus(app, focus_dir);
                                     });
-                                    app.last_pane_path = old_path;
-                                } else {
-                                    // No reachable pane (single-pane window) — re-zoom
-                                    toggle_zoom(&mut app);
-                                }
-                            } else {
-                                let old_path = app.windows[app.active_idx].active_path.clone();
-                                switch_with_copy_save(&mut app, |app| {
-                                    move_focus(app, focus_dir);
-                                });
-                                if app.windows[app.active_idx].active_path != old_path {
-                                    app.last_pane_path = old_path;
+                                    if app.windows[app.active_idx].active_path != old_path {
+                                        app.last_pane_path = old_path;
+                                    }
                                 }
                             }
                         }

--- a/src/types.rs
+++ b/src/types.rs
@@ -932,7 +932,7 @@ pub enum CtrlReq {
     SetPaneStyle(String),
     SendKeys(String, bool),
     SendKeysX(String),  // send-keys -X copy-mode-command
-    SelectPane(String),
+    SelectPane(String, bool),
     SelectWindow(usize),
     ListPanes(mpsc::Sender<String>),
     ListPanesFormat(mpsc::Sender<String>, String),

--- a/tests-rs/test_server.rs
+++ b/tests-rs/test_server.rs
@@ -285,6 +285,32 @@ fn normalize_only_strips_shift_from_char() {
     assert_eq!(shift_bs, (KeyCode::Backspace, KeyModifiers::SHIFT));
 }
 
+#[test]
+fn bind_key_select_pane_z_stays_as_command() {
+    let mut app = AppState::new("test".to_string());
+    crate::config::parse_bind_key(&mut app, "bind-key -n C-h select-pane -Z -L");
+    let root = app.key_tables.get("root").expect("root table should exist");
+    let bind = &root[0];
+    assert!(matches!(&bind.action, crate::types::Action::Command(cmd) if cmd == "select-pane -Z -L"));
+}
+
+#[test]
+fn parse_config_line_select_pane_z_stays_as_command() {
+    let mut app = AppState::new("test".to_string());
+    crate::config::parse_config_line(&mut app, "bind-key -r h select-pane -Z -L");
+    let prefix = app.key_tables.get("prefix").expect("prefix table should exist");
+    let bind = prefix.iter().find(|b| matches!(b.key.0, KeyCode::Char('h'))).expect("h binding should exist");
+    assert!(matches!(&bind.action, crate::types::Action::Command(cmd) if cmd == "select-pane -Z -L"));
+}
+
+#[test]
+fn serialized_bindings_preserve_select_pane_z_command() {
+    let mut app = AppState::new("test".to_string());
+    crate::config::parse_config_line(&mut app, "bind-key -r h select-pane -Z -L");
+    let json = crate::server::helpers::serialize_bindings_json(&app);
+    assert!(json.contains("select-pane -Z -L"));
+}
+
 // ── combined_data_version includes copy mode state (issue #152) ──
 
 #[test]


### PR DESCRIPTION
`select-pane -Z` is documented as supported (`keep zoomed`), but when it is used in `bind-key`, the stored binding gets rewritten into plain directional `select-pane` and loses the `-Z` behavior.

For example:
```tmux
bind-key -r h select-pane -Z -L
bind-key -r j select-pane -Z -D
bind-key -r k select-pane -Z -U
bind-key -r l select-pane -Z -R
```
### Repro
1. Start psmux
2. Split into multiple panes
3. Zoom the active pane
4. Press prefix + h/j/k/l

### Expected
The binding should preserve the original command, e.g.
select-pane -Z -L
and pane switching should keep zoom.

### Actual
The binding is rewritten into plain directional navigation, e.g.
select-pane -L
so the zoom-preserving behavior is lost before runtime.
 
### Likely cause
bind-key appears to normalize commands into simplified internal actions too aggressively.
That works for exact commands like:
select-pane -L
but not for commands where extra flags change semantics, such as:
select-pane -Z -L

### Proposed fix
When a key binding is parsed, only convert it into a simplified internal action if the command is an exact match.
For example:
- select-pane -L can safely be treated as “move focus left”
- select-pane -Z -L should not be treated the same way, because -Z changes the behavior

So if a binding includes extra flags that matter, the original command should be kept as-is instead of being rewritten into the simpler directional action.

In short:
- exact simple commands can be normalized
- commands with additional semantic flags should be preserved verbatim