### PR TITLE
fix(server): Simplify frame buffer and avoid starvation

### DIFF
--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -259,16 +259,14 @@ if line.trim() == "PERSISTENT" {
     let _ = ws_bg.set_write_timeout(Some(Duration::from_secs(5)));
     let (resp_tx, resp_rx) = mpsc::channel::<mpsc::Receiver<String>>();
 
-    // Register a bounded frame channel for server-pushed frames (event-driven
-    // rendering).  The channel queues up to FRAME_CHANNEL_CAPACITY frames,
-    // allowing short bursts (e.g. fast typing) to be delivered without dropping
-    // intermediate states, while still bounding memory for sustained throughput
-    // scenarios (e.g. rapid scroll in copy mode).
-    let frame_chan = crate::types::register_frame_channel(client_id);
+    // Register a frame slot for server-pushed frames (event-driven rendering).
+    // Slot holds at most one pending frame; push_frame() overwrites any
+    // unconsumed frame because only the latest snapshot is worth rendering.
+    let frame_slot = crate::types::register_frame_channel(client_id);
 
     // Register a directive channel for queued directives (e.g. SWITCH).
     // Directives use a separate mpsc channel so they are never affected
-    // by frame channel backpressure.
+    // by frame slot contention.
     let directive_rx = crate::types::register_directive_channel(client_id);
 
     // Clone the write socket so the Guard can shut down the connection when
@@ -301,12 +299,17 @@ if line.trim() == "PERSISTENT" {
         let _guard = Guard { client_id, shutdown: ws_shutdown };
 
         loop {
-            // 0. Check for queued directives (non-blocking) — these take priority
+            // Each iteration drains all three sources in priority order
+            // (directives, command responses, frame slot). The frame slot
+            // is always checked, so command-response activity cannot
+            // starve frame delivery.
+
+            // 0. Drain queued directives (non-blocking).
             while let Ok(directive) = directive_rx.try_recv() {
                 if write!(ws_bg, "{}\n", directive).is_err() { return; }
                 if ws_bg.flush().is_err() { return; }
             }
-            // 1. Drain all pending command responses (non-blocking after first)
+            // 1. Drain pending command responses.
             match resp_rx.recv_timeout(Duration::from_millis(5)) {
                 Ok(rrx) => {
                     // Use a timeout matching the TCP write timeout (5 s) so the
@@ -331,26 +334,13 @@ if line.trim() == "PERSISTENT" {
                             Err(_) => return,
                         }
                     }
-                    continue;
                 }
                 Err(mpsc::RecvTimeoutError::Disconnected) => return,
                 Err(mpsc::RecvTimeoutError::Timeout) => {}
             }
-            // 2. Drain all queued frames from the bounded channel.
-            // Drain into a local buffer while holding rx.lock(), then drop
-            // the lock before writing to TCP. Holding rx.lock() across a
-            // blocking flush would deadlock push_frame() on the server loop.
-            let mut pending_frames: Vec<String> = Vec::new();
-            match frame_chan.rx.lock() {
-                Ok(frame_rx) => {
-                    while let Ok(text) = frame_rx.try_recv() {
-                        pending_frames.push(text);
-                    }
-                }
-                Err(_) => return,
-            }
-            // rx.lock released here — TCP writes happen with no lock held
-            for text in &pending_frames {
+            // 2. Take the latest pushed frame from the slot.
+            let frame = frame_slot.lock().ok().and_then(|mut slot| slot.take());
+            if let Some(text) = frame {
                 if write!(ws_bg, "{}\n", text).is_err() { return; }
                 if ws_bg.flush().is_err() { return; }
             }

--- a/src/types.rs
+++ b/src/types.rs
@@ -1312,88 +1312,64 @@ pub fn shutdown_client_stream(client_id: u64) {
             }
         });
     }
-    if let Ok(mut v) = FRAME_PUSH_CHANNELS.lock() {
+    if let Ok(mut v) = FRAME_PUSH_SLOTS.lock() {
         v.retain(|(cid, _)| *cid != client_id);
     }
     remove_directive_channel(client_id);
 }
 
-/// Server-push frame channels for persistent (attached) clients.
-/// Uses a bounded `sync_channel` with a small capacity to allow short bursts
-/// of frames to queue without dropping, while still bounding memory.
+/// Server-push frame slot for persistent (attached) clients.
 ///
-/// When the channel is full (sustained high-throughput, e.g. rapid scroll in
-/// copy mode), the oldest unconsumed frame is drained before pushing the new
-/// one, so the client always receives the latest frame without unbounded
-/// memory growth.
+/// Each slot holds at most one pending frame. `push_frame()` overwrites any
+/// unconsumed frame; frames are full snapshots, so a stale ready frame has
+/// no value once a newer one exists. Memory is bounded to O(clients), not
+/// O(frames).
 ///
-/// Previous single-slot design (694156e) overwrote unconsumed frames, which
-/// fixed a memory leak during copy-mode scrolling but dropped intermediate
-/// frames during fast typing — the cursor advanced but characters were not
-/// rendered.  A bounded channel preserves intermediate frames under normal
-/// typing speeds while still capping memory for pathological scroll bursts.
-const FRAME_CHANNEL_CAPACITY: usize = 16;
+/// The slot uses `Mutex<Option<String>>`. The producer (main loop's
+/// `push_frame`) locks, replaces, unlocks. The consumer (writer thread)
+/// locks, takes, unlocks, then writes to TCP *outside* the lock. Neither
+/// side ever holds the lock across blocking I/O, so a slow client cannot
+/// stall the main event loop.
+///
+/// Design constraints:
+///   - The lock must not be held across blocking I/O. The writer thread
+///     does TCP writes that can block (slow client, full kernel buffer).
+///     A design where the writer holds a lock during the write -- and the
+///     producer also takes that lock to enqueue -- lets a slow client
+///     stall the server main loop.
+///   - Per-client storage must be bounded. An unbounded queue (e.g. plain
+///     `mpsc::channel`) leaks memory under sustained producer-faster-than-
+///     consumer load (rapid copy-mode scroll).
+///   - `std::sync::atomic` has no atomic-swap for owned heap values;
+///     `AtomicPtr<String>` would require `unsafe` ownership management.
+///     `arc-swap` would be lock-free but adds a third-party dependency
+///     for a path that is not measured-hot.
+pub type FrameSlot = std::sync::Arc<std::sync::Mutex<Option<String>>>;
 
-pub type FrameChannel = std::sync::Arc<FrameChannelInner>;
-
-pub struct FrameChannelInner {
-    pub tx: std::sync::mpsc::SyncSender<String>,
-    pub rx: std::sync::Mutex<std::sync::mpsc::Receiver<String>>,
-}
-
-static FRAME_PUSH_CHANNELS: std::sync::Mutex<Vec<(u64, FrameChannel)>> =
+static FRAME_PUSH_SLOTS: std::sync::Mutex<Vec<(u64, FrameSlot)>> =
     std::sync::Mutex::new(Vec::new());
 
-/// Register a bounded frame channel for a persistent connection's writer
-/// thread, tagged with client_id for targeted operations (e.g. force-detach).
-/// Returns the channel Arc for the writer thread to consume from.
-pub fn register_frame_channel(client_id: u64) -> FrameChannel {
-    let (tx, rx) = std::sync::mpsc::sync_channel::<String>(FRAME_CHANNEL_CAPACITY);
-    let channel = std::sync::Arc::new(FrameChannelInner {
-        tx,
-        rx: std::sync::Mutex::new(rx),
-    });
-    if let Ok(mut v) = FRAME_PUSH_CHANNELS.lock() {
-        v.push((client_id, channel.clone()));
+/// Register a frame slot for a persistent connection's writer thread.
+/// Returns the slot Arc for the writer thread to consume from.
+pub fn register_frame_channel(client_id: u64) -> FrameSlot {
+    let slot: FrameSlot = std::sync::Arc::new(std::sync::Mutex::new(None));
+    if let Ok(mut v) = FRAME_PUSH_SLOTS.lock() {
+        v.push((client_id, slot.clone()));
     }
-    channel
+    slot
 }
 
 /// Push a serialized frame to all persistent clients.
-/// If a client's channel is full, drain the oldest frame first so the
-/// newest frame is always delivered — this bounds memory while ensuring
-/// the client never stalls the server.
-/// Dead channels (writer thread exited) are pruned automatically.
+/// Overwrites any unconsumed frame; frames are full snapshots, so only
+/// the latest matters. The lock is held only for the duration of an
+/// Option::replace, never across I/O.
+/// Dead slots (poisoned mutex) are pruned automatically.
 pub fn push_frame(frame: &str) {
-    if let Ok(mut channels) = FRAME_PUSH_CHANNELS.lock() {
-        channels.retain(|(_, channel)| {
-            match channel.tx.try_send(frame.to_string()) {
-                Ok(()) => true,
-                Err(std::sync::mpsc::TrySendError::Full(frame)) => {
-                    // Frames are full snapshots, not deltas. If the client is
-                    // behind, stale queued frames should not block the newest
-                    // corrective frame from reaching the terminal.
-                    //
-                    // Use try_lock, not lock: the writer thread holds rx.lock()
-                    // while it drains into its local buffer (before TCP writes).
-                    // Blocking here would deadlock the server's main loop.
-                    // If try_lock fails the writer is mid-drain; skip our drain
-                    // and try_send anyway — the writer will free space shortly.
-                    if let Ok(rx) = channel.rx.try_lock() {
-                        loop {
-                            match rx.try_recv() {
-                                Ok(_) => {}
-                                Err(std::sync::mpsc::TryRecvError::Empty) => break,
-                                Err(std::sync::mpsc::TryRecvError::Disconnected) => return false,
-                            }
-                        }
-                    }
-                    matches!(
-                        channel.tx.try_send(frame),
-                        Ok(()) | Err(std::sync::mpsc::TrySendError::Full(_))
-                    )
-                }
-                Err(std::sync::mpsc::TrySendError::Disconnected(_)) => false,
+    if let Ok(mut slots) = FRAME_PUSH_SLOTS.lock() {
+        slots.retain(|(_, slot)| {
+            match slot.lock() {
+                Ok(mut s) => { *s = Some(frame.to_string()); true }
+                Err(_) => false, // writer thread panicked; prune
             }
         });
     }
@@ -1401,14 +1377,14 @@ pub fn push_frame(frame: &str) {
 
 /// Check if any persistent clients are registered for push.
 pub fn has_frame_receivers() -> bool {
-    FRAME_PUSH_CHANNELS.lock().map_or(false, |v| !v.is_empty())
+    FRAME_PUSH_SLOTS.lock().map_or(false, |v| !v.is_empty())
 }
 
-/// Remove the frame channel for a specific client. Called by the writer thread
-/// on exit so the server stops pushing to dead channels and has_frame_receivers()
+/// Remove the frame slot for a specific client. Called by the writer thread
+/// on exit so the server stops pushing to dead slots and has_frame_receivers()
 /// returns false when no live clients remain.
 pub fn deregister_frame_channel(client_id: u64) {
-    if let Ok(mut v) = FRAME_PUSH_CHANNELS.lock() {
+    if let Ok(mut v) = FRAME_PUSH_SLOTS.lock() {
         v.retain(|(cid, _)| *cid != client_id);
     }
 }

--- a/tests-rs/test_pr267_backpressure_proof.rs
+++ b/tests-rs/test_pr267_backpressure_proof.rs
@@ -1,62 +1,74 @@
 use super::*;
 
 /// Serialize backpressure tests: push_frame broadcasts to ALL registered
-/// channels globally, so concurrent tests cross-contaminate each other.
+/// slots globally, so concurrent tests cross-contaminate each other.
 static BP_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
-/// Proof that push_frame now delivers the newest frame when the channel is full.
-/// Previously (before PR #267 fix), the newest frame was silently dropped.
+/// Burst large enough that any naive "first wins" or unbounded-buffer
+/// implementation would be observable. The swap-chain slot has effective
+/// capacity 1, so any value > 1 is sufficient; 20 makes intent obvious.
+const BURST_SIZE: usize = 20;
+
+/// Proof that push_frame delivers the newest frame after a burst of pushes
+/// without an intervening read. The swap-chain slot (Arc<Mutex<Option<String>>>)
+/// holds at most one pending frame; later pushes overwrite earlier ones.
+///
+/// History: PR #267 introduced a bounded sync_channel(16) with drain-on-Full
+/// to preserve the "newest wins" property. That fix held a Mutex<Receiver>
+/// across blocking TCP writes, causing the freeze this branch replaces with
+/// a single-slot swap chain.
 #[test]
-fn push_frame_drops_newest_when_channel_full() {
+fn push_frame_slot_holds_only_newest_after_burst() {
     let _guard = BP_TEST_LOCK.lock().unwrap();
     let client_id = u64::MAX - 9990;
     // Clean up any prior registration
     shutdown_client_stream(client_id);
 
-    let channel = register_frame_channel(client_id);
+    let slot = register_frame_channel(client_id);
 
-    // Fill channel to capacity with stale frames
-    for idx in 0..FRAME_CHANNEL_CAPACITY {
+    // Push a burst of stale frames, then the one we care about.
+    assert!(BURST_SIZE > 1, "precondition: burst must exceed slot capacity (1)");
+    for idx in 0..BURST_SIZE {
         push_frame(&format!("stale-{idx}"));
     }
-
-    // Now push a new frame while channel is full
     push_frame("NEWEST_CRITICAL_FRAME");
 
-    // Drain everything from the channel
-    let rx = channel.rx.lock().expect("frame receiver lock");
-    let mut frames = Vec::new();
-    while let Ok(frame) = rx.try_recv() {
-        frames.push(frame);
-    }
-    drop(rx);
+    // Take the slot's content, then verify the slot is now empty.
+    let first = slot.lock().expect("frame slot lock").take();
+    let second = slot.lock().expect("frame slot lock").take();
     shutdown_client_stream(client_id);
 
-    // After the fix, the stale frames should be drained and
-    // ONLY the newest frame should be in the queue.
-    assert_eq!(frames, vec!["NEWEST_CRITICAL_FRAME".to_string()],
-        "Expected only the newest frame after backpressure drain");
+    assert_eq!(
+        first.as_deref(),
+        Some("NEWEST_CRITICAL_FRAME"),
+        "expected only the newest frame in the swap-chain slot",
+    );
+    assert!(
+        second.is_none(),
+        "slot should hold at most one frame; second take must be empty",
+    );
 }
 
-/// PR #267's original test: saturated frame queue delivers latest snapshot.
+/// PR #267's original intent: saturated frame queue delivers latest snapshot.
+/// With the swap-chain replacement, "saturation" is implicit (capacity = 1)
+/// and the assertion collapses to "only the latest push survives a burst".
 #[test]
-fn push_frame_replaces_stale_backlog_when_full() {
+fn push_frame_replaces_stale_backlog() {
     let _guard = BP_TEST_LOCK.lock().unwrap();
     let client_id = u64::MAX - 246;
     shutdown_client_stream(client_id);
 
-    let channel = register_frame_channel(client_id);
-    for idx in 0..FRAME_CHANNEL_CAPACITY {
+    let slot = register_frame_channel(client_id);
+    assert!(BURST_SIZE > 1, "precondition: burst must exceed slot capacity (1)");
+    for idx in 0..BURST_SIZE {
         push_frame(&format!("stale-{idx}"));
     }
     push_frame("newest");
 
-    let rx = channel.rx.lock().expect("frame receiver lock");
-    let mut frames = Vec::new();
-    while let Ok(frame) = rx.try_recv() {
-        frames.push(frame);
-    }
-
+    let first = slot.lock().expect("frame slot lock").take();
+    let second = slot.lock().expect("frame slot lock").take();
     shutdown_client_stream(client_id);
-    assert_eq!(frames, vec!["newest".to_string()]);
+
+    assert_eq!(first.as_deref(), Some("newest"));
+    assert!(second.is_none(), "slot should hold at most one frame");
 }


### PR DESCRIPTION
## Summary

The persistent-client frame-push path between the server main loop and each per-client writer thread is currently a bounded `sync_channel(16)` wrapped in a mutex. #316 fixed the biggest issue with this design (holding lock across TCP writes), but two issues remain.

### Frame starvation

The writer thread's response-processing block ends with `continue`, skipping the frame-drain step whenever any command response was pending. Under heavy activity the push path starves (this is the original #224 issue that motivated #267).

### Buffering complexity

The bounded channel was added to preserve intermediate frames during fast typing. However, `push_frame`'s drain-on-Full path discards all queued frames the moment the channel fills, so under sustained load the buffering doesn't behave any differently than a single slot. The bounded channel + drain-on-Full + `Mutex<Receiver>` adds notable complexity for behavior that is approximately single-slot in practice.

## Fix

Replace the channel with a single-slot `Arc<Mutex<Option<String>>>`.

The producer locks, replaces, and unlocks. It never holds the lock across I/O. The consumer locks, takes, unlocks, and _then_ writes to TCP outside the lock.

Because the lock is never held during I/O, lock contention is no longer an issue. Further, because frames are full snapshots, a superseded frame has no value. That means that overwriting unconsumed frames is correct by construction. At most 3 frames are in play at once: 1 being created on the main loop (shared across clients), 1 ready in each client's slot, and 1 in flight on each client's writer thread.

## Tests

Includes regression tests that push a burst of frames without an intervening read.
