### PR TITLE
An improvement in send_ctrl_c_event so it's less likely to drop the ctrl event

### DIFF
--- a/src/platform.rs
+++ b/src/platform.rs
@@ -1117,17 +1117,26 @@ pub mod mouse_inject {
             let err = GetLastError();
 
             log(&format!("GenerateConsoleCtrlEvent => ok={} err={}", ok, err));
+            
+            // Brief sleep to let the async CTRL_C_EVENT handler thread finish
+            // before we re-enable default handling.
+            std::thread::sleep(std::time::Duration::from_millis(5));
 
+            // GenerateConsoleCtrlEvent is Asynchronous delivery
+            // it returns as soon as the signal is queued for delivery, not when it's actually handled by the target process.
+            // FreeConsole will reset the table of control handlers in the client process.
+            // If current process finishes detaching before the console subsystem finishes distributing the event,
+            // the context tracking who generated the signal is destroyed, 
+            // or the signal execution queue for that instance is aborted.
+            // So the sleep above won't guarantee no race condition here,
+            // in the worst case, the signal might be lost and never delivered to the child process.
+            
             // Detach from the child's console BEFORE restoring Ctrl+C handling.
             // GenerateConsoleCtrlEvent dispatches asynchronously via a new thread;
             // if we restore the default handler while still attached, the async
             // handler thread might terminate psmux.  Detaching first ensures the
             // event only targets processes that remain on the console.
             FreeConsole();
-
-            // Brief sleep to let the async CTRL_C_EVENT handler thread finish
-            // before we re-enable default handling.
-            std::thread::sleep(std::time::Duration::from_millis(5));
 
             // Restore default Ctrl+C handling now that we're detached
             SetConsoleCtrlHandler(None, 0);

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -1122,9 +1122,9 @@ pub mod mouse_inject {
             // before we re-enable default handling.
             std::thread::sleep(std::time::Duration::from_millis(5));
 
-            // GenerateConsoleCtrlEvent is Asynchronous delivery
-            // it returns as soon as the signal is queued for delivery, not when it's actually handled by the target process.
-            // FreeConsole will reset the table of control handlers in the client process.
+            // GenerateConsoleCtrlEvent delivers asynchronously: it returns as soon as the
+            // signal is queued for delivery, not when it's actually handled by the target process.
+            // FreeConsole resets the table of control handlers in the client process.
             // If current process finishes detaching before the console subsystem finishes distributing the event,
             // the context tracking who generated the signal is destroyed, 
             // or the signal execution queue for that instance is aborted.


### PR DESCRIPTION
Wait before FreeConsole to make it less likely to drop the Ctrl event.

    GenerateConsoleCtrlEvent dispatches the CTRL_C_EVENT asynchronously
    via a system thread pool. The original 5ms sleep before FreeConsole()
    was often too short for the async dispatch to complete, causing the
    signal to be lost before reaching the target console's process group.

   Moved it before FreeConsole() so we
    remain attached to the child's console while the async thread finishes.
    psmux itself is protected during this window by the preceding
    SetConsoleCtrlHandler(None, 1) which ignores the signal.