### PR TITLE
fix: correct active pane border indicator for all split layouts

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -3243,7 +3243,7 @@ pub fn run_remote(terminal: &mut Terminal<CrosstermBackend<crate::platform::Psmu
                 }
             }
 
-            fn render_json(f: &mut Frame, node: &LayoutJson, area: Rect, dim_preds: bool, border_fg: Color, active_border_fg: Color, clock_mode: bool, clock_colour: Color, active_rect: Option<Rect>, mode_style_str: &str, zoomed: bool, border_status: &str, border_format: &str) {
+            fn render_json(f: &mut Frame, node: &LayoutJson, area: Rect, dim_preds: bool, border_fg: Color, active_border_fg: Color, clock_mode: bool, clock_colour: Color, active_rect: Option<Rect>, mode_style_str: &str, zoomed: bool, border_status: &str, border_format: &str, total_panes: usize) {
                 match node {
                     LayoutJson::Leaf {
                         id,
@@ -3512,7 +3512,7 @@ pub fn run_remote(terminal: &mut Terminal<CrosstermBackend<crate::platform::Psmu
 
                         // Render children first
                         for (i, child) in children.iter().enumerate() {
-                            if i < rects.len() { render_json(f, child, rects[i], dim_preds, border_fg, active_border_fg, clock_mode, clock_colour, active_rect, mode_style_str, zoomed, border_status, border_format); }
+                            if i < rects.len() { render_json(f, child, rects[i], dim_preds, border_fg, active_border_fg, clock_mode, clock_colour, active_rect, mode_style_str, zoomed, border_status, border_format, total_panes); }
                         }
 
                         // Draw separator lines between children using direct buffer access.
@@ -3536,7 +3536,7 @@ pub fn run_remote(terminal: &mut Terminal<CrosstermBackend<crate::platform::Psmu
                                 // Vertical separator line between left/right children.
                                 let sep_x = rects[i].x + rects[i].width;
                                 if sep_x < buf.area.x + buf.area.width {
-                                    if both_leaves {
+                                    if both_leaves && total_panes == 2 {
                                         let left_active = matches!(&children[i], LayoutJson::Leaf { active, .. } if *active);
                                         let right_active = matches!(children.get(i + 1), Some(LayoutJson::Leaf { active, .. }) if *active);
                                         let left_sty = if left_active { active_border_style } else { border_style };
@@ -3571,7 +3571,7 @@ pub fn run_remote(terminal: &mut Terminal<CrosstermBackend<crate::platform::Psmu
                                 // Horizontal separator line between top/bottom children.
                                 let sep_y = rects[i].y + rects[i].height;
                                 if sep_y < buf.area.y + buf.area.height {
-                                    if both_leaves {
+                                    if both_leaves && total_panes == 2 {
                                         let top_active = matches!(&children[i], LayoutJson::Leaf { active, .. } if *active);
                                         let bot_active = matches!(children.get(i + 1), Some(LayoutJson::Leaf { active, .. }) if *active);
                                         let top_sty = if top_active { active_border_style } else { border_style };
@@ -3612,7 +3612,9 @@ pub fn run_remote(terminal: &mut Terminal<CrosstermBackend<crate::platform::Psmu
             let clock_col = clock_colour_str.as_deref().map(|s| map_color(s)).unwrap_or(Color::Cyan);
             let border_status = state.pane_border_status.as_deref().unwrap_or("off");
             let border_format = state.pane_border_format.as_deref().unwrap_or("");
-            render_json(f, &root, content_chunk, dim_preds, pane_border_fg, pane_active_border_fg, clock_active, clock_col, active_rect, &mode_style_str, state.zoomed, border_status, border_format);
+            // O(N) per frame but pane counts are small in practice (typically < 20).
+            let total_panes = if state.zoomed { 1 } else { root.count_leaves() };
+            render_json(f, &root, content_chunk, dim_preds, pane_border_fg, pane_active_border_fg, clock_active, clock_col, active_rect, &mode_style_str, state.zoomed, border_status, border_format, total_panes);
             fix_border_intersections(f.buffer_mut());
             // Re-color all border characters based on adjacency to the active pane.
             // render_json and fix_border_intersections can leave inconsistent styles
@@ -3628,7 +3630,7 @@ pub fn run_remote(terminal: &mut Terminal<CrosstermBackend<crate::platform::Psmu
                         let idx = row * w + col;
                         if idx >= buf.content.len() { continue; }
                         let ch = buf.content[idx].symbol().chars().next().unwrap_or(' ');
-                        if !matches!(ch, '│' | '─' | '┼' | '├' | '┤' | '┬' | '┴') { continue; }
+                        if !matches!(ch, '┼' | '├' | '┤' | '┬' | '┴') { continue; }
                         let x = buf.area.x + col as u16;
                         let y = buf.area.y + row as u16;
                         let adj = (x + 1 == ar.x && y >= ar.y && y < ar.y + ar.height)

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -156,6 +156,15 @@ pub enum LayoutJson {
     },
 }
 
+impl LayoutJson {
+    pub fn count_leaves(&self) -> usize {
+        match self {
+            LayoutJson::Leaf { .. } => 1,
+            LayoutJson::Split { children, .. } => children.iter().map(|c| c.count_leaves()).sum(),
+        }
+    }
+}
+
 pub fn dump_layout_json(app: &mut AppState) -> io::Result<String> {
     let in_copy_mode = matches!(app.mode, Mode::CopyMode | Mode::CopySearch { .. });
     let scroll_offset = app.copy_scroll_offset;


### PR DESCRIPTION
The `pane-active-border-style` indicator is not visible when panes are split, and behaves incorrectly in nested layouts.

### Repro

1. Start psmux
2. Split into left and right panes
3. Switch focus between panes

### Expected

The border segment adjacent to the focused pane should be highlighted with `pane-active-border-style`. For exactly 2 panes, the shared separator is split at the midpoint so each half reflects its adjacent pane's active state (matching tmux `pane-border-indicators colour` behaviour).

### Actual

No visible change when switching focus — the separator appears the same color regardless of which pane is active. In nested layouts (e.g. left pane + top-right / bottom-right), the separators are either all highlighted or split at an arbitrary midpoint unrelated to the focused pane's position.

### Root cause

Two separate issues:

**1. Post-render re-coloring pass overwrites everything**

After `render_json` draws the separators, a post-render pass re-colors all border characters based on adjacency to the active pane rect. For a simple 2-pane split, the separator is *always* geometrically adjacent to whichever pane is active — so the entire separator is always painted with `active_border_style`, producing no visible change when switching focus.

### Fix

**Re-coloring pass:** Restrict the post-render pass to junction characters only (`┼ ├ ┤ ┬ ┴`). This lets `render_json` own the style of straight `│` and `─` cells without being overwritten. Keeping `│` and `─` in the pass causes it to overwrite the midpoint styles computed by `render_json` for the 2-pane case, so removal is necessary.

**Separator rendering:** Unify the logic into two cases:
- **Exactly 2 panes (whole window):** Use the midpoint half-highlight for the shared separator, matching tmux's `pane-border-indicators colour` behaviour.
- **3+ panes:** Use per-cell adjacency — each cell of the separator is highlighted only if the active pane directly borders that specific cell. This ensures only the segments forming the actual border of the focused pane are highlighted, regardless of layout complexity.

`LayoutJson::count_leaves()` is added to compute the total pane count. When zoomed, `total_panes` is set to 1 to reflect that only one pane is visible and to skip the traversal.

---

Current State
<img width="1918" height="1003" alt="image" src="https://github.com/user-attachments/assets/5bd11b07-169f-4c77-9f8d-019439ab4342" />

After change
<img width="1915" height="1009" alt="image" src="https://github.com/user-attachments/assets/0c147f7b-eb55-4297-ba5b-b39bd5fb31fe" />

3+ pane still working as usaul
<img width="1917" height="1002" alt="image" src="https://github.com/user-attachments/assets/261dc72b-d530-4932-8b76-4c925b5c4043" />
