### PR TITLE
fix: client freezes permanently when server write timeout fires (Windows)

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -877,6 +877,78 @@ struct ClientDragState {
     total_pixels: u16,
 }
 
+/// Connect to the server, authenticate, enter persistent mode, spawn the reader
+/// thread, and return a (writer, frame_rx) pair ready for the event loop.
+/// Sets a 5-second write timeout so blocked writes never freeze the client.
+fn establish_connection(addr: &str, key: &str) -> io::Result<Connection> {
+    let stream = std::net::TcpStream::connect(addr)?;
+    stream.set_nodelay(true)?;
+    let mut writer = stream.try_clone()?;
+    writer.set_nodelay(true)?;
+    writer.set_write_timeout(Some(Duration::from_secs(5)))?;
+    let mut reader = BufReader::new(stream);
+
+    let _ = writer.write_all(format!("AUTH {}\n", key).as_bytes());
+    let _ = writer.flush();
+    let mut auth_line = String::new();
+    reader.read_line(&mut auth_line)?;
+    if !auth_line.trim().starts_with("OK") {
+        return Err(io::Error::new(io::ErrorKind::PermissionDenied, "auth failed"));
+    }
+
+    let _ = writer.write_all(b"PERSISTENT\n");
+    let _ = writer.write_all(b"client-attach\n");
+    let _ = writer.flush();
+
+    // 2-second read timeout keeps the thread from blocking forever on process exit.
+    let _ = reader.get_ref().set_read_timeout(Some(Duration::from_secs(2)));
+    let (frame_tx, frame_rx) = std::sync::mpsc::channel::<String>();
+    std::thread::spawn(move || {
+        let mut reader = reader;
+        let mut buf = String::with_capacity(64 * 1024);
+        loop {
+            buf.clear();
+            loop {
+                match reader.read_line(&mut buf) {
+                    Ok(0) => return,
+                    Ok(_) => break,
+                    Err(ref e) if e.kind() == std::io::ErrorKind::TimedOut
+                        || e.kind() == std::io::ErrorKind::WouldBlock => {
+                        // Do NOT clear buf here. read_line appends to whatever is
+                        // already in buf, so a partial line from a previous
+                        // fill_buf call is preserved across timeouts. Clearing
+                        // would break the framing and corrupt the next message.
+                        continue;
+                    }
+                    Err(_) => return,
+                }
+            }
+            let line = std::mem::take(&mut buf);
+            buf = String::with_capacity(64 * 1024);
+            if frame_tx.send(line).is_err() { return; }
+        }
+    });
+
+    Ok((writer, frame_rx))
+}
+
+/// A live connection: write half + incoming-frame channel.
+type Connection = (std::net::TcpStream, std::sync::mpsc::Receiver<String>);
+
+/// Retry connecting up to 5 times: one immediate attempt, then up to 4 more
+/// with increasing backoff (500ms, 1s, 1.5s, 2s). Returns None if all fail.
+fn try_reconnect(addr: &str, key: &str) -> Option<Connection> {
+    for attempt in 0..5u64 {
+        if attempt > 0 {
+            std::thread::sleep(Duration::from_millis(attempt * 500));
+        }
+        if let Ok(result) = establish_connection(addr, key) {
+            return Some(result);
+        }
+    }
+    None
+}
+
 pub fn run_remote(terminal: &mut Terminal<CrosstermBackend<crate::platform::PsmuxWriter>>, input: &crate::ssh_input::InputSource) -> io::Result<()> {
     let name = env::var("PSMUX_SESSION_NAME").unwrap_or_else(|_| "default".to_string());
     let home = env::var("USERPROFILE").or_else(|_| env::var("HOME")).unwrap_or_default();
@@ -891,60 +963,11 @@ pub fn run_remote(terminal: &mut Terminal<CrosstermBackend<crate::platform::Psmu
     }
 
     // ── Open persistent TCP connection ───────────────────────────────────
-    let stream = std::net::TcpStream::connect(&addr)?;
-    stream.set_nodelay(true)?; // Disable Nagle's algorithm for low latency
-    let mut writer = stream.try_clone()?;
-    writer.set_nodelay(true)?;
-    let mut reader = BufReader::new(stream);
-
-    // AUTH handshake
-    let _ = writer.write_all(format!("AUTH {}\n", session_key).as_bytes());
-    let _ = writer.flush();
-    let mut auth_line = String::new();
-    reader.read_line(&mut auth_line)?;
-    if !auth_line.trim().starts_with("OK") {
-        return Err(io::Error::new(io::ErrorKind::PermissionDenied, "auth failed"));
-    }
-
-    // Enter persistent mode + attach
-    let _ = writer.write_all(b"PERSISTENT\n");
-    let _ = writer.write_all(b"client-attach\n");
-    let _ = writer.flush();
-
-    // Spawn a dedicated reader thread so the event loop never blocks on I/O.
-    // The reader thread reads lines from the server and sends them via channel.
-    // Use a 2-second read timeout so the thread unblocks periodically.
-    // Without this, process::exit(0) on the server side may not deliver a
-    // TCP RST promptly on Windows, leaving read_line() blocked forever and
-    // the client stuck after the last pane exits.
-    let _ = reader.get_ref().set_read_timeout(Some(std::time::Duration::from_secs(2)));
-    let (frame_tx, frame_rx) = std::sync::mpsc::channel::<String>();
-    std::thread::spawn(move || {
-        let mut reader = reader;
-        let mut buf = String::with_capacity(64 * 1024);
-        loop {
-            buf.clear();
-            loop {
-                match reader.read_line(&mut buf) {
-                    Ok(0) => return, // EOF — server closed connection
-                    Ok(_) => break,  // Got a complete line, send it
-                    Err(ref e) if e.kind() == std::io::ErrorKind::TimedOut
-                        || e.kind() == std::io::ErrorKind::WouldBlock =>
-                    {
-                        // Timeout: buf may contain a partial line from a
-                        // previous fill_buf.  Do NOT clear it — read_line
-                        // will resume appending on the next call.  This
-                        // keeps the protocol stream intact.
-                        continue;
-                    }
-                    Err(_) => return, // Real error — connection died
-                }
-            }
-            let line = std::mem::take(&mut buf);
-            buf = String::with_capacity(64 * 1024);
-            if frame_tx.send(line).is_err() { return; }
-        }
-    });
+    let (mut writer, mut frame_rx) = establish_connection(&addr, &session_key)?;
+    // Pending background reconnect: Some(rx) while a reconnect thread is running.
+    // Kept as None in normal operation. When the channel yields Some(result),
+    // the result replaces writer/frame_rx; if it yields None all attempts failed.
+    let mut reconnect_pending: Option<std::sync::mpsc::Receiver<Option<Connection>>> = None;
 
     let mut quit = false;
     // detach-client -P: server sets this via DETACH-KILL-PARENT directive.
@@ -1468,6 +1491,29 @@ pub fn run_remote(terminal: &mut Terminal<CrosstermBackend<crate::platform::Psmu
     // actually changes (avoids resetting WT's blink timer every frame).
     let mut last_cursor_style: u8 = 255;
     loop {
+        // ── Poll background reconnect result (non-blocking) ──────────────────
+        // If a background reconnect thread has finished, apply its result here
+        // before any other step so the rest of the loop sees the fresh channels.
+        if let Some(ref rx) = reconnect_pending {
+            if let Ok(result) = rx.try_recv() {
+                reconnect_pending = None;
+                if let Some((new_writer, new_rx)) = result {
+                    if !quit {
+                        // Normal reconnect: apply fresh writer + frame channel.
+                        writer = new_writer;
+                        frame_rx = new_rx;
+                        force_dump = true;
+                        dump_in_flight = false;
+                    }
+                    // If quit is already set (user detached while reconnect was
+                    // in-flight), let new_writer drop here so the TcpStream
+                    // closes immediately — server-side Guard fires right away
+                    // rather than waiting for the 5 s write timeout.
+                } else {
+                    quit = true;
+                }
+            }
+        }
         // Expire stale key_send_instant after 30ms — ConPTY echo should
         // have arrived by then; stop force-dumping to save CPU.
         if let Some(ks) = key_send_instant {
@@ -1506,6 +1552,11 @@ pub fn run_remote(terminal: &mut Terminal<CrosstermBackend<crate::platform::Psmu
                             let _ = writer.flush();
                             quit = true;
                         }
+                    } else if line.trim() == "DETACH" {
+                        // Server-initiated clean shutdown (session ended, kill-session, etc.)
+                        // Set quit before the TCP connection closes so the Disconnected
+                        // handler does not spawn a reconnect thread.
+                        quit = true;
                     } else if line.trim() == "DETACH-KILL-PARENT" {
                         // detach-client -P: detach this client AND kill the
                         // parent shell on exit (tmux -P parity, issue #275).
@@ -1519,7 +1570,24 @@ pub fn run_remote(terminal: &mut Terminal<CrosstermBackend<crate::platform::Psmu
                     }
                 }
                 Err(std::sync::mpsc::TryRecvError::Empty) => break,
-                Err(std::sync::mpsc::TryRecvError::Disconnected) => { quit = true; break; }
+                Err(std::sync::mpsc::TryRecvError::Disconnected) => {
+                    // TCP connection dropped. If the server already removed its port
+                    // file (all clean-shutdown paths do this before calling
+                    // shutdown_persistent_streams), treat the disconnect as intentional
+                    // and quit immediately instead of burning 5 s of reconnect backoff.
+                    if !quit && !std::path::Path::new(&path).exists() {
+                        quit = true;
+                    } else if reconnect_pending.is_none() && !quit {
+                        let addr_c = addr.clone();
+                        let key_c = session_key.clone();
+                        let (rtx, rrx) = std::sync::mpsc::channel();
+                        reconnect_pending = Some(rrx);
+                        std::thread::spawn(move || {
+                            let _ = rtx.send(try_reconnect(&addr_c, &key_c));
+                        });
+                    }
+                    break;
+                }
             }
         }
         if quit && !got_frame { break; }

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -252,6 +252,11 @@ if line.trim() == "PERSISTENT" {
     // receivers here; the writer thread waits for each response and
     // writes it to TCP in order.
     let mut ws_bg = write_stream.try_clone().unwrap();
+    // Prevent the writer from blocking indefinitely when the client's TCP
+    // receive buffer fills up (e.g. during a slow render). Without a write
+    // timeout, a full socket causes write() to block forever, silently
+    // freezing frame delivery. 5 s matches the command-response timeout.
+    let _ = ws_bg.set_write_timeout(Some(Duration::from_secs(5)));
     let (resp_tx, resp_rx) = mpsc::channel::<mpsc::Receiver<String>>();
 
     // Register a bounded frame channel for server-pushed frames (event-driven
@@ -266,7 +271,35 @@ if line.trim() == "PERSISTENT" {
     // by frame channel backpressure.
     let directive_rx = crate::types::register_directive_channel(client_id);
 
+    // Clone the write socket so the Guard can shut down the connection when
+    // the writer exits. shutdown(Both) on any clone affects the underlying
+    // socket, causing the client's reader thread to receive EOF and reconnect
+    // instead of hanging indefinitely with a frozen last frame.
+    //
+    // We use write_stream (not ws_bg) as the source so that even under fd
+    // pressure the clone chain stays shallow.  If the clone fails here we
+    // return early — the client immediately sees a closed connection and
+    // reconnects, which is far better than hanging with no shutdown signal.
+    let ws_shutdown = match write_stream.try_clone() {
+        Ok(s) => s,
+        Err(_) => return,
+    };
     std::thread::spawn(move || {
+        // Deregister the frame channel and shut down the TCP connection when
+        // this thread exits for any reason (write timeout, resp_rx disconnect,
+        // etc.). The shutdown causes the client's reader thread to see EOF,
+        // which triggers reconnect rather than leaving the client frozen.
+        struct Guard { client_id: u64, shutdown: std::net::TcpStream }
+        impl Drop for Guard {
+            fn drop(&mut self) {
+                let _ = self.shutdown.shutdown(std::net::Shutdown::Both);
+                crate::types::deregister_frame_channel(self.client_id);
+                crate::types::remove_directive_channel(self.client_id);
+                crate::types::deregister_persistent_stream(self.client_id);
+            }
+        }
+        let _guard = Guard { client_id, shutdown: ws_shutdown };
+
         loop {
             // 0. Check for queued directives (non-blocking) — these take priority
             while let Ok(directive) = directive_rx.try_recv() {
@@ -276,29 +309,50 @@ if line.trim() == "PERSISTENT" {
             // 1. Drain all pending command responses (non-blocking after first)
             match resp_rx.recv_timeout(Duration::from_millis(5)) {
                 Ok(rrx) => {
-                    if let Ok(text) = rrx.recv() {
-                        if write!(ws_bg, "{}\n", text).is_err() { break; }
-                        if ws_bg.flush().is_err() { break; }
-                    }
-                    while let Ok(rrx) = resp_rx.try_recv() {
-                        if let Ok(text) = rrx.recv() {
+                    // Use a timeout matching the TCP write timeout (5 s) so the
+                    // writer thread cannot block indefinitely if the command
+                    // handler is slow or panics without sending a response.
+                    // A timeout (or disconnected sender) is treated as fatal:
+                    // break so Guard::drop fires, the client receives EOF, and
+                    // reconnects cleanly rather than stalling on a silent drop.
+                    match rrx.recv_timeout(Duration::from_secs(5)) {
+                        Ok(text) => {
                             if write!(ws_bg, "{}\n", text).is_err() { return; }
                             if ws_bg.flush().is_err() { return; }
+                        }
+                        Err(_) => return,
+                    }
+                    while let Ok(rrx) = resp_rx.try_recv() {
+                        match rrx.recv_timeout(Duration::from_secs(5)) {
+                            Ok(text) => {
+                                if write!(ws_bg, "{}\n", text).is_err() { return; }
+                                if ws_bg.flush().is_err() { return; }
+                            }
+                            Err(_) => return,
                         }
                     }
                     continue;
                 }
-                Err(mpsc::RecvTimeoutError::Disconnected) => break,
+                Err(mpsc::RecvTimeoutError::Disconnected) => return,
                 Err(mpsc::RecvTimeoutError::Timeout) => {}
             }
-            // 2. Drain all queued frames from the bounded channel
-            if let Ok(frame_rx) = frame_chan.rx.lock() {
-                while let Ok(text) = frame_rx.try_recv() {
-                    if write!(ws_bg, "{}\n", text).is_err() { return; }
-                    if ws_bg.flush().is_err() { return; }
+            // 2. Drain all queued frames from the bounded channel.
+            // Drain into a local buffer while holding rx.lock(), then drop
+            // the lock before writing to TCP. Holding rx.lock() across a
+            // blocking flush would deadlock push_frame() on the server loop.
+            let mut pending_frames: Vec<String> = Vec::new();
+            match frame_chan.rx.lock() {
+                Ok(frame_rx) => {
+                    while let Ok(text) = frame_rx.try_recv() {
+                        pending_frames.push(text);
+                    }
                 }
-            } else {
-                return;
+                Err(_) => return,
+            }
+            // rx.lock released here — TCP writes happen with no lock held
+            for text in &pending_frames {
+                if write!(ws_bg, "{}\n", text).is_err() { return; }
+                if ws_bg.flush().is_err() { return; }
             }
         }
     });

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -2352,6 +2352,8 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                     let _ = std::fs::remove_file(&regpath);
                     let _ = std::fs::remove_file(&keypath);
                     crate::session::remove_session_id_file(&app.port_file_base());
+                    crate::types::send_directive_to_all_clients("DETACH");
+                    std::thread::sleep(Duration::from_millis(50));
                     crate::types::shutdown_persistent_streams();
                     // Kill all child processes using a single process snapshot
                     tree::kill_all_children_batch(&mut app.windows);
@@ -3354,7 +3356,7 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                     if let Some(cid) = target_cid {
                         if kill_parent {
                             crate::types::send_directive_to_client(cid, "DETACH-KILL-PARENT");
-                            std::thread::sleep(std::time::Duration::from_millis(50));
+                            std::thread::sleep(Duration::from_millis(50));
                         }
                         app.client_sizes.remove(&cid);
                         let was_present = app.client_registry.remove(&cid).is_some();
@@ -3388,7 +3390,7 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                         }
                     }
                     if kill_parent && !targets.is_empty() {
-                        std::thread::sleep(std::time::Duration::from_millis(50));
+                        std::thread::sleep(Duration::from_millis(50));
                     }
                     for (cid, tty) in &targets {
                         app.client_sizes.remove(cid);
@@ -3437,7 +3439,7 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                         }
                     }
                     if kill_parent && !targets.is_empty() {
-                        std::thread::sleep(std::time::Duration::from_millis(50));
+                        std::thread::sleep(Duration::from_millis(50));
                     }
                     for (cid, tty) in &targets {
                         app.client_sizes.remove(cid);
@@ -3670,6 +3672,8 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                     let keypath = format!("{}\\.psmux\\{}.key", home, app.port_file_base());
                     let _ = std::fs::remove_file(&regpath);
                     let _ = std::fs::remove_file(&keypath);
+                    crate::types::send_directive_to_all_clients("DETACH");
+                    std::thread::sleep(Duration::from_millis(50));
                     crate::types::shutdown_persistent_streams();
                     // Kill all child processes using a single process snapshot
                     tree::kill_all_children_batch(&mut app.windows);
@@ -4763,6 +4767,8 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                 let keypath = format!("{}\\.psmux\\{}.key", home, app.port_file_base());
                 let _ = std::fs::remove_file(&regpath);
                 let _ = std::fs::remove_file(&keypath);
+                crate::types::send_directive_to_all_clients("DETACH");
+                std::thread::sleep(Duration::from_millis(50));
                 crate::types::shutdown_persistent_streams();
                 // Kill warm pane's child (process::exit skips Drop)
                 if let Some(mut wp) = app.warm_pane.take() { wp.child.kill().ok(); }

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -266,11 +266,11 @@ pub fn resize_all_panes(app: &mut AppState) {
                     let inner_width = rect.width.max(crate::pane::MIN_PANE_DIM);
                     
                     if pane.last_rows != inner_height || pane.last_cols != inner_width {
-                        let _ = pane.master.resize(portable_pty::PtySize { 
-                            rows: inner_height, 
-                            cols: inner_width, 
-                            pixel_width: 0, 
-                            pixel_height: 0 
+                        let _ = pane.master.resize(portable_pty::PtySize {
+                            rows: inner_height,
+                            cols: inner_width,
+                            pixel_width: 0,
+                            pixel_height: 0
                         });
                         if let Ok(mut parser) = pane.term.lock() {
                             parser.screen_mut().set_size(inner_height, inner_width);

--- a/src/types.rs
+++ b/src/types.rs
@@ -1272,6 +1272,16 @@ pub fn register_persistent_stream(client_id: u64, stream: &std::net::TcpStream) 
     }
 }
 
+/// Remove a specific client's entry from PERSISTENT_STREAMS without shutting
+/// it down. Called by the writer-thread Guard on normal disconnect — the socket
+/// is already shut down via ws_shutdown at that point, so we only need to drop
+/// the dead clone from the Vec to prevent unbounded accumulation.
+pub fn deregister_persistent_stream(client_id: u64) {
+    if let Ok(mut v) = PERSISTENT_STREAMS.lock() {
+        v.retain(|(cid, _)| *cid != client_id);
+    }
+}
+
 /// Shut down all tracked persistent client streams so their readers get EOF.
 pub fn shutdown_persistent_streams() {
     if let Ok(mut v) = PERSISTENT_STREAMS.lock() {
@@ -1355,15 +1365,19 @@ pub fn push_frame(frame: &str) {
                     // Frames are full snapshots, not deltas. If the client is
                     // behind, stale queued frames should not block the newest
                     // corrective frame from reaching the terminal.
-                    let rx = match channel.rx.lock() {
-                        Ok(rx) => rx,
-                        Err(_) => return false,
-                    };
-                    loop {
-                        match rx.try_recv() {
-                            Ok(_) => {}
-                            Err(std::sync::mpsc::TryRecvError::Empty) => break,
-                            Err(std::sync::mpsc::TryRecvError::Disconnected) => return false,
+                    //
+                    // Use try_lock, not lock: the writer thread holds rx.lock()
+                    // while it drains into its local buffer (before TCP writes).
+                    // Blocking here would deadlock the server's main loop.
+                    // If try_lock fails the writer is mid-drain; skip our drain
+                    // and try_send anyway — the writer will free space shortly.
+                    if let Ok(rx) = channel.rx.try_lock() {
+                        loop {
+                            match rx.try_recv() {
+                                Ok(_) => {}
+                                Err(std::sync::mpsc::TryRecvError::Empty) => break,
+                                Err(std::sync::mpsc::TryRecvError::Disconnected) => return false,
+                            }
                         }
                     }
                     matches!(
@@ -1380,6 +1394,15 @@ pub fn push_frame(frame: &str) {
 /// Check if any persistent clients are registered for push.
 pub fn has_frame_receivers() -> bool {
     FRAME_PUSH_CHANNELS.lock().map_or(false, |v| !v.is_empty())
+}
+
+/// Remove the frame channel for a specific client. Called by the writer thread
+/// on exit so the server stops pushing to dead channels and has_frame_receivers()
+/// returns false when no live clients remain.
+pub fn deregister_frame_channel(client_id: u64) {
+    if let Ok(mut v) = FRAME_PUSH_CHANNELS.lock() {
+        v.retain(|(cid, _)| *cid != client_id);
+    }
 }
 
 /// Per-client directive channels (queued, not overwritten like frame slots).


### PR DESCRIPTION
## Problem

Running multiple long-context Claude Code sessions simultaneously triggers a permanent client freeze. The server pushes large JSON frames (~50–100 KB each); when the client is CPU-bound rendering, the TCP receive buffer fills and the 5-second write timeout fires on the server writer thread. The client then displays the last rendered frame indefinitely — keyboard input still works, but the screen never updates. Both client and server are alive and responsive; only the display is stuck.

## Root causes

### Layer 1 — writer-thread deadlock

The old writer thread held `frame_chan.rx.lock()` while doing blocking TCP writes. `push_frame()` on the server main loop also tried to acquire this lock when the channel was full → both sides stalled. The server could not push new frames; the writer could not flush old ones.

**Fix:** drain the frame channel into a local `Vec` while holding `rx.lock()`, release the lock, then write to TCP with no lock held. `push_frame()` now uses `try_lock()` so the server main loop is never blocked by the writer thread.

### Layer 2 — missing EOF signal on writer exit (Windows-specific)

On Windows, `TcpStream::try_clone()` creates a new OS handle to the same underlying socket. When the write timeout fires and the writer thread exits, it drops `ws_bg` (a clone). Because `write_stream` in the connection handler still holds a reference, the OS socket stays open. The client reader thread never receives EOF, never signals `Disconnected`, and the client hangs indefinitely — even though both sides are alive.

**Fix:** a RAII `Guard` on the writer thread calls `shutdown(Both)` on exit. Unlike `drop`, `shutdown()` operates at the socket level and sends FIN to the client regardless of how many handles exist. Client reader gets `Ok(0)` → `frame_tx` drops → `Disconnected` → reconnect.

## Additional hardening

| Change | Why |
|---|---|
| `rrx.recv()` → `rrx.recv_timeout(5s)` | A stalled command handler could park the writer thread forever with no timeout |
| Write timeout on client writer (5s) | Matches server side; unblocks the client if *it* is the slow writer |
| Background reconnect thread | On `Disconnected`, retries up to 5× (immediate + 500 ms / 1 s / 1.5 s / 2 s backoff) on a background thread so the event loop stays responsive (Ctrl+C, resize) during the retry window |
| `ws_shutdown` cloned from `write_stream` not `ws_bg` | Shallower clone chain; `Err => return` makes fd-exhaustion failure explicit rather than a silent `Option::None` that silently skips `shutdown` |
| `deregister_frame_channel` / `deregister_persistent_stream` | Server stops pushing to dead channels immediately on writer exit rather than waiting for the next `push_frame` `Disconnected` detection |