### PR TITLE
fix: clip mouse selection copy to pane

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -196,6 +196,45 @@ fn normalize_selection(start: (u16, u16), end: (u16, u16), block: bool) -> (u16,
     }
 }
 
+fn selection_row_cols(
+    row: u16,
+    r0: u16,
+    c0: u16,
+    r1: u16,
+    c1: u16,
+    block: bool,
+    term_width: u16,
+    pane_clip: Option<Rect>,
+) -> Option<(u16, u16)> {
+    if term_width == 0 {
+        return None;
+    }
+
+    let mut col_start = if block || row == r0 { c0 } else { 0 };
+    let mut col_end = if block || row == r1 {
+        c1
+    } else {
+        term_width.saturating_sub(1)
+    };
+
+    if let Some(clip) = pane_clip {
+        if clip.width == 0 || clip.height == 0 {
+            return None;
+        }
+
+        let clip_bottom = clip.y.saturating_add(clip.height).saturating_sub(1);
+        if row < clip.y || row > clip_bottom {
+            return None;
+        }
+
+        let clip_right = clip.x.saturating_add(clip.width).saturating_sub(1);
+        col_start = col_start.max(clip.x);
+        col_end = col_end.min(clip_right);
+    }
+
+    (col_start <= col_end).then_some((col_start, col_end))
+}
+
 fn extract_selection_text(
     layout: &LayoutJson,
     term_width: u16,
@@ -203,25 +242,37 @@ fn extract_selection_text(
     start: (u16, u16),
     end: (u16, u16),
     block: bool,
+    pane_clip: Option<Rect>,
 ) -> String {
     let (r0, c0, r1, c1) = normalize_selection(start, end, block);
 
-    let content_area = Rect { x: 0, y: 0, width: term_width, height: content_height };
+    let content_area = Rect {
+        x: 0,
+        y: 0,
+        width: term_width,
+        height: content_height,
+    };
     let mut leaves: Vec<PaneLeaf> = Vec::new();
     collect_leaves(layout, content_area, &mut leaves);
 
     let mut result = String::new();
+    let mut wrote_line = false;
     for row in r0..=r1 {
-        let col_start = if block || row == r0 { c0 } else { 0 };
-        let col_end = if block || row == r1 { c1 } else { term_width.saturating_sub(1) };
+        let Some((col_start, col_end)) =
+            selection_row_cols(row, r0, c0, r1, c1, block, term_width, pane_clip)
+        else {
+            continue;
+        };
 
         let mut line = String::new();
         for col in col_start..=col_end {
             let mut ch = ' ';
             for leaf in &leaves {
                 let inner = &leaf.inner;
-                if col >= inner.x && col < inner.x + inner.width
-                    && row >= inner.y && row < inner.y + inner.height
+                if col >= inner.x
+                    && col < inner.x + inner.width
+                    && row >= inner.y
+                    && row < inner.y + inner.height
                 {
                     let local_row = (row - inner.y) as usize;
                     let local_col = (col - inner.x) as usize;
@@ -233,11 +284,11 @@ fn extract_selection_text(
             }
             line.push(ch);
         }
-        let trimmed = line.trim_end();
-        result.push_str(trimmed);
-        if row < r1 {
+        if wrote_line {
             result.push('\n');
         }
+        result.push_str(line.trim_end());
+        wrote_line = true;
     }
 
     result
@@ -3107,6 +3158,7 @@ pub fn run_remote(terminal: &mut Terminal<CrosstermBackend<crate::platform::Psmu
                                                     last_sent_size.1,
                                                     s, e,
                                                     rsel_block,
+                                                    rsel_pane_rect,
                                                 );
                                                 if !text.is_empty() {
                                                     copy_to_system_clipboard(&text);
@@ -3152,6 +3204,7 @@ pub fn run_remote(terminal: &mut Terminal<CrosstermBackend<crate::platform::Psmu
                                                 last_sent_size.1,
                                                 s, e,
                                                 rsel_block,
+                                                rsel_pane_rect,
                                             );
                                             if !text.is_empty() {
                                                 copy_to_system_clipboard(&text);
@@ -3523,6 +3576,7 @@ pub fn run_remote(terminal: &mut Terminal<CrosstermBackend<crate::platform::Psmu
                                                 last_sent_size.1,
                                                 s, e,
                                                 rsel_block,
+                                                rsel_pane_rect,
                                             );
                                             if !text.is_empty() {
                                                 copy_to_system_clipboard(&text);
@@ -3650,6 +3704,7 @@ pub fn run_remote(terminal: &mut Terminal<CrosstermBackend<crate::platform::Psmu
                                                     last_sent_size.1,
                                                     s, e,
                                                     false,
+                                                    rsel_pane_rect,
                                                 );
                                                 if !text.is_empty() {
                                                     copy_to_system_clipboard(&text);

--- a/tests-rs/test_client.rs
+++ b/tests-rs/test_client.rs
@@ -200,6 +200,37 @@ fn make_row(runs: Vec<crate::layout::CellRunJson>) -> crate::layout::RowRunsJson
 }
 
 #[cfg(windows)]
+fn make_leaf(id: usize, rows: &[&str]) -> crate::layout::LayoutJson {
+    let cols = rows.first().map(|row| row.chars().count()).unwrap_or(0) as u16;
+    crate::layout::LayoutJson::Leaf {
+        id,
+        rows: rows.len() as u16,
+        cols,
+        cursor_row: 0,
+        cursor_col: 0,
+        alternate_screen: false,
+        hide_cursor: false,
+        cursor_shape: 0,
+        active: id == 0,
+        copy_mode: false,
+        scroll_offset: 0,
+        sel_start_row: None,
+        sel_start_col: None,
+        sel_end_row: None,
+        sel_end_col: None,
+        sel_mode: None,
+        copy_cursor_row: None,
+        copy_cursor_col: None,
+        content: Vec::new(),
+        rows_v2: rows
+            .iter()
+            .map(|row| make_row(vec![make_run(row, cols)]))
+            .collect(),
+        title: None,
+    }
+}
+
+#[cfg(windows)]
 #[test]
 fn normalize_selection_reading_order() {
     // Start before end: no swap
@@ -270,7 +301,6 @@ fn char_at_col_basics() {
 #[cfg(windows)]
 #[test]
 fn extract_selection_text_block_mode() {
-    use ratatui::layout::Rect as Rect;
     // A single leaf pane 10 cols wide, 3 rows
     let layout = crate::layout::LayoutJson::Leaf {
         id: 0,
@@ -301,12 +331,48 @@ fn extract_selection_text_block_mode() {
     };
 
     // Block select cols 2..5, rows 0..2
-    let text = extract_selection_text(&layout, 10, 3, (2, 0), (5, 2), true);
+    let text = extract_selection_text(&layout, 10, 3, (2, 0), (5, 2), true, None);
     assert_eq!(text, "2345\ncdef\nCDEF");
 
     // Non-block (reading order) same coordinates should give full intermediate rows
-    let text_normal = extract_selection_text(&layout, 10, 3, (2, 0), (5, 2), false);
+    let text_normal = extract_selection_text(&layout, 10, 3, (2, 0), (5, 2), false, None);
     assert_eq!(text_normal, "23456789\nabcdefghij\nABCDEF");
+}
+
+#[cfg(windows)]
+#[test]
+fn extract_selection_text_clips_reading_order_to_origin_pane() {
+    let layout = crate::layout::LayoutJson::Split {
+        kind: "Horizontal".to_string(),
+        sizes: vec![50, 50],
+        children: vec![
+            make_leaf(0, &["abcde", "fghij", "klmno"]),
+            make_leaf(1, &["ABCDE", "FGHIJ", "KLMNO"]),
+        ],
+    };
+    let pane_clip = ratatui::layout::Rect { x: 0, y: 0, width: 5, height: 3 };
+
+    let text = extract_selection_text(&layout, 11, 3, (1, 0), (3, 2), false, Some(pane_clip));
+
+    assert_eq!(text, "bcde\nfghij\nklmn");
+}
+
+#[cfg(windows)]
+#[test]
+fn extract_selection_text_clips_block_mode_to_origin_pane() {
+    let layout = crate::layout::LayoutJson::Split {
+        kind: "Horizontal".to_string(),
+        sizes: vec![50, 50],
+        children: vec![
+            make_leaf(0, &["abcde", "fghij", "klmno"]),
+            make_leaf(1, &["ABCDE", "FGHIJ", "KLMNO"]),
+        ],
+    };
+    let pane_clip = ratatui::layout::Rect { x: 0, y: 0, width: 5, height: 3 };
+
+    let text = extract_selection_text(&layout, 11, 3, (1, 0), (8, 2), true, Some(pane_clip));
+
+    assert_eq!(text, "bcde\nghij\nlmno");
 }
 
 #[cfg(windows)]


### PR DESCRIPTION
## Summary
Fixes `pwsh-mouse-selection` clipboard extraction so multi-line mouse selections are clipped to the originating pane, matching the visible selection overlay.

Previously, the overlay was pane-clipped but `Ctrl+C`, `Ctrl+Shift+C`, right-click copy, and legacy copy-on-release could still extract full terminal-width intermediate rows, which could include text from neighboring panes.

Related to #211 

## Approach

 - Thread the originating pane rect into mouse-selection text extraction.
 - Intersect each selected row with that pane rect before reading cells from the layout tree.
 - Preserve existing behavior when no pane clip is provided.

## Tests

- `cargo test -q extract_selection_text`