### PR TITLE
fix(client): choose-tree marks active window and opens cursor on current window

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -2588,7 +2588,7 @@ pub fn run_remote(terminal: &mut Terminal<CrosstermBackend<crate::platform::Psmu
                                 // Query ALL sessions (like tmux choose-tree)
                                 let dir = format!("{}\\.psmux", home);
                                 if let Ok(entries) = std::fs::read_dir(&dir) {
-                                    let mut sessions: Vec<(String, Vec<(usize, String, Vec<(usize, String)>)>)> = Vec::new();
+                                    let mut sessions: Vec<(String, Vec<ChooserWin>)> = Vec::new();
                                     for e in entries.flatten() {
                                         if let Some(fname) = e.file_name().to_str().map(|s| s.to_string()) {
                                             if let Some((base, ext)) = fname.rsplit_once('.') {
@@ -2608,10 +2608,10 @@ pub fn run_remote(terminal: &mut Terminal<CrosstermBackend<crate::platform::Psmu
                                                                 Duration::from_millis(100),
                                                             ) {
                                                                 if let Ok(wins) = serde_json::from_str::<Vec<WinTree>>(tree_line.trim()) {
-                                                                    let mut win_data = Vec::new();
+                                                                    let mut win_data: Vec<ChooserWin> = Vec::new();
                                                                     for w in &wins {
                                                                         let panes: Vec<(usize, String)> = w.panes.iter().map(|p| (p.id, p.title.clone())).collect();
-                                                                        win_data.push((w.id, w.name.clone(), panes));
+                                                                        win_data.push((w.id, w.name.clone(), w.active, panes));
                                                                     }
                                                                     sessions.push((base.to_string(), win_data));
                                                                 }
@@ -2627,41 +2627,14 @@ pub fn run_remote(terminal: &mut Terminal<CrosstermBackend<crate::platform::Psmu
                                         else if b.0 == current_session { std::cmp::Ordering::Greater }
                                         else { a.0.cmp(&b.0) }
                                     });
-                                    for (sess_name, wins) in &sessions {
-                                        let is_current = sess_name == &current_session;
-                                        let attached = if is_current { " (attached)" } else { "" };
-                                        let nw = wins.len();
-                                        tree_entries.push((true, usize::MAX, 0,
-                                            format!("{}: {} windows{}", sess_name, nw, attached),
-                                            sess_name.clone()));
-                                        if is_current {
-                                            for (wi, (wid, wname, panes)) in wins.iter().enumerate() {
-                                                let flag = if panes.len() > 0 { "" } else { "" };
-                                                tree_entries.push((true, *wid, 0,
-                                                    format!("  {}: {}{} ({} panes)", wi, wname, flag, panes.len()),
-                                                    sess_name.clone()));
-                                                for (pid, ptitle) in panes {
-                                                    tree_entries.push((false, *wid, *pid,
-                                                        format!("    {}", ptitle),
-                                                        sess_name.clone()));
-                                                }
-                                            }
-                                        } else {
-                                            for (wi, (wid, wname, panes)) in wins.iter().enumerate() {
-                                                tree_entries.push((true, *wid, 0,
-                                                    format!("  {}: {} ({} panes)", wi, wname, panes.len()),
-                                                    sess_name.clone()));
-                                            }
-                                        }
-                                    }
+                                    let (built, selected) = build_tree_entries(&sessions, &current_session);
+                                    tree_entries = built;
+                                    tree_selected = selected;
                                 }
                                 if tree_entries.is_empty() {
-                                    for wi in &last_tree {
-                                        tree_entries.push((true, wi.id, 0, wi.name.clone(), current_session.clone()));
-                                        for pi in &wi.panes {
-                                            tree_entries.push((false, wi.id, pi.id, pi.title.clone(), current_session.clone()));
-                                        }
-                                    }
+                                    let (built, selected) = build_fallback_entries(&last_tree, &current_session);
+                                    tree_entries = built;
+                                    tree_selected = selected;
                                 }
                             }
                             if do_choose_session {
@@ -5945,6 +5918,85 @@ fn route_paste_to_overlay(
     }
 }
 
+/// One window as projected into the choose-tree picker:
+/// `(window id, name, active, panes[(pane id, title)])`.
+type ChooserWin = (usize, String, bool, Vec<(usize, String)>);
+
+/// One flat row in the choose-tree list:
+/// `(selectable, window id, pane id, label, session name)`.
+/// Session-header rows use `window id == usize::MAX`; pane rows use
+/// `selectable == false`.
+type TreeRow = (bool, usize, usize, String, String);
+
+/// Build the flat choose-tree entry list across every reachable session and
+/// return `(rows, selected_index)`, where `selected_index` is the row of the
+/// active window in the current session — so the picker opens with the cursor
+/// on the current window, matching tmux. Falls back to `0` when the current
+/// session has no active window. The active window is marked with ` *`.
+///
+/// The caller sorts `sessions` with the current session first, but that order
+/// is display-only — correctness does not depend on it: only the current
+/// session is expanded, and the selected index is captured against
+/// the absolute row position, so interleaved session-header and pane rows are
+/// accounted for. Pure (no I/O) so it is unit-tested directly.
+fn build_tree_entries(sessions: &[(String, Vec<ChooserWin>)], current_session: &str) -> (Vec<TreeRow>, usize) {
+    let mut tree_entries: Vec<TreeRow> = Vec::new();
+    let mut tree_selected = 0usize;
+    for (sess_name, wins) in sessions {
+        let is_current = sess_name == current_session;
+        let attached = if is_current { " (attached)" } else { "" };
+        let nw = wins.len();
+        tree_entries.push((true, usize::MAX, 0,
+            format!("{}: {} windows{}", sess_name, nw, attached),
+            sess_name.clone()));
+        if is_current {
+            for (wi, (wid, wname, wactive, panes)) in wins.iter().enumerate() {
+                let marker = if *wactive { " *" } else { "" };
+                if *wactive { tree_selected = tree_entries.len(); }
+                tree_entries.push((true, *wid, 0,
+                    format!("  {}: {}{} ({} panes)", wi, wname, marker, panes.len()),
+                    sess_name.clone()));
+                for (pid, ptitle) in panes {
+                    tree_entries.push((false, *wid, *pid,
+                        format!("    {}", ptitle),
+                        sess_name.clone()));
+                }
+            }
+        } else {
+            for (wi, (wid, wname, _wactive, panes)) in wins.iter().enumerate() {
+                tree_entries.push((true, *wid, 0,
+                    format!("  {}: {} ({} panes)", wi, wname, panes.len()),
+                    sess_name.clone()));
+            }
+        }
+    }
+    (tree_entries, tree_selected)
+}
+
+/// Fallback choose-tree builder used when no session port files are reachable
+/// and only the current session's cached `last_tree` is available. Preserves
+/// the minimal cached-tree layout (bare window/pane names) but, like
+/// [`build_tree_entries`], marks the active window with ` *` and selects it so
+/// the cursor still opens on the current window. Pure (no I/O) so it is
+/// unit-tested directly.
+fn build_fallback_entries(last_tree: &[WinTree], current_session: &str) -> (Vec<TreeRow>, usize) {
+    let mut tree_entries: Vec<TreeRow> = Vec::new();
+    let mut tree_selected = 0usize;
+    for w in last_tree {
+        if w.active { tree_selected = tree_entries.len(); }
+        let marker = if w.active { " *" } else { "" };
+        tree_entries.push((true, w.id, 0,
+            format!("{}{}", w.name, marker),
+            current_session.to_string()));
+        for p in &w.panes {
+            tree_entries.push((false, w.id, p.id,
+                p.title.clone(),
+                current_session.to_string()));
+        }
+    }
+    (tree_entries, tree_selected)
+}
+
 #[cfg(test)]
 #[path = "../tests-rs/test_client.rs"]
 mod tests;
@@ -5964,3 +6016,7 @@ mod test_issue345_command_prompt_utf8;
 #[cfg(test)]
 #[path = "../tests-rs/test_issue361_osc8_overlay.rs"]
 mod test_issue361_osc8_overlay;
+
+#[cfg(test)]
+#[path = "../tests-rs/test_choose_tree_active_marker.rs"]
+mod test_choose_tree_active_marker;

--- a/src/client.rs
+++ b/src/client.rs
@@ -5932,7 +5932,8 @@ type TreeRow = (bool, usize, usize, String, String);
 /// return `(rows, selected_index)`, where `selected_index` is the row of the
 /// active window in the current session — so the picker opens with the cursor
 /// on the current window, matching tmux. Falls back to `0` when the current
-/// session has no active window. The active window is marked with ` *`.
+/// session has no active window. The active window is marked with `*`
+/// (glyph-adjacent, matching `list_windows_tmux`).
 ///
 /// The caller sorts `sessions` with the current session first, but that order
 /// is display-only — correctness does not depend on it: only the current
@@ -5951,7 +5952,7 @@ fn build_tree_entries(sessions: &[(String, Vec<ChooserWin>)], current_session: &
             sess_name.clone()));
         if is_current {
             for (wi, (wid, wname, wactive, panes)) in wins.iter().enumerate() {
-                let marker = if *wactive { " *" } else { "" };
+                let marker = if *wactive { "*" } else { "" };
                 if *wactive { tree_selected = tree_entries.len(); }
                 tree_entries.push((true, *wid, 0,
                     format!("  {}: {}{} ({} panes)", wi, wname, marker, panes.len()),
@@ -5976,7 +5977,7 @@ fn build_tree_entries(sessions: &[(String, Vec<ChooserWin>)], current_session: &
 /// Fallback choose-tree builder used when no session port files are reachable
 /// and only the current session's cached `last_tree` is available. Preserves
 /// the minimal cached-tree layout (bare window/pane names) but, like
-/// [`build_tree_entries`], marks the active window with ` *` and selects it so
+/// [`build_tree_entries`], marks the active window with `*` and selects it so
 /// the cursor still opens on the current window. Pure (no I/O) so it is
 /// unit-tested directly.
 fn build_fallback_entries(last_tree: &[WinTree], current_session: &str) -> (Vec<TreeRow>, usize) {
@@ -5984,7 +5985,7 @@ fn build_fallback_entries(last_tree: &[WinTree], current_session: &str) -> (Vec<
     let mut tree_selected = 0usize;
     for w in last_tree {
         if w.active { tree_selected = tree_entries.len(); }
-        let marker = if w.active { " *" } else { "" };
+        let marker = if w.active { "*" } else { "" };
         tree_entries.push((true, w.id, 0,
             format!("{}{}", w.name, marker),
             current_session.to_string()));

--- a/src/client.rs
+++ b/src/client.rs
@@ -5923,9 +5923,10 @@ fn route_paste_to_overlay(
 type ChooserWin = (usize, String, bool, Vec<(usize, String)>);
 
 /// One flat row in the choose-tree list:
-/// `(selectable, window id, pane id, label, session name)`.
-/// Session-header rows use `window id == usize::MAX`; pane rows use
-/// `selectable == false`.
+/// `(is_win, window id, pane id, label, session name)`.
+/// `is_win` is true for window rows and session-header rows, false for pane
+/// rows; on Enter it selects `focus-window` vs `focus-pane`. Session-header
+/// rows additionally have `window id == usize::MAX`. Every row is selectable.
 type TreeRow = (bool, usize, usize, String, String);
 
 /// Build the flat choose-tree entry list across every reachable session and

--- a/tests-rs/test_choose_tree_active_marker.rs
+++ b/tests-rs/test_choose_tree_active_marker.rs
@@ -32,7 +32,7 @@ fn active_marker_appended_after_name() {
     let sessions = vec![("work".to_string(), vec![win(0, "editor", true, &[(0, "p")])])];
     let (entries, _) = build_tree_entries(&sessions, "work");
     // entries[0] is the session header; entries[1] is the (only) window row.
-    assert_eq!(entries[1].3, "  0: editor * (1 panes)");
+    assert_eq!(entries[1].3, "  0: editor* (1 panes)");
 }
 
 #[test]
@@ -72,7 +72,7 @@ fn active_window_not_first_selects_correct_absolute_row() {
     ])];
     let (entries, selected) = build_tree_entries(&sessions, "work");
     assert_eq!(selected, 3);
-    assert_eq!(entries[selected].3, "  1: b * (1 panes)");
+    assert_eq!(entries[selected].3, "  1: b* (1 panes)");
 }
 
 #[test]
@@ -97,7 +97,7 @@ fn pane_rows_offset_the_selected_index() {
     ])];
     let (entries, selected) = build_tree_entries(&sessions, "work");
     assert_eq!(selected, 4);
-    assert_eq!(entries[4].3, "  1: b * (1 panes)"); // pin row identity, not just the index
+    assert_eq!(entries[4].3, "  1: b* (1 panes)"); // pin row identity, not just the index
 }
 
 // ---- build_tree_entries: cross-session isolation -------------------------
@@ -114,6 +114,10 @@ fn other_session_active_window_is_not_marked_or_selected() {
     let (entries, selected) = build_tree_entries(&sessions, "work");
     assert_eq!(selected, 0);
     assert!(entries.iter().all(|e| !e.3.contains('*')));
+    // The other (non-current) session's window stays collapsed, carries no
+    // marker, and keeps its normal label shape. Rows: work header(0),
+    // work win a(1), work pane(2), play header(3), play win x(4).
+    assert_eq!(entries[4].3, "  0: x (1 panes)");
 }
 
 // ---- build_fallback_entries: cached last_tree path -----------------------
@@ -127,7 +131,7 @@ fn fallback_marks_and_selects_active_window() {
     ];
     let (entries, selected) = build_fallback_entries(&last, "work");
     assert_eq!(selected, 2);
-    assert_eq!(entries[2].3, "b *"); // minimal cached layout: bare name + marker
+    assert_eq!(entries[2].3, "b*"); // minimal cached layout: bare name + marker
     assert_eq!(entries[0].3, "a");   // inactive window: no marker
 }
 

--- a/tests-rs/test_choose_tree_active_marker.rs
+++ b/tests-rs/test_choose_tree_active_marker.rs
@@ -1,0 +1,140 @@
+//! Unit tests for the choose-tree active-window marker and initial selection
+//! (the picker opens with the cursor on the current window). The picker's
+//! entry-building logic is factored into the pure `build_tree_entries` /
+//! `build_fallback_entries` helpers in `client.rs` precisely so this behaviour
+//! is verifiable without driving the TUI.
+//!
+//! The helpers are platform-independent (pure string/index logic), so these
+//! tests run on every CI target rather than being gated to Windows.
+
+use super::*;
+use crate::util::{WinTree, PaneInfo};
+
+/// Construct a `ChooserWin`: `(id, name, active, panes[(id, title)])`.
+fn win(id: usize, name: &str, active: bool, panes: &[(usize, &str)]) -> ChooserWin {
+    (id, name.to_string(), active, panes.iter().map(|(i, t)| (*i, t.to_string())).collect())
+}
+
+/// Construct a `WinTree` for the cached-fallback path tests.
+fn wtree(id: usize, name: &str, active: bool, panes: &[(usize, &str)]) -> WinTree {
+    WinTree {
+        id,
+        name: name.to_string(),
+        active,
+        panes: panes.iter().map(|(i, t)| PaneInfo { id: *i, title: t.to_string() }).collect(),
+    }
+}
+
+// ---- build_tree_entries: marker rendering --------------------------------
+
+#[test]
+fn active_marker_appended_after_name() {
+    let sessions = vec![("work".to_string(), vec![win(0, "editor", true, &[(0, "p")])])];
+    let (entries, _) = build_tree_entries(&sessions, "work");
+    // entries[0] is the session header; entries[1] is the (only) window row.
+    assert_eq!(entries[1].3, "  0: editor * (1 panes)");
+}
+
+#[test]
+fn inactive_window_has_no_marker() {
+    let sessions = vec![("work".to_string(), vec![win(0, "editor", false, &[(0, "p")])])];
+    let (entries, _) = build_tree_entries(&sessions, "work");
+    assert_eq!(entries[1].3, "  0: editor (1 panes)");
+}
+
+// ---- build_tree_entries: initial selection (absolute row index) ----------
+
+#[test]
+fn single_active_window_is_selected() {
+    let sessions = vec![("work".to_string(), vec![win(0, "only", true, &[(0, "p")])])];
+    let (_entries, selected) = build_tree_entries(&sessions, "work");
+    // header(0), window(1) -> the window row is index 1.
+    assert_eq!(selected, 1);
+}
+
+#[test]
+fn no_active_window_selects_zero_and_renders_no_marker() {
+    let sessions = vec![("work".to_string(), vec![
+        win(0, "a", false, &[(0, "p")]),
+        win(1, "b", false, &[(1, "q")]),
+    ])];
+    let (entries, selected) = build_tree_entries(&sessions, "work");
+    assert_eq!(selected, 0);
+    assert!(entries.iter().all(|e| !e.3.contains('*')));
+}
+
+#[test]
+fn active_window_not_first_selects_correct_absolute_row() {
+    // header(0), a(1), a-pane(2), b ACTIVE(3), b-pane(4)
+    let sessions = vec![("work".to_string(), vec![
+        win(0, "a", false, &[(10, "p")]),
+        win(1, "b", true, &[(11, "q")]),
+    ])];
+    let (entries, selected) = build_tree_entries(&sessions, "work");
+    assert_eq!(selected, 3);
+    assert_eq!(entries[selected].3, "  1: b * (1 panes)");
+}
+
+#[test]
+fn active_window_last_selects_last_window_row() {
+    // No panes, so rows are contiguous: header(0), a(1), b(2), c ACTIVE(3).
+    let sessions = vec![("work".to_string(), vec![
+        win(0, "a", false, &[]),
+        win(1, "b", false, &[]),
+        win(2, "c", true, &[]),
+    ])];
+    let (_entries, selected) = build_tree_entries(&sessions, "work");
+    assert_eq!(selected, 3);
+}
+
+#[test]
+fn pane_rows_offset_the_selected_index() {
+    // The first window owns TWO panes, pushing the active second window down.
+    // header(0), w0(1), w0-p0(2), w0-p1(3), w1 ACTIVE(4), w1-p(5)
+    let sessions = vec![("work".to_string(), vec![
+        win(0, "a", false, &[(1, "p"), (2, "q")]),
+        win(1, "b", true, &[(3, "r")]),
+    ])];
+    let (entries, selected) = build_tree_entries(&sessions, "work");
+    assert_eq!(selected, 4);
+    assert_eq!(entries[4].3, "  1: b * (1 panes)"); // pin row identity, not just the index
+}
+
+// ---- build_tree_entries: cross-session isolation -------------------------
+
+#[test]
+fn other_session_active_window_is_not_marked_or_selected() {
+    // The current session "work" has no active window, while a DIFFERENT
+    // session "play" does. The cursor must not jump across sessions, and the
+    // other (collapsed) session's window must carry no marker.
+    let sessions = vec![
+        ("work".to_string(), vec![win(0, "a", false, &[(1, "p")])]),
+        ("play".to_string(), vec![win(0, "x", true, &[(2, "q")])]),
+    ];
+    let (entries, selected) = build_tree_entries(&sessions, "work");
+    assert_eq!(selected, 0);
+    assert!(entries.iter().all(|e| !e.3.contains('*')));
+}
+
+// ---- build_fallback_entries: cached last_tree path -----------------------
+
+#[test]
+fn fallback_marks_and_selects_active_window() {
+    // rows: a(0), a-pane(1), b ACTIVE(2), b-pane(3)
+    let last = vec![
+        wtree(0, "a", false, &[(1, "p")]),
+        wtree(1, "b", true, &[(2, "q")]),
+    ];
+    let (entries, selected) = build_fallback_entries(&last, "work");
+    assert_eq!(selected, 2);
+    assert_eq!(entries[2].3, "b *"); // minimal cached layout: bare name + marker
+    assert_eq!(entries[0].3, "a");   // inactive window: no marker
+}
+
+#[test]
+fn fallback_no_active_window_selects_zero() {
+    let last = vec![wtree(0, "a", false, &[]), wtree(1, "b", false, &[])];
+    let (entries, selected) = build_fallback_entries(&last, "work");
+    assert_eq!(selected, 0);
+    assert!(entries.iter().all(|e| !e.3.contains('*')));
+}


### PR DESCRIPTION
Fixes #373. The `choose-tree`/`choose-window` picker now marks the current session's
active window with `*` and opens the cursor on it (matching tmux). `WinTree.active` was
already sent over the wire — the chooser was dropping it and hardcoding the initial selection
to 0. This mirrors the sibling session chooser, which already marks + preselects the current
session.

- Extracts the entry-building into pure `build_tree_entries` / `build_fallback_entries`
  (both the live and cached-tree paths) that return the **absolute** row index to select.
- Marker is glyph-adjacent (`editor*`) to match `list_windows_tmux` (`util.rs`).
- Adds unit tests (marker rendering byte-exact, absolute-index selection across header/pane
  offsets, cross-session isolation incl. the collapsed-row label, fallback path).
- Client-only; no server/protocol change. Scope is `*`-only; the `#`/`-` flags would need a
  `WinTree` field and are deferred.

Verified on a fork: release build on Windows x64/x86/ARM64 + `cargo test --all-targets`
(all green).
