### PR TITLE
new-window / split-window initial CWD parity

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1227,6 +1227,21 @@ fn run_main() -> io::Result<()> {
                         i += 1;
                     }
                 }
+                // cwd parity: a command-line new-window with no -c must open in
+                // the CALLER's cwd, not the server's (session) cwd. tmux picks a
+                // new window's cwd from three cases — an explicit -c, an attached
+                // client (session start dir), or a detached client (the caller's
+                // dir); the three cases are spelled out in tmux's own source. Each
+                // psmux CLI call is a one-shot detached client, so default -c to
+                // our current dir when the user gave none. Tradeoff: this defeats
+                // the warm-pane fast path for command-line new-window (the warm
+                // pane lives in the server's cwd) — interactive prefix-c, which
+                // never routes through here, keeps it.
+                if start_dir.is_none() {
+                    if let Ok(cwd) = std::env::current_dir() {
+                        start_dir = Some(cwd.to_string_lossy().into_owned());
+                    }
+                }
                 let cmd_arg = nw_positional.join(" ");
                 let cmd_arg = cmd_arg.as_str();
                 let mut cmd_line = "new-window".to_string();
@@ -1285,6 +1300,15 @@ fn run_main() -> io::Result<()> {
                             _ => { sw_positional.extend(cmd_args[i..].iter().map(|s| s.to_string())); break; }
                         }
                         i += 1;
+                    }
+                }
+                // cwd parity (same as new-window): a command-line split with no
+                // -c must open in the CALLER's cwd, not the server's (session)
+                // cwd. Each psmux CLI call is a one-shot detached client, so
+                // default -c to our current dir when none given.
+                if start_dir.is_none() {
+                    if let Ok(cwd) = std::env::current_dir() {
+                        start_dir = Some(cwd.to_string_lossy().into_owned());
                     }
                 }
                 let cmd_arg = sw_positional.join(" ");

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -728,7 +728,15 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
 
     // Create initial window — if a warm pane was pre-spawned above,
     // create_window's fast path transplants it instantly.
-    let saved_dir = if start_dir.is_some() { env::current_dir().ok() } else { None };
+    //
+    // Set the server's working directory to the session start directory (the
+    // -c dir if given, otherwise the launch dir) and DO NOT restore it
+    // afterwards. This server process hosts exactly one session, so its cwd is
+    // that session's start directory for the rest of its life. Every later
+    // new-window / split / warm-pane replenish without an explicit -c then
+    // inherits it — which is what makes an attached client's new-window/split
+    // open in the session start directory, while preserving the warm-pane fast
+    // path (warm panes are replenished in this same directory).
     if let Some(ref dir) = start_dir { env::set_current_dir(dir).ok(); }
     let create_result = if let Some(ref raw_args) = raw_command {
         create_window_raw(&*pty_system, &mut app, raw_args)
@@ -752,7 +760,6 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
         if let Some(mut wp) = app.warm_pane.take() { wp.child.kill().ok(); }
         return Err(e);
     }
-    if let Some(prev) = saved_dir { env::set_current_dir(prev).ok(); }
     // Resize panes now that the initial window exists and config is loaded.
     // pane-border-status needs 1 row per pane for the border label (#288).
     resize_all_panes(&mut app);

--- a/tests/test_new_window_attached_cwd.ps1
+++ b/tests/test_new_window_attached_cwd.ps1
@@ -1,0 +1,158 @@
+#!/usr/bin/env pwsh
+# Test: a new window created by an ATTACHED client opens in the session start
+# directory, NOT the directory the session was launched from.
+#
+# This is the cwd bug this PR fixes: the server used to restore its cwd to the
+# launch dir after creating the initial window (before replenishing the warm
+# pane), so a later new-window spawned in the launch dir instead of the session
+# start dir. tmux opens an attached client's new-window in the session start
+# dir (the attached one of its three cwd cases — the issuing client IS attached).
+#
+# We exercise the attached path headlessly via CONTROL MODE (`psmux -CC attach`):
+# a control client is attached to the session, so a new-window it issues is an
+# attached-client command. We pipe "new-window" on its stdin and let stdin EOF
+# make the control client process the command and exit. The control client is run
+# FROM the launch dir, so if the new window wrongly used the attached client's
+# cwd (the old bug) it would land there — the test requires the session dir.
+#
+# Runs with warm panes BOTH on and off: a warm pane is pre-spawned in the server
+# (session) cwd, so the attached new-window must land in the session dir either
+# way — the optimisation must not change where the window opens.
+#
+# Well-behaved on a shared server: unique session name, cleans up with
+# kill-session (never kill-server).
+
+$ErrorActionPreference = "Continue"
+$results = @()
+
+function Add-Result($name, $pass, $detail = "") {
+    $script:results += [PSCustomObject]@{
+        Test = $name; Result = if ($pass) { "PASS" } else { "FAIL" }; Detail = $detail
+    }
+}
+
+# Binary discovery: $env:PSMUX_EXE first (CI convention), then local build outputs.
+$PSMUX = $env:PSMUX_EXE
+if (-not $PSMUX -or -not (Test-Path $PSMUX)) { $PSMUX = Join-Path $PSScriptRoot "..\target\debug\psmux.exe" }
+if (-not (Test-Path $PSMUX)) { $PSMUX = Join-Path $PSScriptRoot "..\target\release\psmux.exe" }
+if (-not (Test-Path $PSMUX)) {
+    Write-Host "psmux binary not found; build the project first." -ForegroundColor Red
+    exit 1
+}
+
+# Launch every pane as `pwsh -NoProfile` so the pane shell never changes its own
+# cwd, making #{pane_current_path} the spawn dir (see test_new_window_detached_cwd.ps1).
+$cfgFile = Join-Path ([System.IO.Path]::GetTempPath()) ("psmux_attcwd_" + [guid]::NewGuid().ToString("N") + ".conf")
+Set-Content -LiteralPath $cfgFile -Value 'set -g default-command "pwsh -NoProfile"'
+$env:PSMUX_CONFIG_FILE = $cfgFile
+
+function Normalize-Path($p) {
+    if ([string]::IsNullOrWhiteSpace($p)) { return "" }
+    try { $p = (Get-Item -LiteralPath $p -ErrorAction Stop).FullName } catch { }
+    ($p -replace '/', '\').TrimEnd('\').ToLower()
+}
+function Get-PanePath($target) {
+    (& $PSMUX display-message -p -t $target '#{pane_current_path}' 2>&1 | Out-String).Trim()
+}
+function Wait-ForSession($name, $timeoutSec = 10) {
+    for ($i = 0; $i -lt ($timeoutSec * 5); $i++) {
+        & $PSMUX has-session -t $name 2>$null
+        if ($LASTEXITCODE -eq 0) { return $true }
+        Start-Sleep -Milliseconds 200
+    }
+    return $false
+}
+# Poll #{pane_current_path} until it converges to $expectNorm, then return the raw
+# value. Panes run -NoProfile so they never change cwd; we only wait out the
+# latency between spawning the pane process and it reporting its cwd. A wrong cwd
+# never converges -> fails by timeout with the last value seen, so this can't
+# mask a regression.
+function Wait-PanePath($target, $expectNorm, $timeoutSec = 10) {
+    $last = ""
+    for ($i = 0; $i -lt ($timeoutSec * 5); $i++) {
+        $last = Get-PanePath $target
+        if ((Normalize-Path $last) -eq $expectNorm) { return $last }
+        Start-Sleep -Milliseconds 200
+    }
+    return $last
+}
+
+# Poll until $winTarget reports >= $count panes (each with a resolved cwd) and
+# return their raw cwds; on timeout return whatever was last seen.
+function Wait-AllPanePaths($winTarget, $count, $timeoutSec = 10) {
+    $paths = @()
+    for ($i = 0; $i -lt ($timeoutSec * 5); $i++) {
+        $paths = & $PSMUX list-panes -t $winTarget -F '#{pane_current_path}' 2>&1 |
+            ForEach-Object { $_.ToString().Trim() } | Where-Object { $_ }
+        if ($paths.Count -ge $count) { return $paths }
+        Start-Sleep -Milliseconds 200
+    }
+    return $paths
+}
+
+$testRoot = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot "..\target\cwd_attached_test"))
+
+function Test-Mode {
+    param([string]$Mode, [bool]$WarmOff)
+
+    if ($WarmOff) { $env:PSMUX_NO_WARM = "1" } else { Remove-Item Env:\PSMUX_NO_WARM -ErrorAction SilentlyContinue }
+
+    $sess     = "attcwd_${Mode}_"        + [guid]::NewGuid().ToString("N").Substring(0, 8)
+    $startDir = Join-Path $testRoot ("start_${Mode}_"  + [guid]::NewGuid().ToString("N").Substring(0, 8))
+    $launchDir = Join-Path $testRoot ("launch_${Mode}_" + [guid]::NewGuid().ToString("N").Substring(0, 8))
+    New-Item -ItemType Directory -Path $startDir, $launchDir -Force | Out-Null
+
+    try {
+        # Create the session FROM $launchDir but with -c $startDir.
+        Push-Location $launchDir
+        & $PSMUX new-session -d -s $sess -c $startDir
+        Pop-Location
+        if (-not (Wait-ForSession $sess)) {
+            Add-Result "[$Mode] session ready" $false "new-session never became ready"
+            return
+        }
+
+        # Attached new-window via control mode, issued from $launchDir. The control
+        # client is attached, so tmux semantics put the window in the session dir.
+        # Piping the command then closing stdin makes -CC attach run it and exit.
+        Push-Location $launchDir
+        "new-window`n" | & $PSMUX -CC attach -t $sess *> $null
+        Pop-Location
+
+        $expectStart = Normalize-Path $startDir
+        $raw = Wait-PanePath "${sess}:1" $expectStart
+        Add-Result "[$Mode] attached new-window opens in session dir (not launch dir)" `
+            ((Normalize-Path $raw) -eq $expectStart) "got '$raw' expected '$startDir' (launch was '$launchDir')"
+
+        # Attached split-window via control mode, issued from $launchDir. The new
+        # pane must also open in the session dir. Split the initial window (window
+        # 0, whose pane is already in the session dir) and require BOTH its panes
+        # to be in the session dir -- pre-fix the split pane spawned in the launch
+        # dir (the server's restored cwd).
+        Push-Location $launchDir
+        "split-window -t ${sess}:0`n" | & $PSMUX -CC attach -t $sess *> $null
+        Pop-Location
+
+        $paths = Wait-AllPanePaths "${sess}:0" 2
+        $allInStart = ($paths.Count -ge 2) -and (@($paths | Where-Object { (Normalize-Path $_) -ne $expectStart }).Count -eq 0)
+        Add-Result "[$Mode] attached split-window opens in session dir (not launch dir)" `
+            $allInStart "panes: $($paths -join ' | ') expected all '$startDir' (launch was '$launchDir')"
+
+    } finally {
+        & $PSMUX kill-session -t $sess 2>$null
+        Remove-Item $startDir, $launchDir -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}
+
+Test-Mode -Mode "warm-off" -WarmOff $true
+Test-Mode -Mode "warm-on"  -WarmOff $false
+
+Remove-Item -LiteralPath $cfgFile -Force -ErrorAction SilentlyContinue
+
+Write-Host "`n=== attached (control-mode) new-window opens in session start dir (warm on + off) ===" -ForegroundColor Cyan
+$results | Format-Table -AutoSize
+$failed = ($results | Where-Object { $_.Result -eq "FAIL" }).Count
+$total = $results.Count
+$passed = $total - $failed
+Write-Host "Total: $total | Passed: $passed | Failed: $failed" -ForegroundColor $(if ($failed -gt 0) { "Red" } else { "Green" })
+if ($failed -gt 0) { exit 1 }

--- a/tests/test_new_window_detached_cwd.ps1
+++ b/tests/test_new_window_detached_cwd.ps1
@@ -1,0 +1,191 @@
+#!/usr/bin/env pwsh
+# Test: where does a new window open? tmux's cwd is DISPATCH-MODE dependent:
+# `-c` wins; else a command-line / detached client uses the CALLER's cwd (the
+# issuing client is not attached); else (attached) the session start dir. These
+# are tmux's three cwd cases, visible in its own source.
+#
+# This test drives the COMMAND-LINE (detached) path — every psmux/tmux call is a
+# separate, unattached client — so the tmux-faithful expectations are:
+#   - initial window (new-session -c SDIR)   -> SDIR
+#   - detached new-window (no -c) from dir X  -> X      (caller cwd)
+#   - detached split-window (no -c) from dir X -> X     (caller cwd)
+#   - new-window -c DIR2 (from anywhere)      -> DIR2
+# The attached/interactive path (prefix+c -> session start dir) needs a pty or
+# control-mode client and is NOT covered here.
+#
+# Runs with warm panes BOTH disabled and enabled: where a window opens must not
+# depend on the warm-pane optimisation — a warm pane pre-spawned in the server's
+# cwd must NOT override the caller's cwd for a detached new-window.
+#
+# Well-behaved on a shared server: uses a unique session name and cleans up
+# with kill-session (never kill-server), so it does not disturb other sessions.
+
+$ErrorActionPreference = "Continue"
+$results = @()
+
+function Add-Result($name, $pass, $detail = "") {
+    $script:results += [PSCustomObject]@{
+        Test   = $name
+        Result = if ($pass) { "PASS" } else { "FAIL" }
+        Detail = $detail
+    }
+}
+
+# Binary discovery: honour $env:PSMUX_EXE first (CI convention), then the local
+# build outputs (debug preferred — usually the build under test).
+$PSMUX = $env:PSMUX_EXE
+if (-not $PSMUX -or -not (Test-Path $PSMUX)) { $PSMUX = Join-Path $PSScriptRoot "..\target\debug\psmux.exe" }
+if (-not (Test-Path $PSMUX)) { $PSMUX = Join-Path $PSScriptRoot "..\target\release\psmux.exe" }
+if (-not (Test-Path $PSMUX)) {
+    Write-Host "psmux binary not found; build the project first." -ForegroundColor Red
+    exit 1
+}
+
+# Launch every pane as `pwsh -NoProfile` so the pane shell NEVER changes its own
+# cwd during startup. A profile `Set-Location` would otherwise make
+# #{pane_current_path} drift away from the spawn dir and this test would assert
+# against a shell-dependent value; with -NoProfile explicit, psmux also skips its
+# manual profile sourcing. Base-index is left at the default, no warm/option
+# overrides.
+$cfgFile = Join-Path ([System.IO.Path]::GetTempPath()) ("psmux_ssd_" + [guid]::NewGuid().ToString("N") + ".conf")
+Set-Content -LiteralPath $cfgFile -Value 'set -g default-command "pwsh -NoProfile"'
+$env:PSMUX_CONFIG_FILE = $cfgFile
+
+# Canonicalise a path for comparison: resolve via the filesystem (collapses 8.3
+# short names to long form), forward slashes to backslashes, drop trailing
+# slash, lower-case. Sidesteps C:\ vs C:/, casing, and short-vs-long-name
+# differences in #{pane_current_path}.
+function Normalize-Path($p) {
+    if ([string]::IsNullOrWhiteSpace($p)) { return "" }
+    try { $p = (Get-Item -LiteralPath $p -ErrorAction Stop).FullName } catch { }
+    ($p -replace '/', '\').TrimEnd('\').ToLower()
+}
+function Get-PanePath($target) {
+    (& $PSMUX display-message -p -t $target '#{pane_current_path}' 2>&1 | Out-String).Trim()
+}
+
+# Poll until the server has created the session (the client may return before the
+# server is ready). Mirrors the suite's has-session readiness idiom.
+function Wait-ForSession($name, $timeoutSec = 10) {
+    for ($i = 0; $i -lt ($timeoutSec * 5); $i++) {
+        & $PSMUX has-session -t $name 2>$null
+        if ($LASTEXITCODE -eq 0) { return $true }
+        Start-Sleep -Milliseconds 200
+    }
+    return $false
+}
+
+# Poll #{pane_current_path} until it converges to $expectNorm (already
+# normalised), then return the raw value. The pane runs -NoProfile so it never
+# changes its own cwd: any readable value IS the spawn dir, and we only wait out
+# the latency between spawning the pane process and it reporting its cwd. A wrong
+# cwd never converges, so this can't mask a regression — it fails by timeout and
+# returns the last value seen for a meaningful diff.
+function Wait-PanePath($target, $expectNorm, $timeoutSec = 10) {
+    $last = ""
+    for ($i = 0; $i -lt ($timeoutSec * 5); $i++) {
+        $last = Get-PanePath $target
+        if ((Normalize-Path $last) -eq $expectNorm) { return $last }
+        Start-Sleep -Milliseconds 200
+    }
+    return $last
+}
+
+# Poll a window's panes until one converges to $expectNorm; return that raw path
+# (or the panes seen, on timeout). Scans all panes in the window so we don't
+# depend on a pane index / pane-base-index — we just look for the expected cwd.
+function Wait-PaneInWindow($winTarget, $expectNorm, $timeoutSec = 10) {
+    $last = @()
+    for ($i = 0; $i -lt ($timeoutSec * 5); $i++) {
+        $last = & $PSMUX list-panes -t $winTarget -F '#{pane_current_path}' 2>&1 |
+            ForEach-Object { $_.ToString().Trim() } | Where-Object { $_ }
+        foreach ($p in $last) { if ((Normalize-Path $p) -eq $expectNorm) { return $p } }
+        Start-Sleep -Milliseconds 200
+    }
+    return ($last -join ' | ')
+}
+
+# Target dirs live under the build dir (target\): no user name in the path, no
+# special permissions, gitignored.
+$testRoot = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot "..\target\cwd_start_dir_test"))
+
+function Test-Mode {
+    param([string]$Mode, [bool]$WarmOff)
+
+    if ($WarmOff) { $env:PSMUX_NO_WARM = "1" } else { Remove-Item Env:\PSMUX_NO_WARM -ErrorAction SilentlyContinue }
+
+    $sess     = "ssdtest_${Mode}_"             + [guid]::NewGuid().ToString("N").Substring(0, 8)
+    $startDir = Join-Path $testRoot ("start_${Mode}_"    + [guid]::NewGuid().ToString("N").Substring(0, 8))
+    $cliDir   = Join-Path $testRoot ("cli_${Mode}_"      + [guid]::NewGuid().ToString("N").Substring(0, 8))
+    $winDir   = Join-Path $testRoot ("explicit_${Mode}_" + [guid]::NewGuid().ToString("N").Substring(0, 8))
+    New-Item -ItemType Directory -Path $startDir, $cliDir, $winDir -Force | Out-Null
+
+    try {
+        # Create the session FROM the tests directory (the launch dir) but with
+        # -c $startDir, to prove -c wins over the launch directory.
+        Push-Location $PSScriptRoot
+        & $PSMUX new-session -d -s $sess -c $startDir
+        Pop-Location
+        if (-not (Wait-ForSession $sess)) {
+            Add-Result "[$Mode] session ready" $false "new-session never became ready"
+            return
+        }
+
+        # Initial window was created WITH -c: it must open in the session start dir.
+        $expectStart = Normalize-Path $startDir
+        $raw0 = Wait-PanePath "${sess}:0" $expectStart
+        Add-Result "[$Mode] initial window (-c) opens in start dir" `
+            ((Normalize-Path $raw0) -eq $expectStart) "got '$raw0' expected '$startDir'"
+
+        # Command-line (detached) new-window WITHOUT -c. tmux resolves this to the
+        # CALLER's cwd (the issuing client is not attached), NOT the session start
+        # dir. Invoke it from a distinct CLI dir and require the new window to open
+        # THERE. (psmux currently opens it in the session dir because it never
+        # propagates the client cwd — the RED.)
+        Push-Location $cliDir
+        & $PSMUX new-window -t $sess
+        Pop-Location
+        $expectCli = Normalize-Path $cliDir
+        $raw1 = Wait-PanePath "${sess}:1" $expectCli
+        Add-Result "[$Mode] detached new-window (no -c) opens in caller cwd" `
+            ((Normalize-Path $raw1) -eq $expectCli) "got '$raw1' expected '$cliDir'"
+
+        # Explicit per-window -c always wins, even over the caller cwd: invoke from
+        # the CLI dir but pass -c $winDir, and require the window to open in $winDir.
+        Push-Location $cliDir
+        & $PSMUX new-window -t $sess -c $winDir
+        Pop-Location
+        $expectWin = Normalize-Path $winDir
+        $raw2 = Wait-PanePath "${sess}:2" $expectWin
+        Add-Result "[$Mode] new-window -c DIR2 opens in DIR2" `
+            ((Normalize-Path $raw2) -eq $expectWin) "got '$raw2' expected '$winDir'"
+
+        # Detached split-window WITHOUT -c: same rule as new-window — the new pane
+        # opens in the CALLER's cwd, not the session dir. Split window 0
+        # (whose initial pane is in $startDir) from the CLI dir and require one of
+        # its panes to land in $cliDir.
+        Push-Location $cliDir
+        & $PSMUX split-window -d -t "${sess}:0" *> $null
+        Pop-Location
+        $rawS = Wait-PaneInWindow "${sess}:0" $expectCli
+        Add-Result "[$Mode] detached split-window (no -c) opens in caller cwd" `
+            ((Normalize-Path $rawS) -eq $expectCli) "got '$rawS' expected '$cliDir'"
+
+    } finally {
+        & $PSMUX kill-session -t $sess 2>$null
+        Remove-Item $startDir, $cliDir, $winDir -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}
+
+Test-Mode -Mode "warm-off" -WarmOff $true
+Test-Mode -Mode "warm-on"  -WarmOff $false
+
+Remove-Item -LiteralPath $cfgFile -Force -ErrorAction SilentlyContinue
+
+Write-Host "`n=== new-session -c / session start directory (warm on + off) ===" -ForegroundColor Cyan
+$results | Format-Table -AutoSize
+$failed = ($results | Where-Object { $_.Result -eq "FAIL" }).Count
+$total = $results.Count
+$passed = $total - $failed
+Write-Host "Total: $total | Passed: $passed | Failed: $failed" -ForegroundColor $(if ($failed -gt 0) { "Red" } else { "Green" })
+if ($failed -gt 0) { exit 1 }


### PR DESCRIPTION
This PR fixes new-window / split-window initial working directory to match tmux behavior.

### Summary

A new window or split should inherit its working directory the way tmux resolves it, which depends on **who issues the command**:

| Caller | tmux behavior | psmux before this PR |
|---|---|---|
| Explicit `-c DIR` | opens in `DIR` | ✅ correct |
| **Detached** client (any command-line `new-window`/`split-window` with no `-c`) | opens in the **caller's** directory | ❌ opened in the session's directory |
| **Attached** client (interactive `prefix`+`c`, or a control-mode client) | opens in the **session start** directory | ❌ opened in the directory the *server* was launched from |

Every `psmux <cmd>` CLI invocation is a one-shot, unattached client, so the detached row meant the directory you ran the command from was silently lost. The attached path was wrong in a different way: the server reset its own cwd back to the launch directory right after creating the initial window, so a later `prefix`+`c` opened in the launch dir instead of the session start dir.

tmux picks the new window/split cwd from three cases — explicit `-c`, attached client, detached client — and those three cases are spelled out in tmux's own source. This PR makes psmux match the detached and attached cases (explicit `-c` already worked).

### Changes

- **Detached path** (`src/main.rs`): when the user gives no `-c`, the client now defaults `-c` to its current directory before forwarding the command to the server. Trade-off: a command-line `new-window`/`split-window` now always carries a `-c`, so it no longer reuses the warm pane (which lives in the server's cwd) — but a warm pane is unusable anyway when the target dir differs from where it was spawned, which is the common case for a CLI call. Interactive `prefix`+`c` still reuses the warm pane.
- **Attached path** (`src/server/mod.rs`): a psmux server process hosts exactly one session, so it now leaves its working directory at the session start directory for its whole lifetime instead of restoring it to the launch dir. Attached new-windows, splits, and warm-pane replenishes then inherit the session start dir.

### Repro

The two cases differ only in *how* the window is created, so one session with three distinct directories surfaces both bugs at once — a detached window and an attached window each land in a different wrong place before the fix:

```powershell
mkdir C:\tmp\launch, C:\tmp\sess, C:\tmp\caller -Force

# Server launched from C:\tmp\launch; session start dir = C:\tmp\sess
cd C:\tmp\launch
psmux new-session -d -s demo -c C:\tmp\sess

# Window :1 — DETACHED: command-line new-window with no -c, issued from C:\tmp\caller
cd C:\tmp\caller
psmux new-window -t demo

# Window :2 — ATTACHED: new-window via control mode (same dispatch path as prefix+c)
"new-window`n" | psmux -CC attach -t demo *> $null

psmux display-message -p -t demo:1 '#{pane_current_path}'   # detached window
psmux display-message -p -t demo:2 '#{pane_current_path}'   # attached window

psmux kill-session -t demo
```

| Window | tmux / psmux (after) | psmux (before) |
|---|---|---|
| `:1` detached (issued from `caller`) | `C:\tmp\caller` | `C:\tmp\sess` ❌ caller's dir lost |
| `:2` attached (control mode) | `C:\tmp\sess` | `C:\tmp\launch` ❌ used server's launch dir |

### Tests

- `tests/test_new_window_detached_cwd.ps1` drives the **detached** path from a distinct CLI dir and asserts `new-window` **and** `split-window` with no `-c` open there, `-c DIR2` still wins, and the initial window stays in the session dir — warm panes on and off (8 assertions).
- `tests/test_new_window_attached_cwd.ps1` drives the **attached** path headlessly via control mode (`-CC attach`, piping the command on stdin) and asserts an attached `new-window` and split open in the session dir, not the launch dir — warm panes on and off (4 assertions).