### PR TITLE
Fix/send keys ctrlc force signal

### DIFF
--- a/docs/scripting.md
+++ b/docs/scripting.md
@@ -48,12 +48,22 @@ psmux send-keys -N 5 Up
 # Send copy mode command
 psmux send-keys -X copy-mode-up
 
+# Force Ctrl+C to the foreground process (Windows CTRL_C_EVENT)
+# Useful for a dedicated interrupt binding when a raw-mode TUI consumes Ctrl+C.
+psmux send-keys -f C-c
+
 # Special keys supported:
 # Enter, Tab, Escape, Space, Backspace
 # Up, Down, Left, Right, Home, End
 # PageUp, PageDown, Delete, Insert
 # F1-F12, C-a through C-z (Ctrl+key)
 ```
+
+`send-keys -f C-c` (or `--force-signal`) is a psmux extension for Windows. It
+bypasses the raw-mode TUI heuristic and sends a CTRL_C_EVENT to the foreground
+process. This keeps normal keyboard Ctrl+C pass-through behavior unchanged while
+allowing an explicit binding such as `bind -n C-F12 send-keys -f C-c` to force an
+interrupt.
 
 ## Pane Information
 

--- a/docs/tmux_args_reference.md
+++ b/docs/tmux_args_reference.md
@@ -309,6 +309,8 @@
 **send-keys** (`send`) — `"c:FHKlMN:Rt:X"`
 - Boolean: `-F` (expand formats), `-H` (hex), `-K` (key name), `-l` (literal), `-M` (mouse), `-R` (reset terminal), `-X` (copy-mode command)
 - Value: `-c` (target-client), `-N` (repeat count), `-t` (target-pane)
+- psmux extension: `-f` / `--force-signal` with `C-c` forces a Windows
+  CTRL_C_EVENT to the foreground process, bypassing the raw-mode TUI heuristic.
 
 **send-prefix** — `"2t:"`
 - Boolean: `-2` (send prefix2)

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1324,6 +1324,7 @@ fn execute_command_string_single(app: &mut AppState, cmd: &str) -> io::Result<()
             } else {
                 // Local: write key text directly to active pane
                 let literal = parts.iter().any(|p| *p == "-l");
+                let force_signal = parts.iter().any(|p| *p == "-f" || *p == "--force-signal");
                 let key_parts: Vec<&str> = parts[1..].iter().filter(|p| !p.starts_with('-')).copied().collect();
                 if !key_parts.is_empty() {
                     if literal {
@@ -1391,7 +1392,7 @@ fn execute_command_string_single(app: &mut AppState, cmd: &str) -> io::Result<()
                                                             p.child_pid = crate::platform::mouse_inject::get_child_pid(&*p.child);
                                                         }
                                                         if let Some(pid) = p.child_pid {
-                                                            crate::platform::mouse_inject::send_ctrl_c_event(pid, false);
+                                                            crate::platform::mouse_inject::send_ctrl_c_event(pid, false, force_signal);
                                                         }
                                                     }
                                                 }

--- a/src/input.rs
+++ b/src/input.rs
@@ -2065,7 +2065,9 @@ pub fn forward_key_to_active(app: &mut AppState, key: KeyEvent) -> io::Result<()
                                 #[cfg(windows)]
                                 if let Some(pid) = p.child_pid {
                                     if is_ctrl_c {
-                                        crate::platform::mouse_inject::send_ctrl_c_event(pid, false);
+                                        // Keyboard pass-through: let raw-mode TUIs (opencode,
+                                        // neovim) handle 0x03 themselves (force=false).
+                                        crate::platform::mouse_inject::send_ctrl_c_event(pid, false, false);
                                     } else {
                                         crate::platform::mouse_inject::send_modified_key_event(pid, ch, true, false, false);
                                     }
@@ -2089,7 +2091,9 @@ pub fn forward_key_to_active(app: &mut AppState, key: KeyEvent) -> io::Result<()
                             #[cfg(windows)]
                             if let Some(pid) = active.child_pid {
                                 if is_ctrl_c {
-                                    crate::platform::mouse_inject::send_ctrl_c_event(pid, false);
+                                    // Keyboard pass-through: let raw-mode TUIs (opencode,
+                                    // neovim) handle 0x03 themselves (force=false).
+                                    crate::platform::mouse_inject::send_ctrl_c_event(pid, false, false);
                                 } else {
                                     crate::platform::mouse_inject::send_modified_key_event(pid, inject_char, true, false, false);
                                 }
@@ -3053,7 +3057,7 @@ fn handle_copy_mode_char(app: &mut AppState, c: char) -> io::Result<()> {
     Ok(())
 }
 
-pub fn send_key_to_active(app: &mut AppState, k: &str) -> io::Result<()> {
+pub fn send_key_to_active(app: &mut AppState, k: &str, force_signal: bool) -> io::Result<()> {
     // In clock mode, any key exits back to passthrough
     if matches!(app.mode, Mode::ClockMode) {
         app.mode = Mode::Passthrough;
@@ -3252,7 +3256,9 @@ pub fn send_key_to_active(app: &mut AppState, k: &str) -> io::Result<()> {
     }
     
     // Write a named key to a single pane (extracted for sync_input support).
-    fn write_named_key_to_pane(p: &mut crate::types::Pane, k: &str) {
+    // force_signal: when true, bypass the raw-mode TUI heuristic for C-c and
+    // always deliver CTRL_C_EVENT.  Pass true for `send-keys -f C-c` bindings.
+    fn write_named_key_to_pane(p: &mut crate::types::Pane, k: &str, force_signal: bool) {
         use std::io::Write as _;
         match k {
             "enter" => { let _ = write!(p.writer, "\r"); }
@@ -3312,10 +3318,15 @@ pub fn send_key_to_active(app: &mut AppState, k: &str) -> io::Result<()> {
                 let _ = p.writer.flush();
                 // Ctrl+C is the sole exception: a CTRL_C_EVENT must be raised so
                 // the child's console handler runs (SIGINT parity, issue #338).
+                // force_signal comes from `send-keys -f` in psmux.conf: when true,
+                // bypass the raw-mode TUI heuristic and always deliver the signal,
+                // allowing a dedicated keybinding (e.g. `bind -n C-F12 send-keys -f C-c`)
+                // to terminate any foreground app (including opencode, neovim).
+                // Without -f, direct keyboard Ctrl+C lets TUIs handle 0x03 themselves.
                 #[cfg(windows)]
                 if c.eq_ignore_ascii_case(&'c') {
                     if let Some(pid) = p.child_pid {
-                        crate::platform::mouse_inject::send_ctrl_c_event(pid, false);
+                        crate::platform::mouse_inject::send_ctrl_c_event(pid, false, force_signal);
                     }
                 }
             }
@@ -3398,19 +3409,19 @@ pub fn send_key_to_active(app: &mut AppState, k: &str) -> io::Result<()> {
     // Distribute the key to all panes (sync) or just the active pane.
     if app.sync_input {
         let win = &mut app.windows[app.active_idx];
-        fn send_key_all_panes(node: &mut crate::types::Node, k: &str) {
+        fn send_key_all_panes(node: &mut crate::types::Node, k: &str, force_signal: bool) {
             match node {
-                crate::types::Node::Leaf(p) => write_named_key_to_pane(p, k),
+                crate::types::Node::Leaf(p) => write_named_key_to_pane(p, k, force_signal),
                 crate::types::Node::Split { children, .. } => {
-                    for c in children { send_key_all_panes(c, k); }
+                    for c in children { send_key_all_panes(c, k, force_signal); }
                 }
             }
         }
-        send_key_all_panes(&mut win.root, k);
+        send_key_all_panes(&mut win.root, k, force_signal);
     } else {
         let win = &mut app.windows[app.active_idx];
         if let Some(p) = active_pane_mut(&mut win.root, &win.active_path) {
-            write_named_key_to_pane(p, k);
+            write_named_key_to_pane(p, k, force_signal);
         }
     }
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -1405,14 +1405,16 @@ fn run_main() -> io::Result<()> {
             "send-keys" | "send" | "send-key" => {
                 let mut literal = false;
                 let mut has_x = false;
+                let mut force_signal = false;
                 let mut keys: Vec<String> = Vec::new();
-                // Getopt-style parsing: -t consumes next arg, -l/-R/-X are flags
+                // Getopt-style parsing: -t/-N consume next arg; -l/-R/-X/-f are flags.
                 let mut i = 1;
                 while i < cmd_args.len() {
                     match cmd_args[i].as_str() {
                         "-l" => { literal = true; }
                         "-R" => { keys.push("__RESET__".to_string()); }
                         "-X" => { has_x = true; }
+                        "-f" | "--force-signal" => { force_signal = true; }
                         "-t" => { i += 1; } // consume target value (already handled globally)
                         "-N" => { i += 1; } // repeat count, consume value
                         _ => { keys.push(cmd_args[i].to_string()); }
@@ -1422,6 +1424,7 @@ fn run_main() -> io::Result<()> {
                 let mut cmd = "send-keys".to_string();
                 if literal { cmd.push_str(" -l"); }
                 if has_x { cmd.push_str(" -X"); }
+                if force_signal { cmd.push_str(" -f"); }
                 // Quote arguments that contain spaces to preserve them
                 for k in keys { 
                     if k.contains(' ') || k.contains('\t') || k.contains('"') {

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -1050,7 +1050,16 @@ pub mod mouse_inject {
     /// (Call sites write the raw 0x03 either just before or just after invoking
     /// this function; the skip behavior is correct regardless of that ordering.)
     /// See `process_info::foreground_is_shell`.
-    pub fn send_ctrl_c_event(child_pid: u32, reattach: bool) -> bool {
+    /// `force`: when `true` (e.g. an explicit `send-keys -f C-c` command from a
+    /// keybinding like `bind -n C-F12 send-keys -f C-c`), the TUI-protection
+    /// heuristic is bypassed and `CTRL_C_EVENT` is always delivered.  This
+    /// lets users assign a dedicated "kill foreground app" key that works even
+    /// when the pane is running a raw-mode TUI such as opencode or neovim.
+    ///
+    /// When `force` is `false` (keyboard pass-through path), the heuristic
+    /// runs normally: raw-mode TUI apps receive raw 0x03 and decide for
+    /// themselves whether to treat it as copy or interrupt.
+    pub fn send_ctrl_c_event(child_pid: u32, reattach: bool, force: bool) -> bool {
         const CTRL_C_EVENT: u32 = 0;
         const ENABLE_PROCESSED_INPUT: u32 = 0x0001;
 
@@ -1082,7 +1091,11 @@ pub mod mouse_inject {
         // established interrupt behavior (#338 line-cancel, #346 ping).  This
         // process-tree walk does not touch our console, so it is done before
         // the FreeConsole/AttachConsole dance below.
-        let fg_is_shell = crate::platform::process_info::foreground_is_shell(child_pid)
+        //
+        // When `force=true` the caller is an explicit user command (e.g. a
+        // keybinding that runs `send-keys -f C-c` to kill the foreground app);
+        // skip the heuristic and always deliver the signal.
+        let fg_is_shell = force || crate::platform::process_info::foreground_is_shell(child_pid)
             .unwrap_or(true);
 
         unsafe {
@@ -1471,7 +1484,7 @@ pub mod mouse_inject {
     pub fn send_mouse_event(_pid: u32, _col: i16, _row: i16, _btn: u32, _flags: u32, _reattach: bool) -> bool { false }
     pub fn send_vt_sequence(_pid: u32, _sequence: &[u8]) -> bool { false }
     pub fn query_vti_enabled(_pid: u32) -> Option<bool> { None }
-    pub fn send_ctrl_c_event(_pid: u32, _reattach: bool) -> bool { false }
+    pub fn send_ctrl_c_event(_pid: u32, _reattach: bool, _force: bool) -> bool { false }
     pub fn query_mouse_input_enabled(_pid: u32) -> Option<bool> { None }
     pub fn send_bracketed_paste(_pid: u32, _text: &str, _bracket: bool) -> bool { false }
     pub fn send_modified_key_event(_pid: u32, _ch: char, _ctrl: bool, _alt: bool, _shift: bool) -> bool { false }

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -1189,6 +1189,10 @@ match cmd {
         let literal = flag_has('l');
         let paste_mode = flag_has('p');
         let has_x = flag_has('X');
+        // -f / --force-signal: bypass raw-mode TUI heuristic and always deliver
+        // CTRL_C_EVENT when C-c is sent.  Intended for explicit kill bindings
+        // like `bind -n C-F12 send-keys -f C-c` in psmux.conf.
+        let force_signal = flag_has('f') || args.iter().any(|a| *a == "--force-signal");
         // Parse -N <count> for repeat (look for any cluster ending in 'N')
         let mut repeat_count: usize = 1;
         if let Some(n_pos) = args.iter().position(|a| a.starts_with('-') && !a.starts_with("--") && a.ends_with('N')) {
@@ -1241,9 +1245,9 @@ match cmd {
                     let _ = tx.send(CtrlReq::SendPaste(keys.join("")));
                 } else if effective_literal {
                     // Literal: concatenate without space separator.
-                    let _ = tx.send(CtrlReq::SendKeys(keys.join(""), true));
+                    let _ = tx.send(CtrlReq::SendKeys(keys.join(""), true, force_signal));
                 } else {
-                    let _ = tx.send(CtrlReq::SendKeys(keys.join(" "), false));
+                    let _ = tx.send(CtrlReq::SendKeys(keys.join(" "), false, force_signal));
                 }
             }
         }
@@ -3081,6 +3085,7 @@ fn dispatch_control_command(
                 false
             };
             let literal = flag_has('l');
+            let force_signal = flag_has('f') || args.iter().any(|a| *a == "--force-signal");
             // Convert real-tmux 0xNN hex codepoint syntax (used by iTerm2 for
             // every keystroke: `send -t %1 0xd` etc.) into literal characters.
             let keys: Vec<String> = args.iter().enumerate().filter(|(i, a)| {
@@ -3107,7 +3112,7 @@ fn dispatch_control_command(
             });
             let effective_literal = literal || any_hex;
             let text = if effective_literal { keys.join("") } else { keys.join(" ") };
-            let _ = tx.send(CtrlReq::SendKeys(text, effective_literal));
+            let _ = tx.send(CtrlReq::SendKeys(text, effective_literal, force_signal));
             let _ = resp_tx.send(String::new());
             true
         }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1730,7 +1730,7 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                     let _ = resp.send(combined_buf.clone());
                 }
                 CtrlReq::SendText(s) => { app.status_message = None; send_text_to_active(&mut app, &s)?; echo_pending_until = Some(Instant::now()); }
-                CtrlReq::SendKey(k) => { app.status_message = None; send_key_to_active(&mut app, &k)?; echo_pending_until = Some(Instant::now()); }
+                CtrlReq::SendKey(k) => { app.status_message = None; send_key_to_active(&mut app, &k, false)?; echo_pending_until = Some(Instant::now()); }
                 CtrlReq::SendPaste(s) => { send_paste_to_active(&mut app, &s)?; echo_pending_until = Some(Instant::now()); }
                 CtrlReq::ZoomPane => { toggle_zoom(&mut app); state_dirty = true; meta_dirty = true; hook_event = Some("after-resize-pane"); }
                 CtrlReq::PrefixBegin => { app.client_prefix_active = true; state_dirty = true; }
@@ -1851,7 +1851,7 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                         p.pane_style = Some(style);
                     }
                 }
-                CtrlReq::SendKeys(keys, literal) => {
+                CtrlReq::SendKeys(keys, literal, force_signal) => {
                     let in_copy = matches!(app.mode, Mode::CopyMode | Mode::CopySearch { .. });
                     if in_copy {
                         // In copy/search mode — route through mode-aware handlers
@@ -1881,9 +1881,9 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                                     _ => "",
                                 };
                                 if !normalized.is_empty() {
-                                    send_key_to_active(&mut app, normalized)?;
+                                    send_key_to_active(&mut app, normalized, false)?;
                                 } else if key_upper.starts_with("C-") || key_upper.starts_with("M-") || (key_upper.starts_with("F") && key_upper.len() >= 2 && key_upper[1..].chars().all(|c| c.is_ascii_digit())) {
-                                    send_key_to_active(&mut app, &key.to_lowercase())?;
+                                    send_key_to_active(&mut app, &key.to_lowercase(), false)?;
                                 } else {
                                     // Plain text char — route through send_text_to_active (handles copy mode chars)
                                     send_text_to_active(&mut app, key)?;
@@ -1981,6 +1981,8 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                                         // is disabled (e.g. after a TUI app).  Fire the real
                                         // signal via the platform helper so detached/headless
                                         // send-keys C-c reliably interrupts processes.
+                                        // force_signal=true (from `send-keys -f C-c`) bypasses
+                                        // the raw-mode TUI heuristic and always delivers the signal.
                                         #[cfg(windows)]
                                         if ctrl == 0x03 {
                                             if let Some(win) = app.windows.get_mut(app.active_idx) {
@@ -1989,7 +1991,7 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                                                         p.child_pid = crate::platform::mouse_inject::get_child_pid(&*p.child);
                                                     }
                                                     if let Some(pid) = p.child_pid {
-                                                        crate::platform::mouse_inject::send_ctrl_c_event(pid, false);
+                                                        crate::platform::mouse_inject::send_ctrl_c_event(pid, false, force_signal);
                                                     }
                                                 }
                                             }

--- a/src/types.rs
+++ b/src/types.rs
@@ -1006,7 +1006,7 @@ pub enum CtrlReq {
     ToggleSync,
     SetPaneTitle(String),
     SetPaneStyle(String),
-    SendKeys(String, bool),
+    SendKeys(String, bool, bool),  // (keys, literal, force_signal)
     SendKeysX(String),  // send-keys -X copy-mode-command
     SelectPane(String, bool),
     SelectWindow(usize),

--- a/tests-rs/test_flag_parity.rs
+++ b/tests-rs/test_flag_parity.rs
@@ -1201,6 +1201,20 @@ fn send_keys_flag_l_literal() {
 }
 
 #[test]
+fn send_keys_flag_f_force_signal_short() {
+    let mut app = mock_app_with_window();
+    execute_command_string(&mut app, "send-keys -f C-c").unwrap();
+    // psmux extension: -f is accepted and only affects Ctrl+C signal delivery.
+}
+
+#[test]
+fn send_keys_flag_force_signal_long() {
+    let mut app = mock_app_with_window();
+    execute_command_string(&mut app, "send-keys --force-signal C-c").unwrap();
+    // Long-form alias should parse the same way as -f.
+}
+
+#[test]
 fn send_keys_flag_t_target() {
     let mut app = mock_app_with_window();
     execute_command_string(&mut app, "send-keys -t 0 Enter").unwrap();


### PR DESCRIPTION
# Add opt-in force-signal mode for send-keys Ctrl+C
## Summary
This PR adds an opt-in force-signal mode for `send-keys`:
~~~tmux
bind -n C-F12 send-keys -f C-c
~~~
On Windows, `send-keys -f C-c` bypasses the raw-mode TUI heuristic and sends a `CTRL_C_EVENT` to the foreground process.
Users can configure this in `psmux.conf` with any key binding they prefer. `C-F12` is only an example.
## Motivation
Recent Ctrl+C handling preserves normal keyboard Ctrl+C behavior for raw-mode TUIs such as opencode or neovim. This is useful because those applications may want to handle raw `0x03` themselves.
However, there are still cases where users need a separate, explicit “force interrupt” binding. For example, a raw-mode TUI may consume Ctrl+C, or handle it in a way that does not reliably terminate the foreground process.
This PR provides a user-configurable escape hatch without changing the default keyboard Ctrl+C behavior.
## Behavior
- Normal keyboard Ctrl+C remains unchanged.
  - Raw-mode TUIs can continue handling Ctrl+C themselves.
- `send-keys C-c` without `-f` keeps the existing heuristic behavior.
- `send-keys -f C-c` explicitly forces a Windows `CTRL_C_EVENT`.
- `--force-signal` is also accepted as a long-form alias.
- Users can bind this command to any shortcut in `psmux.conf`.
## Example
~~~tmux
# Dedicated force interrupt binding for raw-mode TUIs.
# C-F12 is only an example; users can choose any preferred key.
bind -n C-F12 send-keys -f C-c
~~~
This is useful for applications like opencode, where plain Ctrl+C may be consumed by the application or may trigger undesirable exit behavior. With this explicit binding, users can reliably interrupt or terminate the foreground process while preserving normal Ctrl+C pass-through behavior.
## Changes
- Adds force-signal plumbing for `send-keys -f/--force-signal C-c`.
- Preserves the force-signal flag through CLI forwarding.
- Documents the new psmux extension.
- Adds regression coverage for both `-f` and `--force-signal`.
## Validation
Tested locally on Windows:
~~~powershell
cargo build
cargo test send_keys_flag_force_signal -- --nocapture
cargo test send_keys_flag_f_force_signal_short -- --nocapture
~~~