### PR TITLE
fix(issue338): restore Ctrl+C line-cancel behavior on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,9 +59,9 @@ jobs:
       - name: Run Rust input tests
         run: cargo test --test test_input
 
-      - name: Run issue #338 Ctrl+C regression test
+      - name: Run PR smoke tests
         shell: pwsh
         run: |
           $exe = (Resolve-Path "target\release\psmux.exe").Path
           Set-Alias psmux $exe
-          .\tests\test_issue338_ctrlc_line_cancel.ps1
+          .\tests\test_smoke_pr.ps1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,11 +57,11 @@ jobs:
         run: cargo build --release --target x86_64-pc-windows-msvc
 
       - name: Run Rust input tests
-        run: 'cargo test --bin psmux -- "tests_input::"'
+        run: 'cargo test --bin psmux -- "ctrl_c_key_event_"'
 
       - name: Run PR smoke tests
         shell: pwsh
         run: |
-          $exe = (Resolve-Path "target\release\psmux.exe").Path
+          $exe = (Resolve-Path "target\x86_64-pc-windows-msvc\release\psmux.exe").Path
           Set-Alias psmux $exe
           .\tests\test_smoke_pr.ps1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
         run: cargo build --release --target x86_64-pc-windows-msvc
 
       - name: Run Rust input tests
-        run: cargo test --test test_input
+        run: cargo test --bin psmux -- tests_input::
 
       - name: Run PR smoke tests
         shell: pwsh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
         run: cargo build --release --target x86_64-pc-windows-msvc
 
       - name: Run Rust input tests
-        run: cargo test --bin psmux -- tests_input::
+        run: 'cargo test --bin psmux -- "tests_input::"'
 
       - name: Run PR smoke tests
         shell: pwsh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,5 +63,5 @@ jobs:
         shell: pwsh
         run: |
           $exe = (Resolve-Path "target\x86_64-pc-windows-msvc\release\psmux.exe").Path
-          Set-Alias psmux $exe
+          $env:PSMUX_EXE = $exe
           .\tests\test_smoke_pr.ps1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,3 +40,28 @@ jobs:
 
       - name: Build
         run: cargo build --release --target ${{ matrix.target }}
+
+  test:
+    name: Test Windows x64
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-pc-windows-msvc
+
+      - name: Build x64 release binary
+        run: cargo build --release --target x86_64-pc-windows-msvc
+
+      - name: Run Rust input tests
+        run: cargo test --test test_input
+
+      - name: Run issue #338 Ctrl+C regression test
+        shell: pwsh
+        run: |
+          $exe = (Resolve-Path "target\release\psmux.exe").Path
+          Set-Alias psmux $exe
+          .\tests\test_issue338_ctrlc_line_cancel.ps1

--- a/src/input.rs
+++ b/src/input.rs
@@ -1883,6 +1883,20 @@ pub(crate) fn is_text_input_key(key: &KeyEvent) -> bool {
     )
 }
 
+/// True when this key event represents plain Ctrl+C (or raw ETX / 0x03)
+/// without Alt modifiers. Used to keep interrupt behavior on Windows.
+pub(crate) fn is_ctrl_c_key_event(key: &KeyEvent) -> bool {
+    match key.code {
+        KeyCode::Char(c) => {
+            (key.modifiers.contains(KeyModifiers::CONTROL)
+                && !key.modifiers.contains(KeyModifiers::ALT)
+                && c.eq_ignore_ascii_case(&'c'))
+                || (!key.modifiers.contains(KeyModifiers::ALT) && c == '\u{0003}')
+        }
+        _ => false,
+    }
+}
+
 /// Apply `f` to every pane that will RECEIVE the current interactive key --
 /// every non-dead pane under sync-input, else the active pane if alive -- so the
 /// route-signal timestamps match what's actually routed.
@@ -2001,6 +2015,7 @@ pub fn forward_key_to_active(app: &mut AppState, key: KeyEvent) -> io::Result<()
         //   2. KeyCode::Char('\x0b') with NO modifiers (raw control byte)
         // We handle both variants here.
         if let KeyCode::Char(c) = key.code {
+            let is_ctrl_c = is_ctrl_c_key_event(&key);
             let (inject_char, is_ctrl_letter) = if key.modifiers.contains(KeyModifiers::CONTROL)
                 && !key.modifiers.contains(KeyModifiers::ALT)
                 && c.is_ascii_alphabetic()
@@ -2022,25 +2037,29 @@ pub fn forward_key_to_active(app: &mut AppState, key: KeyEvent) -> io::Result<()
 
                 if app.sync_input {
                     let win = &mut app.windows[app.active_idx];
-                    fn inject_ctrl_all(node: &mut Node, ch: char, raw: u8) {
+                    fn inject_ctrl_all(node: &mut Node, ch: char, raw: u8, is_ctrl_c: bool) {
                         match node {
                             Node::Leaf(p) if !p.dead => {
                                 let _ = p.writer.write_all(&[raw]);
                                 let _ = p.writer.flush();
                                 #[cfg(windows)]
                                 if let Some(pid) = p.child_pid {
-                                    crate::platform::mouse_inject::send_modified_key_event(pid, ch, true, false, false);
+                                    if is_ctrl_c {
+                                        crate::platform::mouse_inject::send_ctrl_c_event(pid, false);
+                                    } else {
+                                        crate::platform::mouse_inject::send_modified_key_event(pid, ch, true, false, false);
+                                    }
                                 }
                                 crate::debug_log::input_log("ctrl-key",
                                     &format!("sync inject_ctrl char='{}' pid={:?}", ch, p.child_pid));
                             }
                             Node::Leaf(_) => {}
                             Node::Split { children, .. } => {
-                                for child in children { inject_ctrl_all(child, ch, raw); }
+                                for child in children { inject_ctrl_all(child, ch, raw, is_ctrl_c); }
                             }
                         }
                     }
-                    inject_ctrl_all(&mut win.root, inject_char, ctrl_char);
+                    inject_ctrl_all(&mut win.root, inject_char, ctrl_char, is_ctrl_c);
                 } else {
                     let win = &mut app.windows[app.active_idx];
                     if let Some(active) = active_pane_mut(&mut win.root, &win.active_path) {
@@ -2049,7 +2068,11 @@ pub fn forward_key_to_active(app: &mut AppState, key: KeyEvent) -> io::Result<()
                             let _ = active.writer.flush();
                             #[cfg(windows)]
                             if let Some(pid) = active.child_pid {
-                                crate::platform::mouse_inject::send_modified_key_event(pid, inject_char, true, false, false);
+                                if is_ctrl_c {
+                                    crate::platform::mouse_inject::send_ctrl_c_event(pid, false);
+                                } else {
+                                    crate::platform::mouse_inject::send_modified_key_event(pid, inject_char, true, false, false);
+                                }
                             }
                             crate::debug_log::input_log("ctrl-key",
                                 &format!("inject_ctrl char='{}' pid={:?}", inject_char, active.child_pid));
@@ -3261,7 +3284,11 @@ pub fn send_key_to_active(app: &mut AppState, k: &str) -> io::Result<()> {
                 #[cfg(windows)]
                 if c.is_ascii_alphabetic() {
                     if let Some(pid) = p.child_pid {
-                        crate::platform::mouse_inject::send_modified_key_event(pid, c, true, false, false);
+                        if c.eq_ignore_ascii_case(&'c') {
+                            crate::platform::mouse_inject::send_ctrl_c_event(pid, false);
+                        } else {
+                            crate::platform::mouse_inject::send_modified_key_event(pid, c, true, false, false);
+                        }
                     }
                 }
             }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1834,16 +1834,22 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                                         #[cfg(windows)]
                                         {
                                             if c.is_ascii_alphabetic() {
-                                                let vk = crate::platform::mouse_inject::char_to_vk(c);
-                                                let scan = crate::platform::mouse_inject::vk_to_scan(vk);
-                                                let u_char = (c.to_ascii_lowercase() as u16) & 0x1F;
-                                                const LEFT_CTRL_PRESSED: u32 = 0x0008;
-                                                let seq = format!(
-                                                    "\x1b[{};{};{};1;{};1_\x1b[{};{};{};0;{};1_",
-                                                    vk, scan, u_char, LEFT_CTRL_PRESSED,
-                                                    vk, scan, u_char, LEFT_CTRL_PRESSED
-                                                );
-                                                send_text_to_active(&mut app, &seq)?;
+                                                // Keep Ctrl+C on the legacy interrupt path:
+                                                // raw 0x03 + send_ctrl_c_event below.
+                                                if ctrl == 0x03 {
+                                                    send_text_to_active(&mut app, &String::from(ctrl as char))?;
+                                                } else {
+                                                    let vk = crate::platform::mouse_inject::char_to_vk(c);
+                                                    let scan = crate::platform::mouse_inject::vk_to_scan(vk);
+                                                    let u_char = (c.to_ascii_lowercase() as u16) & 0x1F;
+                                                    const LEFT_CTRL_PRESSED: u32 = 0x0008;
+                                                    let seq = format!(
+                                                        "\x1b[{};{};{};1;{};1_\x1b[{};{};{};0;{};1_",
+                                                        vk, scan, u_char, LEFT_CTRL_PRESSED,
+                                                        vk, scan, u_char, LEFT_CTRL_PRESSED
+                                                    );
+                                                    send_text_to_active(&mut app, &seq)?;
+                                                }
                                             } else {
                                                 send_text_to_active(&mut app, &String::from(ctrl as char))?;
                                             }

--- a/tests-rs/test_input.rs
+++ b/tests-rs/test_input.rs
@@ -140,6 +140,24 @@ fn ctrl_a_produces_soh() {
 }
 
 #[test]
+fn ctrl_c_key_event_detects_uppercase_control_c() {
+    let ev = key(KeyCode::Char('C'), KeyModifiers::CONTROL);
+    assert!(is_ctrl_c_key_event(&ev), "Ctrl+C must be recognized as interrupt key");
+}
+
+#[test]
+fn ctrl_c_key_event_detects_raw_etx() {
+    let ev = key(KeyCode::Char('\u{0003}'), KeyModifiers::NONE);
+    assert!(is_ctrl_c_key_event(&ev), "raw ETX (0x03) must be recognized as Ctrl+C");
+}
+
+#[test]
+fn ctrl_c_key_event_rejects_alt_modified_c() {
+    let ev = key(KeyCode::Char('c'), KeyModifiers::CONTROL | KeyModifiers::ALT);
+    assert!(!is_ctrl_c_key_event(&ev), "Ctrl+Alt+C must not be treated as plain Ctrl+C");
+}
+
+#[test]
 fn plain_backslash_no_modifiers() {
     let ev = key(KeyCode::Char('\\'), KeyModifiers::NONE);
     let bytes = encode_key_event(&ev).unwrap();

--- a/tests/test_issue338_ctrlc_line_cancel.ps1
+++ b/tests/test_issue338_ctrlc_line_cancel.ps1
@@ -1,0 +1,96 @@
+$ErrorActionPreference = "Continue"
+$PSMUX = (Get-Command psmux -EA Stop).Source
+$SESSION = "issue338_ctrlc"
+$psmuxDir = "$env:USERPROFILE\.psmux"
+$script:TestsPassed = 0
+$script:TestsFailed = 0
+
+function Write-Pass($msg) { Write-Host "  [PASS] $msg" -ForegroundColor Green; $script:TestsPassed++ }
+function Write-Fail($msg) { Write-Host "  [FAIL] $msg" -ForegroundColor Red; $script:TestsFailed++ }
+
+function Cleanup {
+    & $PSMUX kill-session -t $SESSION 2>&1 | Out-Null
+    Start-Sleep -Milliseconds 400
+    Remove-Item "$psmuxDir\$SESSION.*" -Force -EA SilentlyContinue
+}
+
+function Wait-Session([string]$Name, [int]$TimeoutMs = 12000) {
+    $pf = "$psmuxDir\$Name.port"
+    $sw = [System.Diagnostics.Stopwatch]::StartNew()
+    while ($sw.ElapsedMilliseconds -lt $TimeoutMs) {
+        if (Test-Path $pf) {
+            $port = (Get-Content $pf -Raw -EA SilentlyContinue).Trim()
+            if ($port -match '^\d+$') { return $true }
+        }
+        Start-Sleep -Milliseconds 100
+    }
+    return $false
+}
+
+function Wait-PaneContent([string]$Target, [string]$Pattern, [int]$TimeoutMs = 10000) {
+    $sw = [System.Diagnostics.Stopwatch]::StartNew()
+    while ($sw.ElapsedMilliseconds -lt $TimeoutMs) {
+        $cap = & $PSMUX capture-pane -t $Target -p 2>&1 | Out-String
+        if ($cap -match $Pattern) { return $true }
+        Start-Sleep -Milliseconds 200
+    }
+    return $false
+}
+
+Write-Host "`n=== Issue #338: Ctrl+C line cancel regression ===" -ForegroundColor Cyan
+
+Cleanup
+Start-Sleep -Milliseconds 700
+& $PSMUX new-session -d -s $SESSION -x 120 -y 30 | Out-Null
+if (-not (Wait-Session $SESSION)) {
+    Write-Host "FATAL: Session creation failed" -ForegroundColor Red
+    exit 1
+}
+Start-Sleep -Seconds 2
+
+# Test 1: Ctrl+C cancels a typed line (no command execution)
+Write-Host "`n[Test 1] Ctrl+C cancels current input line" -ForegroundColor Yellow
+$markerFile = Join-Path $env:TEMP "psmux_issue338_marker_$([guid]::NewGuid().ToString('N')).txt"
+if (Test-Path $markerFile) { Remove-Item $markerFile -Force -EA SilentlyContinue }
+
+$pendingCmd = "New-Item -ItemType File -Path '$markerFile' -Force | Out-Null"
+& $PSMUX send-keys -t $SESSION $pendingCmd 2>&1 | Out-Null
+Start-Sleep -Milliseconds 300
+& $PSMUX send-keys -t $SESSION C-c 2>&1 | Out-Null
+Start-Sleep -Milliseconds 300
+& $PSMUX send-keys -t $SESSION Enter 2>&1 | Out-Null
+Start-Sleep -Milliseconds 500
+
+if (-not (Test-Path $markerFile)) {
+    Write-Pass "Canceled line did not execute (marker file not created)"
+} else {
+    Write-Fail "Canceled line executed unexpectedly (marker file exists)"
+    Remove-Item $markerFile -Force -EA SilentlyContinue
+}
+
+if (Wait-PaneContent $SESSION "PS [A-Z]:\\|[A-Z]:\\.*>" 5000) {
+    Write-Pass "Prompt is still responsive after Ctrl+C line cancel"
+} else {
+    Write-Fail "Prompt was not detected after Ctrl+C line cancel"
+}
+
+# Test 2: Ctrl+C still interrupts a running command
+Write-Host "`n[Test 2] Ctrl+C interrupts running command" -ForegroundColor Yellow
+& $PSMUX send-keys -t $SESSION "ping -t 127.0.0.1" Enter 2>&1 | Out-Null
+if (Wait-PaneContent $SESSION "Reply from" 10000) {
+    & $PSMUX send-keys -t $SESSION C-c 2>&1 | Out-Null
+    if (Wait-PaneContent $SESSION "Control-C|Ping statistics|PS [A-Z]:\\|[A-Z]:\\.*>" 8000) {
+        Write-Pass "Ctrl+C interrupted running ping command"
+    } else {
+        Write-Fail "Ctrl+C did not interrupt running ping command"
+    }
+} else {
+    Write-Fail "ping did not start in time"
+}
+
+Cleanup
+
+Write-Host "`n=== Results ===" -ForegroundColor Cyan
+Write-Host "  Passed: $($script:TestsPassed)" -ForegroundColor Green
+Write-Host "  Failed: $($script:TestsFailed)" -ForegroundColor $(if ($script:TestsFailed -gt 0) { "Red" } else { "Green" })
+exit $script:TestsFailed

--- a/tests/test_smoke_pr.ps1
+++ b/tests/test_smoke_pr.ps1
@@ -1,0 +1,103 @@
+$ErrorActionPreference = "Continue"
+$PSMUX = (Get-Command psmux -EA Stop).Source
+$SESSION = "smoke_pr"
+$psmuxDir = "$env:USERPROFILE\.psmux"
+$script:TestsPassed = 0
+$script:TestsFailed = 0
+
+function Write-Pass($msg) { Write-Host "  [PASS] $msg" -ForegroundColor Green; $script:TestsPassed++ }
+function Write-Fail($msg) { Write-Host "  [FAIL] $msg" -ForegroundColor Red; $script:TestsFailed++ }
+
+function Cleanup {
+    & $PSMUX kill-session -t $SESSION 2>&1 | Out-Null
+    Start-Sleep -Milliseconds 300
+    Remove-Item "$psmuxDir\$SESSION.*" -Force -EA SilentlyContinue
+}
+
+function Wait-Session([string]$Name, [int]$TimeoutMs = 10000) {
+    $pf = "$psmuxDir\$Name.port"
+    $sw = [System.Diagnostics.Stopwatch]::StartNew()
+    while ($sw.ElapsedMilliseconds -lt $TimeoutMs) {
+        if (Test-Path $pf) {
+            $port = (Get-Content $pf -Raw -EA SilentlyContinue).Trim()
+            if ($port -match '^\d+$') { return $true }
+        }
+        Start-Sleep -Milliseconds 100
+    }
+    return $false
+}
+
+function Wait-PaneContent([string]$Target, [string]$Pattern, [int]$TimeoutMs = 8000) {
+    $sw = [System.Diagnostics.Stopwatch]::StartNew()
+    while ($sw.ElapsedMilliseconds -lt $TimeoutMs) {
+        $cap = & $PSMUX capture-pane -t $Target -p 2>&1 | Out-String
+        if ($cap -match $Pattern) { return $true }
+        Start-Sleep -Milliseconds 200
+    }
+    return $false
+}
+
+Write-Host "`n=== PR Smoke Tests ===" -ForegroundColor Cyan
+
+Cleanup
+& $PSMUX new-session -d -s $SESSION -x 120 -y 30 | Out-Null
+if (-not (Wait-Session $SESSION)) {
+    Write-Host "FATAL: failed to create smoke session" -ForegroundColor Red
+    exit 1
+}
+
+# Test 1: basic session liveness
+$ls = (& $PSMUX ls 2>&1) -join "`n"
+if ($ls -match [regex]::Escape($SESSION)) {
+    Write-Pass "Session created and visible in list-sessions"
+} else {
+    Write-Fail "Session missing from list-sessions"
+}
+
+# Test 2: basic pane ops
+& $PSMUX split-window -v -t $SESSION 2>&1 | Out-Null
+Start-Sleep -Milliseconds 500
+$panes = & $PSMUX list-panes -t $SESSION 2>&1
+$paneCount = ($panes | Measure-Object -Line).Lines
+if ($paneCount -ge 2) {
+    Write-Pass "split-window created a second pane"
+} else {
+    Write-Fail "split-window did not create expected pane count"
+}
+
+# Test 3: Ctrl+C line cancel behavior (#338)
+$markerFile = Join-Path $env:TEMP "psmux_smoke_marker_$([guid]::NewGuid().ToString('N')).txt"
+if (Test-Path $markerFile) { Remove-Item $markerFile -Force -EA SilentlyContinue }
+$pendingCmd = "New-Item -ItemType File -Path '$markerFile' -Force | Out-Null"
+& $PSMUX send-keys -t "$SESSION:0.0" $pendingCmd 2>&1 | Out-Null
+Start-Sleep -Milliseconds 300
+& $PSMUX send-keys -t "$SESSION:0.0" C-c 2>&1 | Out-Null
+Start-Sleep -Milliseconds 300
+& $PSMUX send-keys -t "$SESSION:0.0" Enter 2>&1 | Out-Null
+Start-Sleep -Milliseconds 400
+if (-not (Test-Path $markerFile)) {
+    Write-Pass "Ctrl+C cancels current prompt line"
+} else {
+    Write-Fail "Canceled prompt line executed unexpectedly"
+    Remove-Item $markerFile -Force -EA SilentlyContinue
+}
+
+# Test 4: Ctrl+C interrupts running command
+& $PSMUX send-keys -t "$SESSION:0.0" "ping -t 127.0.0.1" Enter 2>&1 | Out-Null
+if (Wait-PaneContent "$SESSION:0.0" "Reply from" 10000) {
+    & $PSMUX send-keys -t "$SESSION:0.0" C-c 2>&1 | Out-Null
+    if (Wait-PaneContent "$SESSION:0.0" "Control-C|Ping statistics|PS [A-Z]:\\|[A-Z]:\\.*>" 8000) {
+        Write-Pass "Ctrl+C interrupts running process"
+    } else {
+        Write-Fail "Ctrl+C did not interrupt running process"
+    }
+} else {
+    Write-Fail "Could not start ping for interrupt smoke test"
+}
+
+Cleanup
+
+Write-Host "`n=== Smoke Results ===" -ForegroundColor Cyan
+Write-Host "  Passed: $($script:TestsPassed)" -ForegroundColor Green
+Write-Host "  Failed: $($script:TestsFailed)" -ForegroundColor $(if ($script:TestsFailed -gt 0) { "Red" } else { "Green" })
+exit $script:TestsFailed

--- a/tests/test_smoke_pr.ps1
+++ b/tests/test_smoke_pr.ps1
@@ -1,5 +1,13 @@
 $ErrorActionPreference = "Continue"
-$PSMUX = (Get-Command psmux -EA Stop).Source
+$PSMUX = $env:PSMUX_EXE
+if (-not $PSMUX) {
+    $cmd = Get-Command psmux -EA Stop
+    $PSMUX = if ($cmd.Path) { $cmd.Path } elseif ($cmd.Source) { $cmd.Source } else { $cmd.Definition }
+}
+if (-not $PSMUX) {
+    Write-Host "FATAL: could not resolve psmux executable path" -ForegroundColor Red
+    exit 1
+}
 $SESSION = "smoke_pr"
 $psmuxDir = "$env:USERPROFILE\.psmux"
 $script:TestsPassed = 0


### PR DESCRIPTION
## Summary
- keep `Ctrl+C` on the legacy interrupt path for Windows input handling, while preserving the newer Ctrl+letter behavior for non-`C` keys
- apply the same `Ctrl+C` exception across interactive key handling and `send-keys C-c` server routing
- add regression coverage for Ctrl+C key classification in Rust tests and a new issue-focused PowerShell e2e for prompt line-cancel + running-command interrupt
