### PR TITLE
fix: deliver latest frame under client backpressure

### DIFF
--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -110,7 +110,6 @@ if line.trim() == "PERSISTENT" {
     let directive_rx = crate::types::register_directive_channel(client_id);
 
     std::thread::spawn(move || {
-        let frame_rx = frame_chan.rx.lock().unwrap();
         loop {
             // 0. Check for queued directives (non-blocking) — these take priority
             while let Ok(directive) = directive_rx.try_recv() {
@@ -136,9 +135,13 @@ if line.trim() == "PERSISTENT" {
                 Err(mpsc::RecvTimeoutError::Timeout) => {}
             }
             // 2. Drain all queued frames from the bounded channel
-            while let Ok(text) = frame_rx.try_recv() {
-                if write!(ws_bg, "{}\n", text).is_err() { return; }
-                if ws_bg.flush().is_err() { return; }
+            if let Ok(frame_rx) = frame_chan.rx.lock() {
+                while let Ok(text) = frame_rx.try_recv() {
+                    if write!(ws_bg, "{}\n", text).is_err() { return; }
+                    if ws_bg.flush().is_err() { return; }
+                }
+            } else {
+                return;
             }
         }
     });

--- a/src/types.rs
+++ b/src/types.rs
@@ -1270,7 +1270,7 @@ pub struct FrameChannelInner {
     pub rx: std::sync::Mutex<std::sync::mpsc::Receiver<String>>,
 }
 
-static FRAME_PUSH_CHANNELS: std::sync::Mutex<Vec<(u64, std::sync::mpsc::SyncSender<String>)>> =
+static FRAME_PUSH_CHANNELS: std::sync::Mutex<Vec<(u64, FrameChannel)>> =
     std::sync::Mutex::new(Vec::new());
 
 /// Register a bounded frame channel for a persistent connection's writer
@@ -1278,13 +1278,14 @@ static FRAME_PUSH_CHANNELS: std::sync::Mutex<Vec<(u64, std::sync::mpsc::SyncSend
 /// Returns the channel Arc for the writer thread to consume from.
 pub fn register_frame_channel(client_id: u64) -> FrameChannel {
     let (tx, rx) = std::sync::mpsc::sync_channel::<String>(FRAME_CHANNEL_CAPACITY);
-    if let Ok(mut v) = FRAME_PUSH_CHANNELS.lock() {
-        v.push((client_id, tx.clone()));
-    }
-    std::sync::Arc::new(FrameChannelInner {
+    let channel = std::sync::Arc::new(FrameChannelInner {
         tx,
         rx: std::sync::Mutex::new(rx),
-    })
+    });
+    if let Ok(mut v) = FRAME_PUSH_CHANNELS.lock() {
+        v.push((client_id, channel.clone()));
+    }
+    channel
 }
 
 /// Push a serialized frame to all persistent clients.
@@ -1294,18 +1295,28 @@ pub fn register_frame_channel(client_id: u64) -> FrameChannel {
 /// Dead channels (writer thread exited) are pruned automatically.
 pub fn push_frame(frame: &str) {
     if let Ok(mut channels) = FRAME_PUSH_CHANNELS.lock() {
-        channels.retain(|(_, tx)| {
-            match tx.try_send(frame.to_string()) {
+        channels.retain(|(_, channel)| {
+            match channel.tx.try_send(frame.to_string()) {
                 Ok(()) => true,
-                Err(std::sync::mpsc::TrySendError::Full(_)) => {
-                    // Channel full — this happens during sustained high-throughput
-                    // (e.g. rapid scroll in copy mode).  The oldest frame in the
-                    // channel is stale, so we make room by creating a fresh channel
-                    // pair isn't practical here.  Instead, we just skip this frame
-                    // for this client — the next push will likely succeed, and the
-                    // client already has FRAME_CHANNEL_CAPACITY frames queued to
-                    // drain, so it won't miss content.
-                    true
+                Err(std::sync::mpsc::TrySendError::Full(frame)) => {
+                    // Frames are full snapshots, not deltas. If the client is
+                    // behind, stale queued frames should not block the newest
+                    // corrective frame from reaching the terminal.
+                    let rx = match channel.rx.lock() {
+                        Ok(rx) => rx,
+                        Err(_) => return false,
+                    };
+                    loop {
+                        match rx.try_recv() {
+                            Ok(_) => {}
+                            Err(std::sync::mpsc::TryRecvError::Empty) => break,
+                            Err(std::sync::mpsc::TryRecvError::Disconnected) => return false,
+                        }
+                    }
+                    matches!(
+                        channel.tx.try_send(frame),
+                        Ok(()) | Err(std::sync::mpsc::TrySendError::Full(_))
+                    )
                 }
                 Err(std::sync::mpsc::TrySendError::Disconnected(_)) => false,
             }
@@ -1388,4 +1399,30 @@ pub struct ParsedTarget {
     pub pane: Option<usize>,
     pub pane_is_id: bool,
     pub window_is_id: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn push_frame_replaces_stale_backlog_when_full() {
+        let client_id = u64::MAX - 246;
+        shutdown_client_stream(client_id);
+
+        let channel = register_frame_channel(client_id);
+        for idx in 0..FRAME_CHANNEL_CAPACITY {
+            push_frame(&format!("stale-{idx}"));
+        }
+        push_frame("newest");
+
+        let rx = channel.rx.lock().expect("frame receiver lock");
+        let mut frames = Vec::new();
+        while let Ok(frame) = rx.try_recv() {
+            frames.push(frame);
+        }
+
+        shutdown_client_stream(client_id);
+        assert_eq!(frames, vec!["newest".to_string()]);
+    }
 }


### PR DESCRIPTION
## Summary

Fixes a second-layer candidate for the sparse-cell rendering artifact tracked in #246.

The original #246 parser-side race fix is present in the locally reproduced build, and the existing sparse-render harness does not reproduce against it. The remaining suspicious path is persistent-client frame backpressure: `push_frame()` documented latest-frame-wins behavior when the bounded channel is full, but actually skipped the newest frame.

Because pushed frames are complete snapshots, not deltas, a saturated client should drop stale queued frames and deliver the newest corrective snapshot.

## Changes

- Store registered frame channels instead of only their senders so `push_frame()` can access the receiver backlog.
- Scope the persistent writer's receiver lock to each drain pass instead of holding it forever.
- On full frame queues, drain stale queued frames and retry the newest frame.
- Add a focused unit test for saturated frame queue behavior.

## Validation

- `cargo test --quiet push_frame_replaces_stale_backlog_when_full`
- `cargo check --quiet`

Refs #246