### PR TITLE
fix: align zoomed pane origin for non-first panes

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -488,6 +488,47 @@ pub fn compute_active_rect_json(node: &LayoutJson, area: Rect) -> Option<Rect> {
     }
 }
 
+/// Compute the active pane rectangle, optionally treating the layout as zoomed.
+///
+/// When `zoomed` is true, this mirrors `render_layout_json` behavior by walking
+/// only the visible (non-zero) split child and passing down the full parent area.
+pub(crate) fn compute_active_rect_json_zoom_aware(
+    node: &LayoutJson,
+    area: Rect,
+    zoomed: bool,
+) -> Option<Rect> {
+    match node {
+        LayoutJson::Leaf { active, .. } => {
+            if *active { Some(area) } else { None }
+        }
+        LayoutJson::Split { kind, sizes, children } => {
+            let effective_sizes: Vec<u16> = if sizes.len() == children.len() {
+                sizes.clone()
+            } else {
+                vec![(100 / children.len().max(1)) as u16; children.len()]
+            };
+            if zoomed {
+                if let Some(i) = effective_sizes.iter().position(|&s| s != 0) {
+                    if let Some(child) = children.get(i) {
+                        return compute_active_rect_json_zoom_aware(child, area, zoomed);
+                    }
+                }
+                return None;
+            }
+            let is_horizontal = kind == "Horizontal";
+            let rects = split_with_gaps(is_horizontal, &effective_sizes, area);
+            for (i, child) in children.iter().enumerate() {
+                if i < rects.len() {
+                    if let Some(r) = compute_active_rect_json_zoom_aware(child, rects[i], zoomed) {
+                        return Some(r);
+                    }
+                }
+            }
+            None
+        }
+    }
+}
+
 /// Render a large ASCII clock overlay (tmux clock-mode).
 /// Top-level so both the main viewport and the choose-tree/choose-session
 /// preview can share one implementation.
@@ -5510,37 +5551,6 @@ pub fn run_remote(terminal: &mut Terminal<CrosstermBackend<crate::platform::Psmu
             }
             let effective = find_active_cursor_shape(&root)
                 .unwrap_or_else(|| state_cursor_style_code.unwrap_or_else(crate::rendering::configured_cursor_code));
-            // Compute the active pane's screen Rect so we can translate
-            // pane-local cursor coords to terminal-global coords.
-            fn find_active_rect(node: &LayoutJson, area: Rect, zoomed: bool) -> Option<Rect> {
-                match node {
-                    LayoutJson::Leaf { active, .. } => {
-                        if *active { Some(area) } else { None }
-                    }
-                    LayoutJson::Split { kind, sizes, children } => {
-                        let eff: Vec<u16> = if sizes.len() == children.len() {
-                            sizes.clone()
-                        } else {
-                            vec![(100 / children.len().max(1)) as u16; children.len()]
-                        };
-                        if zoomed {
-                            if let Some(i) = eff.iter().position(|&s| s != 0) {
-                                if let Some(child) = children.get(i) {
-                                    return find_active_rect(child, area, zoomed);
-                                }
-                            }
-                            return None;
-                        }
-                        let rects = crate::tree::split_with_gaps(kind == "Horizontal", &eff, area);
-                        for (i, child) in children.iter().enumerate() {
-                            if i < rects.len() {
-                                if let Some(r) = find_active_rect(child, rects[i], zoomed) { return Some(r); }
-                            }
-                        }
-                        None
-                    }
-                }
-            }
             let active_pane_area: Option<Rect> = {
                 let sz = terminal.size().unwrap_or_default();
                 let constraints = if status_at_top {
@@ -5551,7 +5561,7 @@ pub fn run_remote(terminal: &mut Terminal<CrosstermBackend<crate::platform::Psmu
                 let chunks = Layout::default().direction(Direction::Vertical)
                     .constraints(constraints).split(sz.into());
                 let content_chunk = if status_at_top { chunks[1] } else { chunks[0] };
-                find_active_rect(&root, content_chunk, client_zoomed)
+                compute_active_rect_json_zoom_aware(&root, content_chunk, client_zoomed)
             };
             // Compute screen-global cursor position from pane-local coords.
             let cursor_visible = if let (Some((cc, cr)), Some(inner)) = (post_draw_cursor, active_pane_area) {
@@ -5735,3 +5745,7 @@ mod tests;
 #[cfg(test)]
 #[path = "../tests-rs/test_zoom_bleed.rs"]
 mod test_zoom_bleed;
+
+#[cfg(test)]
+#[path = "../tests-rs/test_zoom_cursor_rect.rs"]
+mod test_zoom_cursor_rect;

--- a/src/client.rs
+++ b/src/client.rs
@@ -5512,7 +5512,7 @@ pub fn run_remote(terminal: &mut Terminal<CrosstermBackend<crate::platform::Psmu
                 .unwrap_or_else(|| state_cursor_style_code.unwrap_or_else(crate::rendering::configured_cursor_code));
             // Compute the active pane's screen Rect so we can translate
             // pane-local cursor coords to terminal-global coords.
-            fn find_active_rect(node: &LayoutJson, area: Rect) -> Option<Rect> {
+            fn find_active_rect(node: &LayoutJson, area: Rect, zoomed: bool) -> Option<Rect> {
                 match node {
                     LayoutJson::Leaf { active, .. } => {
                         if *active { Some(area) } else { None }
@@ -5523,10 +5523,18 @@ pub fn run_remote(terminal: &mut Terminal<CrosstermBackend<crate::platform::Psmu
                         } else {
                             vec![(100 / children.len().max(1)) as u16; children.len()]
                         };
+                        if zoomed {
+                            if let Some(i) = eff.iter().position(|&s| s != 0) {
+                                if let Some(child) = children.get(i) {
+                                    return find_active_rect(child, area, zoomed);
+                                }
+                            }
+                            return None;
+                        }
                         let rects = crate::tree::split_with_gaps(kind == "Horizontal", &eff, area);
                         for (i, child) in children.iter().enumerate() {
                             if i < rects.len() {
-                                if let Some(r) = find_active_rect(child, rects[i]) { return Some(r); }
+                                if let Some(r) = find_active_rect(child, rects[i], zoomed) { return Some(r); }
                             }
                         }
                         None
@@ -5543,7 +5551,7 @@ pub fn run_remote(terminal: &mut Terminal<CrosstermBackend<crate::platform::Psmu
                 let chunks = Layout::default().direction(Direction::Vertical)
                     .constraints(constraints).split(sz.into());
                 let content_chunk = if status_at_top { chunks[1] } else { chunks[0] };
-                find_active_rect(&root, content_chunk)
+                find_active_rect(&root, content_chunk, client_zoomed)
             };
             // Compute screen-global cursor position from pane-local coords.
             let cursor_visible = if let (Some((cc, cr)), Some(inner)) = (post_draw_cursor, active_pane_area) {

--- a/tests-rs/test_zoom_cursor_rect.rs
+++ b/tests-rs/test_zoom_cursor_rect.rs
@@ -1,0 +1,86 @@
+use ratatui::layout::Rect;
+use crate::layout::LayoutJson;
+
+fn leaf(id: usize, active: bool) -> LayoutJson {
+    LayoutJson::Leaf {
+        id,
+        rows: 5,
+        cols: 10,
+        cursor_row: 0,
+        cursor_col: 0,
+        alternate_screen: false,
+        hide_cursor: false,
+        cursor_shape: 0,
+        active,
+        copy_mode: false,
+        scroll_offset: 0,
+        sel_start_row: None,
+        sel_start_col: None,
+        sel_end_row: None,
+        sel_end_col: None,
+        sel_mode: None,
+        copy_cursor_row: None,
+        copy_cursor_col: None,
+        content: Vec::new(),
+        rows_v2: Vec::new(),
+        title: None,
+    }
+}
+
+#[test]
+fn zoomed_horizontal_non_first_active_uses_full_area() {
+    let area = Rect::new(0, 0, 60, 20);
+    let layout = LayoutJson::Split {
+        kind: "Horizontal".to_string(),
+        sizes: vec![0, 100],
+        children: vec![leaf(0, false), leaf(1, true)],
+    };
+
+    let unzoomed = crate::client::compute_active_rect_json_zoom_aware(&layout, area, false).unwrap();
+    let zoomed = crate::client::compute_active_rect_json_zoom_aware(&layout, area, true).unwrap();
+
+    assert_ne!(unzoomed.x, area.x, "baseline split traversal should offset second pane");
+    assert_eq!(zoomed, area, "zoom-aware traversal should keep full-area origin");
+}
+
+#[test]
+fn zoomed_vertical_non_first_active_uses_full_area() {
+    let area = Rect::new(0, 0, 60, 20);
+    let layout = LayoutJson::Split {
+        kind: "Vertical".to_string(),
+        sizes: vec![0, 100],
+        children: vec![leaf(0, false), leaf(1, true)],
+    };
+
+    let unzoomed = crate::client::compute_active_rect_json_zoom_aware(&layout, area, false).unwrap();
+    let zoomed = crate::client::compute_active_rect_json_zoom_aware(&layout, area, true).unwrap();
+
+    assert_ne!(unzoomed.y, area.y, "baseline split traversal should offset lower pane");
+    assert_eq!(zoomed, area, "zoom-aware traversal should keep full-area origin");
+}
+
+#[test]
+fn zoomed_nested_non_first_active_does_not_compound_offsets() {
+    let area = Rect::new(0, 0, 100, 40);
+    let layout = LayoutJson::Split {
+        kind: "Horizontal".to_string(),
+        sizes: vec![0, 100],
+        children: vec![
+            leaf(0, false),
+            LayoutJson::Split {
+                kind: "Vertical".to_string(),
+                sizes: vec![0, 100],
+                children: vec![leaf(1, false), leaf(2, true)],
+            },
+        ],
+    };
+
+    let unzoomed = crate::client::compute_active_rect_json_zoom_aware(&layout, area, false).unwrap();
+    let zoomed = crate::client::compute_active_rect_json_zoom_aware(&layout, area, true).unwrap();
+
+    assert!(
+        unzoomed.x > area.x || unzoomed.y > area.y,
+        "baseline split traversal should offset nested non-first pane"
+    );
+    assert_eq!(zoomed, area, "zoom-aware traversal should avoid cumulative nested offsets");
+}


### PR DESCRIPTION
## Summary
- Fix issue #336: zoomed panes that are not top-left could show shifted placement.
- Root cause: post-draw active-rect traversal still used split geometry while zoomed rendering bypassed splits.
- Fix: make post-draw active-rect lookup zoom-aware and recurse into the visible child with the full area.