### PR TITLE
fix(new-session): wait for readiness, don't orphan slow servers

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1182,14 +1182,14 @@ fn run_main() -> io::Result<()> {
                                 break;
                             }
                             // Detached: also require the initial window to exist.
-                            // A non-empty reply means >0 windows: this is the
-                            // default (tmux-text) list-windows, which is "" for
-                            // zero windows — NOT the `-J` JSON form, whose empty
-                            // value would be "[]" (non-empty). It also can't be an
-                            // error string (list_windows_tmux is infallible), and
-                            // only the main loop answers it, after create_window.
+                            // A non-empty, non-error reply means >0 windows: the
+                            // default (tmux-text) list-windows is "" for zero
+                            // windows (not the `-J` JSON form, whose empty value
+                            // "[]" is non-empty), and only the main loop answers
+                            // it, after create_window. The non-error guard rejects
+                            // a racing auth failure — see detached_list_windows_ready.
                             if let Ok(resp) = send_control_with_response("list-windows\n".to_string()) {
-                                if !resp.trim().is_empty() { ready = true; break; }
+                                if detached_list_windows_ready(&resp) { ready = true; break; }
                             }
                         }
                     } else if port_seen {
@@ -4248,4 +4248,38 @@ fn is_ssh_session() -> bool {
     env::var("SSH_CLIENT").is_ok()
         || env::var("SSH_CONNECTION").is_ok()
         || env::var("SSH_TTY").is_ok()
+}
+
+/// Decide whether a detached-session readiness probe's `list-windows` reply
+/// means the initial window exists. A non-empty body is >0 windows (the
+/// tmux-text form is "" for zero windows) — EXCEPT a protocol-level error
+/// reply, which is also non-empty. The startup .key write can race the
+/// client's read, so the server may answer with an "ERROR: ..." auth failure;
+/// that must NOT be mistaken for a ready window list.
+fn detached_list_windows_ready(resp: &str) -> bool {
+    let t = resp.trim();
+    !t.is_empty() && !t.starts_with("ERROR")
+}
+
+#[cfg(test)]
+mod readiness_tests {
+    use super::detached_list_windows_ready;
+
+    #[test]
+    fn nonempty_window_list_is_ready() {
+        assert!(detached_list_windows_ready("0: bash* (1 panes) [80x24]\n"));
+    }
+
+    #[test]
+    fn empty_reply_is_not_ready() {
+        assert!(!detached_list_windows_ready(""));
+        assert!(!detached_list_windows_ready("   \n"));
+    }
+
+    #[test]
+    fn auth_error_reply_is_not_ready() {
+        // The key read can race the server's .key write; an auth failure is
+        // a non-empty reply but is NOT a ready window list.
+        assert!(!detached_list_windows_ready("ERROR: Invalid session key\n"));
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1137,48 +1137,79 @@ fn run_main() -> io::Result<()> {
                 } // end if !claimed_warm (cold path)
                 } // end else (not PSMUX_REMOTE_ATTACH)
                 
-                // Wait for server to create port file (up to 5 seconds)
-                // Poll fast (10ms) — the server writes the port file early,
-                // before spawning ConPTY/pwsh, so it should appear quickly.
-                for _ in 0..500 {
+                // Wait for the server to become READY before returning.
+                //
+                // The server writes its .port file and binds/accepts BEFORE it
+                // creates the initial window and BEFORE its main request loop
+                // runs; under load any of those steps can take seconds. A tight
+                // single-shot check (the old 5s port poll + one 100ms connect)
+                // wrongly declared a slow-but-healthy server dead — and even
+                // deleted its .port file, orphaning a live session. So gate on
+                // ACTUAL readiness with a bounded retry loop:
+                //   - .port present + readable + a TCP connect succeeds, AND
+                //   - for detached sessions, list-windows is non-empty (the
+                //     initial window exists). list-windows is answered only by
+                //     the main loop, which runs only after create_window — so a
+                //     non-empty reply IS the "command finished server-side"
+                //     signal — the same request/reply the `new-window -P` path
+                //     already relies on — matching how tmux gates on command
+                //     completion rather than mere socket reachability.
+                // The client NEVER deletes the .port file: the server owns it and
+                // removes it itself on a genuine create_window failure. We detect
+                // that genuine failure as the .port file vanishing after we first
+                // saw it (the server cleaned up and exited).
+                env::set_var("PSMUX_TARGET_SESSION", &port_file_base);
+                let ready_deadline = std::time::Instant::now() + Duration::from_secs(15);
+                let mut port_seen = false;
+                let mut ready = false;
+                loop {
                     if std::path::Path::new(&port_path).exists() {
+                        port_seen = true;
+                        let connectable = std::fs::read_to_string(&port_path).ok()
+                            .and_then(|s| s.trim().parse::<u16>().ok())
+                            .map(|port| {
+                                let addr = format!("127.0.0.1:{}", port);
+                                std::net::TcpStream::connect_timeout(
+                                    &addr.parse().unwrap(),
+                                    Duration::from_millis(200),
+                                ).is_ok()
+                            })
+                            .unwrap_or(false);
+                        if connectable {
+                            if !detached {
+                                // Attached: connectivity is enough — we attach below.
+                                ready = true;
+                                break;
+                            }
+                            // Detached: also require the initial window to exist.
+                            // A non-empty reply means >0 windows: this is the
+                            // default (tmux-text) list-windows, which is "" for
+                            // zero windows — NOT the `-J` JSON form, whose empty
+                            // value would be "[]" (non-empty). It also can't be an
+                            // error string (list_windows_tmux is infallible), and
+                            // only the main loop answers it, after create_window.
+                            if let Ok(resp) = send_control_with_response("list-windows\n".to_string()) {
+                                if !resp.trim().is_empty() { ready = true; break; }
+                            }
+                        }
+                    } else if port_seen {
+                        // .port vanished after appearing → the server hit a
+                        // genuine startup failure (e.g. a bad shell command),
+                        // cleaned up and exited. Stop fast and report it.
                         break;
                     }
-                    std::thread::sleep(Duration::from_millis(10));
+                    if std::time::Instant::now() >= ready_deadline { break; }
+                    std::thread::sleep(Duration::from_millis(20));
                 }
-
-                // Verify the server is actually alive — the TCP listener is
-                // already active when the port file appears (we moved file write
-                // before create_window), so this connect should succeed instantly.
-                if !std::path::Path::new(&port_path).exists() {
+                if !ready {
                     eprintln!("psmux: failed to create session '{}'", name);
                     std::process::exit(1);
                 }
-                {
-                    let server_alive = if let Ok(port_str) = std::fs::read_to_string(&port_path) {
-                        if let Ok(port) = port_str.trim().parse::<u16>() {
-                            let addr = format!("127.0.0.1:{}", port);
-                            std::net::TcpStream::connect_timeout(
-                                &addr.parse().unwrap(),
-                                Duration::from_millis(100)
-                            ).is_ok()
-                        } else { false }
-                    } else { false };
-                    if !server_alive {
-                        let _ = std::fs::remove_file(&port_path);
-                        eprintln!("psmux: session '{}' exited immediately (check shell command)", name);
-                        std::process::exit(1);
-                    }
-                }
-                
+
                 if detached {
-                    // If -P flag, print pane info before returning
+                    // The readiness wait above already confirmed the initial
+                    // window exists. If -P, print the pane info before returning.
                     if print_info {
-                        // Set target session so send_control_with_response connects to the right server
-                        env::set_var("PSMUX_TARGET_SESSION", &port_file_base);
-                        // Give server a moment to initialize
-                        std::thread::sleep(Duration::from_millis(200));
-                        // Query the server for pane info using display-message
                         let fmt = if let Some(ref f) = format_str {
                             f.clone()
                         } else {

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -581,14 +581,16 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
 
     app.session_key = session_key.clone();
 
-    ensure_session_registry_files(&home, &app);
-
     // TEST-ONLY latency injection — compiled out of release builds entirely
     // (gated on debug_assertions); inert in debug unless the env var is set.
     // Delays the .port file write while the server is otherwise healthy, to
     // deterministically reproduce a SLOW server startup under load. The client's
     // startup gate must wait for the (eventually-reachable) server rather than
     // give up and orphan it. See test_new_session_no_orphan.ps1.
+    //
+    // Must run BEFORE ensure_session_registry_files, which writes .port: the
+    // injected delay has to precede the real .port write for the test to
+    // exercise the slow-.port-write path it targets.
     #[cfg(debug_assertions)]
     {
         if let Ok(ms) = env::var("PSMUX_TEST_PORTFILE_DELAY_MS") {
@@ -597,6 +599,8 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
             }
         }
     }
+
+    ensure_session_registry_files(&home, &app);
 
     let regpath = format!("{}\\{}.port", dir, app.port_file_base());
     let keypath = format!("{}\\{}.key", dir, app.port_file_base());

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -582,6 +582,22 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
     app.session_key = session_key.clone();
 
     ensure_session_registry_files(&home, &app);
+
+    // TEST-ONLY latency injection — compiled out of release builds entirely
+    // (gated on debug_assertions); inert in debug unless the env var is set.
+    // Delays the .port file write while the server is otherwise healthy, to
+    // deterministically reproduce a SLOW server startup under load. The client's
+    // startup gate must wait for the (eventually-reachable) server rather than
+    // give up and orphan it. See test_new_session_no_orphan.ps1.
+    #[cfg(debug_assertions)]
+    {
+        if let Ok(ms) = env::var("PSMUX_TEST_PORTFILE_DELAY_MS") {
+            if let Ok(ms) = ms.parse::<u64>() {
+                thread::sleep(Duration::from_millis(ms));
+            }
+        }
+    }
+
     let regpath = format!("{}\\{}.port", dir, app.port_file_base());
     let keypath = format!("{}\\{}.key", dir, app.port_file_base());
 
@@ -724,6 +740,23 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
     // Update shared aliases now that config has been loaded
     if let Ok(mut w) = shared_aliases_main.write() {
         *w = app.command_aliases.clone();
+    }
+
+    // TEST-ONLY latency injection — compiled out of release builds entirely
+    // (gated on debug_assertions); inert in debug unless the env var is set.
+    // Widens the new-session readiness race deterministically: the .port file and
+    // accept thread are already up (the client's connect check passes), but the
+    // initial window does not yet exist. Lets test_new_session_readiness.ps1
+    // catch the session in its window-less state (server accepting connections,
+    // initial window not yet created), so the readiness gate is tested for the
+    // right reason.
+    #[cfg(debug_assertions)]
+    {
+        if let Ok(ms) = env::var("PSMUX_TEST_WINDOW_DELAY_MS") {
+            if let Ok(ms) = ms.parse::<u64>() {
+                thread::sleep(Duration::from_millis(ms));
+            }
+        }
     }
 
     // Create initial window — if a warm pane was pre-spawned above,

--- a/tests/test_new_session_no_orphan.ps1
+++ b/tests/test_new_session_no_orphan.ps1
@@ -1,0 +1,127 @@
+# Regression test: `new-session -d` must WAIT for a slow-but-healthy server
+# instead of giving up (and orphaning it) on a tight fixed timeout.
+#
+# ROOT CAUSE: under load a healthy server can simply be slow to come up — slow
+# to write its .port file, or slow to accept the first TCP connection. That
+# slowness is normal, not a failure.
+#
+# THE BUG (pre-fix): the client's startup gate allowed only a tight, fixed budget
+# — a 5s .port poll, then a single 100ms connect attempt — and mistook anything
+# slower for death. It gave up with rc=1 ("failed to create session" / "exited
+# immediately") on a server that was alive and about to be ready — and in the
+# connect-miss branch it even deleted the .port file, orphaning the live server.
+# Observed in 38 of 6000 sessions under load, every one leaving a live server
+# behind. (Post-fix replaces both limits with one 15s bounded readiness wait.)
+#
+# DETERMINISTIC RED via latency injection: PSMUX_TEST_PORTFILE_DELAY_MS makes the
+# server sleep before writing .port while otherwise healthy. Set LONGER than the
+# old 5s port poll, so:
+#   - pre-fix : the client's 5s poll expires -> rc=1, even though the server is
+#               alive and writes .port shortly after (orphan).
+#   - post-fix: the client's bounded readiness wait keeps waiting, the server
+#               comes up, and new-session returns rc=0 with a listable window.
+# Removal recipe: when PSMUX_TEST_PORTFILE_DELAY_MS is deleted from server/mod.rs,
+# delete this test.
+
+$ErrorActionPreference = "Stop"
+# Prefer the local build under test (debug carries the latency-injection hooks);
+# do NOT fall back to a psmux on PATH, which is typically an installed release
+# binary where the injection is a no-op and the test would pass for free.
+$PSMUX = $env:PSMUX_EXE
+if (-not $PSMUX -or -not (Test-Path $PSMUX)) { $PSMUX = "$PSScriptRoot\..\target\debug\psmux.exe" }
+if (-not (Test-Path $PSMUX)) { $PSMUX = "$PSScriptRoot\..\target\release\psmux.exe" }
+if (-not (Test-Path $PSMUX)) {
+    Write-Host "FATAL: could not resolve psmux executable ($PSMUX)" -ForegroundColor Red
+    exit 1
+}
+
+# Isolate into a throwaway home so we never touch the real ~/.psmux and any
+# orphan is contained. The spawned server inherits this via the env (CreateProcessW).
+$tmpHome = Join-Path $env:TEMP ("psmux_noorphan_" + [guid]::NewGuid().ToString("N").Substring(0,8))
+New-Item -ItemType Directory -Path $tmpHome -Force | Out-Null
+$ns = "noorphan_" + [guid]::NewGuid().ToString("N").Substring(0,8)
+$session = "d"
+$sdir = Join-Path $tmpHome "SDIR"
+New-Item -ItemType Directory -Path $sdir -Force | Out-Null
+
+$pass = 0
+$fail = 0
+function Write-Result($name, $ok, $msg) {
+    if ($ok) { Write-Host "  [PASS] $name" -ForegroundColor Green; $script:pass++ }
+    else     { Write-Host "  [FAIL] $name : $msg" -ForegroundColor Red; $script:fail++ }
+}
+
+function Get-ListWindows($homeRoot, $portBase) {
+    # With `-L <ns>` psmux prefixes the discovery files as <ns>__<session>.port
+    $portFile = "$homeRoot\.psmux\$portBase.port"
+    $keyFile  = "$homeRoot\.psmux\$portBase.key"
+    if (-not (Test-Path $portFile)) { return $null }
+    $port = (Get-Content $portFile -Raw).Trim()
+    $key  = if (Test-Path $keyFile) { (Get-Content $keyFile -Raw).Trim() } else { "" }
+    try {
+        $tcp = [System.Net.Sockets.TcpClient]::new()
+        $tcp.Connect("127.0.0.1", [int]$port)
+        $stream = $tcp.GetStream(); $stream.ReadTimeout = 2000
+        $w = [System.IO.StreamWriter]::new($stream); $w.AutoFlush = $true
+        $r = [System.IO.StreamReader]::new($stream)
+        $w.WriteLine("AUTH $key"); $r.ReadLine() | Out-Null
+        $w.WriteLine("list-windows")
+        $sb = [System.Text.StringBuilder]::new()
+        try { while ($null -ne ($l = $r.ReadLine())) { [void]$sb.AppendLine($l) } } catch {}
+        $tcp.Close()
+        return $sb.ToString().Trim()
+    } catch { return $null }
+}
+
+Write-Host ""
+Write-Host "=== new-session waits for a slow server (no early give-up / orphan) ===" -ForegroundColor Cyan
+Write-Host "  psmux: $PSMUX" -ForegroundColor DarkGray
+Write-Host "  home : $tmpHome   ns: $ns" -ForegroundColor DarkGray
+
+# Make the server slow to write its .port file (7s > the old 5s client poll).
+$env:USERPROFILE = $tmpHome
+$env:HOME = $tmpHome
+$env:PSMUX_TEST_PORTFILE_DELAY_MS = "7000"
+$env:PSMUX_NO_WARM = "1"
+$env:PSMUX_CONFIG_FILE = "NUL"
+
+try {
+    $sw = [System.Diagnostics.Stopwatch]::StartNew()
+    & $PSMUX -L $ns new-session -d -s $session -c $sdir 2>&1 | Out-Null
+    $code = $LASTEXITCODE
+    $sw.Stop()
+    $elapsed = $sw.ElapsedMilliseconds
+    Write-Host "  (new-session returned after ${elapsed}ms, rc=$code)" -ForegroundColor DarkGray
+
+    # Guard against a falsely-green pass: the orphan race is only exercised if the
+    # injected 7000ms .port delay actually fired. PSMUX_TEST_PORTFILE_DELAY_MS
+    # exists only in debug_assertions builds, so against a release/installed binary
+    # it is a no-op and new-session returns fast. thread::sleep is a floor and the
+    # sleep starts after the stopwatch, so elapsed >= 7000ms when injection fired.
+    Write-Result "latency injection active (new-session waited out the injected delay)" `
+        ($elapsed -ge 7000) "elapsed=${elapsed}ms < injected 7000ms - latency injection not compiled in; use a debug build"
+
+    Write-Result "new-session -d waited for the slow server (rc=0)" ($code -eq 0) `
+        "rc=$code — client gave up on a slow-but-healthy server"
+
+    $windows = Get-ListWindows $tmpHome "${ns}__${session}"
+    $hasWindow = ($null -ne $windows -and $windows.Length -gt 0)
+    Write-Result "initial window listable after new-session returns" $hasWindow `
+        "list-windows empty/null (got: '$windows')"
+}
+finally {
+    Remove-Item Env:\PSMUX_TEST_PORTFILE_DELAY_MS -EA SilentlyContinue
+    Remove-Item Env:\PSMUX_NO_WARM -EA SilentlyContinue
+    Remove-Item Env:\PSMUX_CONFIG_FILE -EA SilentlyContinue
+    & $PSMUX -L $ns kill-server 2>&1 | Out-Null
+    Start-Sleep -Milliseconds 300
+    # Backstop: kill any server still bound to this ns home, then remove temp home.
+    Get-CimInstance Win32_Process -Filter "Name='psmux.exe'" -EA SilentlyContinue |
+        Where-Object { $_.CommandLine -match [regex]::Escape($ns) } |
+        ForEach-Object { Stop-Process -Id $_.ProcessId -Force -EA SilentlyContinue }
+    Remove-Item $tmpHome -Recurse -Force -EA SilentlyContinue
+}
+
+Write-Host ""
+Write-Host "=== Results: $pass passed, $fail failed ===" -ForegroundColor Cyan
+if ($fail -gt 0) { exit 1 } else { exit 0 }

--- a/tests/test_new_session_readiness.ps1
+++ b/tests/test_new_session_readiness.ps1
@@ -1,0 +1,124 @@
+# Regression test: `new-session -d` must not return until its initial window
+# is listable (tmux's "command finished server-side" semantics).
+#
+# ROOT CAUSE: psmux's server writes its .port file and starts
+# accepting connections BEFORE it creates the initial window. The client's
+# readiness gate for `new-session -d` waited only for the port file + a TCP
+# connect, so it could return exit 0 while `list-windows` was still empty —
+# a window-less session that callers and scripts then trip over.
+#
+# DETERMINISTIC RED via latency injection: the server sleeps
+# PSMUX_TEST_WINDOW_DELAY_MS right before create_window (after .port + accept
+# thread are up). We set it LONGER than the client read timeout (2000ms), so:
+#   - pre-fix : new-session returns immediately; an immediate list-windows
+#               blocks on the not-yet-running main loop and times out EMPTY.
+#   - post-fix: the client gate polls until the window is listable, so by the
+#               time new-session returns, list-windows is non-empty.
+# Removal recipe: when the PSMUX_TEST_WINDOW_DELAY_MS hook is deleted from
+# server/mod.rs, delete this test (or drop it to a best-effort statistical loop).
+
+$ErrorActionPreference = "Stop"
+# Prefer the local build under test (debug carries the latency-injection hooks);
+# do NOT fall back to a psmux on PATH, which is typically an installed release
+# binary where the injection is a no-op and the test would pass for free.
+$PSMUX = $env:PSMUX_EXE
+if (-not $PSMUX -or -not (Test-Path $PSMUX)) { $PSMUX = "$PSScriptRoot\..\target\debug\psmux.exe" }
+if (-not (Test-Path $PSMUX)) { $PSMUX = "$PSScriptRoot\..\target\release\psmux.exe" }
+if (-not (Test-Path $PSMUX)) {
+    Write-Host "FATAL: could not resolve psmux executable ($PSMUX)" -ForegroundColor Red
+    exit 1
+}
+
+$psmuxDir = "$env:USERPROFILE\.psmux"
+$session  = "rdy_$($PID)_$(Get-Random -Maximum 99999)"
+$pass = 0
+$fail = 0
+
+function Write-Result($name, $ok, $msg) {
+    if ($ok) { Write-Host "  [PASS] $name" -ForegroundColor Green; $script:pass++ }
+    else     { Write-Host "  [FAIL] $name : $msg" -ForegroundColor Red; $script:fail++ }
+}
+
+# Query a session's own server directly over TCP (independent of CLI target
+# resolution). ReadTimeout mirrors the real client's 2000ms RPC timeout.
+function Get-ListWindows($sess) {
+    $portFile = "$psmuxDir\$sess.port"
+    $keyFile  = "$psmuxDir\$sess.key"
+    if (-not (Test-Path $portFile)) { return $null }
+    $port = (Get-Content $portFile -Raw).Trim()
+    $key  = if (Test-Path $keyFile) { (Get-Content $keyFile -Raw).Trim() } else { "" }
+    try {
+        $tcp = [System.Net.Sockets.TcpClient]::new()
+        $tcp.Connect("127.0.0.1", [int]$port)
+        $tcp.NoDelay = $true
+        $stream = $tcp.GetStream()
+        $stream.ReadTimeout = 2000
+        $writer = [System.IO.StreamWriter]::new($stream); $writer.AutoFlush = $true
+        $reader = [System.IO.StreamReader]::new($stream)
+        $writer.WriteLine("AUTH $key")
+        $authResp = $reader.ReadLine()   # "OK"
+        $writer.WriteLine("list-windows")
+        $sb = [System.Text.StringBuilder]::new()
+        try { while ($null -ne ($l = $reader.ReadLine())) { [void]$sb.AppendLine($l) } } catch {}
+        $tcp.Close()
+        return $sb.ToString().Trim()
+    } catch {
+        return $null
+    }
+}
+
+function Cleanup {
+    & $PSMUX kill-session -t $session 2>&1 | Out-Null
+    Start-Sleep -Milliseconds 300
+    Remove-Item "$psmuxDir\$session.*" -Force -EA SilentlyContinue
+}
+
+Write-Host ""
+Write-Host "=== new-session readiness gate (window listable before return) ===" -ForegroundColor Cyan
+Write-Host "  psmux: $PSMUX" -ForegroundColor DarkGray
+Write-Host "  session: $session" -ForegroundColor DarkGray
+
+Cleanup
+
+# Force the readiness race wide open: server sleeps 3000ms before creating the
+# window; the client read timeout is 2000ms, so an un-gated client loses.
+$env:PSMUX_TEST_WINDOW_DELAY_MS = "3000"
+$env:PSMUX_NO_WARM = "1"
+
+try {
+    $sw = [System.Diagnostics.Stopwatch]::StartNew()
+    & $PSMUX new-session -d -s $session 2>&1 | Out-Null
+    $code = $LASTEXITCODE
+    $sw.Stop()
+    $elapsed = $sw.ElapsedMilliseconds
+
+    Write-Result "new-session -d exited 0" ($code -eq 0) "exit=$code"
+    Write-Host "  (new-session returned after ${elapsed}ms)" -ForegroundColor DarkGray
+
+    # Guard against a falsely-green pass: the readiness gate is only exercised if
+    # the injected 3000ms delay actually fired. PSMUX_TEST_WINDOW_DELAY_MS exists
+    # only in debug_assertions builds, so against a release/installed binary it is
+    # a no-op, new-session returns fast, and the window is listable anyway. The
+    # fixed client must have waited the delay out. thread::sleep is a floor (never
+    # short) and the sleep starts after the stopwatch, so elapsed is always >=
+    # 3000ms when injection fired (and ~tens of ms when it didn't).
+    Write-Result "latency injection active (new-session waited out the injected delay)" `
+        ($elapsed -ge 3000) "elapsed=${elapsed}ms < injected 3000ms - latency injection not compiled in; use a debug build"
+
+    # THE assertion: the moment new-session returns, the initial window must be
+    # listable. Pre-fix this is empty (client returned too early); post-fix it
+    # is non-empty (client gated on window existence).
+    $windows = Get-ListWindows $session
+    $hasWindow = ($null -ne $windows -and $windows.Length -gt 0)
+    Write-Result "initial window listable immediately after new-session returns" `
+        $hasWindow "list-windows returned empty/null right after new-session (got: '$windows')"
+}
+finally {
+    Remove-Item Env:\PSMUX_TEST_WINDOW_DELAY_MS -EA SilentlyContinue
+    Remove-Item Env:\PSMUX_NO_WARM -EA SilentlyContinue
+    Cleanup
+}
+
+Write-Host ""
+Write-Host "=== Results: $pass passed, $fail failed ===" -ForegroundColor Cyan
+if ($fail -gt 0) { exit 1 } else { exit 0 }


### PR DESCRIPTION
`new-session -d` returned exit 0 on mere socket reachability, not on the command having finished server-side. Two client-side defects followed, both surfacing under concurrent load:

1. Readiness race (rc=0): the client returned before the initial window existed, so `list-windows` could be empty right after a successful new-session.
2. The dominant one (rc=1): the client gave up on a slow-but-healthy server. It did a 5s .port poll then a single 100ms connect, and on a connect miss also deleted the .port file -- orphaning a live session. A concurrent stress test showed several sessions failed this way, every one leaving a live server behind, when the server was merely slow to write .port / accept the first connection.

Fix: replace the brittle 'poll .port -> single connect -> delete' with one bounded readiness wait (15s) that gates on actual readiness -- _.port present + readable + a TCP connect succeeds, AND for detached sessions that `list-windows` returns a non-empty result (the window exists)_. 

`list-windows` is answered only by the server's main loop, which runs only after create_window, so a non-empty reply IS the 'command finished server-side' signal -- the same request/reply the new-window -P path already relies on, matching how tmux gates on command completion. The client never deletes the .port file (the server owns it and removes it on a genuine create_window failure); a genuine failure is detected as .port vanishing after first appearing -> fail fast.

Validated: deterministic RED->GREEN via tests/test_new_session_readiness.ps1 and tests/test_new_session_no_orphan.ps1, using `#[cfg(debug_assertions)]`-only latency-injection hooks in the server (compiled out of release builds); a concurrent stress test went from 38/6000 failures (every one orphaning a live server) to 0/6000.