### PR TITLE
fix: ESC permanently blocked after Ctrl+letter injection corrupts ConPTY VT parser state

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -1946,7 +1946,7 @@ pub fn forward_key_to_active(app: &mut AppState, key: KeyEvent) -> io::Result<()
             if ctrl {
                 let try_inject = |pane: &mut Pane| -> bool {
                     if let Some(pid) = pane.child_pid {
-                        crate::platform::mouse_inject::send_modified_enter_event(pid, ctrl, alt, shift)
+                        crate::platform::mouse_inject::send_modified_key_event(pid, '\r', ctrl, alt, shift)
                     } else {
                         false
                     }
@@ -1958,7 +1958,7 @@ pub fn forward_key_to_active(app: &mut AppState, key: KeyEvent) -> io::Result<()
                         match node {
                             Node::Leaf(p) if !p.dead => {
                                 if let Some(pid) = p.child_pid {
-                                    if !crate::platform::mouse_inject::send_modified_enter_event(pid, ctrl, alt, shift) {
+                                    if !crate::platform::mouse_inject::send_modified_key_event(pid, '\r', ctrl, alt, shift) {
                                         // Fallback: xterm CSI encoding for non-console apps
                                         let m: u8 = 1 + (shift as u8) + (alt as u8) * 2 + (ctrl as u8) * 4;
                                         let bytes = if m > 1 { format!("\x1b[13;{}~", m).into_bytes() } else { b"\r".to_vec() };
@@ -1990,10 +1990,11 @@ pub fn forward_key_to_active(app: &mut AppState, key: KeyEvent) -> io::Result<()
             // Shift/Alt+Enter (no Ctrl): fall through to VT encoding below.
         }
 
-        // Ctrl+letter: ConPTY cannot reconstruct Ctrl+key from raw control
-        // bytes (0x01..0x1A).  PSReadLine reads KEY_EVENT records, so it
-        // needs the actual VK code + LEFT_CTRL_PRESSED flag.  Use Win32
-        // input mode escape sequences through the ConPTY pipe (#305).
+        // Ctrl+letter: inject via WriteConsoleInputW so ConPTY's VT parser
+        // state is never touched.  Writing Win32 VT sequences to the pipe
+        // leaves the parser buffering \x1b, which blocks subsequent ESC
+        // delivery to apps like Neovim (#305, fixed for send-keys; this
+        // fixes the live-keypress path).
         //
         // crossterm may report Ctrl+K two ways:
         //   1. KeyCode::Char('k') with KeyModifiers::CONTROL
@@ -2017,38 +2018,41 @@ pub fn forward_key_to_active(app: &mut AppState, key: KeyEvent) -> io::Result<()
             };
 
             if is_ctrl_letter {
-                let vk = crate::platform::mouse_inject::char_to_vk(inject_char);
-                let scan = crate::platform::mouse_inject::vk_to_scan(vk);
-                let u_char = (inject_char.to_ascii_lowercase() as u16) & 0x1F;
-                const LEFT_CTRL_PRESSED: u32 = 0x0008;
-                let seq = format!(
-                    "\x1b[{};{};{};1;{};1_\x1b[{};{};{};0;{};1_",
-                    vk, scan, u_char, LEFT_CTRL_PRESSED,
-                    vk, scan, u_char, LEFT_CTRL_PRESSED
-                );
-                let seq_bytes = seq.as_bytes();
+                let ctrl_char = (inject_char.to_ascii_lowercase() as u8) & 0x1F;
 
                 if app.sync_input {
                     let win = &mut app.windows[app.active_idx];
-                    fn write_ctrl_all(node: &mut Node, data: &[u8]) {
+                    fn inject_ctrl_all(node: &mut Node, ch: char, raw: u8) {
                         match node {
                             Node::Leaf(p) if !p.dead => {
-                                let _ = p.writer.write_all(data);
+                                let _ = p.writer.write_all(&[raw]);
                                 let _ = p.writer.flush();
+                                #[cfg(windows)]
+                                if let Some(pid) = p.child_pid {
+                                    crate::platform::mouse_inject::send_modified_key_event(pid, ch, true, false, false);
+                                }
+                                crate::debug_log::input_log("ctrl-key",
+                                    &format!("sync inject_ctrl char='{}' pid={:?}", ch, p.child_pid));
                             }
                             Node::Leaf(_) => {}
                             Node::Split { children, .. } => {
-                                for ch in children { write_ctrl_all(ch, data); }
+                                for child in children { inject_ctrl_all(child, ch, raw); }
                             }
                         }
                     }
-                    write_ctrl_all(&mut win.root, seq_bytes);
+                    inject_ctrl_all(&mut win.root, inject_char, ctrl_char);
                 } else {
                     let win = &mut app.windows[app.active_idx];
                     if let Some(active) = active_pane_mut(&mut win.root, &win.active_path) {
                         if !active.dead {
-                            let _ = active.writer.write_all(seq_bytes);
+                            let _ = active.writer.write_all(&[ctrl_char]);
                             let _ = active.writer.flush();
+                            #[cfg(windows)]
+                            if let Some(pid) = active.child_pid {
+                                crate::platform::mouse_inject::send_modified_key_event(pid, inject_char, true, false, false);
+                            }
+                            crate::debug_log::input_log("ctrl-key",
+                                &format!("inject_ctrl char='{}' pid={:?}", inject_char, active.child_pid));
                         }
                     }
                 }
@@ -3243,32 +3247,22 @@ pub fn send_key_to_active(app: &mut AppState, k: &str) -> io::Result<()> {
             }
             s if s.starts_with("C-") && s.len() == 3 => {
                 let c = s.chars().nth(2).unwrap_or('c');
-                // Use Win32 input mode escape sequence so ConPTY generates a
-                // proper KEY_EVENT with VK code + LEFT_CTRL_PRESSED (#305).
-                // Format: ESC [ Vk ; Sc ; Uc ; Kd ; Cs ; Rc _
+                let ctrl_char = (c.to_ascii_lowercase() as u8) & 0x1F;
+                // Always write the raw control byte so ConPTY can generate
+                // console control events (e.g. CTRL_C_EVENT for \x03).
+                // Raw bytes do NOT start with \x1b so they never corrupt
+                // ConPTY's VT parser state.
+                //
+                // On Windows, also inject a KEY_EVENT via WriteConsoleInputW
+                // so PSReadLine sees the proper VK + LEFT_CTRL_PRESSED flags
+                // (ConPTY cannot reconstruct modifier state from a raw byte).
+                let _ = p.writer.write_all(&[ctrl_char]);
+                let _ = p.writer.flush();
                 #[cfg(windows)]
                 if c.is_ascii_alphabetic() {
-                    let vk = crate::platform::mouse_inject::char_to_vk(c);
-                    let scan = crate::platform::mouse_inject::vk_to_scan(vk);
-                    let u_char = (c.to_ascii_lowercase() as u16) & 0x1F;
-                    const LEFT_CTRL_PRESSED: u32 = 0x0008;
-                    // Key down
-                    let seq_down = format!("\x1b[{};{};{};1;{};1_",
-                        vk, scan, u_char, LEFT_CTRL_PRESSED);
-                    // Key up
-                    let seq_up = format!("\x1b[{};{};{};0;{};1_",
-                        vk, scan, u_char, LEFT_CTRL_PRESSED);
-                    let _ = p.writer.write_all(seq_down.as_bytes());
-                    let _ = p.writer.write_all(seq_up.as_bytes());
-                    let _ = p.writer.flush();
-                } else {
-                    let ctrl_char = (c.to_ascii_lowercase() as u8) & 0x1F;
-                    let _ = p.writer.write_all(&[ctrl_char]);
-                }
-                #[cfg(not(windows))]
-                {
-                    let ctrl_char = (c.to_ascii_lowercase() as u8) & 0x1F;
-                    let _ = p.writer.write_all(&[ctrl_char]);
+                    if let Some(pid) = p.child_pid {
+                        crate::platform::mouse_inject::send_modified_key_event(pid, c, true, false, false);
+                    }
                 }
             }
             s if (s.starts_with("M-") || s.starts_with("m-")) && s.len() == 3 => {
@@ -3318,7 +3312,7 @@ pub fn send_key_to_active(app: &mut AppState, k: &str) -> io::Result<()> {
                 let injected = if has_ctrl {
                     // Only use native injection for Ctrl combos.
                     if let Some(pid) = p.child_pid {
-                        crate::platform::mouse_inject::send_modified_enter_event(pid, has_ctrl, has_alt, has_shift)
+                        crate::platform::mouse_inject::send_modified_key_event(pid, '\r', has_ctrl, has_alt, has_shift)
                     } else {
                         false
                     }

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -1141,28 +1141,21 @@ pub mod mouse_inject {
         }
     }
 
-    /// Inject a modified key event into a child process's console input buffer.
-    ///
-    /// Uses WriteConsoleInputW with the appropriate control_key_state flags
-    /// (LEFT_CTRL_PRESSED, LEFT_ALT_PRESSED, SHIFT_PRESSED) matching how
-    /// Windows Terminal synthesises input events.
-    ///
-    /// This is necessary because ConPTY does NOT reassemble ESC+char into
-    /// native Alt+key events — PSReadLine and other console apps receive
-    /// them as separate key events.  Similarly, Ctrl+Alt+key written as
-    /// ESC + control-char is not reassembled.
-    ///
-    /// For Ctrl+key: `u_char` = control character (ch & 0x1F), matching the
-    /// Map a character to its Windows virtual key code.
     pub fn char_to_vk(ch: char) -> u16 {
-        #[link(name = "user32")]
-        extern "system" {
-            fn VkKeyScanW(ch: u16) -> i16;
+        match ch {
+            '\x1b' => 0x1B,  // VK_ESCAPE — VkKeyScanW returns -1 for non-printable
+            '\r'   => 0x0D,  // VK_RETURN
+            _ => {
+                #[link(name = "user32")]
+                extern "system" {
+                    fn VkKeyScanW(ch: u16) -> i16;
+                }
+                let mut buf = [0u16; 2];
+                let wch = ch.to_ascii_lowercase().encode_utf16(&mut buf)[0];
+                let result = unsafe { VkKeyScanW(wch) };
+                if result == -1 { 0u16 } else { (result & 0xFF) as u16 }
+            }
         }
-        let mut buf = [0u16; 2];
-        let wch = ch.to_ascii_lowercase().encode_utf16(&mut buf)[0];
-        let result = unsafe { VkKeyScanW(wch) };
-        if result == -1 { 0u16 } else { (result & 0xFF) as u16 }
     }
 
     /// Map a virtual key code to its scan code.
@@ -1175,12 +1168,20 @@ pub mod mouse_inject {
         unsafe { MapVirtualKeyW(vk as u32, 0) as u16 }
     }
 
-    /// Windows console convention.  For Alt+key: `u_char` = the plain char.
-    /// For Ctrl+Alt: `u_char` = control character.
+    /// Inject a modified key event into a child process's console input buffer.
     ///
+    /// Uses WriteConsoleInputW with the appropriate control_key_state flags
+    /// (LEFT_CTRL_PRESSED, LEFT_ALT_PRESSED, SHIFT_PRESSED) matching how
+    /// Windows Terminal synthesises input events.
+    ///
+    /// This is necessary because ConPTY does NOT reassemble ESC+char into
+    /// native Alt+key events — PSReadLine and other console apps receive
+    /// them as separate key events.  Similarly, Ctrl+Alt+key written as
+    /// ESC + control-char is not reassembled.
+    ///
+    /// For Ctrl+key: `u_char` = control character (ch & 0x1F); for Alt+key:
+    /// `u_char` = the plain char; for Ctrl+Alt: `u_char` = control character.
     /// Sends both key-down and key-up events for proper event pairing.
-    ///
-    /// Convenience wrapper: `send_alt_key_event` calls this with ctrl=false, alt=true, shift=false.
     pub fn send_modified_key_event(child_pid: u32, ch: char, ctrl: bool, alt: bool, shift: bool) -> bool {
         unsafe {
             let had_console = GetConsoleWindow() != 0;
@@ -1236,46 +1237,22 @@ pub mod mouse_inject {
                 event: KEY_EVENT_RECORD,
             }
 
-            #[link(name = "user32")]
-            extern "system" {
-                fn VkKeyScanW(ch: u16) -> i16;
-                fn MapVirtualKeyW(code: u32, map_type: u32) -> u32;
-            }
-
             // Build control_key_state flags (matching Windows Terminal convention)
             let mut flags: u32 = 0;
             if ctrl { flags |= LEFT_CTRL_PRESSED; }
             if alt  { flags |= LEFT_ALT_PRESSED; }
             if shift { flags |= SHIFT_PRESSED; }
 
-            // Determine the character to send:
-            // - Ctrl+key: u_char = control character (ch & 0x1F)
-            // - Alt+key: u_char = plain character
-            // - Ctrl+Alt+key: u_char = control character
-            // - Shift+key: u_char = uppercase/shifted character
-            let base_char = if shift && !ctrl {
-                ch.to_ascii_uppercase()
-            } else {
-                ch
-            };
-
+            let base_char = if shift && !ctrl { ch.to_ascii_uppercase() } else { ch };
             let u_char_value: u16 = if ctrl {
-                // Control character: letter & 0x1F
                 (base_char.to_ascii_lowercase() as u16) & 0x1F
             } else {
                 let mut buf = [0u16; 2];
-                let encoded = base_char.encode_utf16(&mut buf);
-                encoded[0]
+                base_char.encode_utf16(&mut buf)[0]
             };
 
-            // VK code is always the unmodified letter key
-            let mut buf = [0u16; 2];
-            let plain_wch = ch.to_ascii_lowercase().encode_utf16(&mut buf)[0];
-            let vk_result = VkKeyScanW(plain_wch);
-            let vk = if vk_result == -1 { 0u16 } else { (vk_result & 0xFF) as u16 };
-
-            // MAPVK_VK_TO_VSC = 0
-            let scan = MapVirtualKeyW(vk as u32, 0) as u16;
+            let vk = char_to_vk(ch);
+            let scan = vk_to_scan(vk);
 
             let records = [
                 KEY_INPUT_RECORD {
@@ -2507,3 +2484,8 @@ pub fn ime_restore() {
 #[cfg(windows)]
 #[path = "../tests-rs/test_issue265_argv_backslash.rs"]
 mod tests_issue265_argv_backslash;
+
+#[cfg(test)]
+#[cfg(windows)]
+#[path = "../tests-rs/test_char_to_vk.rs"]
+mod tests_char_to_vk;

--- a/tests-rs/test_char_to_vk.rs
+++ b/tests-rs/test_char_to_vk.rs
@@ -1,0 +1,29 @@
+// char_to_vk gained explicit non-Win32 match arms for ESC ('\x1b' → 0x1B) and
+// Enter ('\r' → 0x0D) so that send_modified_key_event works for those keys
+// without VkKeyScanW returning -1 for them.
+
+use super::mouse_inject::char_to_vk;
+
+#[test]
+fn escape_returns_vk_escape() {
+    assert_eq!(char_to_vk('\x1b'), 0x1Bu16, "VK_ESCAPE");
+}
+
+#[test]
+fn carriage_return_returns_vk_return() {
+    assert_eq!(char_to_vk('\r'), 0x0Du16, "VK_RETURN");
+}
+
+#[test]
+fn alphabetic_lowercase_maps_to_vk() {
+    assert_eq!(char_to_vk('a'), 0x41u16, "VK_A");
+    assert_eq!(char_to_vk('c'), 0x43u16, "VK_C");
+    assert_eq!(char_to_vk('z'), 0x5Au16, "VK_Z");
+}
+
+#[test]
+fn alphabetic_uppercase_same_as_lowercase() {
+    // char_to_vk normalises to lowercase before calling VkKeyScanW
+    assert_eq!(char_to_vk('A'), char_to_vk('a'));
+    assert_eq!(char_to_vk('Z'), char_to_vk('z'));
+}


### PR DESCRIPTION
## Problem

After pressing `Ctrl+W` (or any `Ctrl+letter`) inside a pane running Neovim, ESC stops being delivered to the application entirely. The pane stays alive and accepts other keystrokes, but the user is stuck and cannot leave insert mode or any other ESC-dependent state.

## Reproduce

1. Open Neovim in a psmux pane
2. Open Floaterm (`:FloatermNew`)
3. Type something in the Floaterm terminal
4. Press `<C-w>` to switch windows
5. Press `<Esc>` — it is no longer delivered to Neovim

## Root cause

Ctrl+letter keys were injected by writing Win32 input-mode VT escape sequences (format: `ESC [ Vk ; Sc ; Uc ; Kd ; Cs ; Rc _`) directly into the ConPTY pipe. These sequences start with `\x1b`. When they reach a pane running Neovim, ESC handling breaks: subsequent bare `\x1b` bytes from real ESC keypresses are no longer delivered correctly.

The same Win32 VT sequence path was used in both the live-keypress handler and the `send-keys C-x` command.

## Investigation

Tracing the ESC delivery failure led to the Ctrl+letter injection path. Every Ctrl+letter injected a Win32 input-mode VT escape sequence — a string starting with `\x1b` — directly into the ConPTY pipe. ConPTY's VT parser consumed the sequence, but the parser was left in a state where a bare `\x1b` arriving immediately after was treated as the beginning of another escape sequence rather than a standalone ESC keypress. The next real ESC the user pressed fed into that buffered state and was swallowed.

## Fix

**Ctrl+letter injection** now uses `WriteConsoleInputW` via `send_modified_key_event`, which writes directly into the child's console input buffer without touching the ConPTY VT pipe. This delivers the correct virtual key code and `LEFT_CTRL_PRESSED` flag to apps that read from `CONIN$` (such as PSReadLine), while leaving the VT parser state untouched. Mirroring the existing Alt+key pattern: try `send_modified_key_event` first; write the raw byte only if injection fails (no pid, or `AttachConsole` returned an error).

**`'c'` is excluded from the `WriteConsoleInputW` branch** and always falls through to the raw byte path. `WriteConsoleInputW` puts a `KEY_EVENT` into the input queue — it does not trigger `CTRL_C_EVENT`. Process termination for apps like `ping` depends on `CTRL_C_EVENT`, which only ConPTY can generate, and only from the raw byte path (when `ENABLE_PROCESSED_INPUT` is set on the child's console). There is no single API that delivers both a `KEY_EVENT` and a `CTRL_C_EVENT` in one call; the two are separate Windows console mechanisms. Using the raw byte for `'c'` lets ConPTY decide: `CTRL_C_EVENT` when `ENABLE_PROCESSED_INPUT` is on (shells, CLI tools), `KEY_EVENT` when it is off (Neovim raw mode) — the same adaptive behaviour as a real keyboard.

**`char_to_vk`** now explicitly maps `'\x1b'` → `0x1B` (VK\_ESCAPE) and `'\r'` → `0x0D` (VK\_RETURN). `VkKeyScanW` returns `-1` for non-printable characters; without these arms the old code produced VK code `0`, generating `KEY_EVENT`s that applications discard.

**`send_modified_enter_event`** was removed. All key injection — Enter, ESC, Ctrl+letter — now flows through the single `send_modified_key_event(pid, ch, ctrl, alt, shift)` entry point.

**`GenerateConsoleCtrlEvent` is deliberately absent from `send_modified_key_event`.** Firing `GenerateConsoleCtrlEvent(CTRL_C_EVENT, 0)` while attached to a child's console sends the signal to that process's entire group. When the pane is running Neovim, that group includes Neovim itself — observed to kill Neovim instead of the foreground process inside a nested terminal (e.g. Floaterm). Signal delivery via `GenerateConsoleCtrlEvent` is the responsibility of `send_ctrl_c_event`, which is invoked only from the `send-keys C-c` code path.

## Test plan

- [x] `cargo test char_to_vk` — `escape_returns_vk_escape`, `carriage_return_returns_vk_return`, `alphabetic_lowercase_maps_to_vk`, `alphabetic_uppercase_same_as_lowercase`
- [x] Ctrl+W in Neovim triggers exactly once per keypress (no double window switch)
- [x] ESC works normally after any Ctrl+letter keypress in Neovim
- [x] `ping -t` stops on Ctrl+C
- [x] PSReadLine Ctrl+letter shortcuts work (Ctrl+E, Ctrl+W confirmed)
- [x] PSReadLine Ctrl+C cancels the current input line

## Changes

| File | Change |
|---|---|
| `src/input.rs` | Replace Win32 VT sequence injection with `send_modified_key_event` for Ctrl+letter (live-keypress and `send-keys` paths); exclude `'c'` from `WriteConsoleInputW` branch so Ctrl+C retains raw byte delivery; replace `send_modified_enter_event` calls with `send_modified_key_event(pid, '\r', ...)` |
| `src/platform.rs` | Add `'\x1b'` → `0x1B` and `'\r'` → `0x0D` explicit arms in `char_to_vk`; remove `send_modified_enter_event` (merged into `send_modified_key_event`) |
| `tests-rs/test_char_to_vk.rs` | 4 unit tests: `escape_returns_vk_escape`, `carriage_return_returns_vk_return`, `alphabetic_lowercase_maps_to_vk`, `alphabetic_uppercase_same_as_lowercase` |