### PR TITLE
feat: export live human text-input via `@human-input-marker` option

### DIFF
--- a/docs/integration.md
+++ b/docs/integration.md
@@ -554,6 +554,42 @@ When porting Unix tmux integrations to Windows:
 - **Ctrl+C**: `GenerateConsoleCtrlEvent` sends to all processes sharing the console. Prefer app-specific quit keys over `C-c` in automation.
 - **TUI exit timing**: After a TUI exits, ConPTY needs 4 to 6 seconds to restore the screen. Add a delay before `capture-pane` after TUI exit.
 
+## Live human-input marker (`@human-input-marker`)
+
+Some integrations need to know **when a human is actively typing into a
+pane**, as distinct from input they injected programmatically via
+`send-keys` / `paste-buffer`. `capture-pane` can't tell them apart (it only
+shows rendered output, where a human's echo and the app's output are
+already merged), and polling it misses typing while the app is busy
+streaming.
+
+psmux can export this signal directly. Set the session option
+`@human-input-marker` to a file path:
+
+```powershell
+psmux set-option -t mysession @human-input-marker "C:/path/to/typing.marker"
+```
+
+While it's set, psmux **touches that file** (updates its mtime) on every
+real human **text** keystroke routed to a pane in that session — and
+**never** on `send-keys` / `paste-buffer`, because those take a different
+internal path. Your tool then treats "marker mtime within the last N
+seconds" as "a human is typing now".
+
+- **Text only.** Printable characters; control codes, `Enter`, `Tab`,
+  navigation keys, and any `Ctrl`/`Alt`-modified key are ignored, so moving
+  around a pane doesn't read as typing.
+- **Throttled.** At most ~once per 200 ms, so fast typing doesn't hammer
+  the filesystem (the signal is "typed recently", not a keylog — the file
+  content is just a timestamp).
+- **Opt-in, zero-cost when unset.** No file I/O happens unless the option
+  points at a path.
+
+This is what [claude-loop](https://github.com/quazardous/aiball) uses on
+Windows to drive its "human present" status without a nested-PTY proxy
+(the bytes a human types and the bytes a tool injects are physically
+separate paths inside psmux, so no heuristic is needed).
+
 ## Related Documentation
 
 - [compatibility.md](compatibility.md) : Full tmux command and feature compatibility matrix

--- a/src/input.rs
+++ b/src/input.rs
@@ -1,5 +1,5 @@
 use std::io::{self, Write};
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseEvent};
 use portable_pty::native_pty_system;
@@ -1862,7 +1862,58 @@ pub fn encode_key_event(key: &KeyEvent) -> Option<Vec<u8>> {
     Some(encoded)
 }
 
+/// #281 strategy A: when the session option `@human-input-marker` points at
+/// a file, touch that file (its mtime) on every real human TEXT keystroke,
+/// so external tools (e.g. claude-loop) can tell "a human is typing in the
+/// pane" apart from programmatic `send-keys` — live, even while the child
+/// app is busy. Printable chars only (no Ctrl/Alt, no control codes);
+/// throttled to ~once per 200ms so fast typing doesn't hammer the FS. No-op
+/// (zero overhead) when the option is unset. Never fatal.
+/// Is `key` a printable human text keystroke (paint "typing")? Excludes
+/// control codes and any Ctrl/Alt-modified key, so navigation, shortcuts,
+/// Enter, Tab, etc. don't count. Shift is fine (capitals). Pure — unit
+/// tested in `tests_issue281_human_input`.
+pub(crate) fn is_human_text_key(key: &KeyEvent) -> bool {
+    matches!(
+        key.code,
+        KeyCode::Char(c)
+            if !c.is_control()
+                && !key.modifiers.contains(KeyModifiers::CONTROL)
+                && !key.modifiers.contains(KeyModifiers::ALT)
+    )
+}
+
+pub(crate) fn note_human_input(app: &mut AppState, key: &KeyEvent) {
+    if !is_human_text_key(key) {
+        return;
+    }
+    let path = match app.user_options.get("@human-input-marker") {
+        Some(p) if !p.is_empty() => p.clone(),
+        _ => return,
+    };
+    let now = Instant::now();
+    if let Some(prev) = app.last_human_input {
+        if now.duration_since(prev) < Duration::from_millis(200) {
+            return;
+        }
+    }
+    app.last_human_input = Some(now);
+    let stamp = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis())
+        .unwrap_or(0);
+    // mtime is the signal the reader checks; the content is just for humans.
+    let _ = std::fs::write(&path, format!("{stamp}\n"));
+}
+
 pub fn forward_key_to_active(app: &mut AppState, key: KeyEvent) -> io::Result<()> {
+    // #281: record live human text input for external tooling. This is the
+    // ONLY path real client keystrokes take to the pane (handle_key →
+    // forward_key_to_active); send-keys/paste-buffer go through
+    // send_text_to_active instead, so the marker is never touched by
+    // programmatic injection — that physical separation is the whole point.
+    note_human_input(app, &key);
+
     // On Windows, modified Enter delivery depends on the modifier:
     //
     // Shift/Alt+Enter (no Ctrl): Use VT encoding ONLY (\x1b\r).  Native
@@ -3208,3 +3259,7 @@ mod tests_issue226_ctrl_slash;
 #[cfg(test)]
 #[path = "../tests-rs/test_issue284_pageup_wsl.rs"]
 mod tests_issue284_pageup_wsl;
+
+#[cfg(test)]
+#[path = "../tests-rs/test_issue281_human_input.rs"]
+mod tests_issue281_human_input;

--- a/src/types.rs
+++ b/src/types.rs
@@ -371,6 +371,11 @@ pub struct AppState {
     pub allow_predictions: bool,
     pub drag: Option<DragState>,
     pub last_window_area: Rect,
+    /// Throttle for the `@human-input-marker` integration (#281): the
+    /// last time a real human text keystroke touched the marker file.
+    /// `None` until the first keystroke. Keeps fast typing from hammering
+    /// the filesystem (we only need "typed recently", not every byte).
+    pub last_human_input: Option<Instant>,
     pub mouse_enabled: bool,
     /// scroll-enter-copy-mode: when off, mouse scroll at a shell prompt does NOT
     /// auto-enter copy mode.  Default: on (tmux parity).
@@ -697,6 +702,7 @@ impl AppState {
             allow_predictions: false,
             drag: None,
             last_window_area: Rect { x: 0, y: 0, width: 120, height: 30 },
+            last_human_input: None,
             mouse_enabled: true,
             scroll_enter_copy_mode: true,
             pwsh_mouse_selection: false,

--- a/tests-rs/test_issue281_human_input.rs
+++ b/tests-rs/test_issue281_human_input.rs
@@ -1,0 +1,98 @@
+// Issue #281 (strategy A): psmux exports live human text-input via the
+// `@human-input-marker` session option, so external tooling (e.g.
+// claude-loop) can tell a human typing apart from programmatic send-keys
+// — busy included, without a nested PTY proxy. These tests pin:
+//   1. the key classifier (printable text vs control / Ctrl / Alt / nav),
+//   2. that note_human_input touches the marker only on real text input,
+//      only when the option is set, and that rapid typing is throttled.
+
+use crate::input::{is_human_text_key, note_human_input};
+use crate::types::AppState;
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+fn k(code: KeyCode, mods: KeyModifiers) -> KeyEvent {
+    KeyEvent::new(code, mods)
+}
+
+/// Unique temp path per call so parallel tests don't collide.
+fn tmp_marker(tag: &str) -> std::path::PathBuf {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    std::env::temp_dir().join(format!(
+        "psmux_test_human_{}_{}_{}.marker",
+        tag,
+        std::process::id(),
+        nanos
+    ))
+}
+
+// === classifier ===
+
+#[test]
+fn plain_text_keys_are_human_input() {
+    assert!(is_human_text_key(&k(KeyCode::Char('a'), KeyModifiers::NONE)));
+    assert!(is_human_text_key(&k(KeyCode::Char('Z'), KeyModifiers::SHIFT))); // capitals
+    assert!(is_human_text_key(&k(KeyCode::Char(' '), KeyModifiers::NONE))); // space is text
+    assert!(is_human_text_key(&k(KeyCode::Char('é'), KeyModifiers::NONE))); // non-ASCII
+}
+
+#[test]
+fn control_and_modified_keys_are_not_human_input() {
+    assert!(!is_human_text_key(&k(KeyCode::Char('c'), KeyModifiers::CONTROL))); // Ctrl-C
+    assert!(!is_human_text_key(&k(KeyCode::Char('x'), KeyModifiers::ALT))); // Alt-x
+    assert!(!is_human_text_key(&k(KeyCode::Enter, KeyModifiers::NONE)));
+    assert!(!is_human_text_key(&k(KeyCode::Tab, KeyModifiers::NONE)));
+    assert!(!is_human_text_key(&k(KeyCode::Backspace, KeyModifiers::NONE)));
+    assert!(!is_human_text_key(&k(KeyCode::Left, KeyModifiers::NONE))); // navigation
+}
+
+// === marker side effect ===
+
+#[test]
+fn text_key_touches_marker_when_option_set() {
+    let marker = tmp_marker("touch");
+    let _ = std::fs::remove_file(&marker);
+    let mut app = AppState::new("t".into());
+    app.user_options
+        .insert("@human-input-marker".into(), marker.to_string_lossy().into_owned());
+    note_human_input(&mut app, &k(KeyCode::Char('h'), KeyModifiers::NONE));
+    assert!(marker.exists(), "a text keystroke must touch the marker");
+    let _ = std::fs::remove_file(&marker);
+}
+
+#[test]
+fn control_key_does_not_touch_marker() {
+    let marker = tmp_marker("ctrl");
+    let _ = std::fs::remove_file(&marker);
+    let mut app = AppState::new("t".into());
+    app.user_options
+        .insert("@human-input-marker".into(), marker.to_string_lossy().into_owned());
+    note_human_input(&mut app, &k(KeyCode::Enter, KeyModifiers::NONE));
+    assert!(!marker.exists(), "Enter must not touch the marker");
+}
+
+#[test]
+fn unset_option_is_a_noop() {
+    // No option → no write, no panic, throttle state untouched.
+    let mut app = AppState::new("t".into());
+    note_human_input(&mut app, &k(KeyCode::Char('h'), KeyModifiers::NONE));
+    assert!(app.last_human_input.is_none());
+}
+
+#[test]
+fn rapid_typing_is_throttled() {
+    let marker = tmp_marker("throttle");
+    let _ = std::fs::remove_file(&marker);
+    let mut app = AppState::new("t".into());
+    app.user_options
+        .insert("@human-input-marker".into(), marker.to_string_lossy().into_owned());
+    note_human_input(&mut app, &k(KeyCode::Char('a'), KeyModifiers::NONE));
+    assert!(marker.exists());
+    std::fs::remove_file(&marker).unwrap();
+    // An immediate second keystroke (< 200ms) is throttled → not re-created.
+    note_human_input(&mut app, &k(KeyCode::Char('b'), KeyModifiers::NONE));
+    assert!(!marker.exists(), "a rapid second keystroke should be throttled");
+    let _ = std::fs::remove_file(&marker);
+}


### PR DESCRIPTION
## Problem

Some integrations need to know **when a human is actively typing into a pane**, as distinct from input injected programmatically via `send-keys` / `paste-buffer`.

`capture-pane` can't answer this: it only shows *rendered* output, where a human's keystroke echo and the application's own output are already merged into the same cells. Polling it also misses typing that happens *while the app is busy streaming* (the screen is changing for other reasons). The only place the two input sources are physically distinct is **inside psmux itself** — a human's keys arrive via `handle_key → forward_key_to_active`, while `send-keys`/`paste-buffer` go through `commands.rs → send_text_to_active`. Two different code paths.

## What this adds

An opt-in session option, `@human-input-marker`, pointing at a file path:

```sh
psmux set-option -t mysession @human-input-marker /path/to/typing.marker
```

While it's set, psmux **touches that file** (updates its mtime) on every real human **text** keystroke routed to a pane in that session — and **never** on `send-keys`/`paste-buffer`. An external tool then treats *"marker mtime within the last N seconds"* as *"a human is typing now"*, live, even while the child app is busy.

Design choices:
- **Text only** — printable chars. Control codes, `Enter`, `Tab`, navigation keys, and any `Ctrl`/`Alt`-modified key are ignored (moving around a pane isn't "typing"). Classifier: `is_human_text_key`.
- **Throttled** to ~once per 200 ms, so fast typing doesn't hammer the filesystem — the signal is "typed recently", not a keylog (file content is just a timestamp).
- **Opt-in, zero-cost when unset** — no file I/O happens unless the option points at a path. No behavior change for anyone not using it.

## Implementation

- `note_human_input(app, key)` is called at the top of `forward_key_to_active` — the single path real client keystrokes take to a pane. Programmatic injection doesn't go through it, so the marker is never touched by `send-keys`/`paste-buffer`. That physical separation is the whole point.
- `is_human_text_key` is split out as a pure function for unit testing.
- One new `AppState` field (`last_human_input: Option<Instant>`) for the throttle.

## Tests

`tests-rs/test_issue281_human_input.rs` (6 tests): the classifier (text vs control/Ctrl/Alt/nav), that the marker is touched only on text input, only when the option is set, and that rapid typing is throttled.

> Heads-up unrelated to this PR: `src/input.rs` on `master` references `tests-rs/test_issue284_pageup_wsl.rs` via `#[path = ...] mod`, but that file isn't in the repo, so `cargo test` currently fails to compile the test target on a clean checkout. I stubbed it locally to run these tests; you may want to add or remove that `mod` declaration separately.

## Motivation / consumer

Built for [claude-loop](https://github.com/quazardous/aiball) (an autonomous Claude Code wrapper) running on Windows under psmux: it needs to yield to a human typing in the pane. The alternative was a nested-ConPTY proxy interposed between psmux and the child — which works but pays a double-conhost translation tax. Since psmux already has the human/injection separation natively, exposing it directly is far cleaner. Generic enough for any tool that wants a live "human present" signal.
