### PR TITLE
fix: respond to ESC[6n cursor position queries reactively

### DIFF
--- a/src/cross_session_server.rs
+++ b/src/cross_session_server.rs
@@ -274,6 +274,7 @@ pub fn handle_pane_forward_inject(
         proxy_pane.data_version.clone(),
         proxy_pane.cursor_shape.clone(),
         proxy_pane.bell_pending.clone(),
+        proxy_pane.cpr_pending.clone(),
         proxy_pane.output_ring.clone(),
     );
     // Graft into the target window tree

--- a/src/pane.rs
+++ b/src/pane.rs
@@ -97,7 +97,7 @@ pub fn create_window(pty_system: &dyn portable_pty::PtySystem, app: &mut AppStat
         }
         let epoch = std::time::Instant::now() - Duration::from_secs(2);
         let configured_shell = if app.default_shell.is_empty() { None } else { Some(app.default_shell.as_str()) };
-        let pane = Pane { master: wp.master, writer: wp.writer, child: wp.child, term: wp.term, last_rows: rows, last_cols: cols, id: wp.pane_id, title: hostname_cached(), title_locked: false, child_pid: wp.child_pid, data_version: wp.data_version, last_title_check: epoch, last_infer_title: epoch, dead: false, vt_bridge_cache: None, vti_mode_cache: None, mouse_input_cache: None, cursor_shape: wp.cursor_shape, bell_pending: wp.bell_pending, copy_state: None, pane_style: None, squelch_until: None, output_ring: wp.output_ring };
+        let pane = Pane { master: wp.master, writer: wp.writer, child: wp.child, term: wp.term, last_rows: rows, last_cols: cols, id: wp.pane_id, title: hostname_cached(), title_locked: false, child_pid: wp.child_pid, data_version: wp.data_version, last_title_check: epoch, last_infer_title: epoch, dead: false, vt_bridge_cache: None, vti_mode_cache: None, mouse_input_cache: None, cursor_shape: wp.cursor_shape, bell_pending: wp.bell_pending, cpr_pending: wp.cpr_pending, copy_state: None, pane_style: None, squelch_until: None, output_ring: wp.output_ring };
         let win_name = default_shell_name(None, configured_shell);
         let initial_pane_id = wp.pane_id;
         app.windows.push(Window { root: Node::Leaf(pane), active_path: vec![], name: win_name, id: app.next_win_id, activity_flag: false, bell_flag: false, silence_flag: false, last_output_time: std::time::Instant::now(), last_seen_version: 0, manual_rename: false, layout_index: 0, pane_mru: vec![initial_pane_id], zoom_saved: None, linked_from: None });
@@ -152,13 +152,15 @@ pub fn create_window(pty_system: &dyn portable_pty::PtySystem, app: &mut AppStat
     let cs_writer = cursor_shape.clone();
     let bell_pending = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
     let bell_writer = bell_pending.clone();
+    let cpr_pending = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let cpr_writer = cpr_pending.clone();
     let reader = pair
         .master
         .try_clone_reader()
         .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("clone reader error: {e}")))?;
 
     let output_ring = std::sync::Arc::new(std::sync::Mutex::new(std::collections::VecDeque::<u8>::new()));
-    spawn_reader_thread(reader, term_reader, dv_writer, cs_writer, bell_writer, output_ring.clone());
+    spawn_reader_thread(reader, term_reader, dv_writer, cs_writer, bell_writer, cpr_writer, output_ring.clone());
 
     let configured_shell = if app.default_shell.is_empty() { None } else { Some(app.default_shell.as_str()) };
     let child_pid = crate::platform::mouse_inject::get_child_pid(&*child);
@@ -167,7 +169,7 @@ pub fn create_window(pty_system: &dyn portable_pty::PtySystem, app: &mut AppStat
     conpty_preemptive_dsr_response(&mut *pty_writer);
     let epoch = std::time::Instant::now() - Duration::from_secs(2);
     let pane_id = app.next_pane_id;
-    let pane = Pane { master: pair.master, writer: pty_writer, child, term, last_rows: size.rows, last_cols: size.cols, id: pane_id, title: hostname_cached(), title_locked: false, child_pid, data_version, last_title_check: epoch, last_infer_title: epoch, dead: false, vt_bridge_cache: None, vti_mode_cache: None, mouse_input_cache: None, cursor_shape, bell_pending, copy_state: None, pane_style: None, squelch_until: None, output_ring };
+    let pane = Pane { master: pair.master, writer: pty_writer, child, term, last_rows: size.rows, last_cols: size.cols, id: pane_id, title: hostname_cached(), title_locked: false, child_pid, data_version, last_title_check: epoch, last_infer_title: epoch, dead: false, vt_bridge_cache: None, vti_mode_cache: None, mouse_input_cache: None, cursor_shape, bell_pending, cpr_pending, copy_state: None, pane_style: None, squelch_until: None, output_ring };
     app.next_pane_id += 1;
     let win_name = command.map(|c| default_shell_name(Some(c), None)).unwrap_or_else(|| default_shell_name(None, configured_shell));
     app.windows.push(Window { root: Node::Leaf(pane), active_path: vec![], name: win_name, id: app.next_win_id, activity_flag: false, bell_flag: false, silence_flag: false, last_output_time: std::time::Instant::now(), last_seen_version: 0, manual_rename: false, layout_index: 0, pane_mru: vec![pane_id], zoom_saved: None, linked_from: None });
@@ -218,16 +220,18 @@ pub fn spawn_warm_pane(pty_system: &dyn portable_pty::PtySystem, app: &mut AppSt
     let cs_writer = cursor_shape.clone();
     let bell_pending = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
     let bell_writer = bell_pending.clone();
+    let cpr_pending = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let cpr_writer = cpr_pending.clone();
     let reader = pair.master
         .try_clone_reader()
         .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("clone reader error: {e}")))?;
     let output_ring = std::sync::Arc::new(std::sync::Mutex::new(std::collections::VecDeque::<u8>::new()));
-    spawn_reader_thread(reader, term_reader, dv_writer, cs_writer, bell_writer, output_ring.clone());
+    spawn_reader_thread(reader, term_reader, dv_writer, cs_writer, bell_writer, cpr_writer, output_ring.clone());
     let child_pid = crate::platform::mouse_inject::get_child_pid(&*child);
     let mut pty_writer = pair.master.take_writer()
         .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("take writer error: {e}")))?;
     conpty_preemptive_dsr_response(&mut *pty_writer);
-    Ok(crate::types::WarmPane { master: pair.master, writer: pty_writer, child, term, data_version, cursor_shape, bell_pending, child_pid, pane_id, rows, cols, output_ring })
+    Ok(crate::types::WarmPane { master: pair.master, writer: pty_writer, child, term, data_version, cursor_shape, bell_pending, cpr_pending, child_pid, pane_id, rows, cols, output_ring })
 }
 
 pub fn split_active(app: &mut AppState, kind: LayoutKind) -> io::Result<()> {
@@ -265,13 +269,15 @@ pub fn create_window_raw(pty_system: &dyn portable_pty::PtySystem, app: &mut App
     let cs_writer = cursor_shape.clone();
     let bell_pending = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
     let bell_writer = bell_pending.clone();
+    let cpr_pending = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let cpr_writer = cpr_pending.clone();
     let reader = pair
         .master
         .try_clone_reader()
         .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("clone reader error: {e}")))?;
 
     let output_ring = std::sync::Arc::new(std::sync::Mutex::new(std::collections::VecDeque::<u8>::new()));
-    spawn_reader_thread(reader, term_reader, dv_writer, cs_writer, bell_writer, output_ring.clone());
+    spawn_reader_thread(reader, term_reader, dv_writer, cs_writer, bell_writer, cpr_writer, output_ring.clone());
 
     let child_pid = crate::platform::mouse_inject::get_child_pid(&*child);
     let mut pty_writer = pair.master.take_writer()
@@ -279,7 +285,7 @@ pub fn create_window_raw(pty_system: &dyn portable_pty::PtySystem, app: &mut App
     conpty_preemptive_dsr_response(&mut *pty_writer);
     let epoch = std::time::Instant::now() - Duration::from_secs(2);
     let raw_pane_id = app.next_pane_id;
-    let pane = Pane { master: pair.master, writer: pty_writer, child, term, last_rows: size.rows, last_cols: size.cols, id: raw_pane_id, title: hostname_cached(), title_locked: false, child_pid, data_version, last_title_check: epoch, last_infer_title: epoch, dead: false, vt_bridge_cache: None, vti_mode_cache: None, mouse_input_cache: None, cursor_shape, bell_pending, copy_state: None, pane_style: None, squelch_until: None, output_ring };
+    let pane = Pane { master: pair.master, writer: pty_writer, child, term, last_rows: size.rows, last_cols: size.cols, id: raw_pane_id, title: hostname_cached(), title_locked: false, child_pid, data_version, last_title_check: epoch, last_infer_title: epoch, dead: false, vt_bridge_cache: None, vti_mode_cache: None, mouse_input_cache: None, cursor_shape, bell_pending, cpr_pending, copy_state: None, pane_style: None, squelch_until: None, output_ring };
     app.next_pane_id += 1;
     let win_name = std::path::Path::new(&raw_args[0]).file_stem().and_then(|s| s.to_str()).unwrap_or(&raw_args[0]).to_string();
     app.windows.push(Window { root: Node::Leaf(pane), active_path: vec![], name: win_name, id: app.next_win_id, activity_flag: false, bell_flag: false, silence_flag: false, last_output_time: std::time::Instant::now(), last_seen_version: 0, manual_rename: false, layout_index: 0, pane_mru: vec![raw_pane_id], zoom_saved: None, linked_from: None });
@@ -382,7 +388,7 @@ pub fn split_active_with_command(app: &mut AppState, kind: LayoutKind, command: 
         }
         let epoch = std::time::Instant::now() - Duration::from_secs(2);
         let new_pane_id = wp.pane_id;
-        let new_leaf = Node::Leaf(Pane { master: wp.master, writer: wp.writer, child: wp.child, term: wp.term, last_rows: rows, last_cols: cols, id: new_pane_id, title: hostname_cached(), title_locked: false, child_pid: wp.child_pid, data_version: wp.data_version, last_title_check: epoch, last_infer_title: epoch, dead: false, vt_bridge_cache: None, vti_mode_cache: None, mouse_input_cache: None, cursor_shape: wp.cursor_shape, bell_pending: wp.bell_pending, copy_state: None, pane_style: None, squelch_until: None, output_ring: wp.output_ring });
+        let new_leaf = Node::Leaf(Pane { master: wp.master, writer: wp.writer, child: wp.child, term: wp.term, last_rows: rows, last_cols: cols, id: new_pane_id, title: hostname_cached(), title_locked: false, child_pid: wp.child_pid, data_version: wp.data_version, last_title_check: epoch, last_infer_title: epoch, dead: false, vt_bridge_cache: None, vti_mode_cache: None, mouse_input_cache: None, cursor_shape: wp.cursor_shape, bell_pending: wp.bell_pending, cpr_pending: wp.cpr_pending, copy_state: None, pane_style: None, squelch_until: None, output_ring: wp.output_ring });
         let win = &mut app.windows[app.active_idx];
         replace_leaf_with_split(&mut win.root, &win.active_path, kind, new_leaf);
         let mut new_path = win.active_path.clone();
@@ -425,15 +431,17 @@ pub fn split_active_with_command(app: &mut AppState, kind: LayoutKind, command: 
     let cs_writer = cursor_shape.clone();
     let bell_pending = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
     let bell_writer = bell_pending.clone();
+    let cpr_pending = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let cpr_writer = cpr_pending.clone();
     let output_ring = std::sync::Arc::new(std::sync::Mutex::new(std::collections::VecDeque::<u8>::new()));
-    spawn_reader_thread(reader, term_reader, dv_writer, cs_writer, bell_writer, output_ring.clone());
+    spawn_reader_thread(reader, term_reader, dv_writer, cs_writer, bell_writer, cpr_writer, output_ring.clone());
     let child_pid = crate::platform::mouse_inject::get_child_pid(&*child);
     let mut pty_writer = pair.master.take_writer()
         .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("take writer error: {e}")))?;
     conpty_preemptive_dsr_response(&mut *pty_writer);
     let epoch = std::time::Instant::now() - Duration::from_secs(2);
     let split_pane_id = app.next_pane_id;
-    let new_leaf = Node::Leaf(Pane { master: pair.master, writer: pty_writer, child, term, last_rows: size.rows, last_cols: size.cols, id: split_pane_id, title: hostname_cached(), title_locked: false, child_pid, data_version, last_title_check: epoch, last_infer_title: epoch, dead: false, vt_bridge_cache: None, vti_mode_cache: None, mouse_input_cache: None, cursor_shape, bell_pending, copy_state: None, pane_style: None, squelch_until: None, output_ring });
+    let new_leaf = Node::Leaf(Pane { master: pair.master, writer: pty_writer, child, term, last_rows: size.rows, last_cols: size.cols, id: split_pane_id, title: hostname_cached(), title_locked: false, child_pid, data_version, last_title_check: epoch, last_infer_title: epoch, dead: false, vt_bridge_cache: None, vti_mode_cache: None, mouse_input_cache: None, cursor_shape, bell_pending, cpr_pending, copy_state: None, pane_style: None, squelch_until: None, output_ring });
     app.next_pane_id += 1;
     let win = &mut app.windows[app.active_idx];
     replace_leaf_with_split(&mut win.root, &win.active_path, kind, new_leaf);
@@ -1181,12 +1189,24 @@ fn scan_rmcup(data: &[u8]) -> bool {
     data.windows(RMCUP.len()).any(|w| w == RMCUP)
 }
 
+/// Returns true if `data` contains a Cursor Position Request (ESC[6n).
+/// ConPTY children (e.g. pwsh) emit this at startup and after session events
+/// such as lock/unlock.  The host must respond with ESC[row;colR or the
+/// child blocks indefinitely.
+fn scan_cpr_query(data: &[u8]) -> bool {
+    const CPR: &[u8] = b"\x1b[6n";
+    data.contains(&0x1b) && data.windows(CPR.len()).any(|w| w == CPR)
+}
+
+// TODO: The 7 Arc parameters below should be grouped into a `ReaderSignals`
+// struct the next time a new signal is added, to keep the call-site manageable.
 pub fn spawn_reader_thread(
     mut reader: Box<dyn std::io::Read + Send>,
     term_reader: Arc<Mutex<vt100::Parser>>,
     dv_writer: Arc<std::sync::atomic::AtomicU64>,
     cursor_shape: Arc<std::sync::atomic::AtomicU8>,
     bell_pending: Arc<std::sync::atomic::AtomicBool>,
+    cpr_pending: Arc<std::sync::atomic::AtomicBool>,
     output_ring: Arc<Mutex<std::collections::VecDeque<u8>>>,
 ) {
     // ── Issue #246: split the old single reader thread into two threads ──
@@ -1340,6 +1360,7 @@ pub fn spawn_reader_thread(
                 cursor_shape.store(shape, Ordering::Release);
             }
             let rmcup = scan_rmcup(&bytes);
+            let has_cpr_query = scan_cpr_query(&bytes);
 
             if let Ok(mut parser) = term_reader.lock() {
                 parser.process(&bytes);
@@ -1351,6 +1372,13 @@ pub fn spawn_reader_thread(
             // persist from the exiting TUI app.
             if rmcup {
                 cursor_shape.store(0, Ordering::Release);
+            }
+            // Signal the main loop to inject a CPR response (ESC[row;colR).
+            // pwsh emits ESC[6n at startup and after session events such as
+            // lock/unlock; the main loop writes the response via pane.writer.
+            if has_cpr_query {
+                cpr_pending.store(true, Ordering::Release);
+                crate::types::CPR_DATA_PENDING.store(true, Ordering::Release);
             }
             dv_writer.fetch_add(1, Ordering::Release);
             crate::types::PTY_DATA_READY.store(true, Ordering::Release);
@@ -1377,6 +1405,10 @@ mod test_issue271_warm_pane_history;
 #[cfg(test)]
 #[path = "../tests-rs/test_issue88_alt_screen_toggle.rs"]
 mod test_issue88_alt_screen_toggle;
+
+#[cfg(test)]
+#[path = "../tests-rs/test_cpr_responder.rs"]
+mod test_cpr_responder;
 
 #[cfg(test)]
 mod test_parser_audible_bell {

--- a/src/popup.rs
+++ b/src/popup.rs
@@ -119,6 +119,11 @@ pub fn create_popup_pane(
         mouse_input_cache: None,
         cursor_shape,
         bell_pending,
+        // cpr_pending is intentionally unused for popups: the popup spawns its
+        // own inline reader thread (see lines ~71-85 of this file) that never
+        // calls scan_cpr_query.  Popups are not expected to run interactive
+        // shells, so CPR detection is not wired up here.
+        cpr_pending: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
         copy_state: None,
         pane_style: None,
         squelch_until: None,

--- a/src/proxy_pane.rs
+++ b/src/proxy_pane.rs
@@ -268,6 +268,9 @@ pub fn create_proxy_pane(
         mouse_input_cache: None,
         cursor_shape: Arc::new(std::sync::atomic::AtomicU8::new(0)),
         bell_pending: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        // CPR responses written via this field are TCP-forwarded to the source
+        // ConPTY via the ProxyMasterPty writer.
+        cpr_pending: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         copy_state: None,
         pane_style: None,
         squelch_until: None,

--- a/src/server/helpers.rs
+++ b/src/server/helpers.rs
@@ -1,13 +1,19 @@
 use std::io;
 
-use crate::types::{AppState, Node, Window};
 use crate::format::expand_format_for_window;
+use crate::types::{AppState, Node, Window};
 use crate::util::WinInfo;
 
 /// Collect all leaf pane paths in tree order (for next/prev pane cycling).
-pub(crate) fn collect_pane_paths_server(node: &Node, path: &mut Vec<usize>, panes: &mut Vec<Vec<usize>>) {
+pub(crate) fn collect_pane_paths_server(
+    node: &Node,
+    path: &mut Vec<usize>,
+    panes: &mut Vec<Vec<usize>>,
+) {
     match node {
-        Node::Leaf(_) => { panes.push(path.clone()); }
+        Node::Leaf(_) => {
+            panes.push(path.clone());
+        }
         Node::Split { children, .. } => {
             for (i, c) in children.iter().enumerate() {
                 path.push(i);
@@ -27,13 +33,17 @@ pub(crate) fn serialize_bindings_json(app: &AppState) -> String {
     let mut first = true;
     for (table_name, binds) in &app.key_tables {
         for bind in binds {
-            if !first { out.push(','); }
+            if !first {
+                out.push(',');
+            }
             first = false;
             let key_str = json_escape_string(&format_key_binding(&bind.key));
             let cmd_str = json_escape_string(&format_action(&bind.action));
             let tbl_str = json_escape_string(table_name);
-            out.push_str(&format!("{{\"t\":\"{}\",\"k\":\"{}\",\"c\":\"{}\",\"r\":{}}}",
-                tbl_str, key_str, cmd_str, bind.repeat));
+            out.push_str(&format!(
+                "{{\"t\":\"{}\",\"k\":\"{}\",\"c\":\"{}\",\"r\":{}}}",
+                tbl_str, key_str, cmd_str, bind.repeat
+            ));
         }
     }
     out.push(']');
@@ -66,7 +76,11 @@ pub(crate) fn list_windows_json_with_tabs(app: &AppState) -> io::Result<String> 
     let mut v: Vec<WinInfo> = Vec::new();
     for (i, w) in app.windows.iter().enumerate() {
         let is_active = i == app.active_idx;
-        let fmt = if is_active { &app.window_status_current_format } else { &app.window_status_format };
+        let fmt = if is_active {
+            &app.window_status_current_format
+        } else {
+            &app.window_status_format
+        };
         let tab = expand_format_for_window(fmt, app, i);
         v.push(WinInfo {
             id: w.id,
@@ -76,7 +90,8 @@ pub(crate) fn list_windows_json_with_tabs(app: &AppState) -> io::Result<String> 
             tab_text: tab,
         });
     }
-    serde_json::to_string(&v).map_err(|e| io::Error::new(io::ErrorKind::Other, format!("json error: {e}")))
+    serde_json::to_string(&v)
+        .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("json error: {e}")))
 }
 
 /// Sum data_version counters across all panes in the active window.
@@ -84,8 +99,14 @@ pub(crate) fn combined_data_version(app: &AppState) -> u64 {
     let mut v = 0u64;
     fn walk(node: &Node, v: &mut u64) {
         match node {
-            Node::Leaf(p) => { *v = v.wrapping_add(p.data_version.load(std::sync::atomic::Ordering::Acquire)); }
-            Node::Split { children, .. } => { for c in children { walk(c, v); } }
+            Node::Leaf(p) => {
+                *v = v.wrapping_add(p.data_version.load(std::sync::atomic::Ordering::Acquire));
+            }
+            Node::Split { children, .. } => {
+                for c in children {
+                    walk(c, v);
+                }
+            }
         }
     }
     if let Some(win) = app.windows.get(app.active_idx) {
@@ -141,8 +162,14 @@ pub(crate) fn window_data_version(win: &Window) -> u64 {
     let mut v = 0u64;
     fn walk(node: &Node, v: &mut u64) {
         match node {
-            Node::Leaf(p) => { *v = v.wrapping_add(p.data_version.load(std::sync::atomic::Ordering::Acquire)); }
-            Node::Split { children, .. } => { for c in children { walk(c, v); } }
+            Node::Leaf(p) => {
+                *v = v.wrapping_add(p.data_version.load(std::sync::atomic::Ordering::Acquire));
+            }
+            Node::Split { children, .. } => {
+                for c in children {
+                    walk(c, v);
+                }
+            }
         }
     }
     walk(&win.root, &mut v);
@@ -167,7 +194,10 @@ pub(crate) fn check_window_activity(app: &mut AppState) -> Vec<&'static str> {
             // "other" = only non-active (this path), "none" = never
             match bell_action.as_str() {
                 "any" | "other" => {
-                    if !win.bell_flag { win.bell_flag = true; triggered_hooks.push("alert-bell"); }
+                    if !win.bell_flag {
+                        win.bell_flag = true;
+                        triggered_hooks.push("alert-bell");
+                    }
                     forward_bell = true;
                 }
                 _ => {} // "none" or "current" — don't flag non-active windows
@@ -175,7 +205,10 @@ pub(crate) fn check_window_activity(app: &mut AppState) -> Vec<&'static str> {
         } else if has_bell && i == active {
             match bell_action.as_str() {
                 "any" | "current" => {
-                    if !win.bell_flag { win.bell_flag = true; triggered_hooks.push("alert-bell"); }
+                    if !win.bell_flag {
+                        win.bell_flag = true;
+                        triggered_hooks.push("alert-bell");
+                    }
                     forward_bell = true;
                 }
                 _ => {}
@@ -229,7 +262,9 @@ pub(crate) fn check_window_activity(app: &mut AppState) -> Vec<&'static str> {
 /// Returns true if any pane title changed (i.e. state is dirty).
 pub(crate) fn propagate_osc_titles(app: &mut AppState) -> bool {
     let allow_set_title = app.allow_set_title;
-    if !allow_set_title { return false; }
+    if !allow_set_title {
+        return false;
+    }
     let mut dirty = false;
     for win in app.windows.iter_mut() {
         propagate_osc_titles_in_tree(&mut win.root, &mut dirty);
@@ -255,7 +290,9 @@ pub(crate) fn active_pane_progress(app: &AppState) -> Option<(u8, u8)> {
 fn propagate_osc_titles_in_tree(node: &mut Node, dirty: &mut bool) {
     match node {
         Node::Leaf(p) => {
-            if p.dead || p.title_locked { return; }
+            if p.dead || p.title_locked {
+                return;
+            }
             if let Ok(parser) = p.term.lock() {
                 let osc = parser.screen().title();
                 if !osc.is_empty() {
@@ -280,62 +317,141 @@ fn propagate_osc_titles_in_tree(node: &mut Node, dirty: &mut bool) {
 /// Returns true if any pane had a pending bell.
 fn check_pane_bells(node: &Node) -> bool {
     match node {
-        Node::Leaf(p) => {
-            p.bell_pending.swap(false, std::sync::atomic::Ordering::AcqRel)
-        }
+        Node::Leaf(p) => p
+            .bell_pending
+            .swap(false, std::sync::atomic::Ordering::AcqRel),
         Node::Split { children, .. } => {
             let mut any = false;
             for c in children {
-                if check_pane_bells(c) { any = true; }
+                if check_pane_bells(c) {
+                    any = true;
+                }
             }
             any
         }
     }
 }
 
+/// Injects ESC[row;colR into any pane whose reader thread detected ESC[6n.
+/// pwsh re-issues the CPR query after lock/unlock; without this response it
+/// blocks indefinitely since the preemptive write at spawn time is long gone.
+pub(crate) fn drain_cpr_pending(node: &mut crate::types::Node) {
+    use std::io::Write as _;
+    match node {
+        crate::types::Node::Leaf(p) => {
+            if p.cpr_pending
+                .swap(false, std::sync::atomic::Ordering::AcqRel)
+            {
+                let (r, c) = p
+                    .term
+                    .lock()
+                    .map(|g| g.screen().cursor_position())
+                    .unwrap_or((0, 0));
+                let response = format!("\x1b[{};{}R", r + 1, c + 1);
+                let _ = p.writer.write_all(response.as_bytes());
+                let _ = p.writer.flush();
+            }
+        }
+        crate::types::Node::Split { children, .. } => {
+            for c in children {
+                drain_cpr_pending(c);
+            }
+        }
+    }
+}
+
 /// Complete list of supported tmux-compatible commands (for list-commands).
 pub(crate) const TMUX_COMMANDS: &[&str] = &[
-    "attach-session (attach)", "bind-key (bind)", "break-pane (breakp)",
-    "capture-pane (capturep)", "choose-buffer (chooseb)", "choose-client",
-    "choose-session", "choose-tree", "choose-window",
-    "clear-history (clearhist)", "clear-prompt-history (clearphist)",
-    "clock-mode", "command-prompt",
-    "confirm-before (confirm)", "copy-mode", "customize-mode",
-    "delete-buffer (deleteb)", "detach-client (detach)",
-    "display-menu (menu)", "display-message (display)",
-    "display-panes (displayp)", "display-popup (popup)",
-    "find-window (findw)", "has-session (has)",
-    "if-shell (if)", "join-pane (joinp)",
-    "kill-pane (killp)", "kill-server", "kill-session",
-    "kill-window (killw)", "last-pane (lastp)", "last-window (last)",
-    "link-window (linkw)", "list-buffers (lsb)", "list-clients (lsc)",
-    "list-commands (lscm)", "list-keys (lsk)", "list-panes (lsp)",
-    "list-sessions (ls)", "list-windows (lsw)",
-    "load-buffer (loadb)", "lock-client (lockc)",
-    "lock-server (lock)", "lock-session (locks)",
-    "move-pane (movep)", "move-window (movew)",
-    "new-session (new)", "new-window (neww)",
-    "next-layout (nextl)", "next-window (next)",
-    "paste-buffer (pasteb)", "pipe-pane (pipep)",
-    "previous-layout (prevl)", "previous-window (prev)",
-    "refresh-client (refresh)", "rename-session (rename)",
-    "rename-window (renamew)", "resize-pane (resizep)",
-    "resize-window (resizew)", "respawn-pane (respawnp)",
-    "respawn-window (respawnw)", "rotate-window (rotatew)",
-    "run-shell (run)", "save-buffer (saveb)",
-    "select-layout (selectl)", "select-pane (selectp)",
-    "select-window (selectw)", "send-keys (send)",
-    "send-prefix", "server-info (info)",
-    "set-buffer (setb)", "set-environment (setenv)",
-    "set-hook", "set-option (set)",
-    "set-window-option (setw)", "show-buffer (showb)",
-    "show-environment (showenv)", "show-hooks",
-    "show-messages (showmsgs)", "show-options (show)",
-    "show-prompt-history (showphist)", "show-window-options (showw)",
+    "attach-session (attach)",
+    "bind-key (bind)",
+    "break-pane (breakp)",
+    "capture-pane (capturep)",
+    "choose-buffer (chooseb)",
+    "choose-client",
+    "choose-session",
+    "choose-tree",
+    "choose-window",
+    "clear-history (clearhist)",
+    "clear-prompt-history (clearphist)",
+    "clock-mode",
+    "command-prompt",
+    "confirm-before (confirm)",
+    "copy-mode",
+    "customize-mode",
+    "delete-buffer (deleteb)",
+    "detach-client (detach)",
+    "display-menu (menu)",
+    "display-message (display)",
+    "display-panes (displayp)",
+    "display-popup (popup)",
+    "find-window (findw)",
+    "has-session (has)",
+    "if-shell (if)",
+    "join-pane (joinp)",
+    "kill-pane (killp)",
+    "kill-server",
+    "kill-session",
+    "kill-window (killw)",
+    "last-pane (lastp)",
+    "last-window (last)",
+    "link-window (linkw)",
+    "list-buffers (lsb)",
+    "list-clients (lsc)",
+    "list-commands (lscm)",
+    "list-keys (lsk)",
+    "list-panes (lsp)",
+    "list-sessions (ls)",
+    "list-windows (lsw)",
+    "load-buffer (loadb)",
+    "lock-client (lockc)",
+    "lock-server (lock)",
+    "lock-session (locks)",
+    "move-pane (movep)",
+    "move-window (movew)",
+    "new-session (new)",
+    "new-window (neww)",
+    "next-layout (nextl)",
+    "next-window (next)",
+    "paste-buffer (pasteb)",
+    "pipe-pane (pipep)",
+    "previous-layout (prevl)",
+    "previous-window (prev)",
+    "refresh-client (refresh)",
+    "rename-session (rename)",
+    "rename-window (renamew)",
+    "resize-pane (resizep)",
+    "resize-window (resizew)",
+    "respawn-pane (respawnp)",
+    "respawn-window (respawnw)",
+    "rotate-window (rotatew)",
+    "run-shell (run)",
+    "save-buffer (saveb)",
+    "select-layout (selectl)",
+    "select-pane (selectp)",
+    "select-window (selectw)",
+    "send-keys (send)",
+    "send-prefix",
+    "server-info (info)",
+    "set-buffer (setb)",
+    "set-environment (setenv)",
+    "set-hook",
+    "set-option (set)",
+    "set-window-option (setw)",
+    "show-buffer (showb)",
+    "show-environment (showenv)",
+    "show-hooks",
+    "show-messages (showmsgs)",
+    "show-options (show)",
+    "show-prompt-history (showphist)",
+    "show-window-options (showw)",
     "source-file (source)",
-    "split-window (splitw)", "start-server (start)",
-    "suspend-client (suspendc)", "swap-pane (swapp)",
-    "swap-window (swapw)", "switch-client (switchc)",
-    "unbind-key (unbind)", "unlink-window (unlinkw)",
+    "split-window (splitw)",
+    "start-server (start)",
+    "suspend-client (suspendc)",
+    "swap-pane (swapp)",
+    "swap-window (swapw)",
+    "switch-client (switchc)",
+    "unbind-key (unbind)",
+    "unlink-window (unlinkw)",
     "wait-for (wait)",
 ];

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -772,6 +772,12 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                     }
                 }
             }
+            // Answer any ESC[6n queries — pwsh re-issues this after lock/unlock.
+            if crate::types::CPR_DATA_PENDING.swap(false, std::sync::atomic::Ordering::AcqRel) {
+                for win in &mut app.windows {
+                    helpers::drain_cpr_pending(&mut win.root);
+                }
+            }
         }
         // When a popup PTY is active, always push frames so interactive
         // content (e.g. fzf, shell prompts) updates in real-time.

--- a/src/types.rs
+++ b/src/types.rs
@@ -125,6 +125,12 @@ pub struct Pane {
     /// Set by the PTY reader thread when a BEL character (\x07) is detected.
     /// Consumed by the server loop to set the window's bell_flag.
     pub bell_pending: std::sync::Arc<std::sync::atomic::AtomicBool>,
+    /// Set by the PTY reader thread when ESC[6n (Cursor Position Request) is
+    /// detected in the child's output.  Consumed by the server loop, which
+    /// then injects ESC[row;colR into the pane's PTY input.  This handles
+    /// the case where pwsh re-issues the CPR after lock/unlock — the single
+    /// preemptive write at spawn time is no longer in the pipe at that point.
+    pub cpr_pending: std::sync::Arc<std::sync::atomic::AtomicBool>,
     /// Per-pane copy mode state (tmux-style pane-local copy mode).
     /// Some(_) when this pane is in copy mode, None otherwise.
     pub copy_state: Option<CopyModeState>,
@@ -154,6 +160,7 @@ pub struct WarmPane {
     pub data_version: std::sync::Arc<std::sync::atomic::AtomicU64>,
     pub cursor_shape: std::sync::Arc<std::sync::atomic::AtomicU8>,
     pub bell_pending: std::sync::Arc<std::sync::atomic::AtomicBool>,
+    pub cpr_pending: std::sync::Arc<std::sync::atomic::AtomicBool>,
     pub child_pid: Option<u32>,
     pub pane_id: usize,
     pub rows: u16,
@@ -1235,6 +1242,10 @@ pub enum CtrlReq {
 /// The server loop checks this to use a shorter recv_timeout, reducing
 /// keystroke-to-display latency for nested shells (e.g. WSL inside pwsh).
 pub static PTY_DATA_READY: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+
+/// Set by the parser thread when any pane's `cpr_pending` flag is raised.
+/// Lets the server loop skip the tree walk when no CPR response is needed.
+pub static CPR_DATA_PENDING: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
 
 /// Tracked persistent client TCP streams.
 /// Connection handlers register clones here so the server can explicitly

--- a/src/window_ops.rs
+++ b/src/window_ops.rs
@@ -1296,14 +1296,16 @@ pub fn respawn_active_pane(app: &mut AppState, pty_system_ref: Option<&dyn porta
     
     let bell_pending = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
     let bell_writer = bell_pending.clone();
-    
+    let cpr_pending = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let cpr_writer = cpr_pending.clone();
+
     let output_ring = std::sync::Arc::new(std::sync::Mutex::new(std::collections::VecDeque::new()));
-    crate::pane::spawn_reader_thread(reader, term_reader, dv_writer, cs_writer, bell_writer, output_ring.clone());
+    crate::pane::spawn_reader_thread(reader, term_reader, dv_writer, cs_writer, bell_writer, cpr_writer, output_ring.clone());
     pane.output_ring = output_ring;
-    
+
     let mut pty_writer = pair.master.take_writer().map_err(|e| io::Error::new(io::ErrorKind::Other, format!("take writer error: {e}")))?;
     crate::pane::conpty_preemptive_dsr_response(&mut *pty_writer);
-    
+
     pane.master = pair.master;
     pane.writer = pty_writer;
     pane.child = child;
@@ -1311,6 +1313,7 @@ pub fn respawn_active_pane(app: &mut AppState, pty_system_ref: Option<&dyn porta
     pane.data_version = data_version;
     pane.cursor_shape = cursor_shape;
     pane.bell_pending = bell_pending;
+    pane.cpr_pending = cpr_pending;
     pane.child_pid = None;
     pane.vt_bridge_cache = None;
     pane.vti_mode_cache = None;

--- a/tests-rs/test_cpr_responder.rs
+++ b/tests-rs/test_cpr_responder.rs
@@ -1,0 +1,89 @@
+// Regression tests for the reactive CPR (Cursor Position Request) responder.
+//
+// Root cause (issue: pwsh hangs after lock/unlock):
+//   pwsh emits ESC[6n at startup and again after session events such as
+//   Win+L / unlock.  psmux's original preemptive ESC[1;1R (written once at
+//   spawn time) is long gone by then.  Without a reactive responder pwsh
+//   blocks indefinitely.
+//
+// Fix: the parser thread scans every byte batch for ESC[6n via
+// `scan_cpr_query` and sets `cpr_pending`; the server loop calls
+// `drain_cpr_pending` which writes ESC[row;colR and clears the flag.
+
+use super::*;
+
+// ── scan_cpr_query ────────────────────────────────────────────────────────
+
+#[test]
+fn detects_standalone_cpr_query() {
+    assert!(scan_cpr_query(b"\x1b[6n"));
+}
+
+#[test]
+fn detects_cpr_query_embedded_in_startup_sequence() {
+    // This is the exact 88-byte sequence logged for pane=16 when pwsh hung.
+    let startup = b"\x1b[6n\x1b[?9001h\x1b[?1004h\x1b[m\x1b]0;pwsh.exe\x07\x1b[?25h";
+    assert!(scan_cpr_query(startup));
+}
+
+#[test]
+fn no_false_positive_for_rmcup_only() {
+    assert!(!scan_cpr_query(b"\x1b[?1049l"));
+}
+
+#[test]
+fn no_false_positive_for_empty_input() {
+    assert!(!scan_cpr_query(b""));
+}
+
+#[test]
+fn no_false_positive_for_plain_text() {
+    assert!(!scan_cpr_query(b"hello world"));
+}
+
+#[test]
+fn no_false_positive_for_partial_sequence() {
+    // ESC + '[' without '6n' — must not match
+    assert!(!scan_cpr_query(b"\x1b[6"));
+    assert!(!scan_cpr_query(b"\x1b[n"));
+    assert!(!scan_cpr_query(b"\x1b[6m")); // wrong terminator
+}
+
+#[test]
+fn detects_cpr_query_at_end_of_buffer() {
+    let mut buf = vec![b'X'; 1024];
+    buf.extend_from_slice(b"\x1b[6n");
+    assert!(scan_cpr_query(&buf));
+}
+
+#[test]
+fn escapes_without_0x1b_skip_window_scan() {
+    // Pre-check: no ESC byte → must be false without scanning
+    assert!(!scan_cpr_query(b"[6n"));
+}
+
+// ── drain_cpr_pending — response format ──────────────────────────────────
+//
+// We verify the CPR response string format directly since constructing a
+// full Pane (which requires a live MasterPty) is out of scope for a unit
+// test.  The format is the same one drain_cpr_pending builds.
+
+#[test]
+fn cpr_response_format_is_1_based() {
+    // vt100::Parser uses 0-based (row, col); CPR response uses 1-based.
+    let mut parser = vt100::Parser::new(24, 80, 0);
+    // Move cursor to row 2, col 5 (0-based → 1-based: row=3, col=6)
+    parser.process(b"\x1b[3;6H");
+    let (r, c) = parser.screen().cursor_position();
+    assert_eq!((r, c), (2, 5), "parser uses 0-based coords");
+    let response = format!("\x1b[{};{}R", r + 1, c + 1);
+    assert_eq!(response, "\x1b[3;6R");
+}
+
+#[test]
+fn cpr_response_fallback_produces_valid_sequence() {
+    // unwrap_or((0,0)) → ESC[1;1R — a valid response that unblocks pwsh
+    let (r, c): (u16, u16) = (0, 0);
+    let response = format!("\x1b[{};{}R", r + 1, c + 1);
+    assert_eq!(response, "\x1b[1;1R");
+}

--- a/tests-rs/test_warm_pane_sync.rs
+++ b/tests-rs/test_warm_pane_sync.rs
@@ -125,6 +125,7 @@ fn resize_to_same_size_is_noop() {
         data_version: std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0)),
         cursor_shape: std::sync::Arc::new(std::sync::atomic::AtomicU8::new(0)),
         bell_pending: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        cpr_pending: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
         child_pid: None,
         pane_id: 0,
         rows: 40,


### PR DESCRIPTION
Closes #282 

## Problem

PowerShell (`pwsh`) freezes after Windows lock/unlock when running inside psmux. The root cause: pwsh emits `ESC[6n` (Cursor Position Request) at startup **and** again after session events like lock/unlock. The host must respond with `ESC[row;colR` or pwsh blocks indefinitely waiting for the response.

At spawn time, psmux already sends a preemptive `ESC[1;1R` to unblock the initial startup query. But this preemptive write is a one-shot — it cannot cover re-issued CPR queries after lock/unlock.

## Solution

- Add `scan_cpr_query()` in the reader thread to detect `ESC[6n` in PTY output
- When detected, set a per-pane `cpr_pending` flag and a global `CPR_DATA_PENDING` atomic
- In the server event loop (gated on `data_ready`), drain pending CPR flags and write the real `ESC[row;colR` response using the current cursor position from the VT parser
- Retain the preemptive `ESC[1;1R` write at spawn time to cover the initial startup race window

## Changes

- `src/types.rs` — add `cpr_pending: Arc<AtomicBool>` to `Pane` and `WarmPane`; add `CPR_DATA_PENDING` global atomic
- `src/pane.rs` — add `scan_cpr_query()`, thread `cpr_pending` through `spawn_reader_thread` (all 6 construction sites), add CPR signal in reader thread
- `src/server/helpers.rs` — add `drain_cpr_pending()` tree walker
- `src/server/mod.rs` — call `drain_cpr_pending` when `CPR_DATA_PENDING` is set
- `src/popup.rs` / `src/proxy_pane.rs` — populate `cpr_pending` field (popup's inline reader doesn't detect CPR; proxy forwards over TCP)
- `tests-rs/test_cpr_responder.rs` — 10 unit tests covering detection, false-positives, response format, and the 0x1b pre-check optimization

## Test plan

- [x] `cargo test cpr` — all 10 tests pass
- [x] `cargo build` — clean
- [x] Lock Windows and unlock while pwsh is running in a psmux pane — verify pwsh remains responsive and prompt re-renders correctlys.