### PR TITLE
Refuse to run the destructive ps1 test runner outside a sandbox

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,6 +14,9 @@ ENV VS_INSTALL_PATH="C:\BuildTools"
 ENV RUSTUP_HOME="C:\rustup"
 ENV CARGO_HOME="C:\cargo"
 ENV PATH="C:\cargo\bin;C:\OpenSSH;C:\git\cmd;C:\Windows\System32;C:\Windows;C:\Program Files\PowerShell\latest;${PATH}"
+# Mark this as a throwaway sandbox so tests/run_all_tests.ps1 (which is
+# destructive: it kills all psmux processes and wipes ~/.psmux) will run here.
+ENV PSMUX_TEST_SANDBOX="1"
 
 # Create directories and copy all scripts first
 RUN mkdir C:\Tools && mkdir C:\Profile && mkdir "C:\Users\ContainerAdministrator\Documents\PowerShell"

--- a/tests/run_all_tests.ps1
+++ b/tests/run_all_tests.ps1
@@ -10,6 +10,25 @@ param(
     [switch]$IncludeInteractive  # Include tests that need interactive TUI
 )
 
+# ── Safety gate: this runner is DESTRUCTIVE to a live psmux ──────────────────
+# Before every test it kills ALL psmux processes (by image name) and deletes
+# ~/.psmux\*.port, *.key and ~/.psmux.conf / ~/.psmuxrc. That is fine in a
+# throwaway sandbox (the Docker dev image / CI) but would wipe a real user's
+# running sessions and config. Refuse to run unless the caller has explicitly
+# confirmed a sandbox by setting PSMUX_TEST_SANDBOX=1.
+if ($env:PSMUX_TEST_SANDBOX -ne '1') {
+    Write-Host ''
+    Write-Host 'REFUSING TO RUN: this test runner is destructive to a live psmux.' -ForegroundColor Red
+    Write-Host 'Between tests it kills ALL psmux processes and deletes' -ForegroundColor Yellow
+    Write-Host '~/.psmux\*.port, *.key and ~/.psmux.conf / ~/.psmuxrc.' -ForegroundColor Yellow
+    Write-Host ''
+    Write-Host 'Run it only in a throwaway/sandbox environment (e.g. the Docker dev' -ForegroundColor Yellow
+    Write-Host 'image, which sets this automatically). To confirm a sandbox and run:' -ForegroundColor Yellow
+    Write-Host '    $env:PSMUX_TEST_SANDBOX = "1"; pwsh -File tests\run_all_tests.ps1' -ForegroundColor Cyan
+    Write-Host ''
+    exit 2
+}
+
 $ErrorActionPreference = "Continue"
 $startTime = Get-Date
 

--- a/tests/test_runner_safety_gate.ps1
+++ b/tests/test_runner_safety_gate.ps1
@@ -33,8 +33,13 @@ Check "run_all_tests.ps1 has the PSMUX_TEST_SANDBOX gate" ($gateIdx -ge 0)
 Check "gate aborts with exit when not in a sandbox" ($gate.Success -and ($src.Substring($gateIdx) -match '^[\s\S]{0,1200}?exit\s+\d'))
 
 # 2. The gate must appear BEFORE every destructive operation, so the runner can
-#    never reach them without the opt-in.
-$destructive = @('kill-server', 'Stop-Process', 'taskkill', 'Remove-Item\s+"\$env:USERPROFILE\\\.psmux')
+#    never reach them without the opt-in. Remove-Item is matched broadly (ANY
+#    target, not just ~/.psmux): delete paths are often built from $env: vars,
+#    so a target-specific pattern wouldn't recognise them as destructive. Almost
+#    nothing should run before the gate anyway, so flagging any pre-gate delete
+#    is the safe default. (This is a drift guard, not a defence against a
+#    malicious runner — a small blacklist could never be that.)
+$destructive = @('kill-server', 'Stop-Process', 'taskkill', 'Remove-Item')
 foreach ($pat in $destructive) {
     $m = [regex]::Match($src, $pat)
     if ($m.Success) {

--- a/tests/test_runner_safety_gate.ps1
+++ b/tests/test_runner_safety_gate.ps1
@@ -23,9 +23,14 @@ if (-not (Test-Path $runner)) {
 $src = Get-Content -LiteralPath $runner -Raw
 
 # 1. The gate references PSMUX_TEST_SANDBOX and aborts (exit) shortly after.
-$gateIdx = $src.IndexOf('PSMUX_TEST_SANDBOX')
-Check "run_all_tests.ps1 references the PSMUX_TEST_SANDBOX gate" ($gateIdx -ge 0)
-Check "gate aborts with exit when not in a sandbox" ($src -match 'PSMUX_TEST_SANDBOX[\s\S]{0,1200}?exit\s+\d')
+#    Anchor on the ACTUAL executable check — `if ($env:PSMUX_TEST_SANDBOX ...)` —
+#    not the first textual mention of the variable. Otherwise an explanatory
+#    comment naming the variable, placed before destructive code, would satisfy
+#    this guard while the real gate sat below the destructive operations.
+$gate = [regex]::Match($src, 'if\s*\(\s*\$env:PSMUX_TEST_SANDBOX')
+$gateIdx = if ($gate.Success) { $gate.Index } else { -1 }
+Check "run_all_tests.ps1 has the PSMUX_TEST_SANDBOX gate" ($gateIdx -ge 0)
+Check "gate aborts with exit when not in a sandbox" ($gate.Success -and ($src.Substring($gateIdx) -match '^[\s\S]{0,1200}?exit\s+\d'))
 
 # 2. The gate must appear BEFORE every destructive operation, so the runner can
 #    never reach them without the opt-in.

--- a/tests/test_runner_safety_gate.ps1
+++ b/tests/test_runner_safety_gate.ps1
@@ -27,7 +27,11 @@ $src = Get-Content -LiteralPath $runner -Raw
 #    not the first textual mention of the variable. Otherwise an explanatory
 #    comment naming the variable, placed before destructive code, would satisfy
 #    this guard while the real gate sat below the destructive operations.
-$gate = [regex]::Match($src, 'if\s*\(\s*\$env:PSMUX_TEST_SANDBOX')
+# Match case-insensitively throughout: PowerShell keywords, $env: lookups and
+# cmdlet/command names are all case-insensitive, so differently-cased code
+# (e.g. `remove-item`, `STOP-PROCESS`) must still be recognised.
+$ci = [System.Text.RegularExpressions.RegexOptions]::IgnoreCase
+$gate = [regex]::Match($src, 'if\s*\(\s*\$env:PSMUX_TEST_SANDBOX', $ci)
 $gateIdx = if ($gate.Success) { $gate.Index } else { -1 }
 Check "run_all_tests.ps1 has the PSMUX_TEST_SANDBOX gate" ($gateIdx -ge 0)
 Check "gate aborts with exit when not in a sandbox" ($gate.Success -and ($src.Substring($gateIdx) -match '^[\s\S]{0,1200}?exit\s+\d'))
@@ -41,7 +45,7 @@ Check "gate aborts with exit when not in a sandbox" ($gate.Success -and ($src.Su
 #    malicious runner — a small blacklist could never be that.)
 $destructive = @('kill-server', 'Stop-Process', 'taskkill', 'Remove-Item')
 foreach ($pat in $destructive) {
-    $m = [regex]::Match($src, $pat)
+    $m = [regex]::Match($src, $pat, $ci)
     if ($m.Success) {
         Check "gate precedes destructive '$pat'" (($gateIdx -ge 0) -and ($gateIdx -lt $m.Index)) "gate@$gateIdx match@$($m.Index)"
     }

--- a/tests/test_runner_safety_gate.ps1
+++ b/tests/test_runner_safety_gate.ps1
@@ -34,7 +34,7 @@ Check "gate aborts with exit when not in a sandbox" ($gate.Success -and ($src.Su
 
 # 2. The gate must appear BEFORE every destructive operation, so the runner can
 #    never reach them without the opt-in.
-$destructive = @('Stop-Process', 'taskkill', 'Remove-Item\s+"\$env:USERPROFILE\\\.psmux')
+$destructive = @('kill-server', 'Stop-Process', 'taskkill', 'Remove-Item\s+"\$env:USERPROFILE\\\.psmux')
 foreach ($pat in $destructive) {
     $m = [regex]::Match($src, $pat)
     if ($m.Success) {

--- a/tests/test_runner_safety_gate.ps1
+++ b/tests/test_runner_safety_gate.ps1
@@ -1,0 +1,42 @@
+#!/usr/bin/env pwsh
+# Regression guard for the run_all_tests.ps1 safety gate.
+#
+# run_all_tests.ps1 is DESTRUCTIVE: between every test it kills all psmux
+# processes and wipes ~/.psmux. It must refuse to run unless PSMUX_TEST_SANDBOX=1,
+# and that gate must come BEFORE any destructive operation.
+#
+# This test is purely STATIC — it reads run_all_tests.ps1 and never executes it
+# — so it is safe to run anywhere, including on a machine with a live psmux.
+
+$ErrorActionPreference = "Continue"
+$runner = Join-Path $PSScriptRoot "run_all_tests.ps1"
+$pass = 0; $fail = 0
+function Check($name, $cond, $detail = "") {
+    if ($cond) { Write-Host "[PASS] $name" -ForegroundColor Green; $script:pass++ }
+    else { Write-Host "[FAIL] $name $detail" -ForegroundColor Red; $script:fail++ }
+}
+
+if (-not (Test-Path $runner)) {
+    Write-Host "[FAIL] run_all_tests.ps1 not found at $runner" -ForegroundColor Red
+    exit 1
+}
+$src = Get-Content -LiteralPath $runner -Raw
+
+# 1. The gate references PSMUX_TEST_SANDBOX and aborts (exit) shortly after.
+$gateIdx = $src.IndexOf('PSMUX_TEST_SANDBOX')
+Check "run_all_tests.ps1 references the PSMUX_TEST_SANDBOX gate" ($gateIdx -ge 0)
+Check "gate aborts with exit when not in a sandbox" ($src -match 'PSMUX_TEST_SANDBOX[\s\S]{0,1200}?exit\s+\d')
+
+# 2. The gate must appear BEFORE every destructive operation, so the runner can
+#    never reach them without the opt-in.
+$destructive = @('Stop-Process', 'taskkill', 'Remove-Item\s+"\$env:USERPROFILE\\\.psmux')
+foreach ($pat in $destructive) {
+    $m = [regex]::Match($src, $pat)
+    if ($m.Success) {
+        Check "gate precedes destructive '$pat'" (($gateIdx -ge 0) -and ($gateIdx -lt $m.Index)) "gate@$gateIdx match@$($m.Index)"
+    }
+}
+
+Write-Host "`n=== run_all_tests.ps1 safety gate (static guard) ===" -ForegroundColor Cyan
+Write-Host "Passed: $pass  Failed: $fail" -ForegroundColor $(if ($fail -gt 0) { "Red" } else { "Green" })
+if ($fail -gt 0) { exit 1 }

--- a/tests/test_smoke_pr.ps1
+++ b/tests/test_smoke_pr.ps1
@@ -47,6 +47,19 @@ function Wait-PaneContent([string]$Target, [string]$Pattern, [int]$TimeoutMs = 8
 
 Write-Host "`n=== PR Smoke Tests ===" -ForegroundColor Cyan
 
+# Static safety-gate guard for the destructive comprehensive runner (#342).
+# It only reads run_all_tests.ps1 — no psmux binary or session needed — so a
+# removed or moved PSMUX_TEST_SANDBOX gate fails the PR build here too. Run it
+# first; surface its per-check output only when it fails.
+$gateGuard = Join-Path $PSScriptRoot "test_runner_safety_gate.ps1"
+$guardOut = & pwsh -NoProfile -ExecutionPolicy Bypass -File $gateGuard 2>&1
+if ($LASTEXITCODE -eq 0) {
+    Write-Pass "run_all_tests.ps1 sandbox gate intact (static guard)"
+} else {
+    Write-Fail "run_all_tests.ps1 sandbox gate guard failed (exit $LASTEXITCODE)"
+    $guardOut | ForEach-Object { Write-Host "    $_" }
+}
+
 Cleanup
 & $PSMUX new-session -d -s $SESSION -x 120 -y 30 | Out-Null
 if (-not (Wait-Session $SESSION)) {


### PR DESCRIPTION
This PR is an initial attempt to mitigate #342. Destructive tests are gated behind an environment variable.

tests/run_all_tests.ps1 kills all psmux processes and wipes ~/.psmux (*.port, *.key, .psmux.conf, .psmuxrc) between tests. Run by an unsuspecting user on a machine with a live psmux it silently destroys the user's running sessions and config.

Gate it behind PSMUX_TEST_SANDBOX=1: the runner refuses (exit 2) with a clear explanation unless that opt-in is set. The Docker dev image sets the variable so the intended throwaway environment runs unchanged.

Adds tests/test_runner_safety_gate.ps1, a static guard (it reads the runner, never executes it — safe anywhere, no binary needed) asserting the gate exists and appears before a blacklist of destructive operations.

 