### PR TITLE
fix: remove unused import `get_window_option_value` - code hygiene

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -23,7 +23,7 @@ use crate::tree::{self, active_pane, active_pane_mut, resize_all_panes, kill_all
 
 use helpers::{collect_pane_paths_server, serialize_bindings_json, json_escape_string,
     list_windows_json_with_tabs, combined_data_version, TMUX_COMMANDS};
-use options::{get_option_value, get_window_option_value, render_window_options, apply_set_option};
+use options::{get_option_value, render_window_options, apply_set_option};
 
 use crate::input::{send_text_to_active, send_key_to_active, send_paste_to_active, move_focus, move_focus_preserving_zoom, find_best_pane_in_direction, find_wrap_target};
 use crate::copy_mode::{enter_copy_mode, exit_copy_mode, move_copy_cursor, current_prompt_pos,


### PR DESCRIPTION
## Problem
When I was isntalling the latest the psmux with cargo using the command `cargo install --git github.com/psmux/psmux` , I ran into the following warning:

<img width="988" height="211" alt="image" src="https://github.com/user-attachments/assets/d1c6b244-d3ec-4a27-8921-48401483c1c6" />
Since it is a warning, it was not a blocker and the installation completed, but maintaining the source code hygiene, I opened this PR.

## Summary
- Drops the unused `get_window_option_value` symbol from the `options` use-declaration in `src/server/mod.rs:26`.
- Both call sites (lines 264 and 3723) invoke `crate::server::options::get_window_option_value_for(...)` via the fully-qualified path, so the imported name is never referenced and triggers an `unused_imports` warning on build:

```
warning: unused import: `get_window_option_value`
 --> src/server/mod.rs:26:33
26 | use options::{get_option_value, get_window_option_value, render_window_options, apply_set_option};
   |                                 ^^^^^^^^^^^^^^^^^^^^^^^
```

## Test plan
- [ ] `cargo build` completes without the `unused_imports` warning