### PR TITLE
ci: run full unit and integration tests after merges

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,8 +56,8 @@ jobs:
       - name: Build x64 release binary
         run: cargo build --release --target x86_64-pc-windows-msvc
 
-      - name: Run Rust input tests
-        run: 'cargo test --bin psmux -- "ctrl_c_key_event_"'
+      - name: Run full Rust unit tests
+        run: cargo test --all-targets
 
       - name: Run PR smoke tests
         shell: pwsh

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,65 @@
+name: Integration Tests
+
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+    inputs:
+      test-pattern:
+        description: "PowerShell filter for integration tests (e.g. test_issue*.ps1)"
+        required: false
+        default: "test_*.ps1"
+      fail-fast:
+        description: "Stop after first failing integration test"
+        required: false
+        type: boolean
+        default: false
+  schedule:
+    # Default cadence: nightly at 05:00 UTC.
+    - cron: "0 5 * * *"
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+
+concurrency:
+  group: integration-tests
+  cancel-in-progress: false
+
+jobs:
+  integration:
+    name: Full Integration Suite
+    runs-on: windows-latest
+    timeout-minutes: 180
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-pc-windows-msvc
+
+      - name: Build x64 release binary
+        run: cargo build --release --target x86_64-pc-windows-msvc
+
+      - name: Run all integration tests
+        shell: pwsh
+        run: |
+          $exe = (Resolve-Path "target\x86_64-pc-windows-msvc\release\psmux.exe").Path
+          $env:PSMUX_EXE = $exe
+
+          $pattern = "${{ github.event.inputs['test-pattern'] }}"
+          if ([string]::IsNullOrWhiteSpace($pattern)) {
+            $pattern = "test_*.ps1"
+          }
+
+          $args = @("-Pattern", $pattern)
+          if ("${{ github.event.inputs['fail-fast'] }}" -eq "true") {
+            $args += "-FailFast"
+          }
+
+          .\tests\run_all_integration.ps1 @args

--- a/tests/run_all_integration.ps1
+++ b/tests/run_all_integration.ps1
@@ -1,0 +1,99 @@
+$ErrorActionPreference = "Continue"
+
+param(
+    [string]$PsmuxExe = $env:PSMUX_EXE,
+    [string]$Pattern = "test_*.ps1",
+    [switch]$FailFast
+)
+
+function Resolve-PsmuxExe {
+    param([string]$PreferredPath)
+
+    if ($PreferredPath -and (Test-Path $PreferredPath)) {
+        return (Resolve-Path $PreferredPath).Path
+    }
+
+    $candidates = @(
+        "$PSScriptRoot\..\target\x86_64-pc-windows-msvc\release\psmux.exe",
+        "$PSScriptRoot\..\target\release\psmux.exe",
+        "$PSScriptRoot\..\target\debug\psmux.exe"
+    )
+
+    foreach ($candidate in $candidates) {
+        if (Test-Path $candidate) {
+            return (Resolve-Path $candidate).Path
+        }
+    }
+
+    $cmd = Get-Command psmux -ErrorAction SilentlyContinue
+    if ($cmd) {
+        if ($cmd.Path) { return $cmd.Path }
+        if ($cmd.Source) { return $cmd.Source }
+    }
+
+    return $null
+}
+
+$resolvedPsmuxExe = Resolve-PsmuxExe -PreferredPath $PsmuxExe
+if (-not $resolvedPsmuxExe) {
+    Write-Host "FATAL: could not locate psmux executable for integration suite" -ForegroundColor Red
+    exit 1
+}
+
+$env:PSMUX_EXE = $resolvedPsmuxExe
+$env:Path = "$(Split-Path -Parent $resolvedPsmuxExe);$env:Path"
+
+$tests = Get-ChildItem -Path $PSScriptRoot -File -Filter $Pattern |
+    Where-Object { $_.Name -like "test_*.ps1" } |
+    Sort-Object -Property Name
+
+if ($tests.Count -eq 0) {
+    Write-Host "No tests matched pattern '$Pattern'." -ForegroundColor Yellow
+    exit 0
+}
+
+$suitePass = 0
+$suiteFail = 0
+$failedTests = @()
+
+Write-Host "`n=== Full Integration Test Suite ===" -ForegroundColor Cyan
+Write-Host "psmux: $resolvedPsmuxExe" -ForegroundColor DarkGray
+Write-Host "pattern: $Pattern" -ForegroundColor DarkGray
+Write-Host "tests: $($tests.Count)" -ForegroundColor DarkGray
+
+foreach ($test in $tests) {
+    Write-Host "`n--- Running $($test.Name) ---" -ForegroundColor Yellow
+    & pwsh -NoProfile -ExecutionPolicy Bypass -File $test.FullName
+    $exitCode = $LASTEXITCODE
+
+    if ($exitCode -eq 0) {
+        Write-Host "[PASS] $($test.Name)" -ForegroundColor Green
+        $suitePass++
+    } else {
+        Write-Host "[FAIL] $($test.Name) (exit=$exitCode)" -ForegroundColor Red
+        $suiteFail++
+        $failedTests += $test.Name
+
+        if ($FailFast) {
+            Write-Host "Fail-fast enabled; stopping after first failure." -ForegroundColor Red
+            break
+        }
+    }
+}
+
+Write-Host "`n=== Full Integration Summary ===" -ForegroundColor Cyan
+Write-Host "  Passed suites: $suitePass" -ForegroundColor Green
+Write-Host "  Failed suites: $suiteFail" -ForegroundColor $(if ($suiteFail -gt 0) { "Red" } else { "Green" })
+
+if ($failedTests.Count -gt 0) {
+    Write-Host "  Failed tests:" -ForegroundColor Red
+    foreach ($failed in $failedTests) {
+        Write-Host "    - $failed" -ForegroundColor Red
+    }
+}
+
+if ($suiteFail -gt 0) {
+    exit 1
+}
+
+exit 0


### PR DESCRIPTION
## Summary
- Run full Rust test suite in CI using `cargo test --all-targets` instead of a narrow filtered test.
- Add a dedicated integration workflow that runs the full PowerShell integration suite.
- Trigger integration workflow on `push` to `master` so every merged PR gets full post-merge validation, while keeping manual and scheduled triggers.

## Test plan
- [ ] Merge this PR and confirm `CI` runs on the merge commit and executes full Rust tests.
- [ ] Confirm `Integration Tests` workflow runs on the merge commit and executes `tests/run_all_integration.ps1`.
- [ ] Optionally run `Integration Tests` manually with a custom `test-pattern` to validate dispatch inputs.

Made with [Cursor](https://cursor.com)