### PR TITLE
Fix display-popup default shell

### DIFF
--- a/src/popup.rs
+++ b/src/popup.rs
@@ -41,9 +41,19 @@ pub fn create_popup_pane(
     };
     let pair = pty_sys.openpty(pty_size).ok()?;
 
-    let mut cmd_builder = portable_pty::CommandBuilder::new(
-        if cfg!(windows) { "pwsh" } else { "sh" },
-    );
+    let mut cmd_builder = if command.trim().is_empty() {
+        crate::pane::build_command(None, true, false)
+    } else {
+        let mut builder = portable_pty::CommandBuilder::new(
+            if cfg!(windows) { "pwsh" } else { "sh" },
+        );
+        if cfg!(windows) {
+            builder.args(["-NoProfile", "-Command", command]);
+        } else {
+            builder.args(["-c", command]);
+        }
+        builder
+    };
     if let Some(dir) = start_dir {
         cmd_builder.cwd(dir);
     } else if let Ok(dir) = std::env::current_dir() {
@@ -54,11 +64,6 @@ pub fn create_popup_pane(
     cmd_builder.env("COLORTERM", "truecolor");
     cmd_builder.env("PSMUX_SESSION", session_name);
     crate::pane::apply_user_environment(&mut cmd_builder, environment);
-    if cfg!(windows) {
-        cmd_builder.args(["-NoProfile", "-Command", command]);
-    } else {
-        cmd_builder.args(["-c", command]);
-    }
 
     let child = pair.slave.spawn_command(cmd_builder).ok()?;
     drop(pair.slave); // required for ConPTY

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -3814,46 +3814,32 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                     let start_dir = start_dir.map(|d| expand_format(&d, &app)).filter(|d| !d.is_empty());
                     let saved_dir = if start_dir.is_some() { env::current_dir().ok() } else { None };
                     if let Some(dir) = &start_dir { let _ = env::set_current_dir(dir); }
-                    if !command.is_empty() {
-                        // Spawn popup as a real Pane via the popup module
-                        let inner_h = height.saturating_sub(2);
-                        let inner_w = width.saturating_sub(2);
-                        let pane_result = crate::popup::create_popup_pane(
-                            &command,
-                            start_dir.as_deref(),
-                            inner_h,
-                            inner_w,
-                            app.next_pane_id,
-                            &app.session_name,
-                            &app.environment,
-                        );
-                        if let Some(prev) = saved_dir { let _ = env::set_current_dir(prev); }
-                        
-                        app.mode = Mode::PopupMode {
-                            command: command.clone(),
-                            output: String::new(),
-                            process: None,
-                            width,
-                            height,
-                            close_on_exit,
-                            popup_pane: pane_result,
-                            scroll_offset: 0,
-                        };
-                        state_dirty = true;
-                    } else {
-                        if let Some(prev) = saved_dir { let _ = env::set_current_dir(prev); }
-                        app.mode = Mode::PopupMode {
-                            command: String::new(),
-                            output: "Press 'q' or Escape to close\n".to_string(),
-                            process: None,
-                            width,
-                            height,
-                            close_on_exit: true,
-                            popup_pane: None,
-                            scroll_offset: 0,
-                        };
-                        state_dirty = true;
-                    }
+                    // Spawn popup as a real Pane via the popup module. Empty
+                    // commands launch the default interactive shell.
+                    let inner_h = height.saturating_sub(2);
+                    let inner_w = width.saturating_sub(2);
+                    let pane_result = crate::popup::create_popup_pane(
+                        &command,
+                        start_dir.as_deref(),
+                        inner_h,
+                        inner_w,
+                        app.next_pane_id,
+                        &app.session_name,
+                        &app.environment,
+                    );
+                    if let Some(prev) = saved_dir { let _ = env::set_current_dir(prev); }
+
+                    app.mode = Mode::PopupMode {
+                        command: command.clone(),
+                        output: String::new(),
+                        process: None,
+                        width,
+                        height,
+                        close_on_exit,
+                        popup_pane: pane_result,
+                        scroll_offset: 0,
+                    };
+                    state_dirty = true;
                 }
                 CtrlReq::ConfirmBefore(prompt, cmd) => {
                     let prompt_text = if prompt.is_empty() {

--- a/tests/test_issue351_popup_default_shell.ps1
+++ b/tests/test_issue351_popup_default_shell.ps1
@@ -1,0 +1,117 @@
+#!/usr/bin/env pwsh
+# Regression test for issue #351: display-popup with no command should open
+# an interactive shell-backed popup, not a static close-only message.
+
+$ErrorActionPreference = "Continue"
+$results = @()
+
+function Add-Result($name, $pass, $detail = "") {
+    $script:results += [PSCustomObject]@{
+        Test = $name
+        Result = if ($pass) { "PASS" } else { "FAIL" }
+        Detail = $detail
+    }
+}
+
+$PSMUX = (Resolve-Path "$PSScriptRoot\..\target\release\psmux.exe" -ErrorAction SilentlyContinue).Path
+if (-not $PSMUX) { $PSMUX = (Resolve-Path "$PSScriptRoot\..\target\debug\psmux.exe" -ErrorAction SilentlyContinue).Path }
+if (-not $PSMUX) { $PSMUX = (Get-Command psmux -ErrorAction SilentlyContinue).Source }
+if (-not $PSMUX) { Write-Error "psmux binary not found"; exit 1 }
+
+$SESSION = "test351popup_$$"
+$homeDir = $env:USERPROFILE
+
+function Get-Port {
+    (Get-Content "$homeDir\.psmux\$SESSION.port").Trim()
+}
+
+function Get-Key {
+    if (Test-Path "$homeDir\.psmux\$SESSION.key") {
+        (Get-Content "$homeDir\.psmux\$SESSION.key").Trim()
+    } else {
+        ""
+    }
+}
+
+function Send-ControlLine {
+    param(
+        [string]$Line,
+        [int]$DelayMs = 500
+    )
+
+    $tcp = [System.Net.Sockets.TcpClient]::new()
+    $tcp.Connect("127.0.0.1", [int](Get-Port))
+    $stream = $tcp.GetStream()
+    $writer = [System.IO.StreamWriter]::new($stream)
+    $writer.AutoFlush = $true
+    $writer.WriteLine("AUTH $(Get-Key)")
+    $writer.WriteLine($Line)
+    Start-Sleep -Milliseconds $DelayMs
+    $tcp.Close()
+}
+
+function Get-DumpState {
+    param([int]$DelayMs = 1200)
+
+    $tcp = [System.Net.Sockets.TcpClient]::new()
+    $tcp.Connect("127.0.0.1", [int](Get-Port))
+    $stream = $tcp.GetStream()
+    $writer = [System.IO.StreamWriter]::new($stream)
+    $writer.AutoFlush = $true
+    $writer.WriteLine("AUTH $(Get-Key)")
+    $writer.WriteLine("dump-state")
+    Start-Sleep -Milliseconds $DelayMs
+
+    $buf = New-Object byte[] 1048576
+    $total = 0
+    while ($stream.DataAvailable -and $total -lt $buf.Length) {
+        $total += $stream.Read($buf, $total, $buf.Length - $total)
+    }
+    $tcp.Close()
+    return [System.Text.Encoding]::UTF8.GetString($buf, 0, $total)
+}
+
+try {
+    & $PSMUX kill-session -t $SESSION 2>$null | Out-Null
+    Start-Sleep -Milliseconds 300
+
+    & $PSMUX new-session -d -s $SESSION -x 120 -y 30 | Out-Null
+    Start-Sleep -Seconds 2
+
+    & $PSMUX display-popup -t $SESSION -E -w "80%" -h "80%" 2>&1 | Out-Null
+    Start-Sleep -Milliseconds 800
+
+    $json = Get-DumpState
+    Add-Result "popup is active" ($json -match '"popup_active"\s*:\s*true')
+    Add-Result "popup has PTY" ($json -match '"popup_has_pty"\s*:\s*true')
+    Add-Result "popup command is empty/default shell" ($json -match '"popup_command"\s*:\s*""')
+    Add-Result "not static close-text popup" (-not ($json -match "Press 'q' or Escape to close"))
+
+    $token = "ISSUE351_POPUP_INPUT"
+    $inputBytes = [System.Text.Encoding]::UTF8.GetBytes("echo $token`r")
+    $encoded = [Convert]::ToBase64String($inputBytes)
+    Send-ControlLine "popup-input $encoded" 500
+
+    $inputSeen = $false
+    for ($i = 0; $i -lt 10; $i++) {
+        Start-Sleep -Milliseconds 500
+        $json = Get-DumpState 300
+        if ($json -match $token) {
+            $inputSeen = $true
+            break
+        }
+    }
+    Add-Result "popup input reaches shell" $inputSeen
+} finally {
+    Send-ControlLine "overlay-close" 200 2>$null
+    & $PSMUX kill-session -t $SESSION 2>$null | Out-Null
+    Remove-Item "$homeDir\.psmux\$SESSION.port" -Force -ErrorAction SilentlyContinue
+    Remove-Item "$homeDir\.psmux\$SESSION.key" -Force -ErrorAction SilentlyContinue
+}
+
+Write-Host ""
+Write-Host "=== Issue #351: Default popup shell test results ==="
+$results | Format-Table -AutoSize
+$failed = ($results | Where-Object { $_.Result -eq "FAIL" }).Count
+if ($failed -gt 0) { exit 1 }
+exit 0


### PR DESCRIPTION
Fixes #351.

## Summary
- Make `display-popup` without a command open a PTY-backed popup using the default interactive shell.
- Preserve existing command-backed popup behavior.
- Add a regression script covering no-command popup PTY creation and popup input routing.

## Validation
- `cargo build --release` passed locally.
- Local regression test was not run after user requested PR pipelines handle test execution.