### PR TITLE
fix: correct active pane border indicator for all split layouts

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -3208,7 +3208,7 @@ pub fn run_remote(terminal: &mut Terminal<CrosstermBackend<crate::platform::Psmu
                 }
             }
 
-            fn render_json(f: &mut Frame, node: &LayoutJson, area: Rect, dim_preds: bool, border_fg: Color, active_border_fg: Color, clock_mode: bool, clock_colour: Color, active_rect: Option<Rect>, mode_style_str: &str, zoomed: bool, border_status: &str, border_format: &str) {
+            fn render_json(f: &mut Frame, node: &LayoutJson, area: Rect, dim_preds: bool, border_fg: Color, active_border_fg: Color, clock_mode: bool, clock_colour: Color, active_rect: Option<Rect>, mode_style_str: &str, zoomed: bool, border_status: &str, border_format: &str, total_panes: usize) {
                 match node {
                     LayoutJson::Leaf {
                         id,
@@ -3477,7 +3477,7 @@ pub fn run_remote(terminal: &mut Terminal<CrosstermBackend<crate::platform::Psmu
 
                         // Render children first
                         for (i, child) in children.iter().enumerate() {
-                            if i < rects.len() { render_json(f, child, rects[i], dim_preds, border_fg, active_border_fg, clock_mode, clock_colour, active_rect, mode_style_str, zoomed, border_status, border_format); }
+                            if i < rects.len() { render_json(f, child, rects[i], dim_preds, border_fg, active_border_fg, clock_mode, clock_colour, active_rect, mode_style_str, zoomed, border_status, border_format, total_panes); }
                         }
 
                         // Draw separator lines between children using direct buffer access.
@@ -3501,7 +3501,11 @@ pub fn run_remote(terminal: &mut Terminal<CrosstermBackend<crate::platform::Psmu
                                 // Vertical separator line between left/right children.
                                 let sep_x = rects[i].x + rects[i].width;
                                 if sep_x < buf.area.x + buf.area.width {
-                                    if both_leaves {
+                                    if both_leaves && total_panes == 2 {
+                                        // total_panes is the whole-tree count, not local.
+                                        // When the entire window has exactly 2 panes, use a
+                                        // midpoint top/bottom split so each half of │ reflects
+                                        // its adjacent pane's active state (matches tmux behaviour).
                                         let left_active = matches!(&children[i], LayoutJson::Leaf { active, .. } if *active);
                                         let right_active = matches!(children.get(i + 1), Some(LayoutJson::Leaf { active, .. }) if *active);
                                         let left_sty = if left_active { active_border_style } else { border_style };
@@ -3517,6 +3521,8 @@ pub fn run_remote(terminal: &mut Terminal<CrosstermBackend<crate::platform::Psmu
                                             }
                                         }
                                     } else {
+                                        // 3+ panes: per-row adjacency — only rows that border
+                                        // the active pane are highlighted.
                                         for y in area.y..area.y + area.height {
                                             let active = active_rect.map_or(false, |ar| {
                                                 y >= ar.y && y < ar.y + ar.height
@@ -3536,7 +3542,11 @@ pub fn run_remote(terminal: &mut Terminal<CrosstermBackend<crate::platform::Psmu
                                 // Horizontal separator line between top/bottom children.
                                 let sep_y = rects[i].y + rects[i].height;
                                 if sep_y < buf.area.y + buf.area.height {
-                                    if both_leaves {
+                                    if both_leaves && total_panes == 2 {
+                                        // total_panes is the whole-tree count, not local.
+                                        // When the entire window has exactly 2 panes, use a
+                                        // midpoint left/right split so each half of ─ reflects
+                                        // its adjacent pane's active state (matches tmux behaviour).
                                         let top_active = matches!(&children[i], LayoutJson::Leaf { active, .. } if *active);
                                         let bot_active = matches!(children.get(i + 1), Some(LayoutJson::Leaf { active, .. }) if *active);
                                         let top_sty = if top_active { active_border_style } else { border_style };
@@ -3552,6 +3562,8 @@ pub fn run_remote(terminal: &mut Terminal<CrosstermBackend<crate::platform::Psmu
                                             }
                                         }
                                     } else {
+                                        // 3+ panes: per-column adjacency — only columns that border
+                                        // the active pane are highlighted.
                                         for x in area.x..area.x + area.width {
                                             let active = active_rect.map_or(false, |ar| {
                                                 x >= ar.x && x < ar.x + ar.width
@@ -3577,7 +3589,9 @@ pub fn run_remote(terminal: &mut Terminal<CrosstermBackend<crate::platform::Psmu
             let clock_col = clock_colour_str.as_deref().map(|s| map_color(s)).unwrap_or(Color::Cyan);
             let border_status = state.pane_border_status.as_deref().unwrap_or("off");
             let border_format = state.pane_border_format.as_deref().unwrap_or("");
-            render_json(f, &root, content_chunk, dim_preds, pane_border_fg, pane_active_border_fg, clock_active, clock_col, active_rect, &mode_style_str, state.zoomed, border_status, border_format);
+            // O(N) per frame but pane counts are small in practice (typically < 20).
+            let total_panes = if state.zoomed { 1 } else { root.count_leaves() };
+            render_json(f, &root, content_chunk, dim_preds, pane_border_fg, pane_active_border_fg, clock_active, clock_col, active_rect, &mode_style_str, state.zoomed, border_status, border_format, total_panes);
             fix_border_intersections(f.buffer_mut());
             // Re-color all border characters based on adjacency to the active pane.
             // render_json and fix_border_intersections can leave inconsistent styles
@@ -3593,7 +3607,7 @@ pub fn run_remote(terminal: &mut Terminal<CrosstermBackend<crate::platform::Psmu
                         let idx = row * w + col;
                         if idx >= buf.content.len() { continue; }
                         let ch = buf.content[idx].symbol().chars().next().unwrap_or(' ');
-                        if !matches!(ch, '│' | '─' | '┼' | '├' | '┤' | '┬' | '┴') { continue; }
+                        if !matches!(ch, '┼' | '├' | '┤' | '┬' | '┴') { continue; }
                         let x = buf.area.x + col as u16;
                         let y = buf.area.y + row as u16;
                         let adj = (x + 1 == ar.x && y >= ar.y && y < ar.y + ar.height)

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -503,7 +503,9 @@ pub fn parse_command_to_action(cmd: &str) -> Option<Action> {
         "resize-pane" | "resizep" if parts.iter().any(|p| *p == "-Z") => Some(Action::ZoomPane),
         "zoom-pane" => Some(Action::ZoomPane),
         "select-pane" | "selectp" => {
-            if parts.iter().any(|p| *p == "-U") {
+            if parts.iter().any(|p| *p == "-Z") {
+                Some(Action::Command(cmd.to_string()))
+            } else if parts.iter().any(|p| *p == "-U") {
                 Some(Action::MoveFocus(FocusDir::Up))
             } else if parts.iter().any(|p| *p == "-D") {
                 Some(Action::MoveFocus(FocusDir::Down))
@@ -1010,16 +1012,23 @@ fn execute_command_string_single(app: &mut AppState, cmd: &str) -> io::Result<()
                 });
                 return Ok(());
             }
+            let keep_zoom = parts.iter().any(|p| *p == "-Z");
             let dir = if parts.iter().any(|p| *p == "-U") { FocusDir::Up }
                 else if parts.iter().any(|p| *p == "-D") { FocusDir::Down }
                 else if parts.iter().any(|p| *p == "-L") { FocusDir::Left }
                 else if parts.iter().any(|p| *p == "-R") { FocusDir::Right }
                 else { return Ok(()); };
-            // Zoom-aware directional navigation (tmux parity #134):
-            // If zoomed, check if there's a direct neighbor OR a wrap target.
-            // If yes: cancel zoom and navigate to it.
-            // If no (single-pane window): no-op — stay zoomed.
-            if app.windows[app.active_idx].zoom_saved.is_some() {
+            if keep_zoom {
+                switch_with_copy_save(app, |app| {
+                    let win = &app.windows[app.active_idx];
+                    app.last_pane_path = win.active_path.clone();
+                    crate::input::move_focus_preserving_zoom(app, dir);
+                });
+            } else if app.windows[app.active_idx].zoom_saved.is_some() {
+                // Zoom-aware directional navigation (tmux parity #134):
+                // If zoomed, check if there's a direct neighbor OR a wrap target.
+                // If yes: cancel zoom and navigate to it.
+                // If no (single-pane window): no-op — stay zoomed.
                 // Temporarily unzoom to compute real geometry
                 let saved = app.windows[app.active_idx].zoom_saved.take();
                 if let Some(ref s) = saved {

--- a/src/input.rs
+++ b/src/input.rs
@@ -1388,6 +1388,20 @@ pub fn move_focus(app: &mut AppState, dir: FocusDir) {
     }
 }
 
+pub fn move_focus_preserving_zoom(app: &mut AppState, dir: FocusDir) {
+    if app.windows.get(app.active_idx).map_or(false, |w| w.zoom_saved.is_some()) {
+        let old_path = app.windows[app.active_idx].active_path.clone();
+        toggle_zoom(app);
+        move_focus(app, dir);
+        toggle_zoom(app);
+        if app.windows[app.active_idx].active_path == old_path {
+            app.last_pane_path = old_path;
+        }
+    } else {
+        move_focus(app, dir);
+    }
+}
+
 /// Spatial pane navigation: find the best pane in the given direction.
 /// Prefers panes that overlap on the perpendicular axis (visually adjacent),
 /// then picks the closest by primary-axis gap, tie-broken by MRU recency

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -156,6 +156,15 @@ pub enum LayoutJson {
     },
 }
 
+impl LayoutJson {
+    pub fn count_leaves(&self) -> usize {
+        match self {
+            LayoutJson::Leaf { .. } => 1,
+            LayoutJson::Split { children, .. } => children.iter().map(|c| c.count_leaves()).sum(),
+        }
+    }
+}
+
 pub fn dump_layout_json(app: &mut AppState) -> io::Result<String> {
     let in_copy_mode = matches!(app.mode, Mode::CopyMode | Mode::CopySearch { .. });
     let scroll_offset = app.copy_scroll_offset;

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -874,7 +874,8 @@ match cmd {
             let _ = tx.send(CtrlReq::SetPaneStyle(style));
         }
         if !dir.is_empty() {
-            let _ = tx.send(CtrlReq::SelectPane(dir.to_string()));
+            let keep_zoom = args.iter().any(|a| *a == "-Z");
+            let _ = tx.send(CtrlReq::SelectPane(dir.to_string(), keep_zoom));
         }
     }
     "select-window" | "selectw" => {

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -25,7 +25,7 @@ use helpers::{collect_pane_paths_server, serialize_bindings_json, json_escape_st
     list_windows_json_with_tabs, combined_data_version, TMUX_COMMANDS};
 use options::{get_option_value, get_window_option_value, render_window_options, apply_set_option};
 
-use crate::input::{send_text_to_active, send_key_to_active, send_paste_to_active, move_focus, find_best_pane_in_direction, find_wrap_target};
+use crate::input::{send_text_to_active, send_key_to_active, send_paste_to_active, move_focus, move_focus_preserving_zoom, find_best_pane_in_direction, find_wrap_target};
 use crate::copy_mode::{enter_copy_mode, exit_copy_mode, move_copy_cursor, current_prompt_pos,
     yank_selection, scroll_copy_up, scroll_copy_down, switch_with_copy_save,
     capture_active_pane_text, capture_active_pane_range, capture_active_pane_styled};
@@ -1889,7 +1889,7 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                         _ => {} // ignore unknown copy-mode commands
                     }
                 }
-                CtrlReq::SelectPane(dir) => {
+                CtrlReq::SelectPane(dir, keep_zoom) => {
                     if let Some(cmds) = app.hooks.get("before-select-pane") { let cmds = cmds.clone(); for cmd in &cmds { let _ = execute_command_string(&mut app, cmd); } }
                     // Auto-unzoom when navigating to another pane (tmux behavior).
                     // For directional nav: unzoom first so compute_rects uses
@@ -1902,36 +1902,47 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                                 "U" => FocusDir::Up, "D" => FocusDir::Down,
                                 "L" => FocusDir::Left, _ => FocusDir::Right,
                             };
-                            let was_zoomed = unzoom_if_zoomed(&mut app);
-                            if was_zoomed {
+                            if keep_zoom {
+                                let old_path = app.windows[app.active_idx].active_path.clone();
+                                switch_with_copy_save(&mut app, |app| {
+                                    move_focus_preserving_zoom(app, focus_dir);
+                                });
+                                if app.windows[app.active_idx].active_path != old_path {
+                                    app.last_pane_path = old_path;
+                                }
+                            } else {
+                                let was_zoomed = unzoom_if_zoomed(&mut app);
+                                if was_zoomed {
                                 // Zoom-aware: check direct neighbor or wrap target (tmux parity: unzoom+wrap).
                                 let win = &app.windows[app.active_idx];
                                 let mut rects: Vec<(Vec<usize>, ratatui::layout::Rect)> = Vec::new();
                                 crate::tree::compute_rects(&win.root, app.last_window_area, &mut rects);
                                 let active_idx = rects.iter().position(|(path, _)| *path == win.active_path);
-                                let has_target = if let Some(ai) = active_idx {
-                                    let (_, arect) = &rects[ai];
-                                    find_best_pane_in_direction(&rects, ai, arect, focus_dir, &[], &[])
-                                        .or_else(|| find_wrap_target(&rects, ai, arect, focus_dir, &[], &[]))
-                                        .is_some()
-                                } else { false };
-                                if has_target {
+                                let has_target = 
+                                    if let Some(ai) = active_idx {
+                                        let (_, arect) = &rects[ai];
+                                        find_best_pane_in_direction(&rects, ai, arect, focus_dir, &[], &[])
+                                            .or_else(|| find_wrap_target(&rects, ai, arect, focus_dir, &[], &[]))
+                                            .is_some()
+                                    } else { false };
+                                    if has_target {
+                                        let old_path = app.windows[app.active_idx].active_path.clone();
+                                        switch_with_copy_save(&mut app, |app| {
+                                            move_focus(app, focus_dir);
+                                        });
+                                        app.last_pane_path = old_path;
+                                    } else {
+                                        // No reachable pane (single-pane window) — re-zoom
+                                        toggle_zoom(&mut app);
+                                    }
+                                } else {
                                     let old_path = app.windows[app.active_idx].active_path.clone();
                                     switch_with_copy_save(&mut app, |app| {
                                         move_focus(app, focus_dir);
                                     });
-                                    app.last_pane_path = old_path;
-                                } else {
-                                    // No reachable pane (single-pane window) — re-zoom
-                                    toggle_zoom(&mut app);
-                                }
-                            } else {
-                                let old_path = app.windows[app.active_idx].active_path.clone();
-                                switch_with_copy_save(&mut app, |app| {
-                                    move_focus(app, focus_dir);
-                                });
-                                if app.windows[app.active_idx].active_path != old_path {
-                                    app.last_pane_path = old_path;
+                                    if app.windows[app.active_idx].active_path != old_path {
+                                        app.last_pane_path = old_path;
+                                    }
                                 }
                             }
                         }

--- a/src/types.rs
+++ b/src/types.rs
@@ -932,7 +932,7 @@ pub enum CtrlReq {
     SetPaneStyle(String),
     SendKeys(String, bool),
     SendKeysX(String),  // send-keys -X copy-mode-command
-    SelectPane(String),
+    SelectPane(String, bool),
     SelectWindow(usize),
     ListPanes(mpsc::Sender<String>),
     ListPanesFormat(mpsc::Sender<String>, String),

--- a/tests-rs/test_server.rs
+++ b/tests-rs/test_server.rs
@@ -285,6 +285,32 @@ fn normalize_only_strips_shift_from_char() {
     assert_eq!(shift_bs, (KeyCode::Backspace, KeyModifiers::SHIFT));
 }
 
+#[test]
+fn bind_key_select_pane_z_stays_as_command() {
+    let mut app = AppState::new("test".to_string());
+    crate::config::parse_bind_key(&mut app, "bind-key -n C-h select-pane -Z -L");
+    let root = app.key_tables.get("root").expect("root table should exist");
+    let bind = &root[0];
+    assert!(matches!(&bind.action, crate::types::Action::Command(cmd) if cmd == "select-pane -Z -L"));
+}
+
+#[test]
+fn parse_config_line_select_pane_z_stays_as_command() {
+    let mut app = AppState::new("test".to_string());
+    crate::config::parse_config_line(&mut app, "bind-key -r h select-pane -Z -L");
+    let prefix = app.key_tables.get("prefix").expect("prefix table should exist");
+    let bind = prefix.iter().find(|b| matches!(b.key.0, KeyCode::Char('h'))).expect("h binding should exist");
+    assert!(matches!(&bind.action, crate::types::Action::Command(cmd) if cmd == "select-pane -Z -L"));
+}
+
+#[test]
+fn serialized_bindings_preserve_select_pane_z_command() {
+    let mut app = AppState::new("test".to_string());
+    crate::config::parse_config_line(&mut app, "bind-key -r h select-pane -Z -L");
+    let json = crate::server::helpers::serialize_bindings_json(&app);
+    assert!(json.contains("select-pane -Z -L"));
+}
+
 // ── combined_data_version includes copy mode state (issue #152) ──
 
 #[test]


### PR DESCRIPTION
The `pane-active-border-style` indicator is not visible when panes are split, and behaves incorrectly in nested layouts.

### Repro

1. Start psmux
2. Split into left and right panes
3. Switch focus between panes

### Expected

The border segment adjacent to the focused pane should be highlighted with `pane-active-border-style`. For exactly 2 panes, the shared separator is split at the midpoint so each half reflects its adjacent pane's active state (matching tmux `pane-border-indicators` behaviour).

### Actual

No visible change when switching focus — the separator appears the same color regardless of which pane is active. In nested layouts (e.g. left pane + top-right / bottom-right), the separators are either all highlighted or split at an arbitrary midpoint unrelated to the focused pane's position.

### Root cause

Two separate issues:

**1. Post-render re-coloring pass overwrites everything**

After `render_json` draws the separators, a post-render pass re-colors all border characters based on adjacency to the active pane rect. For a simple 2-pane split, the separator is *always* geometrically adjacent to whichever pane is active — so the entire separator is always painted with `active_border_style`, producing no visible change when switching focus.

**2. Midpoint logic applied unconditionally in nested layouts**

When both adjacent children are leaf panes, the code used a midpoint split: the top half of `│` represents the left pane, the bottom half represents the right pane (and vice-versa for `─`). This works correctly for a simple 2-pane layout, but in a nested layout (e.g. `Split(H: [Left, Split(V: [TopRight, BotRight])])`) the horizontal `─` separator between TopRight and BotRight was being split left/right at an arbitrary midpoint, which does not correspond to the spatial position of either pane.

### Fix

**Re-coloring pass:** Restrict the post-render pass to junction characters only (`┼ ├ ┤ ┬ ┴`). This lets `render_json` own the style of straight `│` and `─` cells without being overwritten.

**Separator rendering:** Unify the logic into two cases:
- **Exactly 2 panes (whole window):** Use the midpoint half-highlight for the shared separator, matching tmux's `pane-border-indicators colour` behaviour.
- **3+ panes:** Use per-cell adjacency — each cell of the separator is highlighted only if the active pane directly borders that specific cell. This ensures only the segments forming the actual border of the focused pane are highlighted, regardless of layout complexity.

`LayoutJson::count_leaves()` is added to compute the total pane count. When zoomed, `total_panes` is set to 1 to reflect that only one pane is visible and to skip the traversal.

---

<!-- Screenshots: before / after -->