### PR TITLE
fix: capture-pane CLI expands POSIX short flag clusters

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1183,6 +1183,18 @@ fn run_main() -> io::Result<()> {
                                 i += 1;
                             }
                         }
+                        a if a.len() > 2
+                            && a.starts_with('-')
+                            && !a.starts_with("--")
+                            && a.chars().skip(1).all(|c| matches!(c, 'p' | 'e' | 'J')) =>
+                        {
+                            // POSIX cluster of capture-pane booleans (-ep, -pe, -pJ, -eJ,
+                            // -epJ, ...). -t/-S/-E/-b take a value, so they are NOT
+                            // eligible for clustering.
+                            if a.contains('p') { cmd.push_str(" -p"); print_stdout = true; }
+                            if a.contains('e') { cmd.push_str(" -e"); }
+                            if a.contains('J') { cmd.push_str(" -J"); }
+                        }
                         _ => {}
                     }
                     i += 1;


### PR DESCRIPTION
## Summary

`psmux capture-pane -ep -t <target>` returned exit 0 with empty stdout, while `psmux capture-pane -e -p -t <target>` (same flags, separated) worked correctly.

## Root cause

The CLI dispatcher for `capture-pane` in `main.rs` matched flag strings exactly (`"-p"`, `"-e"`, `"-J"`), so a POSIX short flag cluster like `-ep` or `-pe` fell through to `_ => {}` and was silently dropped. As a result `print_stdout` stayed `false` and the command was routed to the fire-and-forget `send_control` branch — no response was printed, hence the empty stdout and exit 0.

## Fix

Add a `match` arm that detects an argument of the form `-XYZ` whose every character after the dash is one of the capture-pane boolean shorts (`p`, `e`, `J`), and emit each flag individually. Value-taking flags (`-t`, `-S`, `-E`, `-b`) take a following argument and are not eligible for clustering — they stay on their existing arms.

## Smoke matrix (attached 29×120 session)

| Form    | Before | After |
|---------|--------|-------|
| `-p`    | 1281   | 1281  |
| `-e -p` | 2312   | 2312  |
| `-ep`   | **0**  | **2312** |
| `-pe`   | **0**  | **2312** |

Zero regression on the separated forms; the cluster form now matches the separated-flag output and contains ANSI SGR escapes as expected for `-e`.

## Test plan

- [x] `cargo build --release` clean
- [x] Repro confirmed pre-patch (`-ep`/`-pe` → 0 bytes ; `-p`/`-e -p` → text)
- [x] 4-form smoke matrix verified post-patch
- [ ] Adding a Rust unit test for the cluster expansion would be a reasonable follow-up; current behavior validated by the integration smoke above