### PR TITLE
fix(picker): skip AUTH ack reliably in session-info fetch (#250)

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1689,24 +1689,13 @@ pub fn run_remote(terminal: &mut Terminal<CrosstermBackend<crate::platform::Psmu
                                                         if let Ok(p) = port_str.trim().parse::<u16>() {
                                                             let sess_addr = format!("127.0.0.1:{}", p);
                                                             let sess_key = read_session_key(base).unwrap_or_default();
-                                                            let info = if let Ok(mut ss) = std::net::TcpStream::connect_timeout(
-                                                                &sess_addr.parse().unwrap(), Duration::from_millis(25)
-                                                            ) {
-                                                                let _ = ss.set_read_timeout(Some(Duration::from_millis(25)));
-                                                                let _ = write!(ss, "AUTH {}\n", sess_key);
-                                                                let _ = ss.write_all(b"session-info\n");
-                                                                let mut br = BufReader::new(ss);
-                                                                let mut al = String::new();
-                                                                let _ = br.read_line(&mut al);
-                                                                let mut line = String::new();
-                                                                if br.read_line(&mut line).is_ok() && !line.trim().is_empty() {
-                                                                    line.trim().to_string()
-                                                                } else {
-                                                                    format!("{}: (no info)", base)
-                                                                }
-                                                            } else {
-                                                                format!("{}: (not responding)", base)
-                                                            };
+                                                            let info = crate::session::fetch_session_info(
+                                                                &sess_addr,
+                                                                &sess_key,
+                                                                Duration::from_millis(25),
+                                                                Duration::from_millis(150),
+                                                            )
+                                                            .unwrap_or_else(|| format!("{}: (not responding)", base));
                                                             session_entries.push((base.to_string(), info));
                                                         }
                                                     }

--- a/src/session.rs
+++ b/src/session.rs
@@ -122,6 +122,50 @@ pub fn send_auth_cmd_response(addr: &str, key: &str, cmd: &[u8]) -> io::Result<S
     Ok(buf)
 }
 
+/// Fetch a one-line `session-info` response from a session server.
+///
+/// Connects to `addr`, authenticates with `key`, sends `session-info`, and
+/// returns the server's info line. Returns `None` if the connection fails,
+/// authentication is rejected, or the info line doesn't arrive in time.
+///
+/// The AUTH ack (`OK\n`) is filtered out explicitly rather than assumed to
+/// be the first line: when the AUTH reply is slow enough for the first
+/// `read_line` to time out, a naive two-read protocol picks up the late
+/// `OK` in the second read and mis-reports it as the session info. See
+/// issue #250.
+pub fn fetch_session_info(
+    addr: &str,
+    key: &str,
+    connect_timeout: Duration,
+    read_timeout: Duration,
+) -> Option<String> {
+    let sock_addr: std::net::SocketAddr = addr.parse().ok()?;
+    let mut s = std::net::TcpStream::connect_timeout(&sock_addr, connect_timeout).ok()?;
+    s.set_read_timeout(Some(read_timeout)).ok()?;
+    let _ = s.set_nodelay(true);
+    write!(s, "AUTH {}\n", key).ok()?;
+    s.write_all(b"session-info\n").ok()?;
+    let _ = s.flush();
+
+    let mut br = std::io::BufReader::new(s);
+    let mut line = String::new();
+    if std::io::BufRead::read_line(&mut br, &mut line).ok()? == 0 {
+        return None;
+    }
+    if line.trim() == "OK" {
+        line.clear();
+        if std::io::BufRead::read_line(&mut br, &mut line).ok()? == 0 {
+            return None;
+        }
+    }
+    let trimmed = line.trim();
+    if trimmed.is_empty() || trimmed == "OK" || trimmed.starts_with("ERROR:") {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
 pub fn send_control(line: String) -> io::Result<()> {
     let home = env::var("USERPROFILE").or_else(|_| env::var("HOME")).unwrap_or_default();
     let mut target = env::var("PSMUX_TARGET_SESSION").ok().unwrap_or_else(|| "default".to_string());
@@ -511,3 +555,7 @@ pub fn kill_remaining_server_processes() {
         .args(&["-f", "psmux|pmux"])
         .status();
 }
+
+#[cfg(test)]
+#[path = "../tests-rs/test_session.rs"]
+mod tests;

--- a/tests-rs/test_session.rs
+++ b/tests-rs/test_session.rs
@@ -1,0 +1,179 @@
+// Tests for crate::session::fetch_session_info, covering the AUTH+session-info
+// framing race that motivated issue #250.
+//
+// Each test spins up a minimal in-process TCP listener on 127.0.0.1:0 that
+// acts as a fake psmux session server, then calls the real production
+// function — no re-implementation of the parser in the test.
+
+use super::*;
+
+use std::io::{Read, Write as IoWrite};
+use std::net::{TcpListener, TcpStream};
+use std::sync::mpsc;
+use std::thread;
+use std::time::Duration;
+
+/// Read the `AUTH <key>\n` + `session-info\n` lines the client sends so the
+/// fake server's subsequent writes land against the expected client state.
+fn drain_client_request(stream: &mut TcpStream) {
+    // AUTH line + session-info line — two LFs total.
+    let mut seen_lf = 0u8;
+    let mut buf = [0u8; 1];
+    while seen_lf < 2 {
+        match stream.read(&mut buf) {
+            Ok(0) => return,
+            Ok(_) => {
+                if buf[0] == b'\n' {
+                    seen_lf += 1;
+                }
+            }
+            Err(_) => return,
+        }
+    }
+}
+
+/// Spawns a listener bound to an ephemeral port, hands the accepted stream
+/// to `respond`, and returns `127.0.0.1:<port>` for the client to dial.
+///
+/// Returns the address plus a channel the caller can block on to ensure the
+/// server thread finished before the test exits.
+fn spawn_fake_server<F>(respond: F) -> (String, mpsc::Receiver<()>)
+where
+    F: FnOnce(TcpStream) + Send + 'static,
+{
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind ephemeral port");
+    let addr = listener.local_addr().unwrap().to_string();
+    let (done_tx, done_rx) = mpsc::channel();
+    thread::spawn(move || {
+        if let Ok((stream, _)) = listener.accept() {
+            respond(stream);
+        }
+        let _ = done_tx.send(());
+    });
+    (addr, done_rx)
+}
+
+#[test]
+fn happy_path_returns_info_line() {
+    let (addr, done) = spawn_fake_server(|mut s| {
+        drain_client_request(&mut s);
+        let _ = s.write_all(b"OK\n");
+        let _ = s.write_all(b"call-controller: 2 windows (created Mon Apr 20 11:10:58 2026)\n");
+        let _ = s.flush();
+    });
+
+    let info = fetch_session_info(
+        &addr,
+        "key",
+        Duration::from_millis(200),
+        Duration::from_millis(500),
+    );
+
+    assert_eq!(
+        info.as_deref(),
+        Some("call-controller: 2 windows (created Mon Apr 20 11:10:58 2026)")
+    );
+    let _ = done.recv_timeout(Duration::from_secs(2));
+}
+
+#[test]
+fn issue_250_late_auth_ack_is_not_reported_as_session_info() {
+    // Reproduces the #250 race: AUTH `OK\n` is delayed until after the client's
+    // first read_line would have timed out. In the old code the late "OK"
+    // landed in the second read and was rendered as the session name. The
+    // production function must either return the real info or `None` — never
+    // `Some("OK")`.
+    let (addr, done) = spawn_fake_server(|mut s| {
+        drain_client_request(&mut s);
+        // Hold the "OK" ack longer than the client's per-read timeout so the
+        // first read_line is forced to return (on the old code, empty) and
+        // the ack arrives during what was previously the "info" read.
+        thread::sleep(Duration::from_millis(120));
+        let _ = s.write_all(b"OK\n");
+        let _ = s.flush();
+        // Then send the real info line comfortably within the second read.
+        thread::sleep(Duration::from_millis(20));
+        let _ = s.write_all(b"convserv: 3 windows (created Mon Apr 20 11:11:06 2026)\n");
+        let _ = s.flush();
+    });
+
+    let info = fetch_session_info(
+        &addr,
+        "key",
+        Duration::from_millis(200),
+        Duration::from_millis(80),  // shorter than the 120ms server delay
+    );
+
+    // The critical assertion: even under the race, we never mis-report "OK"
+    // as the info line. Either the real line makes it (if the read timeout
+    // is generous) or we get None — but never Some("OK").
+    assert_ne!(info.as_deref(), Some("OK"), "late AUTH ack leaked as session info");
+    let _ = done.recv_timeout(Duration::from_secs(2));
+}
+
+#[test]
+fn only_ok_ack_received_returns_none() {
+    // Server replies with just the AUTH ack and never sends session-info
+    // (the worst-case of #250: second read's timeout leaves nothing).
+    let (addr, done) = spawn_fake_server(|mut s| {
+        drain_client_request(&mut s);
+        let _ = s.write_all(b"OK\n");
+        let _ = s.flush();
+        // Keep the connection open briefly so the client isn't racing EOF
+        // against its own read_timeout.
+        thread::sleep(Duration::from_millis(200));
+    });
+
+    let info = fetch_session_info(
+        &addr,
+        "key",
+        Duration::from_millis(200),
+        Duration::from_millis(80),
+    );
+
+    assert_eq!(info, None, "sole OK ack must not be reported as info");
+    let _ = done.recv_timeout(Duration::from_secs(2));
+}
+
+#[test]
+fn connect_refused_returns_none() {
+    // Bind then drop the listener so the port is (briefly) closed — on
+    // loopback this produces a fast refusal. The socket might race to be
+    // reused, but `fetch_session_info` must never panic and must return
+    // None on connect failure.
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = listener.local_addr().unwrap().to_string();
+    drop(listener);
+
+    let info = fetch_session_info(
+        &addr,
+        "key",
+        Duration::from_millis(50),
+        Duration::from_millis(50),
+    );
+
+    assert_eq!(info, None);
+}
+
+#[test]
+fn auth_rejected_returns_none() {
+    // Server responds to AUTH with an error instead of OK — must not be
+    // rendered as the session info line.
+    let (addr, done) = spawn_fake_server(|mut s| {
+        drain_client_request(&mut s);
+        let _ = s.write_all(b"ERROR: Invalid session key\n");
+        let _ = s.flush();
+    });
+
+    let info = fetch_session_info(
+        &addr,
+        "wrong-key",
+        Duration::from_millis(200),
+        Duration::from_millis(200),
+    );
+
+    // The picker should fall back to the generic "(not responding)"
+    // label rather than rendering the raw ERROR line as the session info.
+    assert_eq!(info, None, "auth error leaked as session info: {:?}", info);
+    let _ = done.recv_timeout(Duration::from_secs(2));
+}


### PR DESCRIPTION
Closes #250.

## Summary

- The session picker rendered random rows as \`OK\` instead of \`sessname: N windows (created ...)\`, with the affected rows changing on every reopen. Root cause was a framing race in the AUTH+session-info exchange: a late \`OK\n\` ack landed in what the code assumed would be the info line.
- Extract the fetch into \`session::fetch_session_info\`, which detects the \`OK\` ack explicitly (only consumes a second line if the first was actually \`OK\`) and also filters \`ERROR:\` responses so auth failures don't get displayed as session names.
- Bump the per-read timeout to 150 ms so the degraded \`(not responding)\` label is reached much less often on busy systems.

## Test plan

New \`tests-rs/test_session.rs\` mounts onto \`src/session.rs\` via \`#[cfg(test)] mod tests\` (same pattern used by \`test_client.rs\`). Tests spin up an in-process \`TcpListener\` that impersonates the server's protocol and call the real \`fetch_session_info\` — no re-implementation of the parser in the tests.

- [x] \`happy_path_returns_info_line\` — standard \`OK\n<info>\n\` sequence returns the info.
- [x] \`issue_250_late_auth_ack_is_not_reported_as_session_info\` — server delays the ack past the client's per-read timeout; asserts the result is never \`Some(\"OK\")\`. Verified to fail on the old implementation with \`assertion left: Some(\"OK\")\` \`right: Some(\"OK\")\`.
- [x] \`only_ok_ack_received_returns_none\` — server sends ack and nothing else.
- [x] \`connect_refused_returns_none\` — port is closed.
- [x] \`auth_rejected_returns_none\` — server writes \`ERROR: Invalid session key\n\`.

\`\`\`
running 5 tests
test session::tests::auth_rejected_returns_none ... ok
test session::tests::happy_path_returns_info_line ... ok
test session::tests::connect_refused_returns_none ... ok
test session::tests::issue_250_late_auth_ack_is_not_reported_as_session_info ... ok
test session::tests::only_ok_ack_received_returns_none ... ok
test result: ok. 5 passed; 0 failed
\`\`\`

No server restart required to benefit — this is a client-side fix and is wire-compatible with any still-running pre-update server.