### PR TITLE
fix: forward pane-emitted OSC 52 to host terminal

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,14 @@ path = "tests-rs/test_issue201_rename_dialog.rs"
 name = "test_issue269_osc94_dropped"
 path = "tests-rs/test_issue269_osc94_dropped.rs"
 
+[[test]]
+name = "test_h1_osc52_clipboard_capture"
+path = "tests-rs/test_h1_osc52_clipboard_capture.rs"
+
+[[test]]
+name = "test_h1_osc52_end_to_end"
+path = "tests-rs/test_h1_osc52_end_to_end.rs"
+
 # Windows only
 [target.'cfg(not(windows))'.dependencies]
 [target.'cfg(windows)'.dependencies]

--- a/crates/vt100-psmux/src/perform.rs
+++ b/crates/vt100-psmux/src/perform.rs
@@ -253,6 +253,12 @@ impl<CB: crate::callbacks::Callbacks> vte::Perform for WrappedScreen<CB> {
                     (true, data)
                         if data.iter().all(|c| BASE64.contains(c)) =>
                     {
+                        // Stage the payload on Screen so the psmux server
+                        // can drain it and forward an OSC 52 to the host
+                        // terminal.  Unblocks tools like Claude Code's
+                        // `/copy` running inside a pane (OSC 52 was being
+                        // swallowed by the default no-op callbacks).
+                        self.screen.set_clipboard(ty, data);
                         self.callbacks.copy_to_clipboard(
                             &mut self.screen,
                             ty,

--- a/crates/vt100-psmux/src/screen.rs
+++ b/crates/vt100-psmux/src/screen.rs
@@ -124,6 +124,16 @@ pub struct Screen {
     /// stays `Some` after that so a clear (state=0) is also forwarded.
     osc94_progress: Option<(u8, u8)>,
 
+    /// Pending OSC 52 clipboard payload emitted by the child process inside
+    /// this pane.  Format: `Some((selector_bytes, base64_payload))`.  The
+    /// selector is the raw selector field from the OSC (e.g. `b"c"`,
+    /// `b"p"`, etc., or empty) and `base64_payload` is the still-encoded
+    /// data string.  Consumed once via [`Screen::take_clipboard`]; the
+    /// psmux server drains this and stages it onto `App.clipboard_osc52`
+    /// so the client re-emits OSC 52 on its own stdout to reach the host
+    /// terminal (Windows Terminal, etc.).
+    osc52_clipboard: Option<(Vec<u8>, Vec<u8>)>,
+
     /// Set to `true` when the screen is cleared (CSI 2J) while
     /// `squelch_clear_pending` is active.  The layout serialiser
     /// checks this flag to know that `cls` has finished.
@@ -175,6 +185,7 @@ impl Screen {
             osc_title: String::new(),
             osc7_path: None,
             osc94_progress: None,
+            osc52_clipboard: None,
             squelch_cleared: false,
             squelch_clear_pending: false,
             audible_bell_count: 0,
@@ -774,6 +785,33 @@ impl Screen {
         let s = state.min(4);
         let v = value.min(100);
         self.osc94_progress = Some((s, v));
+    }
+
+    /// Store an OSC 52 clipboard copy request emitted by the child.
+    /// `selector` is the raw selector field (e.g. `b"c"`), `data` is the
+    /// base64-encoded payload exactly as received.  Later writes overwrite
+    /// earlier ones until [`Screen::take_clipboard`] consumes the slot.
+    pub fn set_clipboard(&mut self, selector: &[u8], data: &[u8]) {
+        self.osc52_clipboard = Some((selector.to_vec(), data.to_vec()));
+    }
+
+    /// Returns and clears any pending OSC 52 clipboard payload.  Consume-once:
+    /// after a successful drain this returns `None` until the next OSC 52
+    /// arrives.  Used by the psmux server to forward child-emitted clipboard
+    /// requests onto `App.clipboard_osc52`, which the client re-emits as an
+    /// OSC 52 sequence on its own stdout so the host terminal (Windows
+    /// Terminal, etc.) can perform the actual copy.
+    pub fn take_clipboard(&mut self) -> Option<(Vec<u8>, Vec<u8>)> {
+        self.osc52_clipboard.take()
+    }
+
+    /// Peek at the pending OSC 52 clipboard payload without consuming it.
+    /// Returns `None` if no copy request is currently staged.
+    #[must_use]
+    pub fn clipboard(&self) -> Option<(&[u8], &[u8])> {
+        self.osc52_clipboard
+            .as_ref()
+            .map(|(s, d)| (s.as_slice(), d.as_slice()))
     }
 
     /// Returns `true` if a screen clear (CSI 2J) was detected while

--- a/src/server/helpers.rs
+++ b/src/server/helpers.rs
@@ -287,6 +287,41 @@ pub(crate) fn active_pane_progress(app: &AppState) -> Option<(u8, u8)> {
     parser.screen().progress()
 }
 
+/// Drain a pending OSC 52 clipboard payload from any pane in the tree.
+/// Returns the first `(selector, base64_data)` found and clears it on the
+/// source pane.  Lets a child process inside any pane (e.g. Claude Code's
+/// `/copy`) ask the host terminal to copy text — the dump-state builder
+/// stages the result onto `App.clipboard_osc52`, the client re-emits OSC
+/// 52 on its own stdout, and the host terminal performs the copy.
+pub(crate) fn take_pane_clipboard(app: &AppState) -> Option<(Vec<u8>, Vec<u8>)> {
+    for win in &app.windows {
+        if let Some(payload) = drain_clipboard_in_node(&win.root) {
+            return Some(payload);
+        }
+    }
+    None
+}
+
+fn drain_clipboard_in_node(node: &Node) -> Option<(Vec<u8>, Vec<u8>)> {
+    match node {
+        Node::Leaf(p) => {
+            if p.dead {
+                return None;
+            }
+            let mut parser = p.term.lock().ok()?;
+            parser.screen_mut().take_clipboard()
+        }
+        Node::Split { children, .. } => {
+            for c in children {
+                if let Some(r) = drain_clipboard_in_node(c) {
+                    return Some(r);
+                }
+            }
+            None
+        }
+    }
+}
+
 fn propagate_osc_titles_in_tree(node: &mut Node, dirty: &mut bool) {
     match node {
         Node::Leaf(p) => {

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -22,7 +22,7 @@ use crate::tree::{self, active_pane, active_pane_mut, resize_all_panes, kill_all
     get_split_mut, path_exists};
 
 use helpers::{collect_pane_paths_server, serialize_bindings_json, json_escape_string,
-    list_windows_json_with_tabs, combined_data_version, TMUX_COMMANDS};
+    list_windows_json_with_tabs, combined_data_version, take_pane_clipboard, TMUX_COMMANDS};
 use options::{get_option_value, render_window_options, apply_set_option};
 
 use crate::input::{send_text_to_active, send_key_to_active, send_paste_to_active, move_focus, move_focus_preserving_zoom, find_best_pane_in_direction, find_wrap_target};
@@ -1524,6 +1524,21 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                     }
                     cached_dump_state.clear();
                     cached_dump_state.push_str(&combined_buf);
+                    // Forward OSC 52 from pane child processes (e.g. Claude
+                    // Code's `/copy`).  The pane's parser stages incoming
+                    // OSC 52 onto its Screen; drain it and decode to plain
+                    // text so the existing dump-state injection below
+                    // re-emits it as OSC 52 on the client's stdout to the
+                    // host terminal.  Gated by `set-clipboard` option.
+                    if app.set_clipboard != "off" && app.clipboard_osc52.is_none() {
+                        if let Some((_sel, b64)) = take_pane_clipboard(&app) {
+                            if let Ok(b64_str) = std::str::from_utf8(&b64) {
+                                if let Some(text) = crate::util::base64_decode(b64_str) {
+                                    app.clipboard_osc52 = Some(text);
+                                }
+                            }
+                        }
+                    }
                     // Inject one-shot clipboard data for OSC 52 delivery to
                     // the client.  Only the *response* includes this field;
                     // the cached copy does not, so subsequent NC frames won't
@@ -4468,6 +4483,18 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                     combined_buf.pop();
                     combined_buf.push_str(&overlay_json);
                     combined_buf.push('}');
+                }
+            }
+            // Forward OSC 52 from pane child processes (e.g. Claude Code
+            // `/copy`).  See sibling block in the dump-state response path
+            // for full context.  Gated by `set-clipboard`.
+            if app.set_clipboard != "off" && app.clipboard_osc52.is_none() {
+                if let Some((_sel, b64)) = take_pane_clipboard(&app) {
+                    if let Ok(b64_str) = std::str::from_utf8(&b64) {
+                        if let Some(text) = crate::util::base64_decode(b64_str) {
+                            app.clipboard_osc52 = Some(text);
+                        }
+                    }
                 }
             }
             // Inject clipboard data if pending

--- a/tests-rs/test_h1_osc52_clipboard_capture.rs
+++ b/tests-rs/test_h1_osc52_clipboard_capture.rs
@@ -1,0 +1,371 @@
+// H1 — PROOF OF FIX: OSC 52 ("copy to clipboard") sequences emitted by a
+// child process inside a psmux pane are now captured by the vt100 emulator
+// and exposed via `Screen::take_clipboard()`.
+//
+// Background:
+//   - Claude Code's /copy command writes `ESC ] 52 ; c ; <base64> ESC \`
+//     to its tty.  Inside a psmux pane this byte stream went to the default
+//     `impl Callbacks for ()` whose `copy_to_clipboard` method is a no-op,
+//     so the payload was silently dropped.
+//   - psmux already has the other direction (its own copy-mode → host
+//     terminal) plumbed via `App.clipboard_osc52` (drained server-side,
+//     re-emitted by the client on stdout).  We just need the parser to
+//     stage the child's OSC 52 onto a slot the server can drain too.
+//
+// This PoC mirrors the OSC 9;4 pattern (Screen state + take_*() accessor):
+//   1. `Screen` gains `osc52_clipboard: Option<(Vec<u8>, Vec<u8>)>`.
+//   2. `perform.rs`'s OSC 52 dispatch arm calls `Screen::set_clipboard()`
+//      in addition to invoking the existing `copy_to_clipboard` callback.
+//   3. The psmux server is expected to call `take_clipboard()` in the same
+//      loop it uses for the other parser-internal state (e.g. progress),
+//      and stage the result onto `App.clipboard_osc52`.  That wiring is
+//      OUT OF SCOPE for this PoC — but the slot is now populated, which
+//      is what unblocks the rest.
+//
+// Required acceptance cases (from goal lock):
+//   (a) `c` selector with valid base64 ST-terminated.
+//   (b) BEL-terminated.
+//   (c) consume-once semantics (take_clipboard returns None after a drain).
+//   (d) chunked input (OSC split across `process()` calls).
+//   (e) a `set-clipboard = "off"` style gate via a mocked drain — modelled
+//       here as: a consumer that chooses NOT to call `take_clipboard()`
+//       leaves the slot populated; a consumer that does call it drains it.
+//       This is exactly the gate point the server will sit on.
+
+const ST: &[u8] = b"\x1b\\";
+
+fn osc52(selector: &[u8], base64_data: &[u8]) -> Vec<u8> {
+    let mut v = Vec::new();
+    v.extend_from_slice(b"\x1b]52;");
+    v.extend_from_slice(selector);
+    v.push(b';');
+    v.extend_from_slice(base64_data);
+    v.extend_from_slice(ST);
+    v
+}
+
+fn osc52_bel(selector: &[u8], base64_data: &[u8]) -> Vec<u8> {
+    let mut v = Vec::new();
+    v.extend_from_slice(b"\x1b]52;");
+    v.extend_from_slice(selector);
+    v.push(b';');
+    v.extend_from_slice(base64_data);
+    v.push(0x07); // BEL terminator (legal OSC ST)
+    v
+}
+
+fn fresh_parser() -> vt100::Parser {
+    vt100::Parser::new(24, 80, 0)
+}
+
+// =============================================================================
+// PART A: baseline — no OSC 52 yet → take_clipboard is None.
+// =============================================================================
+
+#[test]
+fn baseline_take_clipboard_is_none_on_fresh_screen() {
+    let mut p = fresh_parser();
+    assert!(p.screen_mut().take_clipboard().is_none());
+    assert!(p.screen().clipboard().is_none());
+}
+
+// =============================================================================
+// PART B: the fix — OSC 52 with `c` selector, ST-terminated.
+// =============================================================================
+
+#[test]
+fn fix_osc52_c_selector_st_terminated_is_captured() {
+    // Claude Code's exact shape: selector='c', payload is valid base64.
+    let payload = b"aGVsbG8td29ybGQ="; // base64("hello-world")
+    let mut p = fresh_parser();
+    p.process(&osc52(b"c", payload));
+
+    let got = p
+        .screen_mut()
+        .take_clipboard()
+        .expect("OSC 52 must populate the clipboard slot");
+    assert_eq!(got.0, b"c", "selector must round-trip exactly");
+    assert_eq!(got.1, payload, "base64 payload must round-trip verbatim");
+}
+
+#[test]
+fn fix_osc52_peek_does_not_consume() {
+    let payload = b"cGVlay10ZXN0";
+    let mut p = fresh_parser();
+    p.process(&osc52(b"c", payload));
+
+    let peek = p.screen().clipboard().expect("clipboard must be staged");
+    assert_eq!(peek.0, b"c");
+    assert_eq!(peek.1, payload);
+
+    // After peeking, take_clipboard still drains.
+    let drained = p.screen_mut().take_clipboard().expect("not yet drained");
+    assert_eq!(drained.0, b"c");
+    assert_eq!(drained.1, payload);
+}
+
+// =============================================================================
+// PART C: BEL-terminated variant.
+// =============================================================================
+
+#[test]
+fn fix_osc52_c_selector_bel_terminated_is_captured() {
+    let payload = b"YmVsLXRlcm0=";
+    let mut p = fresh_parser();
+    p.process(&osc52_bel(b"c", payload));
+
+    let got = p
+        .screen_mut()
+        .take_clipboard()
+        .expect("BEL-terminated OSC 52 must populate clipboard");
+    assert_eq!(got.0, b"c");
+    assert_eq!(got.1, payload);
+    assert!(
+        !p.screen_mut().take_audible_bell(),
+        "BEL terminator of an OSC must NOT count as audible bell"
+    );
+}
+
+// =============================================================================
+// PART D: consume-once semantics.
+// =============================================================================
+
+#[test]
+fn fix_consume_once_returns_none_on_second_take() {
+    let payload = b"Y29uc3VtZS1vbmNl";
+    let mut p = fresh_parser();
+    p.process(&osc52(b"c", payload));
+
+    assert!(p.screen_mut().take_clipboard().is_some(), "first take drains");
+    assert!(
+        p.screen_mut().take_clipboard().is_none(),
+        "second take must be None — slot was drained"
+    );
+}
+
+#[test]
+fn fix_new_osc52_after_drain_repopulates() {
+    let mut p = fresh_parser();
+    p.process(&osc52(b"c", b"Zmlyc3Q="));
+    let first = p.screen_mut().take_clipboard().unwrap();
+    assert_eq!(first.1, b"Zmlyc3Q=");
+
+    p.process(&osc52(b"c", b"c2Vjb25k"));
+    let second = p
+        .screen_mut()
+        .take_clipboard()
+        .expect("a new OSC 52 after a drain must re-populate the slot");
+    assert_eq!(second.1, b"c2Vjb25k");
+}
+
+#[test]
+fn fix_back_to_back_osc52_without_drain_overwrites() {
+    // If a child emits two OSC 52s before the server drains, the latest
+    // wins.  Acceptable behaviour: clipboard is "current selection", not
+    // a queue.  This matches xterm and Windows Terminal semantics.
+    let mut p = fresh_parser();
+    p.process(&osc52(b"c", b"b2xkLXZhbHVl"));
+    p.process(&osc52(b"c", b"bmV3LXZhbHVl"));
+    let got = p.screen_mut().take_clipboard().unwrap();
+    assert_eq!(got.1, b"bmV3LXZhbHVl", "second OSC 52 must overwrite first");
+}
+
+// =============================================================================
+// PART E: chunked input — OSC may be split anywhere across `process()` calls.
+// =============================================================================
+
+#[test]
+fn fix_chunked_osc52_is_stitched() {
+    let mut p = fresh_parser();
+    // Split mid-base64.  Full payload is base64("chunked") == "Y2h1bmtlZA==".
+    p.process(b"\x1b]52;c;Y2h1bm");
+    assert!(
+        p.screen().clipboard().is_none(),
+        "before terminator: must not be staged"
+    );
+    p.process(b"tlZA==\x1b\\");
+    let got = p
+        .screen_mut()
+        .take_clipboard()
+        .expect("after terminator: must be staged");
+    assert_eq!(got.0, b"c");
+    assert_eq!(got.1, b"Y2h1bmtlZA=="); // base64("chunked")
+}
+
+#[test]
+fn fix_chunked_at_introducer_is_stitched() {
+    let mut p = fresh_parser();
+    // Split right after the ESC introducer.
+    p.process(b"\x1b");
+    p.process(b"]52;c;");
+    p.process(b"WA==\x1b\\");
+    let got = p.screen_mut().take_clipboard().expect("chunk split at ESC");
+    assert_eq!(got.1, b"WA=="); // base64("X")
+}
+
+// =============================================================================
+// PART F: gate / "set-clipboard = off" — mocked drain.
+//
+// Mirror what `App.clipboard_osc52` does server-side: a `MockDrain` policy
+// that decides whether to consume or discard the staged payload.
+// =============================================================================
+
+struct MockDrain {
+    enabled: bool,
+    last_seen: Option<(Vec<u8>, Vec<u8>)>,
+}
+
+impl MockDrain {
+    fn new(enabled: bool) -> Self {
+        Self {
+            enabled,
+            last_seen: None,
+        }
+    }
+
+    /// Mirrors what the server loop would do once per tick: pull the
+    /// staged clipboard if the `set-clipboard` option allows it, otherwise
+    /// leave it staged (and a later policy change would still see it).
+    fn drain(&mut self, parser: &mut vt100::Parser) {
+        if self.enabled {
+            if let Some(pair) = parser.screen_mut().take_clipboard() {
+                self.last_seen = Some(pair);
+            }
+        }
+        // else: do nothing — slot remains for a later policy-on read.
+    }
+}
+
+#[test]
+fn fix_gate_off_leaves_payload_staged() {
+    let mut p = fresh_parser();
+    let mut drain = MockDrain::new(false); // set-clipboard = off
+    p.process(&osc52(b"c", b"Z2F0ZS1vZmY="));
+    drain.drain(&mut p);
+    assert!(drain.last_seen.is_none(), "drain disabled — must not capture");
+
+    // Slot is still populated because no one drained it.
+    assert!(
+        p.screen().clipboard().is_some(),
+        "with drain off the staged payload must remain available"
+    );
+}
+
+#[test]
+fn fix_gate_on_then_off_then_on_still_sees_latest() {
+    let mut p = fresh_parser();
+    let mut drain_off = MockDrain::new(false);
+    let mut drain_on = MockDrain::new(true);
+
+    p.process(&osc52(b"c", b"YQ=="));
+    drain_off.drain(&mut p); // policy off — payload still staged
+
+    p.process(&osc52(b"c", b"Yg==")); // overwrites
+    drain_on.drain(&mut p);
+
+    assert!(drain_off.last_seen.is_none());
+    let seen = drain_on.last_seen.expect("drain on must capture");
+    assert_eq!(seen.1, b"Yg==", "policy-on drain must see latest payload");
+}
+
+#[test]
+fn fix_gate_on_drains_and_clears_slot() {
+    let mut p = fresh_parser();
+    let mut drain = MockDrain::new(true);
+    p.process(&osc52(b"c", b"ZHJhaW4=")); // base64("drain")
+    drain.drain(&mut p);
+
+    let seen = drain.last_seen.expect("drain on captures");
+    assert_eq!(seen.0, b"c");
+    assert_eq!(seen.1, b"ZHJhaW4=");
+
+    // Slot is cleared after a successful drain.
+    assert!(
+        p.screen().clipboard().is_none(),
+        "slot must be cleared after successful drain"
+    );
+}
+
+// =============================================================================
+// PART G: side-effect isolation — OSC 52 must not pollute other channels.
+// =============================================================================
+
+#[test]
+fn fix_osc52_does_not_appear_in_screen_contents() {
+    let mut p = fresh_parser();
+    p.process(&osc52(b"c", b"YWJj"));
+    let contents = p.screen().contents();
+    assert!(!contents.contains("\x1b]"), "ESC ] leaked into contents");
+    assert!(!contents.contains("YWJj"), "base64 payload leaked into contents");
+}
+
+#[test]
+fn fix_osc52_does_not_set_title_or_path_or_progress() {
+    let mut p = fresh_parser();
+    p.process(&osc52(b"c", b"YWJj"));
+    assert_eq!(p.screen().title(), "", "OSC 52 must not touch title");
+    assert_eq!(p.screen().path(), None, "OSC 52 must not touch path");
+    assert_eq!(p.screen().progress(), None, "OSC 52 must not touch progress");
+}
+
+#[test]
+fn fix_state_machine_ready_for_next_sequence_after_osc52() {
+    let mut p = fresh_parser();
+    p.process(&osc52(b"c", b"YWJj"));
+    p.process(b"hello");
+    assert!(p.screen().contents().contains("hello"));
+}
+
+// =============================================================================
+// PART H: real-world Claude Code shape.
+// =============================================================================
+
+#[test]
+fn fix_claude_code_slash_copy_shape_is_captured() {
+    // The exact shape Claude Code's /copy uses:
+    //   ESC ] 52 ; c ; <base64> ESC \
+    // Round-tripping a multi-line payload to make sure base64 with padding
+    // and length > 80 works.
+    let raw = "line one\nline two\nline three with some longer text to exceed 60 chars";
+    let b64 = simple_b64(raw.as_bytes());
+    let mut p = fresh_parser();
+    p.process(&osc52(b"c", b64.as_bytes()));
+
+    let got = p.screen_mut().take_clipboard().expect("captured");
+    assert_eq!(got.0, b"c");
+    assert_eq!(got.1, b64.as_bytes());
+}
+
+/// Minimal base64 encoder — avoids pulling in `base64` as a dev-dep just
+/// for fixture construction.
+fn simple_b64(input: &[u8]) -> String {
+    const ALPHA: &[u8; 64] =
+        b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    let mut out = String::new();
+    let mut i = 0;
+    while i + 3 <= input.len() {
+        let n = ((input[i] as u32) << 16)
+            | ((input[i + 1] as u32) << 8)
+            | (input[i + 2] as u32);
+        out.push(ALPHA[((n >> 18) & 0x3f) as usize] as char);
+        out.push(ALPHA[((n >> 12) & 0x3f) as usize] as char);
+        out.push(ALPHA[((n >> 6) & 0x3f) as usize] as char);
+        out.push(ALPHA[(n & 0x3f) as usize] as char);
+        i += 3;
+    }
+    let rem = input.len() - i;
+    if rem == 1 {
+        let n = (input[i] as u32) << 16;
+        out.push(ALPHA[((n >> 18) & 0x3f) as usize] as char);
+        out.push(ALPHA[((n >> 12) & 0x3f) as usize] as char);
+        out.push('=');
+        out.push('=');
+    } else if rem == 2 {
+        let n = ((input[i] as u32) << 16) | ((input[i + 1] as u32) << 8);
+        out.push(ALPHA[((n >> 18) & 0x3f) as usize] as char);
+        out.push(ALPHA[((n >> 12) & 0x3f) as usize] as char);
+        out.push(ALPHA[((n >> 6) & 0x3f) as usize] as char);
+        out.push('=');
+    }
+    out
+}

--- a/tests-rs/test_h1_osc52_end_to_end.rs
+++ b/tests-rs/test_h1_osc52_end_to_end.rs
@@ -1,0 +1,261 @@
+// H1 — End-to-end PoC for OSC 52 pane-to-host forwarding.
+//
+// This test models the FULL flow that the parser fix unblocks, without
+// touching `src/server/mod.rs` or `src/client.rs` (PoC constraint):
+//
+//   1. Child process inside a pane writes `ESC ] 52 ; c ; <b64> ESC \`.
+//      → Modelled by feeding bytes into `vt100::Parser`.
+//
+//   2. Parser stages the (selector, base64) pair on `Screen` via the new
+//      `set_clipboard` hook in `perform.rs`.
+//      → Asserted via `take_clipboard()`.
+//
+//   3. Server drains the slot once per dump-state tick and stages the
+//      *decoded* text onto `App.clipboard_osc52: Option<String>`.
+//      → Modelled by `MockServer::drain_pane_clipboard()` below.  This
+//        mirrors the one-line change needed in `src/server/mod.rs`'s
+//        dump-state loop (alongside the existing `app.clipboard_osc52.take()`
+//        at server/mod.rs:1531 and :4474).
+//
+//   4. Server emits the field into the JSON dump; client receives it and
+//      calls `crate::copy_mode::emit_osc52(stdout, &clip_text)` which
+//      base64-encodes the text and writes `ESC ] 52 ; c ; <b64> BEL`.
+//      → Modelled by calling the real `emit_osc52` helper.  Wait — that
+//        function is private to the crate, so we re-implement the exact
+//        byte shape here.  This keeps the test in the same crate as a
+//        plain integration test and avoids leaking internals.
+//
+// The acceptance bar: the bytes a host terminal (Windows Terminal) would
+// see on the client's stdout MUST contain a well-formed OSC 52 carrying
+// a base64 of the original child payload text.
+
+const ST_BEL: u8 = 0x07;
+
+/// Minimal base64 decoder for the test payload — we don't pull in `base64`
+/// for fixture parsing.
+fn b64_decode(input: &[u8]) -> Vec<u8> {
+    const REV: [i16; 256] = build_rev();
+    const fn build_rev() -> [i16; 256] {
+        let mut r = [-1i16; 256];
+        let alpha = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+        let mut i = 0;
+        while i < 64 {
+            r[alpha[i] as usize] = i as i16;
+            i += 1;
+        }
+        r
+    }
+    let trimmed: Vec<u8> =
+        input.iter().copied().filter(|b| *b != b'=' && !b.is_ascii_whitespace()).collect();
+    let mut out = Vec::new();
+    let mut acc: u32 = 0;
+    let mut bits = 0;
+    for b in trimmed {
+        let v = REV[b as usize];
+        if v < 0 {
+            continue;
+        }
+        acc = (acc << 6) | (v as u32);
+        bits += 6;
+        if bits >= 8 {
+            bits -= 8;
+            out.push(((acc >> bits) & 0xff) as u8);
+        }
+    }
+    out
+}
+
+fn b64_encode(input: &[u8]) -> String {
+    const ALPHA: &[u8; 64] =
+        b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    let mut out = String::new();
+    let mut i = 0;
+    while i + 3 <= input.len() {
+        let n = ((input[i] as u32) << 16)
+            | ((input[i + 1] as u32) << 8)
+            | (input[i + 2] as u32);
+        out.push(ALPHA[((n >> 18) & 0x3f) as usize] as char);
+        out.push(ALPHA[((n >> 12) & 0x3f) as usize] as char);
+        out.push(ALPHA[((n >> 6) & 0x3f) as usize] as char);
+        out.push(ALPHA[(n & 0x3f) as usize] as char);
+        i += 3;
+    }
+    let rem = input.len() - i;
+    if rem == 1 {
+        let n = (input[i] as u32) << 16;
+        out.push(ALPHA[((n >> 18) & 0x3f) as usize] as char);
+        out.push(ALPHA[((n >> 12) & 0x3f) as usize] as char);
+        out.push('=');
+        out.push('=');
+    } else if rem == 2 {
+        let n = ((input[i] as u32) << 16) | ((input[i + 1] as u32) << 8);
+        out.push(ALPHA[((n >> 18) & 0x3f) as usize] as char);
+        out.push(ALPHA[((n >> 12) & 0x3f) as usize] as char);
+        out.push(ALPHA[((n >> 6) & 0x3f) as usize] as char);
+        out.push('=');
+    }
+    out
+}
+
+/// Models the *one* line of code the psmux server needs to add to its
+/// dump-state loop, right next to the existing
+/// `if let Some(clip_text) = app.clipboard_osc52.take()` at
+/// `src/server/mod.rs:1531`:
+///
+/// ```ignore
+/// for pane in &mut app.panes {
+///     if let Some((_sel, b64_payload)) = pane.parser.screen_mut().take_clipboard() {
+///         if let Ok(text) = String::from_utf8(base64_decode(&b64_payload)) {
+///             app.clipboard_osc52 = Some(text);
+///         }
+///     }
+/// }
+/// ```
+///
+/// This struct stands in for `App` for the purposes of the test.
+struct MockApp {
+    clipboard_osc52: Option<String>,
+}
+
+impl MockApp {
+    fn new() -> Self {
+        Self { clipboard_osc52: None }
+    }
+
+    /// Mirror of the server drain step (see top-of-file comment).
+    fn drain_pane(&mut self, parser: &mut vt100::Parser) {
+        if let Some((_selector, b64_payload)) = parser.screen_mut().take_clipboard() {
+            let decoded = b64_decode(&b64_payload);
+            if let Ok(text) = String::from_utf8(decoded) {
+                self.clipboard_osc52 = Some(text);
+            }
+        }
+    }
+}
+
+/// Mirror of `src/copy_mode.rs::emit_osc52` — the exact bytes the client
+/// writes to its stdout (which the host terminal reads).
+fn emit_osc52_to_buf(buf: &mut Vec<u8>, text: &str) {
+    let encoded = b64_encode(text.as_bytes());
+    buf.extend_from_slice(b"\x1b]52;c;");
+    buf.extend_from_slice(encoded.as_bytes());
+    buf.push(ST_BEL);
+}
+
+/// Full pipeline: pane emits OSC 52 → parser captures → server drains →
+/// client re-emits to stdout.  We then look for the OSC 52 framing and
+/// for a base64 that decodes back to the original child payload.
+fn pipeline(child_payload: &str) -> Vec<u8> {
+    // (1) Child writes OSC 52 to pane tty.
+    let mut child_out = Vec::new();
+    child_out.extend_from_slice(b"\x1b]52;c;");
+    child_out.extend_from_slice(b64_encode(child_payload.as_bytes()).as_bytes());
+    child_out.extend_from_slice(b"\x1b\\");
+
+    // (2) Parser receives the bytes.
+    let mut parser = vt100::Parser::new(24, 80, 0);
+    parser.process(&child_out);
+
+    // (3) Server drains the staged slot.
+    let mut app = MockApp::new();
+    app.drain_pane(&mut parser);
+    assert!(app.clipboard_osc52.is_some(), "server drain must have staged text");
+
+    // (4) Client emits OSC 52 to its stdout (what Windows Terminal sees).
+    let mut client_stdout = Vec::new();
+    if let Some(text) = app.clipboard_osc52.take() {
+        emit_osc52_to_buf(&mut client_stdout, &text);
+    }
+    client_stdout
+}
+
+#[test]
+fn end_to_end_round_trips_simple_ascii() {
+    let payload = "hello-world";
+    let client_out = pipeline(payload);
+
+    // The client must have produced exactly one OSC 52 frame.
+    let intro = b"\x1b]52;c;";
+    let pos = client_out
+        .windows(intro.len())
+        .position(|w| w == intro)
+        .expect("client stdout must contain OSC 52 introducer");
+    let after = &client_out[pos + intro.len()..];
+
+    // BEL terminator.
+    let bel_pos = after.iter().position(|b| *b == 0x07).expect("BEL terminator");
+    let b64 = &after[..bel_pos];
+    let decoded = b64_decode(b64);
+    assert_eq!(
+        decoded, payload.as_bytes(),
+        "OSC 52 on client stdout must carry the original child payload"
+    );
+}
+
+#[test]
+fn end_to_end_round_trips_multiline() {
+    let payload = "line one\nline two\n  indented\nfinal line";
+    let client_out = pipeline(payload);
+    let intro = b"\x1b]52;c;";
+    let pos = client_out
+        .windows(intro.len())
+        .position(|w| w == intro)
+        .unwrap();
+    let after = &client_out[pos + intro.len()..];
+    let bel_pos = after.iter().position(|b| *b == 0x07).unwrap();
+    let decoded = b64_decode(&after[..bel_pos]);
+    assert_eq!(decoded, payload.as_bytes());
+}
+
+#[test]
+fn end_to_end_round_trips_unicode() {
+    let payload = "snowman: ☃  fire: 🔥  jp: こんにちは";
+    let client_out = pipeline(payload);
+    let intro = b"\x1b]52;c;";
+    let pos = client_out
+        .windows(intro.len())
+        .position(|w| w == intro)
+        .unwrap();
+    let after = &client_out[pos + intro.len()..];
+    let bel_pos = after.iter().position(|b| *b == 0x07).unwrap();
+    let decoded = b64_decode(&after[..bel_pos]);
+    assert_eq!(decoded, payload.as_bytes());
+}
+
+#[test]
+fn end_to_end_claude_code_slash_copy_shape() {
+    // The actual shape Claude Code's /copy emits is a moderately large
+    // multi-line block.  Make sure base64 padding and lengths > 80 work
+    // through the whole pipeline.
+    let payload =
+        "First line of code\n\
+         fn foo() -> i32 {\n\
+         \x20\x20\x20\x20let x = 42;\n\
+         \x20\x20\x20\x20x + 1\n\
+         }\n\
+         // trailing comment with some =/+ characters\n";
+    let client_out = pipeline(payload);
+    let intro = b"\x1b]52;c;";
+    let pos = client_out
+        .windows(intro.len())
+        .position(|w| w == intro)
+        .expect("OSC 52 introducer present in client stdout");
+    let after = &client_out[pos + intro.len()..];
+    let bel_pos = after.iter().position(|b| *b == 0x07).unwrap();
+    let decoded = b64_decode(&after[..bel_pos]);
+    assert_eq!(
+        decoded, payload.as_bytes(),
+        "Claude /copy payload must round-trip end-to-end"
+    );
+}
+
+#[test]
+fn end_to_end_no_osc52_when_child_does_not_emit() {
+    // Sanity: a pane that produces no OSC 52 must NOT cause the client to
+    // emit one.  Otherwise we'd risk stale clipboards.
+    let mut parser = vt100::Parser::new(24, 80, 0);
+    parser.process(b"just some plain output\nno escape sequences here\n");
+    let mut app = MockApp::new();
+    app.drain_pane(&mut parser);
+    assert!(app.clipboard_osc52.is_none());
+}


### PR DESCRIPTION
Closes #300

## What broke

Run Claude Code inside psmux. Use `/copy`. Nothing lands on the clipboard.
Run Claude Code outside psmux (plain Windows Terminal). Same `/copy`. Works.

## Why

Claude `/copy` asks the terminal to copy text by writing a magic escape code (`OSC 52`) to its tty.

- Plain Windows Terminal: sees the code, copies.
- Inside psmux: psmux reads pane output through its parser before it reaches the terminal. The parser had a hook for "child wants to copy" but the hook was empty. The code got eaten. The terminal never saw it.

The hook for the progress code (`OSC 9;4`) was already wired up the same way in #269. This PR does the same thing for `OSC 52`.

## Fix

Catch the OSC 52 in the parser. Pass it through the server. Re-emit it from the client to the host terminal. Done.

Gated by the existing `set-clipboard` option, so it can be turned off.

## File-by-file

- **`crates/vt100-psmux/src/screen.rs`** — Adds a small slot on `Screen` for the OSC 52 payload, plus methods to set, peek, and consume it. Plain getters and setters.
- **`crates/vt100-psmux/src/perform.rs`** — When the parser sees an OSC 52, drop the payload into that slot (one extra line).
- **`src/server/helpers.rs`** — New helper that walks the pane tree and grabs the first pending payload.
- **`src/server/mod.rs`** — In both dump-state build sites, call the helper before the existing client-emit step. If a pane has a fresh payload, decode it and stash it on `App.clipboard_osc52`. The existing code path then carries it to the client, which already knows how to re-emit OSC 52 to the host terminal.
- **`tests-rs/test_h1_osc52_clipboard_capture.rs`** — 16 parser-level tests: capture works for BEL- and ST-terminated, consumed once, chunked input, doesn't leak into screen contents, doesn't interfere with title / path / bell, gate via `set-clipboard = off`.
- **`tests-rs/test_h1_osc52_end_to_end.rs`** — 5 tests that model the whole pipeline (parser → server drain → client emit) with ASCII, multi-line, Unicode, and a Claude-Code-shaped payload.

## Tests

All green:

- 16/16 in `test_h1_osc52_clipboard_capture`
- 5/5 in `test_h1_osc52_end_to_end`
- 25/25 in `test_issue269_osc94_dropped` (regression smoke for the analogous OSC 9;4 fix)
- Live test performed and passed: Built psmux locally, ran Claude `/copy` inside a pane against a marker string, `Get-Clipboard` returned the marker. Confirmed working.