### PR TITLE
fix: deliver raw Ctrl+C to live raw-mode TUIs (Copilot CLI, vim) instead of killing them

### DIFF
--- a/src/platform.rs
+++ b/src/platform.rs
@@ -1046,7 +1046,9 @@ pub mod mouse_inject {
     /// EXCEPTION: when the pane's foreground process is a *live* raw-mode TUI
     /// (e.g. Copilot CLI, vim) that has cleared ENABLE_PROCESSED_INPUT to read
     /// Ctrl+C itself, this function skips the signal so the raw 0x03 byte the
-    /// caller already wrote reaches the app, which decides copy-vs-interrupt.
+    /// caller writes to the PTY reaches the app, which decides copy-vs-interrupt.
+    /// (Call sites write the raw 0x03 either just before or just after invoking
+    /// this function; the skip behavior is correct regardless of that ordering.)
     /// See `process_info::foreground_is_shell`.
     pub fn send_ctrl_c_event(child_pid: u32, reattach: bool) -> bool {
         const CTRL_C_EVENT: u32 = 0;
@@ -1120,12 +1122,12 @@ pub mod mouse_inject {
                         if !fg_is_shell {
                             // Live raw-mode TUI (Copilot CLI, vim, ...): it
                             // cleared ENABLE_PROCESSED_INPUT to read raw 0x03
-                            // itself and decide copy-vs-interrupt.  The caller
-                            // already wrote raw 0x03 to the pipe; firing
-                            // GenerateConsoleCtrlEvent would bypass the app and
-                            // kill it.  Skip the signal and detach cleanly.
-                            // (We have not installed the ignore-handler yet, so
-                            // there is nothing to restore here.)
+                            // itself and decide copy-vs-interrupt.  The call
+                            // site writes raw 0x03 to the PTY (just before or
+                            // just after this call); firing GenerateConsoleCtrlEvent
+                            // would bypass the app and kill it.  Skip the signal
+                            // and detach cleanly.  (We have not installed the
+                            // ignore-handler yet, so there is nothing to restore.)
                             log(&format!("raw-mode non-shell foreground pid={}: deliver raw 0x03, skip CTRL_C_EVENT", child_pid));
                             CloseHandle(handle);
                             FreeConsole();
@@ -2083,14 +2085,19 @@ pub mod process_info {
     /// purpose of Ctrl+C routing.
     ///
     /// Walks the process tree from `root_pid` down to the deepest foreground
-    /// leaf (newest child at each level), so nested wrapper chains such as
-    /// `pwsh -> cmd -> node` resolve to the actual running program rather than
-    /// stopping at the first wrapper.
+    /// leaf (the highest-PID child at each level — a most-recently-created
+    /// heuristic, since Windows exposes no real console foreground group), so
+    /// nested wrapper chains such as `pwsh -> cmd -> node` resolve to the
+    /// actual running program rather than stopping at the first wrapper.
+    ///
+    /// If `root_pid` has no non-system children, the root process itself is
+    /// classified.  This covers both a bare shell prompt (root is pwsh/cmd ->
+    /// shell) and a pane spawned via `create_window_raw` that directly exec'd a
+    /// program with no shell wrapper (root may be a live TUI -> not a shell).
     ///
     /// Returns:
-    ///   `Some(true)`  — the foreground is a shell, a VT bridge (wsl/ssh), or a
-    ///                   bare prompt with no foreground child.  These expect a
-    ///                   console `CTRL_C_EVENT`.
+    ///   `Some(true)`  — the foreground is a shell or a VT bridge (wsl/ssh).
+    ///                   These expect a console `CTRL_C_EVENT`.
     ///   `Some(false)` — a live non-shell program (Copilot CLI, vim, ...) owns
     ///                   the console; it should receive raw 0x03 and decide for
     ///                   itself (copy selection vs. interrupt).
@@ -2114,9 +2121,10 @@ pub mod process_info {
             }
             CloseHandle(snap);
 
-            // Descend to the deepest foreground leaf, skipping system processes.
-            // The iteration guard prevents pathological loops from PID-reuse
-            // cycles in the snapshot.
+            // Descend to the deepest foreground leaf, skipping system
+            // processes, by following the highest-PID child at each level
+            // (a most-recently-created heuristic).  The iteration guard
+            // prevents pathological loops from PID-reuse cycles in the snapshot.
             let mut cur = root_pid;
             let mut leaf_name: Option<String> = None;
             for _ in 0..64 {
@@ -2132,10 +2140,22 @@ pub mod process_info {
                 }
             }
 
-            match leaf_name {
-                // No foreground child: bare shell prompt -> wants the signal.
-                None => Some(true),
+            // The process whose Ctrl+C behavior matters is the deepest
+            // foreground leaf.  If the root has no children, classify the root
+            // itself — a bare shell prompt resolves to pwsh/cmd (shell), while a
+            // directly-exec'd pane (create_window_raw) resolves to the program
+            // it ran, which may be a live TUI that must NOT be force-signalled.
+            let fg_name = leaf_name.or_else(|| {
+                entries.iter()
+                    .find(|(pid, _, _)| *pid == root_pid)
+                    .map(|(_, _, name)| name.clone())
+            });
+
+            match fg_name {
                 Some(name) => Some(is_shell_exe(&name) || is_vt_bridge_exe(&name)),
+                // Root not present in the snapshot (rare race): default to shell
+                // so the established interrupt behavior is preserved.
+                None => Some(true),
             }
         }
     }

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -1039,8 +1039,15 @@ pub mod mouse_inject {
     ///   2. Re-enabling ENABLE_PROCESSED_INPUT if it was cleared
     ///   3. Calling GenerateConsoleCtrlEvent(CTRL_C_EVENT, 0)
     ///
-    /// The combination ensures Ctrl+C always delivers a signal regardless of
-    /// what a previous TUI application did to the console mode.
+    /// The combination ensures Ctrl+C delivers a signal to shells and cooked
+    /// console apps regardless of what a previous TUI application did to the
+    /// console mode.
+    ///
+    /// EXCEPTION: when the pane's foreground process is a *live* raw-mode TUI
+    /// (e.g. Copilot CLI, vim) that has cleared ENABLE_PROCESSED_INPUT to read
+    /// Ctrl+C itself, this function skips the signal so the raw 0x03 byte the
+    /// caller already wrote reaches the app, which decides copy-vs-interrupt.
+    /// See `process_info::foreground_is_shell`.
     pub fn send_ctrl_c_event(child_pid: u32, reattach: bool) -> bool {
         const CTRL_C_EVENT: u32 = 0;
         const ENABLE_PROCESSED_INPUT: u32 = 0x0001;
@@ -1065,6 +1072,16 @@ pub mod mouse_inject {
         fn log(msg: &str) {
             debug_log(&format!("ctrl_c: {}", msg));
         }
+
+        // Decide up-front whether the pane's foreground process wants a console
+        // interrupt (shells / VT bridges / bare prompt) or is a live raw-mode
+        // TUI that should receive raw 0x03 itself (Copilot CLI, vim, ...).
+        // Unknown (snapshot failure) falls back to `true` so we preserve the
+        // established interrupt behavior (#338 line-cancel, #346 ping).  This
+        // process-tree walk does not touch our console, so it is done before
+        // the FreeConsole/AttachConsole dance below.
+        let fg_is_shell = crate::platform::process_info::foreground_is_shell(child_pid)
+            .unwrap_or(true);
 
         unsafe {
             let had_console = reattach && GetConsoleWindow() != 0;
@@ -1098,8 +1115,23 @@ pub mod mouse_inject {
             if handle != INVALID_HANDLE && handle != 0 {
                 let mut mode: u32 = 0;
                 if GetConsoleMode(handle as *mut c_void, &mut mode) != 0 {
-                    log(&format!("console mode=0x{:04X} PROCESSED_INPUT={}", mode, mode & ENABLE_PROCESSED_INPUT != 0));
+                    log(&format!("console mode=0x{:04X} PROCESSED_INPUT={} fg_is_shell={}", mode, mode & ENABLE_PROCESSED_INPUT != 0, fg_is_shell));
                     if mode & ENABLE_PROCESSED_INPUT == 0 {
+                        if !fg_is_shell {
+                            // Live raw-mode TUI (Copilot CLI, vim, ...): it
+                            // cleared ENABLE_PROCESSED_INPUT to read raw 0x03
+                            // itself and decide copy-vs-interrupt.  The caller
+                            // already wrote raw 0x03 to the pipe; firing
+                            // GenerateConsoleCtrlEvent would bypass the app and
+                            // kill it.  Skip the signal and detach cleanly.
+                            // (We have not installed the ignore-handler yet, so
+                            // there is nothing to restore here.)
+                            log(&format!("raw-mode non-shell foreground pid={}: deliver raw 0x03, skip CTRL_C_EVENT", child_pid));
+                            CloseHandle(handle);
+                            FreeConsole();
+                            if had_console { AttachConsole(ATTACH_PARENT_PROCESS); }
+                            return false;
+                        }
                         log(&format!("re-enabling ENABLE_PROCESSED_INPUT for pid={}", child_pid));
                         SetConsoleMode(handle as *mut c_void, mode | ENABLE_PROCESSED_INPUT);
                     }
@@ -2034,6 +2066,80 @@ pub mod process_info {
             || stem.starts_with("wsl")
     }
 
+    /// Native Windows shell executables.  Used by the Ctrl+C router to decide
+    /// whether a pane's foreground process expects a console interrupt signal
+    /// (shells) or should instead receive raw 0x03 and handle Ctrl+C itself
+    /// (live raw-mode TUIs like Copilot CLI, vim, nvim).
+    pub fn is_shell_exe(name: &str) -> bool {
+        let stem = name.strip_suffix(".exe").unwrap_or(name);
+        matches!(stem,
+            "pwsh" | "powershell" | "cmd" | "command"
+            | "bash" | "sh" | "dash" | "zsh" | "fish"
+            | "ksh" | "tcsh" | "csh" | "nu" | "elvish" | "xonsh" | "busybox"
+        )
+    }
+
+    /// Classify the foreground process of the pane rooted at `root_pid` for the
+    /// purpose of Ctrl+C routing.
+    ///
+    /// Walks the process tree from `root_pid` down to the deepest foreground
+    /// leaf (newest child at each level), so nested wrapper chains such as
+    /// `pwsh -> cmd -> node` resolve to the actual running program rather than
+    /// stopping at the first wrapper.
+    ///
+    /// Returns:
+    ///   `Some(true)`  — the foreground is a shell, a VT bridge (wsl/ssh), or a
+    ///                   bare prompt with no foreground child.  These expect a
+    ///                   console `CTRL_C_EVENT`.
+    ///   `Some(false)` — a live non-shell program (Copilot CLI, vim, ...) owns
+    ///                   the console; it should receive raw 0x03 and decide for
+    ///                   itself (copy selection vs. interrupt).
+    ///   `None`        — the process snapshot could not be taken; the caller
+    ///                   should fall back to its default behavior.
+    pub fn foreground_is_shell(root_pid: u32) -> Option<bool> {
+        unsafe {
+            let snap = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
+            if snap == INVALID_HANDLE || snap == 0 {
+                return None;
+            }
+
+            let mut entries: Vec<(u32, u32, String)> = Vec::with_capacity(512);
+            let mut pe: PROCESSENTRY32W = std::mem::zeroed();
+            pe.dw_size = std::mem::size_of::<PROCESSENTRY32W>() as u32;
+            if Process32FirstW(snap, &mut pe) != 0 {
+                entries.push((pe.th32_process_id, pe.th32_parent_process_id, exe_name_from_entry(&pe)));
+                while Process32NextW(snap, &mut pe) != 0 {
+                    entries.push((pe.th32_process_id, pe.th32_parent_process_id, exe_name_from_entry(&pe)));
+                }
+            }
+            CloseHandle(snap);
+
+            // Descend to the deepest foreground leaf, skipping system processes.
+            // The iteration guard prevents pathological loops from PID-reuse
+            // cycles in the snapshot.
+            let mut cur = root_pid;
+            let mut leaf_name: Option<String> = None;
+            for _ in 0..64 {
+                let next = entries.iter()
+                    .filter(|(pid, ppid, name)| *ppid == cur && *pid != cur && !is_system_exe(name))
+                    .max_by_key(|(pid, _, _)| *pid);
+                match next {
+                    Some((pid, _, name)) => {
+                        cur = *pid;
+                        leaf_name = Some(name.clone());
+                    }
+                    None => break,
+                }
+            }
+
+            match leaf_name {
+                // No foreground child: bare shell prompt -> wants the signal.
+                None => Some(true),
+                Some(name) => Some(is_shell_exe(&name) || is_vt_bridge_exe(&name)),
+            }
+        }
+    }
+
     /// Walk the process tree from `root_pid` and check if any descendant
     /// is a VT bridge process (wsl.exe, ssh.exe, etc.).
     /// This is used for mouse injection: VT bridge processes need VT mouse
@@ -2489,3 +2595,8 @@ mod tests_issue265_argv_backslash;
 #[cfg(windows)]
 #[path = "../tests-rs/test_char_to_vk.rs"]
 mod tests_char_to_vk;
+
+#[cfg(test)]
+#[cfg(windows)]
+#[path = "../tests-rs/test_ctrlc_shell_classify.rs"]
+mod tests_ctrlc_shell_classify;

--- a/tests-rs/test_ctrlc_shell_classify.rs
+++ b/tests-rs/test_ctrlc_shell_classify.rs
@@ -1,0 +1,39 @@
+// Unit coverage for the Ctrl+C foreground classifier (issue: Ctrl+C kills
+// raw-mode TUI apps like Copilot CLI instead of letting them handle the key).
+//
+// `is_shell_exe` decides whether a pane's foreground process expects a console
+// CTRL_C_EVENT (shells) or should instead receive raw 0x03 and handle Ctrl+C
+// itself (live raw-mode TUIs).  Misclassifying a TUI as a shell reintroduces
+// the bug, so lock the classification down here.
+
+use super::process_info::is_shell_exe;
+
+#[test]
+fn shells_are_classified_as_shell() {
+    for s in [
+        "pwsh.exe", "pwsh", "powershell.exe", "powershell",
+        "cmd.exe", "cmd", "bash", "bash.exe", "sh", "dash",
+        "zsh", "fish.exe", "nu.exe", "busybox.exe",
+    ] {
+        assert!(is_shell_exe(s), "{s:?} should be classified as a shell");
+    }
+}
+
+#[test]
+fn raw_mode_tui_apps_are_not_shells() {
+    // These get raw 0x03 and decide copy-vs-interrupt themselves.
+    for s in [
+        "copilot.exe", "copilot", "node.exe", "node",
+        "vim.exe", "nvim.exe", "nvim", "python.exe", "btop.exe",
+    ] {
+        assert!(!is_shell_exe(s), "{s:?} must NOT be classified as a shell");
+    }
+}
+
+#[test]
+fn cooked_console_app_is_not_shell() {
+    // ping is a cooked console app; it leaves ENABLE_PROCESSED_INPUT ON, so it
+    // still gets the signal via the processed-input branch, not via shell
+    // classification.  It must not be classified as a shell.
+    assert!(!is_shell_exe("ping.exe"));
+}


### PR DESCRIPTION
## Problem
Pressing **Ctrl+C** while a live raw-mode TUI is the foreground process (e.g. **Copilot CLI**, `vim`, `nvim`) kills/interrupts the app instead of letting it handle the key. Copilot CLI uses Ctrl+C to **copy** a selection (else cancel); users reported it kills Copilot instead of copying.

## Root cause
The #338 fix routed Ctrl+C onto the legacy interrupt path: it always calls `send_ctrl_c_event()` -> `GenerateConsoleCtrlEvent(CTRL_C_EVENT)` and re-enables `ENABLE_PROCESSED_INPUT` if a child cleared it. A live raw-mode TUI deliberately clears `ENABLE_PROCESSED_INPUT` to read raw `0x03` itself, but psmux overrides that and fires a console signal -> the app never sees the key.

A **live raw-mode TUI** and a **shell with leftover raw mode** (the case `send_ctrl_c_event` was built for) both have `ENABLE_PROCESSED_INPUT` cleared, so the flag alone cannot distinguish them.

## Fix
Discriminate on the pane's **foreground process** (`src/platform.rs`):

- `process_info::foreground_is_shell()` — recursive **deepest-leaf** process-tree walk that resolves nested wrapper chains (`pwsh -> cmd -> node`). Returns `Some(true)` for shells / `wsl|ssh` bridges / bare prompt, `Some(false)` for live non-shell programs, `None` on snapshot failure.
- `process_info::is_shell_exe()` classifier.
- `send_ctrl_c_event()`: when `ENABLE_PROCESSED_INPUT` is cleared **and** the foreground is not a shell/bridge -> skip the console signal and let the raw `0x03` the caller already wrote reach the app (clean console detach).

Behavior only diverges from today in the **(processed-input cleared AND foreground not a shell)** case. Unchanged:
- cooked console apps like `ping /t` (processed-input ON) -> still interrupted (#346)
- shell line-cancel (#338)
- shell with leftover raw mode from an exited TUI -> still re-enabled + signalled
- snapshot failure / unknown -> defaults to firing the signal

No call-site changes; all callers already write raw `0x03` before calling.

## Tests
- New unit coverage for the shell/TUI classifier in `tests-rs/test_ctrlc_shell_classify.rs` (3 tests, pass).
- `cargo build` clean.
- e2e `.ps1` Ctrl+C suites not run here (they signal/kill a local psmux); please validate #338 line-cancel + #346 `ping /t` + Copilot CLI copy in CI / manually.

## Known limitation
At a shell prompt where `ENABLE_PROCESSED_INPUT` is already cleared **and** a lingering non-shell background child exists, the deepest-leaf walk may classify the pane as a live TUI. Narrow combination, gated behind processed-input-off at a prompt.
