### PR TITLE
fix: prevent Windows paste from submitting existing CLI input

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -3936,11 +3936,12 @@ pub fn run_remote(terminal: &mut Terminal<CrosstermBackend<crate::platform::Psmu
         // paste even though the user explicitly disabled paste detection.
         #[cfg(windows)]
         {
-            let flush_all = !paste_detection_enabled;
-            if !paste_confirmed && !paste_stage2
-                && paste_pend.len() >= 1
-                && (paste_pend.len() <= 2 || flush_all)
-            {
+            if should_zero_latency_flush_paste_pend(
+                &paste_pend,
+                paste_detection_enabled,
+                paste_confirmed,
+                paste_stage2,
+            ) {
                 if input_log_enabled() {
                     input_log("paste", &format!(
                         "zero-latency flush {} char(s) as typing",
@@ -5740,13 +5741,35 @@ fn should_buffer_leading_paste_control(
     paste_detection_enabled: bool,
     paste_pend_non_empty: bool,
 ) -> bool {
+    if !matches!(code, KeyCode::Enter | KeyCode::Tab) {
+        return false;
+    }
     if paste_pend_non_empty {
         return true;
     }
     if !paste_detection_enabled || !modifiers.is_empty() {
         return false;
     }
-    matches!(code, KeyCode::Enter | KeyCode::Tab)
+    true
+}
+
+#[cfg(windows)]
+fn should_zero_latency_flush_paste_pend(
+    paste_pend: &str,
+    paste_detection_enabled: bool,
+    paste_confirmed: bool,
+    paste_stage2: bool,
+) -> bool {
+    if paste_confirmed || paste_stage2 || paste_pend.is_empty() {
+        return false;
+    }
+    if !paste_detection_enabled {
+        return true;
+    }
+    if paste_pend.starts_with('\n') || paste_pend.starts_with('\t') {
+        return false;
+    }
+    paste_pend.len() <= 2
 }
 
 /// Returns true if the buffer contains any non-ASCII characters (IME / CJK input).

--- a/src/client.rs
+++ b/src/client.rs
@@ -3328,8 +3328,21 @@ pub fn run_remote(terminal: &mut Terminal<CrosstermBackend<crate::platform::Psmu
                                 KeyCode::Enter => {
                                     #[cfg(windows)]
                                     {
-                                        if !paste_pend.is_empty() {
+                                        // If paste detection is enabled, treat plain Enter as
+                                        // bufferable even when it's the first key in the burst.
+                                        // This prevents a leading pasted newline from being
+                                        // forwarded as an immediate submit before the rest of
+                                        // the clipboard payload arrives.
+                                        if should_buffer_leading_paste_control(
+                                            &key.code,
+                                            key.modifiers,
+                                            paste_detection_enabled,
+                                            !paste_pend.is_empty(),
+                                        ) {
                                             paste_pend.push('\n');
+                                            if paste_pend_start.is_none() {
+                                                paste_pend_start = Some(Instant::now());
+                                            }
                                         } else {
                                             cmd_batch.push(format!("send-key {}\n", modified_key_name("Enter", key.modifiers)));
                                         }
@@ -3340,8 +3353,16 @@ pub fn run_remote(terminal: &mut Terminal<CrosstermBackend<crate::platform::Psmu
                                 KeyCode::Tab => {
                                     #[cfg(windows)]
                                     {
-                                        if !paste_pend.is_empty() {
+                                        if should_buffer_leading_paste_control(
+                                            &key.code,
+                                            key.modifiers,
+                                            paste_detection_enabled,
+                                            !paste_pend.is_empty(),
+                                        ) {
                                             paste_pend.push('\t');
+                                            if paste_pend_start.is_none() {
+                                                paste_pend_start = Some(Instant::now());
+                                            }
                                         } else {
                                             cmd_batch.push("send-key tab\n".into());
                                         }
@@ -5710,6 +5731,22 @@ fn flush_paste_pend_as_text(
     paste_pend.clear();
     *paste_pend_start = None;
     *paste_stage2 = false;
+}
+
+#[cfg(windows)]
+fn should_buffer_leading_paste_control(
+    code: &KeyCode,
+    modifiers: KeyModifiers,
+    paste_detection_enabled: bool,
+    paste_pend_non_empty: bool,
+) -> bool {
+    if paste_pend_non_empty {
+        return true;
+    }
+    if !paste_detection_enabled || !modifiers.is_empty() {
+        return false;
+    }
+    matches!(code, KeyCode::Enter | KeyCode::Tab)
 }
 
 /// Returns true if the buffer contains any non-ASCII characters (IME / CJK input).

--- a/tests-rs/test_client.rs
+++ b/tests-rs/test_client.rs
@@ -85,6 +85,50 @@ fn flush_paste_pend_short_ascii_sends_as_text() {
     assert!(cmds[1].starts_with("send-text "));
 }
 
+#[cfg(windows)]
+#[test]
+fn leading_plain_enter_is_buffered_when_paste_detection_on() {
+    assert!(should_buffer_leading_paste_control(
+        &KeyCode::Enter,
+        KeyModifiers::empty(),
+        true,
+        false,
+    ));
+}
+
+#[cfg(windows)]
+#[test]
+fn leading_plain_tab_is_buffered_when_paste_detection_on() {
+    assert!(should_buffer_leading_paste_control(
+        &KeyCode::Tab,
+        KeyModifiers::empty(),
+        true,
+        false,
+    ));
+}
+
+#[cfg(windows)]
+#[test]
+fn leading_enter_not_buffered_when_detection_off() {
+    assert!(!should_buffer_leading_paste_control(
+        &KeyCode::Enter,
+        KeyModifiers::empty(),
+        false,
+        false,
+    ));
+}
+
+#[cfg(windows)]
+#[test]
+fn modified_enter_not_buffered_for_paste() {
+    assert!(!should_buffer_leading_paste_control(
+        &KeyCode::Enter,
+        KeyModifiers::SHIFT,
+        true,
+        false,
+    ));
+}
+
 // ── Issue #164: status-format[] must parse inline styles end-to-end ──
 
 /// Verify that status_format strings from JSON deserialization flow through

--- a/tests-rs/test_client.rs
+++ b/tests-rs/test_client.rs
@@ -129,6 +129,51 @@ fn modified_enter_not_buffered_for_paste() {
     ));
 }
 
+#[cfg(windows)]
+#[test]
+fn non_control_key_not_buffered_even_when_paste_pending() {
+    assert!(!should_buffer_leading_paste_control(
+        &KeyCode::Backspace,
+        KeyModifiers::empty(),
+        true,
+        true,
+    ));
+}
+
+#[cfg(windows)]
+#[test]
+fn leading_enter_waits_past_zero_latency_flush_when_detection_on() {
+    assert!(!should_zero_latency_flush_paste_pend("\n", true, false, false));
+}
+
+#[cfg(windows)]
+#[test]
+fn leading_tab_waits_past_zero_latency_flush_when_detection_on() {
+    assert!(!should_zero_latency_flush_paste_pend("\t", true, false, false));
+}
+
+#[cfg(windows)]
+#[test]
+fn leading_control_flushes_immediately_when_detection_off() {
+    assert!(should_zero_latency_flush_paste_pend("\n", false, false, false));
+    assert!(should_zero_latency_flush_paste_pend("\t", false, false, false));
+}
+
+#[cfg(windows)]
+#[test]
+fn normal_short_typing_still_flushes_immediately() {
+    assert!(should_zero_latency_flush_paste_pend("a", true, false, false));
+    assert!(should_zero_latency_flush_paste_pend("ab", true, false, false));
+}
+
+#[cfg(windows)]
+#[test]
+fn paste_states_do_not_zero_latency_flush() {
+    assert!(!should_zero_latency_flush_paste_pend("a", true, true, false));
+    assert!(!should_zero_latency_flush_paste_pend("a", true, false, true));
+    assert!(!should_zero_latency_flush_paste_pend("abc", true, false, false));
+}
+
 // ── Issue #164: status-format[] must parse inline styles end-to-end ──
 
 /// Verify that status_format strings from JSON deserialization flow through


### PR DESCRIPTION
## Summary
When a Windows paste started with a newline/tab, `psmux` could send Enter/Tab immediately before the rest of the paste arrived. That submitted the current Copilot CLI input unexpectedly. This change buffers leading plain Enter/Tab as part of paste detection so the whole clipboard payload is delivered together.

## Details
In the Windows client input loop (`src/client.rs`), `KeyCode::Enter` and `KeyCode::Tab` were only appended to `paste_pend` when `paste_pend` was already non-empty. If the first injected key in a Ctrl+V burst was Enter/Tab, the code fell through to immediate `send-key`, causing premature command submission in CLI overlays before remaining paste bytes were processed.

This PR adds `should_buffer_leading_paste_control(...)` and uses it in Enter/Tab handling to buffer leading plain Enter/Tab when `paste-detection` is enabled. It also starts `paste_pend_start` when buffering begins. Behavior remains unchanged for modified Enter/Tab and when `paste-detection` is disabled.

Tests were added in `tests-rs/test_client.rs` to verify:
- leading plain Enter buffers when detection is on
- leading plain Tab buffers when detection is on
- leading Enter does not buffer when detection is off
- modified Enter does not buffer

## Test Plan
- [ ] Run Windows unit tests (`cargo test --test test_client`) and verify new helper tests pass
- [ ] Repro manually in Windows: type text in Copilot CLI input, paste content that starts with newline/tab, confirm existing input is not submitted prematurely

Made with [Cursor](https://cursor.com)