### PR TITLE
fix: reset created_at when warm server is claimed as new session

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -2343,6 +2343,10 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                         }
                     }
                     app.session_name = name;
+                    // Warm server's created_at is the warm process start time, not the
+                    // user's session-creation time — reset on claim or list-sessions /
+                    // session_created / uptime would report the warm pool's age.
+                    app.created_at = chrono::Local::now();
                     // Update env so run-shell/hooks from this server target the new name
                     env::set_var("PSMUX_TARGET_SESSION", app.port_file_base());
                     // Honour the client's working directory: the warm server


### PR DESCRIPTION
## What this fixes

New sessions show the wrong creation time.

psmux keeps a spare server running in the background — called the **warm server** (you can see it as `__warm__.port` in your `.psmux\` folder). It is a fully booted psmux server process that sits idle waiting to be used. When you create a new session, psmux does not start a fresh process — it just renames the warm server to your session name and spawns a replacement warm server for next time. That is what makes `new-session` feel instant.

The bug: when the warm server is handed over, its "created" timestamp stays frozen at when the warm process first launched — sometimes hours or days ago.

So `list-sessions` lies. A session you made ten seconds ago can look ancient. Uptime is wrong too.

This patch sets the timestamp to "now" at the moment the warm server is claimed by a new session.

Renaming an existing session does **not** reset the timestamp (matches tmux).

## Where

`src/server/mod.rs`, in the `ClaimSession` handler. One line added next to where `session_name` is updated.

## Repro (before this PR)

1. With at least one warm server in the pool, run `psmux new-session -d -s foo`.
2. `psmux list-sessions` shows `foo` with the warm server's creation timestamp (often hours/days old) rather than "now".

## Test plan

- [x] `cargo build --bin psmux` passes
- [x] Manual: create a new session, confirm `list-sessions` shows a fresh creation time
- [x] Manual: `rename-session` an existing session, confirm the creation time is preserved
