### PR TITLE
fix: display-message -d 0 should wait for key press, not display 0ms

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -52,11 +52,17 @@ fn serialize_overlay_json(app: &AppState) -> String {
     // Popup overlay handles PopupMode, MenuMode, ConfirmMode, PaneChooser, and default
     let mut out = crate::popup::serialize_popup_overlay(app);
 
-    // Include status_message for display-message without -p (#110)
+    // Include status_message for display-message without -p (#110).
+    //
+    // tmux(1) display-message: "a delay of zero waits for a key press."
+    // So `-d 0` should keep the message visible until any key is pressed;
+    // the SendKey / SendText handlers clear status_message, which dismisses
+    // it naturally. Treat display_time == 0 as "sticky until keypress" by
+    // skipping the time-based expiry check.
     if let Some((ref msg, since, per_msg_duration)) = app.status_message {
         let elapsed = since.elapsed().as_millis() as u64;
         let display_time = per_msg_duration.unwrap_or(app.display_time_ms);
-        if elapsed < display_time {
+        if display_time == 0 || elapsed < display_time {
             out.push_str(",\"status_message\":\"");
             out.push_str(&json_escape_string(msg));
             out.push('"');


### PR DESCRIPTION
tmux(1) documents `display-message -d 0` as:

> a delay of zero waits for a key press.

Source: [tmux/tmux `status.c` lines 484–500](https://github.com/tmux/tmux/blob/3f651d9fa9e8433f6c95f02e7613517d3769c2f7/status.c#L484-L500) (function `status_message_set`):

```c
/*
 * With delay -1, the display-time option is used; zero means wait for
 * key press; more than zero is the actual delay time in milliseconds.
 */
if (delay == -1)
    delay = options_get_number(c->session->options, "display-time");
if (delay > 0) {
    ...
    evtimer_add(&c->message_timer, &tv);
}

if (delay != 0)
    c->message_ignore_keys = ignore_keys;
```

`if (delay > 0)` deliberately skips the expiration timer when `delay == 0`, and `if (delay != 0)` leaves `message_ignore_keys` unset so keys dismiss it.

psmux currently treats `0` as a literal `0ms` duration. The overlay render guard (`if elapsed < display_time`) is never true, so the message never appears.

Fix: treat `display_time == 0` as "sticky until keypress" in `serialize_overlay_json`. The `SendKey` / `SendText` handlers already clear `status_message` on any key, so dismissal works without further changes.

One-line behavior change in `src/server/mod.rs`.
