### PR TITLE
fix: copy pwsh selection on mouse release

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -104,7 +104,7 @@ psmux split-window -- "C:/Program Files/Git/bin/bash.exe"
 | `mouse` | Bool | `on` | Mouse support |
 | `mouse-selection` | Bool | `on` | psmux's client-side drag selection. Set `off` to let in-pane TUI apps (opencode, nvim, etc.) handle their own mouse selection without psmux drawing on top |
 | `scroll-enter-copy-mode` | Bool | `on` | Enter copy mode on mouse scroll (set `off` to disable) |
-| `pwsh-mouse-selection` | Bool | `off` | Windows 11 PowerShell-style word/line selection (double/triple-click) |
+| `pwsh-mouse-selection` | Bool | `off` | tmux-like release-copy selection with word/line multi-click and pane-clipped extraction |
 | `paste-detection` | Bool | `on` | Detect Ctrl+V paste from console host and send as bracketed paste (set `off` to let Ctrl+V reach child apps like neovim) |
 | `choose-tree-preview` | Bool | `off` | Open `choose-session` / `choose-tree` pickers with the live preview pane already visible (saves pressing `p`). See [preview.md](preview.md) |
 | `status` | Bool/Int | `on` | Show status bar (number = line count) |
@@ -249,10 +249,12 @@ set -g mouse off
 # Disable entering copy mode on mouse scroll
 set -g scroll-enter-copy-mode off
 
-# Enable Windows 11 PowerShell-style word/line selection
+# Enable tmux-like release-copy selection with pane clipping
 # Double-click selects a word, triple-click selects a line
 set -g pwsh-mouse-selection on
 ```
+
+When `pwsh-mouse-selection` is `on`, releasing a left-drag copies the selected text immediately and clears the transient highlight. Right-click copy and `Ctrl+Shift+C` still work as explicit copy actions.
 
 When `scroll-enter-copy-mode` is `off`, scrolling in a pane does not enter copy mode and instead passes scroll events directly to the running application.
 
@@ -282,7 +284,7 @@ What changes when `mouse-selection` is `off`:
 
 - psmux no longer draws its own selection rectangle on left-click drag
 - Right-click clipboard copy via psmux's selection is no longer triggered (selection never starts)
-- The Windows 11 style word/line multi-click (`pwsh-mouse-selection`) is suppressed too while `mouse-selection off` is in effect
+- The `pwsh-mouse-selection` word/line multi-click and release-copy behavior is suppressed too while `mouse-selection off` is in effect
 
 To restore the default behaviour:
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -22,7 +22,7 @@ A: Yes! psmux includes a `tmux` alias. Commands like `tmux new-session`, `tmux a
 A: Session creation takes < 100ms. New windows/panes add < 80ms overhead. The bottleneck is your shell's startup time, not psmux. Compiled with opt-level 3 and full LTO.
 
 **Q: Does psmux support mouse?**
-A: Full mouse support: click to focus panes, drag to resize borders, scroll wheel, click status-bar tabs, drag-select text, right-click copy. Plus VT mouse forwarding for TUI apps like vim, htop, and midnight commander.
+A: Full mouse support: click to focus panes, drag to resize borders, scroll wheel, click status-bar tabs, drag-select text (including tmux-like copy-on-release with `pwsh-mouse-selection on`), and right-click copy/paste paths. Plus VT mouse forwarding for TUI apps like vim, htop, and midnight commander.
 
 **Q: What shells does psmux support?**
 A: PowerShell 7 (default), PowerShell 5, cmd.exe, Git Bash, WSL, nushell, and any Windows executable. Change with `set -g default-shell <shell>`.

--- a/docs/features.md
+++ b/docs/features.md
@@ -28,7 +28,7 @@
 - **Scroll wheel** in any pane, scrolls that pane's output (configurable via `scroll-enter-copy-mode`)
 - **Drag-select** text to copy to clipboard
 - **Right-click** to paste or copy selection
-- **Windows 11 PowerShell selection** : word and line selection with double/triple-click (`pwsh-mouse-selection on`)
+- **tmux-like release copy selection** : pane-clipped drag copy on left-button release with word/line multi-click (`pwsh-mouse-selection on`)
 - **Disable client-side selection** : let in-pane TUI apps (opencode, lazygit, etc.) handle their own mouse selection (`mouse-selection off`)
 - **VT mouse forwarding** : apps like vim, htop, and midnight commander get full mouse events
 - **3-layer mouse injection** : VT protocol, VT bridge (for WSL/SSH), and native Win32 MOUSE_EVENT

--- a/src/client.rs
+++ b/src/client.rs
@@ -3686,12 +3686,11 @@ pub fn run_remote(terminal: &mut Terminal<CrosstermBackend<crate::platform::Psmu
                                     client_drag = None;
                                 } else if rsel_dragged {
                                     if client_pwsh_selection {
-                                        // Windows 11 style: keep the selection
-                                        // visible until the user right-clicks to
-                                        // copy again. Do not overwrite rsel_end here —
-                                        // the drag handler already tracks it,
-                                        // and double-click word bounds must not
-                                        // be replaced by the release-position.
+                                        // tmux-like copy-on-release for
+                                        // pwsh-mouse-selection: use the drag
+                                        // endpoint tracked by MouseDrag so
+                                        // double/triple-click bounds remain
+                                        // intact, then clear transient state.
                                         if let (Some(s), Some(e)) = (rsel_start, rsel_end) {
                                             if let Ok(state) = serde_json::from_str::<DumpState>(&prev_dump_buf) {
                                                 let text = extract_selection_text(

--- a/src/client.rs
+++ b/src/client.rs
@@ -3688,10 +3688,31 @@ pub fn run_remote(terminal: &mut Terminal<CrosstermBackend<crate::platform::Psmu
                                     if client_pwsh_selection {
                                         // Windows 11 style: keep the selection
                                         // visible until the user right-clicks to
-                                        // copy. Do not overwrite rsel_end here —
+                                        // copy again. Do not overwrite rsel_end here —
                                         // the drag handler already tracks it,
                                         // and double-click word bounds must not
                                         // be replaced by the release-position.
+                                        if let (Some(s), Some(e)) = (rsel_start, rsel_end) {
+                                            if let Ok(state) = serde_json::from_str::<DumpState>(&prev_dump_buf) {
+                                                let text = extract_selection_text(
+                                                    &state.layout,
+                                                    last_sent_size.0,
+                                                    last_sent_size.1,
+                                                    s, e,
+                                                    rsel_block,
+                                                    rsel_pane_rect,
+                                                );
+                                                if !text.is_empty() {
+                                                    copy_to_system_clipboard(&text);
+                                                    pending_osc52 = Some(text);
+                                                }
+                                            }
+                                        }
+                                        rsel_start = None;
+                                        rsel_end = None;
+                                        rsel_pane_rect = None;
+                                        rsel_block = false;
+                                        rsel_dragged = false;
                                         selection_changed = true;
                                     } else {
                                         // Legacy: copy-on-release.

--- a/tests/test_issue211_win32_mouse.ps1
+++ b/tests/test_issue211_win32_mouse.ps1
@@ -12,10 +12,10 @@
 #   0:   DIAGNOSTIC: copy-on-release with pwsh-mouse-selection OFF proves
 #        mouse events reach psmux.
 #   2.1: Set option via TUI command prompt (keybd_event driven)
-#   2.2: Left-click drag: selection persists on mouse-up (no copy-on-release)
-#   2.3: Ctrl+Shift+C copies selection to clipboard
-#   2.4: Smart Ctrl+C copies when selection active
-#   2.5: Click to dismiss, Ctrl+C sends SIGINT (session survives)
+#   2.2: Left-click drag: copy-on-release with pwsh-mouse-selection ON
+#   2.3: Ctrl+Shift+C with no active selection does not clobber clipboard
+#   2.4: Smart Ctrl+C with no active selection sends SIGINT (session survives)
+#   2.5: Click + Ctrl+C path still leaves session alive
 #   2.6: Option roundtrip stays consistent after TUI usage
 #
 # Run:
@@ -484,9 +484,9 @@ if (Skip-IfDead "2.1") {} elseif ($script:hwnd -eq [IntPtr]::Zero) {
 }
 
 # ══════════════════════════════════════════════════════════════════════════
-# TEST 2.2: Left-click drag with pwsh-mouse-selection ON: no copy-on-release
+# TEST 2.2: Left-click drag with pwsh-mouse-selection ON: copy-on-release
 # ══════════════════════════════════════════════════════════════════════════
-Write-Test "2.2: Left-click drag (no copy-on-release)"
+Write-Test "2.2: Left-click drag (copy-on-release)"
 
 if (Skip-IfDead "2.2") {} elseif (-not $script:MouseEventsWork) {
     Write-Skip "2.2: Mouse injection did not work (skipped)"
@@ -499,17 +499,17 @@ if (Skip-IfDead "2.2") {} elseif (-not $script:MouseEventsWork) {
     Start-Sleep -Milliseconds 800
 
     $clip = Get-Clipboard -Raw -EA SilentlyContinue
-    if ($clip -eq "UNTOUCHED_MARKER") {
-        Write-Pass "2.2: Clipboard untouched after drag (no copy-on-release)"
+    if ($null -ne $clip -and $clip.Length -gt 0 -and $clip -ne "UNTOUCHED_MARKER") {
+        Write-Pass "2.2: Drag copied on release: '$($clip.Substring(0, [Math]::Min(60, $clip.Length)))'"
     } else {
-        Write-Fail "2.2: Clipboard changed (copy-on-release still active, got '$clip')"
+        Write-Fail "2.2: Expected copy-on-release with pwsh-mouse-selection on (clipboard: '$clip')"
     }
 }
 
 # ══════════════════════════════════════════════════════════════════════════
-# TEST 2.3: Ctrl+Shift+C copies selected text to clipboard
+# TEST 2.3: Ctrl+Shift+C with no active selection does not clobber clipboard
 # ══════════════════════════════════════════════════════════════════════════
-Write-Test "2.3: Ctrl+Shift+C copies selection to clipboard"
+Write-Test "2.3: Ctrl+Shift+C with no active selection"
 
 if (Skip-IfDead "2.3") {} elseif (-not $script:MouseEventsWork) {
     Write-Skip "2.3: Mouse injection did not work (skipped)"
@@ -517,40 +517,32 @@ if (Skip-IfDead "2.3") {} elseif (-not $script:MouseEventsWork) {
     Set-Clipboard -Value "BEFORE_COPY"
     Start-Sleep -Milliseconds 200
 
-    # Drag + Ctrl+Shift+C in one subprocess
-    $ok = Invoke-ConsoleInject -TargetPid $script:TargetPid -Action "drag-ctrlshiftc" `
-        -Col1 2 -Row1 2 -Col2 30 -Row2 2
-    Start-Sleep -Milliseconds 800
+    # No selection is active here (2.2 clears selection after release).
+    # Ctrl+Shift+C should be a no-op for clipboard contents.
+    $ok = Invoke-ConsoleInject -TargetPid $script:TargetPid -Action "ctrlshiftc"
+    Start-Sleep -Milliseconds 500
 
     $clip = Get-Clipboard -Raw -EA SilentlyContinue
-    if ($null -ne $clip -and $clip.Length -gt 0 -and $clip -ne "BEFORE_COPY") {
-        Write-Pass "2.3: Ctrl+Shift+C copied: '$($clip.Substring(0, [Math]::Min(60, $clip.Length)))'"
+    if ($clip -eq "BEFORE_COPY") {
+        Write-Pass "2.3: Ctrl+Shift+C left clipboard unchanged without active selection"
     } else {
-        Write-Fail "2.3: Ctrl+Shift+C did not copy (clipboard: '$clip')"
+        Write-Fail "2.3: Ctrl+Shift+C unexpectedly changed clipboard (got '$clip')"
     }
 }
 
 # ══════════════════════════════════════════════════════════════════════════
-# TEST 2.4: Smart Ctrl+C copies when selection is active
+# TEST 2.4: Smart Ctrl+C with no active selection sends SIGINT
 # ══════════════════════════════════════════════════════════════════════════
-Write-Test "2.4: Smart Ctrl+C (copy when selection active)"
+Write-Test "2.4: Smart Ctrl+C falls back to SIGINT when no selection"
 
 if (Skip-IfDead "2.4") {} elseif (-not $script:MouseEventsWork) {
     Write-Skip "2.4: Mouse injection did not work (skipped)"
 } else {
-    Set-Clipboard -Value "BEFORE_SMARTC"
-    Start-Sleep -Milliseconds 200
+    & $PSMUX send-keys -t $SESSION "ping -n 50 127.0.0.1" Enter
+    Start-Sleep -Seconds 2
 
-    $ok = Invoke-ConsoleInject -TargetPid $script:TargetPid -Action "drag-ctrlc" `
-        -Col1 2 -Row1 3 -Col2 25 -Row2 3
-    Start-Sleep -Milliseconds 800
-
-    $clip = Get-Clipboard -Raw -EA SilentlyContinue
-    if ($null -ne $clip -and $clip -ne "BEFORE_SMARTC" -and $clip.Length -gt 0) {
-        Write-Pass "2.4: Smart Ctrl+C copied: '$($clip.Substring(0, [Math]::Min(60, $clip.Length)))'"
-    } else {
-        Write-Fail "2.4: Smart Ctrl+C did not copy (clipboard: '$clip')"
-    }
+    Invoke-ConsoleInject -TargetPid $script:TargetPid -Action "ctrlc" | Out-Null
+    Start-Sleep -Seconds 2
 
     & $PSMUX has-session -t $SESSION 2>$null
     if ($LASTEXITCODE -eq 0) { Write-Pass "2.4: Session alive after smart Ctrl+C" }
@@ -558,9 +550,9 @@ if (Skip-IfDead "2.4") {} elseif (-not $script:MouseEventsWork) {
 }
 
 # ══════════════════════════════════════════════════════════════════════════
-# TEST 2.5: Click to dismiss selection, then Ctrl+C sends SIGINT
+# TEST 2.5: Click + Ctrl+C path still leaves session alive
 # ══════════════════════════════════════════════════════════════════════════
-Write-Test "2.5: Click to dismiss, Ctrl+C sends SIGINT"
+Write-Test "2.5: Click + Ctrl+C keeps session alive"
 
 if (Skip-IfDead "2.5") {} elseif (-not $script:MouseEventsWork) {
     Write-Skip "2.5: Mouse injection did not work (skipped)"


### PR DESCRIPTION
## Summary

Copies `pwsh-mouse-selection` text automatically when the mouse button is released, then clears the transient client-side selection highlight.

This restores the tmux-like copy-on-release part of the workflow while keeping the pane-clipped extraction from #327, so multi-line selections copy only text from the originating pane instead of pulling text from neighboring panes.

Related to #211.

## Approach

- On mouse release, extract the current pwsh mouse selection using the originating pane rect.
- Copy non-empty selected text to the system clipboard.
- Queue the copied text for OSC52 clipboard propagation.
- Clear the transient client-side selection after copying.
- Preserve existing behavior for non-`pwsh-mouse-selection` paths.

## Tests

- `cargo build -q`
- `cargo test -q extract_selection_text`