### PR TITLE
fix(input): prevent double Ctrl+letter delivery; use raw byte only for Ctrl+C

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -2025,11 +2025,18 @@ pub fn forward_key_to_active(app: &mut AppState, key: KeyEvent) -> io::Result<()
                     fn inject_ctrl_all(node: &mut Node, ch: char, raw: u8) {
                         match node {
                             Node::Leaf(p) if !p.dead => {
-                                let _ = p.writer.write_all(&[raw]);
-                                let _ = p.writer.flush();
+                                let mut injected = false;
                                 #[cfg(windows)]
-                                if let Some(pid) = p.child_pid {
-                                    crate::platform::mouse_inject::send_modified_key_event(pid, ch, true, false, false);
+                                // Ctrl+C must use the raw byte so ConPTY generates CTRL_C_EVENT;
+                                // WriteConsoleInputW cannot trigger process signals.
+                                if ch.to_ascii_lowercase() != 'c' {
+                                    if let Some(pid) = p.child_pid {
+                                        injected = crate::platform::mouse_inject::send_modified_key_event(pid, ch, true, false, false);
+                                    }
+                                }
+                                if !injected {
+                                    let _ = p.writer.write_all(&[raw]);
+                                    let _ = p.writer.flush();
                                 }
                                 crate::debug_log::input_log("ctrl-key",
                                     &format!("sync inject_ctrl char='{}' pid={:?}", ch, p.child_pid));
@@ -2045,11 +2052,16 @@ pub fn forward_key_to_active(app: &mut AppState, key: KeyEvent) -> io::Result<()
                     let win = &mut app.windows[app.active_idx];
                     if let Some(active) = active_pane_mut(&mut win.root, &win.active_path) {
                         if !active.dead {
-                            let _ = active.writer.write_all(&[ctrl_char]);
-                            let _ = active.writer.flush();
+                            let mut injected = false;
                             #[cfg(windows)]
-                            if let Some(pid) = active.child_pid {
-                                crate::platform::mouse_inject::send_modified_key_event(pid, inject_char, true, false, false);
+                            if inject_char.to_ascii_lowercase() != 'c' {
+                                if let Some(pid) = active.child_pid {
+                                    injected = crate::platform::mouse_inject::send_modified_key_event(pid, inject_char, true, false, false);
+                                }
+                            }
+                            if !injected {
+                                let _ = active.writer.write_all(&[ctrl_char]);
+                                let _ = active.writer.flush();
                             }
                             crate::debug_log::input_log("ctrl-key",
                                 &format!("inject_ctrl char='{}' pid={:?}", inject_char, active.child_pid));
@@ -3248,21 +3260,21 @@ pub fn send_key_to_active(app: &mut AppState, k: &str) -> io::Result<()> {
             s if s.starts_with("C-") && s.len() == 3 => {
                 let c = s.chars().nth(2).unwrap_or('c');
                 let ctrl_char = (c.to_ascii_lowercase() as u8) & 0x1F;
-                // Always write the raw control byte so ConPTY can generate
-                // console control events (e.g. CTRL_C_EVENT for \x03).
-                // Raw bytes do NOT start with \x1b so they never corrupt
-                // ConPTY's VT parser state.
-                //
-                // On Windows, also inject a KEY_EVENT via WriteConsoleInputW
-                // so PSReadLine sees the proper VK + LEFT_CTRL_PRESSED flags
-                // (ConPTY cannot reconstruct modifier state from a raw byte).
-                let _ = p.writer.write_all(&[ctrl_char]);
-                let _ = p.writer.flush();
+                // On Windows, try WriteConsoleInputW first so PSReadLine sees the
+                // proper VK + LEFT_CTRL_PRESSED flags.  Only fall back to the raw
+                // control byte if injection fails (no pid or AttachConsole error).
+                // Writing both causes double delivery: ConPTY converts the raw byte
+                // into a KEY_EVENT and WriteConsoleInputW injects a second one.
+                let mut injected = false;
                 #[cfg(windows)]
-                if c.is_ascii_alphabetic() {
+                if c.is_ascii_alphabetic() && c.to_ascii_lowercase() != 'c' {
                     if let Some(pid) = p.child_pid {
-                        crate::platform::mouse_inject::send_modified_key_event(pid, c, true, false, false);
+                        injected = crate::platform::mouse_inject::send_modified_key_event(pid, c, true, false, false);
                     }
+                }
+                if !injected {
+                    let _ = p.writer.write_all(&[ctrl_char]);
+                    let _ = p.writer.flush();
                 }
             }
             s if (s.starts_with("M-") || s.starts_with("m-")) && s.len() == 3 => {


### PR DESCRIPTION
Hotfix for two regressions introduced by #329.

## Regression 1 — Ctrl+letter triggers twice

### Problem

Any Ctrl+letter keypress (e.g. `<C-w>` in Neovim) fires twice — one press causes two actions.

### Root cause

#329 switched Ctrl+letter injection from Win32 VT sequences to two simultaneous delivery paths: writing the raw C0 control byte to the ConPTY pipe AND injecting a `KEY_EVENT` via `WriteConsoleInputW`. Both paths land in the child's console input buffer. ConPTY converts the raw byte into a `KEY_EVENT`, and `WriteConsoleInputW` injects a second one — the child sees the keypress twice.

### Fix

Mirror the existing Alt+key pattern: try `WriteConsoleInputW` first; write the raw byte only if injection fails. Exactly one delivery fires per keypress.

---

## Regression 2 — Ctrl+C cannot stop processes

### Problem

Pressing `<C-c>` no longer interrupts running processes such as `ping`.

### Root cause

`WriteConsoleInputW` puts a `KEY_EVENT` record into the input queue. It does not trigger `CTRL_C_EVENT`. Process termination for CLI tools depends on `CTRL_C_EVENT`, which only ConPTY generates, and only from the raw byte path when `ENABLE_PROCESSED_INPUT` is set on the child's console. With both fixes from Regression 1 applied, `'c'` now also goes through `WriteConsoleInputW` — so `CTRL_C_EVENT` is never generated and `ping` cannot be interrupted.

### Fix

`'c'` is excluded from the `WriteConsoleInputW` branch and always falls through to the raw byte path. There is no single Windows API that delivers both a `KEY_EVENT` and a `CTRL_C_EVENT`; they are separate console mechanisms. The raw byte delegates the decision to ConPTY: `CTRL_C_EVENT` when `ENABLE_PROCESSED_INPUT` is on (shells, CLI tools), `KEY_EVENT` when it is off (Neovim raw mode) — the same adaptive behaviour as a real keyboard.

---

## Test plan

- [x] `<C-w>` in Neovim triggers exactly once per keypress
- [x] ESC works normally after any Ctrl+letter keypress in Neovim
- [x] `ping -t` stops on Ctrl+C
- [x] PSReadLine Ctrl+letter shortcuts work (Ctrl+E, Ctrl+W)
- [x] PSReadLine Ctrl+C cancels the current input line

## Changes

| File | Change |
|---|---|
| `src/input.rs` | Use `WriteConsoleInputW`-first, raw-byte-fallback pattern for all Ctrl+letters; exclude `'c'` from `WriteConsoleInputW` branch |