### PR TITLE
fix: reap session registry files orphaned by a reboot or port reuse

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -2681,15 +2681,11 @@ pub fn run_remote(terminal: &mut Terminal<CrosstermBackend<crate::platform::Psmu
                                 popup_rect_last = None;
                                 if choose_tree_preview_default { preview_enabled = true; }
                                 let dir = format!("{}\\.psmux", home);
-                                // Reap registry files for sessions whose server
-                                // is gone (crashed, or killed by a reboot) before
-                                // listing — otherwise their port files linger and
-                                // surface here as "(not responding)" zombies.
-                                crate::session::cleanup_stale_port_files();
-                                // Collect (label, addr, key) for every reachable port file first,
-                                // then fan out the per-session AUTH+session-info fetches in parallel.
-                                // Sequential fetches made the picker open in O(N * read_timeout);
-                                // parallelism keeps it bounded by the single-fetch timeout.
+                                // Collect (label, addr, key) for every port file, then run ONE
+                                // bounded liveness probe per session in parallel. This both lists
+                                // and prunes: total wall time is ~one probe window regardless of
+                                // how many sessions exist, so the picker stays responsive (no
+                                // sequential O(N * timeout) cleanup pass).
                                 let mut targets: Vec<(String, String, String)> = Vec::new();
                                 if let Ok(entries) = std::fs::read_dir(&dir) {
                                     for e in entries.flatten() {
@@ -2709,13 +2705,35 @@ pub fn run_remote(terminal: &mut Terminal<CrosstermBackend<crate::platform::Psmu
                                         }
                                     }
                                 }
-                                let fetched = crate::session::fetch_session_infos_parallel(
+                                let verdicts = crate::session::classify_sessions_parallel(
                                     targets,
-                                    Duration::from_millis(25),
-                                    Duration::from_millis(150),
-                                    |label| format!("{}: (not responding)", label),
+                                    Duration::from_millis(50),
+                                    Duration::from_millis(250),
                                 );
-                                session_entries.extend(fetched);
+                                for (label, liveness) in verdicts {
+                                    match liveness {
+                                        crate::session::SessionLiveness::Alive(info) => {
+                                            session_entries.push((label, info));
+                                        }
+                                        crate::session::SessionLiveness::Dead => {
+                                            // Server gone (crashed, killed by a reboot, or its
+                                            // port reused by another server). Reap it so it never
+                                            // shows as a "(not responding)" zombie. A live-but-slow
+                                            // server self-heals on its next 5s registry tick.
+                                            if crate::debug_log::session_log_enabled() {
+                                                crate::debug_log::session_log("picker",
+                                                    &format!("reaping dead session '{}' from chooser", label));
+                                            }
+                                            crate::session::remove_session_registry(&label);
+                                        }
+                                        crate::session::SessionLiveness::Unreachable => {
+                                            // Could not connect (transient, non-refused). Keep it
+                                            // and show the honest "(not responding)" rather than
+                                            // deleting on an ambiguous failure.
+                                            session_entries.push((label.clone(), format!("{}: (not responding)", label)));
+                                        }
+                                    }
+                                }
                                 if session_entries.is_empty() {
                                     session_entries.push((current_session.clone(), format!("{}: (current)", current_session)));
                                 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -2681,6 +2681,11 @@ pub fn run_remote(terminal: &mut Terminal<CrosstermBackend<crate::platform::Psmu
                                 popup_rect_last = None;
                                 if choose_tree_preview_default { preview_enabled = true; }
                                 let dir = format!("{}\\.psmux", home);
+                                // Reap registry files for sessions whose server
+                                // is gone (crashed, or killed by a reboot) before
+                                // listing — otherwise their port files linger and
+                                // surface here as "(not responding)" zombies.
+                                crate::session::cleanup_stale_port_files();
                                 // Collect (label, addr, key) for every reachable port file first,
                                 // then fan out the per-session AUTH+session-info fetches in parallel.
                                 // Sequential fetches made the picker open in O(N * read_timeout);

--- a/src/debug_log.rs
+++ b/src/debug_log.rs
@@ -12,6 +12,7 @@
 //! | `PSMUX_STYLE_DEBUG=1`  | `~/.psmux/style_debug.log`        | Style/theme parsing, inline styles   |/// | `PSMUX_INPUT_DEBUG=1`  | `~/.psmux/input_debug.log`        | Every crossterm event + console mode |//! | `PSMUX_MOUSE_DEBUG=1`  | `~/.psmux/mouse_debug.log`        | Mouse injection (existing)           |
 //! | `PSMUX_SSH_DEBUG=1`    | `~/.psmux/ssh_input.log`          | SSH input handling (existing)        |
 //! | `PSMUX_LATENCY_LOG=1`  | `~/.psmux/latency.log`            | Keypress-to-render latency (existing)|
+//! | `PSMUX_SESSION_DEBUG=1`| `~/.psmux/session_debug.log`      | Session-registry stale-port cleanup  |
 //!
 //! All loggers are:
 //! - **Off by default** — zero overhead when disabled (one atomic load per call)
@@ -219,4 +220,60 @@ pub fn server_log(component: &str, msg: &str) {
 /// Returns `true` if server debug logging is active.
 pub fn server_log_enabled() -> bool {
     SERVER_LOG.lock().ok().map_or(false, |g| g.is_some())
+}
+
+// ─── Session-registry debug log ─────────────────────────────────────────────
+
+/// Session-registry lifecycle log, gated by `PSMUX_SESSION_DEBUG=1`.
+/// Covers stale-port cleanup decisions: boot-time reaps, auth-rejected
+/// (reused-port) reaps, unparseable port files, and live/inconclusive
+/// probe verdicts — exactly the path that decided whether a session shows
+/// up as a `(not responding)` zombie.
+///
+/// Unlike the other loggers this **appends** rather than truncates, because
+/// registry cleanup runs in many short-lived CLI processes (every `psmux`
+/// invocation calls it at startup); truncating on open would clobber the
+/// log before it could be read.
+static SESSION_LOG: LazyLock<Mutex<Option<std::fs::File>>> = LazyLock::new(|| {
+    if !env_enabled("PSMUX_SESSION_DEBUG") { return Mutex::new(None); }
+    let dir = psmux_dir();
+    let _ = std::fs::create_dir_all(&dir);
+    let f = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(format!("{}/session_debug.log", dir))
+        .ok();
+    Mutex::new(f)
+});
+
+static SESSION_LOG_COUNT: AtomicU32 = AtomicU32::new(0);
+const SESSION_LOG_CAP: u32 = 5000;
+
+/// Log a session-registry message. No-op unless `PSMUX_SESSION_DEBUG=1`.
+pub fn session_log(component: &str, msg: &str) {
+    let n = SESSION_LOG_COUNT.fetch_add(1, Ordering::Relaxed);
+    if n >= SESSION_LOG_CAP {
+        if n == SESSION_LOG_CAP {
+            if let Ok(mut guard) = SESSION_LOG.lock() {
+                if let Some(ref mut f) = *guard {
+                    let _ = writeln!(f, "[{}][log] --- log cap reached ---",
+                        chrono::Local::now().format("%H:%M:%S%.3f"));
+                    let _ = f.flush();
+                }
+            }
+        }
+        return;
+    }
+    if let Ok(mut guard) = SESSION_LOG.lock() {
+        if let Some(ref mut f) = *guard {
+            let _ = writeln!(f, "[{}][{}] {}",
+                chrono::Local::now().format("%H:%M:%S%.3f"), component, msg);
+            let _ = f.flush();
+        }
+    }
+}
+
+/// Returns `true` if session-registry debug logging is active.
+pub fn session_log_enabled() -> bool {
+    SESSION_LOG.lock().ok().map_or(false, |g| g.is_some())
 }

--- a/src/session.rs
+++ b/src/session.rs
@@ -584,6 +584,10 @@ pub fn fetch_session_info(
 /// `inputs` is `(label, addr, key)`. Output preserves input order and
 /// pairs each label with the fetched info or the supplied `fallback`
 /// (typically `"<label>: (not responding)"`).
+///
+/// Retained for the #250 regression suite; the picker now uses
+/// `classify_sessions_parallel`, which both lists and prunes in one pass.
+#[allow(dead_code)]
 pub fn fetch_session_infos_parallel<F>(
     inputs: Vec<(String, String, String)>,
     connect_timeout: Duration,
@@ -621,6 +625,135 @@ where
         handles.into_iter().filter_map(|h| h.join().ok()).collect()
     });
     results
+}
+
+/// Liveness verdict for one session, produced by a single bounded probe.
+#[derive(Clone, Debug, PartialEq)]
+pub enum SessionLiveness {
+    /// Server authenticated and returned its session-info line (the payload).
+    Alive(String),
+    /// Definitively gone: connection refused, an `ERROR` auth rejection (a
+    /// different server reused the port), or connected-then-silent past the
+    /// read timeout. Its registry files should be reaped. A genuinely live
+    /// server that was momentarily too slow self-heals: the server rewrites
+    /// its `.port`/`.key`/`.sid` every 5s (see `ensure_session_registry_files`).
+    Dead,
+    /// Could not even establish a connection due to a transient (non-refused)
+    /// error. Identity is unknown, so it is left in place and shown as
+    /// `(not responding)` rather than deleted.
+    Unreachable,
+}
+
+/// Single bounded liveness probe: connect, AUTH with the session's own key,
+/// ask for `session-info`, and classify the reply. Never retries or blocks
+/// beyond `connect_timeout + read_timeout`.
+fn probe_session_liveness(
+    addr: &str,
+    key: &str,
+    connect_timeout: Duration,
+    read_timeout: Duration,
+) -> SessionLiveness {
+    let sock: std::net::SocketAddr = match addr.parse() {
+        Ok(a) => a,
+        Err(_) => return SessionLiveness::Dead,
+    };
+    let key = match validate_auth_key(key) {
+        Some(k) => k,
+        None => return SessionLiveness::Unreachable,
+    };
+    let mut s = match std::net::TcpStream::connect_timeout(&sock, connect_timeout) {
+        Ok(s) => s,
+        Err(e) if e.kind() == ErrorKind::ConnectionRefused => return SessionLiveness::Dead,
+        Err(_) => return SessionLiveness::Unreachable,
+    };
+    let _ = s.set_read_timeout(Some(read_timeout));
+    let _ = s.set_nodelay(true);
+    if write!(s, "AUTH {}\n", key).is_err() || s.write_all(b"session-info\n").is_err() {
+        return SessionLiveness::Unreachable;
+    }
+    let _ = s.flush();
+    let mut br = std::io::BufReader::new(std::io::Read::take(s, MAX_AUTHED_RESPONSE_BYTES));
+    let mut line = String::new();
+    match std::io::BufRead::read_line(&mut br, &mut line) {
+        Ok(0) => SessionLiveness::Dead,
+        Ok(_) => {
+            let t = line.trim();
+            if t.starts_with("ERROR") {
+                return SessionLiveness::Dead;
+            }
+            if t == "OK" {
+                // Ack consumed; the next line is the real payload.
+                line.clear();
+                match std::io::BufRead::read_line(&mut br, &mut line) {
+                    Ok(0) => SessionLiveness::Dead,
+                    Ok(_) => {
+                        let t2 = line.trim();
+                        if t2.is_empty() || t2 == "OK" || t2.starts_with("ERROR") {
+                            SessionLiveness::Dead
+                        } else {
+                            SessionLiveness::Alive(t2.to_string())
+                        }
+                    }
+                    Err(_) => SessionLiveness::Dead,
+                }
+            } else {
+                // Ack pipelined with the payload in one line.
+                SessionLiveness::Alive(t.to_string())
+            }
+        }
+        Err(_) => SessionLiveness::Dead,
+    }
+}
+
+/// Classify many sessions in parallel with a single bounded probe each.
+///
+/// Like `fetch_session_infos_parallel`, total wall time is ~one probe window
+/// regardless of N (each session runs on its own thread). Returns the liveness
+/// verdict per input label, preserving order, so the caller can reap the dead
+/// ones and render the rest. This is what keeps the session picker responsive:
+/// it replaces a sequential cleanup pass (O(N * timeout)) with one parallel
+/// round-trip that both lists and prunes.
+pub fn classify_sessions_parallel(
+    inputs: Vec<(String, String, String)>,
+    connect_timeout: Duration,
+    read_timeout: Duration,
+) -> Vec<(String, SessionLiveness)> {
+    if inputs.is_empty() {
+        return Vec::new();
+    }
+    if inputs.len() == 1 {
+        let (label, addr, key) = &inputs[0];
+        let v = probe_session_liveness(addr, key, connect_timeout, read_timeout);
+        return vec![(label.clone(), v)];
+    }
+    std::thread::scope(|scope| {
+        let handles: Vec<_> = inputs
+            .iter()
+            .map(|(label, addr, key)| {
+                let label = label.clone();
+                let addr = addr.clone();
+                let key = key.clone();
+                scope.spawn(move || {
+                    let v = probe_session_liveness(&addr, &key, connect_timeout, read_timeout);
+                    (label, v)
+                })
+            })
+            .collect();
+        handles.into_iter().filter_map(|h| h.join().ok()).collect()
+    })
+}
+
+/// Reap a single session's registry files (`.port`/`.key`/`.sid`) by base name.
+///
+/// Used when a probe proves the session is dead. Safe against a live server:
+/// it re-creates these files on its next 5s registry tick.
+pub fn remove_session_registry(base: &str) {
+    let home = match env::var("USERPROFILE").or_else(|_| env::var("HOME")) {
+        Ok(h) => h,
+        Err(_) => return,
+    };
+    let port_path = format!("{}\\.psmux\\{}.port", home, base);
+    remove_session_registry_files(Path::new(&port_path));
 }
 
 pub fn send_control(line: String) -> io::Result<()> {

--- a/src/session.rs
+++ b/src/session.rs
@@ -632,15 +632,16 @@ where
 pub enum SessionLiveness {
     /// Server authenticated and returned its session-info line (the payload).
     Alive(String),
-    /// Definitively gone: connection refused, an `ERROR` auth rejection (a
-    /// different server reused the port), or connected-then-silent past the
-    /// read timeout. Its registry files should be reaped. A genuinely live
-    /// server that was momentarily too slow self-heals: the server rewrites
-    /// its `.port`/`.key`/`.sid` every 5s (see `ensure_session_registry_files`).
+    /// Definitively gone: the connection failed (refused / unreachable — on
+    /// loopback any connect failure means nothing is listening), an `ERROR`
+    /// auth rejection (a different server reused the port), or connected then
+    /// silent past the read timeout. Its registry files should be reaped. A
+    /// genuinely live server that was momentarily too slow self-heals: it
+    /// rewrites its `.port`/`.key`/`.sid` every 5s (see
+    /// `ensure_session_registry_files`).
     Dead,
-    /// Could not even establish a connection due to a transient (non-refused)
-    /// error. Identity is unknown, so it is left in place and shown as
-    /// `(not responding)` rather than deleted.
+    /// No usable AUTH key on disk, so identity cannot be verified at all.
+    /// Left in place and shown as `(not responding)` rather than deleted.
     Unreachable,
 }
 
@@ -661,15 +662,20 @@ fn probe_session_liveness(
         Some(k) => k,
         None => return SessionLiveness::Unreachable,
     };
+    // On loopback a live server always completes the TCP handshake (the kernel
+    // accepts into the listen backlog even before the app calls accept()), so
+    // ANY connect failure means nothing usable is listening -> Dead. We do not
+    // branch on the error kind: Windows does not always surface a clean
+    // `ConnectionRefused` for a free port.
     let mut s = match std::net::TcpStream::connect_timeout(&sock, connect_timeout) {
         Ok(s) => s,
-        Err(e) if e.kind() == ErrorKind::ConnectionRefused => return SessionLiveness::Dead,
-        Err(_) => return SessionLiveness::Unreachable,
+        Err(_) => return SessionLiveness::Dead,
     };
     let _ = s.set_read_timeout(Some(read_timeout));
     let _ = s.set_nodelay(true);
     if write!(s, "AUTH {}\n", key).is_err() || s.write_all(b"session-info\n").is_err() {
-        return SessionLiveness::Unreachable;
+        // Connection broke right after connect -> not a healthy server.
+        return SessionLiveness::Dead;
     }
     let _ = s.flush();
     let mut br = std::io::BufReader::new(std::io::Read::take(s, MAX_AUTHED_RESPONSE_BYTES));

--- a/src/session.rs
+++ b/src/session.rs
@@ -1,11 +1,19 @@
 use std::io::{self, ErrorKind, Write};
 use std::path::Path;
-use std::time::Duration;
+use std::time::{Duration, SystemTime};
 use std::env;
 
 const STALE_PORT_PROBE_ATTEMPTS: usize = 3;
 const STALE_PORT_CONNECT_TIMEOUT: Duration = Duration::from_millis(100);
 const STALE_PORT_RETRY_DELAY: Duration = Duration::from_millis(25);
+/// How long to wait for the server's AUTH ack (`OK` / `ERROR`) when verifying
+/// that the listener on a port file's port is actually *our* psmux server.
+const STALE_PORT_AUTH_READ_TIMEOUT: Duration = Duration::from_millis(120);
+/// Grace window subtracted from the system boot time before treating a
+/// registry file as "written before this boot". Absorbs clock jitter and the
+/// inherent imprecision of deriving boot wall-time from uptime, so a server
+/// that wrote its port file moments after boot is never falsely reaped.
+const BOOT_TIME_MARGIN: Duration = Duration::from_secs(10);
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum PortProbeResult {
@@ -130,20 +138,77 @@ pub fn cleanup_stale_port_files() {
 }
 
 fn cleanup_stale_port_files_in(psmux_dir: &Path) {
-    cleanup_stale_port_files_in_with(psmux_dir, probe_port_for_cleanup);
+    cleanup_stale_port_files_in_with(psmux_dir, probe_session_for_cleanup);
+}
+
+/// Resolve the session key stored alongside a `.port` file (the sibling
+/// `.key`). Returns an empty string when the key file is missing, which the
+/// identity probe treats as "cannot verify" (Inconclusive) rather than dead.
+fn read_key_for_port_path(port_path: &Path) -> String {
+    let key_path = port_path.with_extension("key");
+    std::fs::read_to_string(&key_path)
+        .map(|s| s.trim().to_string())
+        .unwrap_or_default()
+}
+
+/// Best-effort wall-clock time the system last booted, derived from uptime.
+///
+/// Any registry file last written before this instant cannot belong to a
+/// server that has been running since the machine started — its owning
+/// process died with the previous boot (e.g. an OS-update reboot). This is
+/// the reliable signal for cleaning up sessions orphaned by a restart, and
+/// it does not depend on the network (the old port may now be free, occupied
+/// by an unrelated process, or even reused by a *different* live psmux
+/// server — all of which a bare TCP probe would misclassify).
+#[cfg(windows)]
+fn system_boot_time() -> Option<SystemTime> {
+    #[link(name = "kernel32")]
+    extern "system" {
+        fn GetTickCount64() -> u64;
+    }
+    let uptime_ms = unsafe { GetTickCount64() };
+    SystemTime::now().checked_sub(Duration::from_millis(uptime_ms))
+}
+
+#[cfg(not(windows))]
+fn system_boot_time() -> Option<SystemTime> {
+    None
+}
+
+/// True when `mtime` is old enough (older than `boot - margin`) that the file
+/// must have been written by a process from a previous boot.
+fn is_pre_boot(mtime: SystemTime, boot: SystemTime, margin: Duration) -> bool {
+    match boot.checked_sub(margin) {
+        Some(cutoff) => mtime < cutoff,
+        None => false,
+    }
 }
 
 fn cleanup_stale_port_files_in_with<F>(psmux_dir: &Path, mut probe: F)
 where
-    F: FnMut(u16) -> PortProbeResult,
+    F: FnMut(&str, u16) -> PortProbeResult,
 {
+    let boot = system_boot_time();
     if let Ok(entries) = std::fs::read_dir(psmux_dir) {
         for entry in entries.flatten() {
             let path = entry.path();
             if path.extension().map(|e| e == "port").unwrap_or(false) {
+                // Boot-time guard: a port file last modified before this boot
+                // belongs to a server that died when the machine restarted.
+                // Reap it unconditionally — no network round-trip, and immune
+                // to the old port being reused by another process this boot.
+                if let Some(boot) = boot {
+                    if let Some(mtime) = entry.metadata().ok().and_then(|m| m.modified().ok()) {
+                        if is_pre_boot(mtime, boot, BOOT_TIME_MARGIN) {
+                            remove_session_registry_files(&path);
+                            continue;
+                        }
+                    }
+                }
                 if let Ok(port_str) = std::fs::read_to_string(&path) {
                     if let Ok(port) = port_str.trim().parse::<u16>() {
-                        if probe(port) == PortProbeResult::Stale {
+                        let key = read_key_for_port_path(&path);
+                        if probe(&key, port) == PortProbeResult::Stale {
                             remove_session_registry_files(&path);
                         }
                     } else {
@@ -163,20 +228,82 @@ fn remove_session_registry_files(port_path: &Path) {
     let _ = std::fs::remove_file(&sid_path);
 }
 
-fn probe_port_for_cleanup(port: u16) -> PortProbeResult {
+/// Outcome of a single AUTH handshake against the listener on a port.
+#[derive(Clone, Copy, PartialEq)]
+enum AuthProbe {
+    /// Server accepted our session key (`OK`) — this is genuinely our session.
+    Authenticated,
+    /// Server explicitly rejected the key (`ERROR ...`) — a *different* psmux
+    /// server has reused this port; the session this file names is dead.
+    Rejected,
+    /// Connected but the peer didn't complete our protocol (no reply, garbage,
+    /// or an unrelated process). Identity is unverifiable from the network.
+    Unknown,
+}
+
+/// Connect to `addr` and verify, via the AUTH handshake, that the listener is
+/// the psmux server that owns `key`.
+///
+/// Returns `Err(kind)` when the connection itself fails so the caller can tell
+/// "nothing is listening" (refused) from a transient network error.
+fn probe_auth_identity(addr: std::net::SocketAddr, key: &str) -> Result<AuthProbe, ErrorKind> {
+    let mut s = std::net::TcpStream::connect_timeout(&addr, STALE_PORT_CONNECT_TIMEOUT)
+        .map_err(|e| e.kind())?;
+    // A successful connect alone proves only that *something* listens. Without
+    // a key we cannot prove it is ours, so leave the verdict to the boot guard.
+    let key = match validate_auth_key(key) {
+        Some(k) => k,
+        None => return Ok(AuthProbe::Unknown),
+    };
+    let _ = s.set_read_timeout(Some(STALE_PORT_AUTH_READ_TIMEOUT));
+    let _ = s.set_nodelay(true);
+    if write!(s, "AUTH {}\n", key).is_err() {
+        return Ok(AuthProbe::Unknown);
+    }
+    let _ = s.flush();
+    let mut br = std::io::BufReader::new(std::io::Read::take(s, 4096));
+    let mut line = String::new();
+    match std::io::BufRead::read_line(&mut br, &mut line) {
+        Ok(0) => Ok(AuthProbe::Unknown),
+        Ok(_) => {
+            let t = line.trim();
+            if t == "OK" {
+                Ok(AuthProbe::Authenticated)
+            } else if t.starts_with("ERROR") {
+                Ok(AuthProbe::Rejected)
+            } else {
+                Ok(AuthProbe::Unknown)
+            }
+        }
+        Err(_) => Ok(AuthProbe::Unknown),
+    }
+}
+
+/// Identity-aware liveness probe used by stale-port cleanup.
+///
+/// A bare TCP connect cannot distinguish our server from any other process
+/// that grabbed the same port after a crash or reboot — that false "alive"
+/// is exactly what left dead sessions showing `(not responding)` in the
+/// picker. This probe instead requires the AUTH key to match:
+///   - connection refused on every attempt        -> `Stale`
+///   - server accepts our key (`OK`)              -> `Alive`
+///   - server rejects our key (`ERROR`, reused port) -> `Stale`
+///   - anything ambiguous (no reply, slow, foreign process) -> `Inconclusive`
+///
+/// Only definitive signals delete a file; ambiguous ones are left for the
+/// boot-time guard, so a live-but-busy server is never reaped by mistake.
+fn probe_session_for_cleanup(key: &str, port: u16) -> PortProbeResult {
     let addr = std::net::SocketAddr::from(([127, 0, 0, 1], port));
     let mut saw_refused = false;
     let mut saw_inconclusive = false;
 
     for attempt in 0..STALE_PORT_PROBE_ATTEMPTS {
-        match std::net::TcpStream::connect_timeout(&addr, STALE_PORT_CONNECT_TIMEOUT) {
-            Ok(_) => return PortProbeResult::Alive,
-            Err(e) if e.kind() == ErrorKind::ConnectionRefused => {
-                saw_refused = true;
-            }
-            Err(_) => {
-                saw_inconclusive = true;
-            }
+        match probe_auth_identity(addr, key) {
+            Ok(AuthProbe::Authenticated) => return PortProbeResult::Alive,
+            Ok(AuthProbe::Rejected) => return PortProbeResult::Stale,
+            Ok(AuthProbe::Unknown) => saw_inconclusive = true,
+            Err(ErrorKind::ConnectionRefused) => saw_refused = true,
+            Err(_) => saw_inconclusive = true,
         }
 
         if attempt + 1 < STALE_PORT_PROBE_ATTEMPTS {

--- a/src/session.rs
+++ b/src/session.rs
@@ -200,6 +200,11 @@ where
                 if let Some(boot) = boot {
                     if let Some(mtime) = entry.metadata().ok().and_then(|m| m.modified().ok()) {
                         if is_pre_boot(mtime, boot, BOOT_TIME_MARGIN) {
+                            if crate::debug_log::session_log_enabled() {
+                                crate::debug_log::session_log("cleanup", &format!(
+                                    "reaping '{}': port file predates last boot (server died on restart)",
+                                    registry_base(&path)));
+                            }
                             remove_session_registry_files(&path);
                             continue;
                         }
@@ -209,15 +214,30 @@ where
                     if let Ok(port) = port_str.trim().parse::<u16>() {
                         let key = read_key_for_port_path(&path);
                         if probe(&key, port) == PortProbeResult::Stale {
+                            if crate::debug_log::session_log_enabled() {
+                                crate::debug_log::session_log("cleanup", &format!(
+                                    "reaping '{}' (port {}): no psmux server authenticated as ours (stale)",
+                                    registry_base(&path), port));
+                            }
                             remove_session_registry_files(&path);
                         }
                     } else {
+                        if crate::debug_log::session_log_enabled() {
+                            crate::debug_log::session_log("cleanup", &format!(
+                                "reaping '{}': unparseable port value {:?}",
+                                registry_base(&path), port_str.trim()));
+                        }
                         remove_session_registry_files(&path);
                     }
                 }
             }
         }
     }
+}
+
+/// Display name (file stem) of a registry path, for logging.
+fn registry_base(port_path: &Path) -> &str {
+    port_path.file_stem().and_then(|s| s.to_str()).unwrap_or("?")
 }
 
 fn remove_session_registry_files(port_path: &Path) {
@@ -299,8 +319,20 @@ fn probe_session_for_cleanup(key: &str, port: u16) -> PortProbeResult {
 
     for attempt in 0..STALE_PORT_PROBE_ATTEMPTS {
         match probe_auth_identity(addr, key) {
-            Ok(AuthProbe::Authenticated) => return PortProbeResult::Alive,
-            Ok(AuthProbe::Rejected) => return PortProbeResult::Stale,
+            Ok(AuthProbe::Authenticated) => {
+                if crate::debug_log::session_log_enabled() {
+                    crate::debug_log::session_log("probe",
+                        &format!("port {}: AUTH accepted -> alive", port));
+                }
+                return PortProbeResult::Alive;
+            }
+            Ok(AuthProbe::Rejected) => {
+                if crate::debug_log::session_log_enabled() {
+                    crate::debug_log::session_log("probe", &format!(
+                        "port {}: AUTH rejected by a different server (reused port) -> stale", port));
+                }
+                return PortProbeResult::Stale;
+            }
             Ok(AuthProbe::Unknown) => saw_inconclusive = true,
             Err(ErrorKind::ConnectionRefused) => saw_refused = true,
             Err(_) => saw_inconclusive = true,
@@ -312,8 +344,16 @@ fn probe_session_for_cleanup(key: &str, port: u16) -> PortProbeResult {
     }
 
     if saw_refused && !saw_inconclusive {
+        if crate::debug_log::session_log_enabled() {
+            crate::debug_log::session_log("probe",
+                &format!("port {}: connection refused on all attempts -> stale", port));
+        }
         PortProbeResult::Stale
     } else {
+        if crate::debug_log::session_log_enabled() {
+            crate::debug_log::session_log("probe",
+                &format!("port {}: no definitive answer -> inconclusive (kept)", port));
+        }
         PortProbeResult::Inconclusive
     }
 }

--- a/tests-rs/test_session.rs
+++ b/tests-rs/test_session.rs
@@ -342,3 +342,85 @@ fn pre_boot_registry_is_reaped_regardless_of_port() {
     let fresh = boot + Duration::from_secs(30);
     assert!(!is_pre_boot(fresh, boot, margin), "post-boot file must be kept");
 }
+
+#[test]
+fn liveness_authenticated_server_is_alive() {
+    let (addr, done) = spawn_fake_server(|mut s| {
+        drain_client_request(&mut s); // AUTH + session-info (two lines)
+        let _ = s.write_all(b"OK\n");
+        let _ = s.write_all(b"mysession: 2 windows (created Mon Apr 20 11:10:58 2026)\n");
+        let _ = s.flush();
+        thread::sleep(Duration::from_millis(50));
+    });
+
+    let v = probe_session_liveness(
+        &addr,
+        "key",
+        Duration::from_millis(300),
+        Duration::from_millis(400),
+    );
+
+    match v {
+        SessionLiveness::Alive(info) => assert!(info.contains("mysession"), "info: {info}"),
+        other => panic!("expected Alive, got {other:?}"),
+    }
+    let _ = done.recv_timeout(Duration::from_secs(2));
+}
+
+#[test]
+fn liveness_auth_rejection_is_dead() {
+    // The reboot/reused-port case: a different server rejects our key.
+    let (addr, done) = spawn_fake_server(|mut s| {
+        drain_client_request(&mut s);
+        let _ = s.write_all(b"ERROR: Invalid session key\n");
+        let _ = s.flush();
+    });
+
+    let v = probe_session_liveness(
+        &addr,
+        "stale-key",
+        Duration::from_millis(300),
+        Duration::from_millis(400),
+    );
+
+    assert_eq!(v, SessionLiveness::Dead, "auth rejection must be Dead");
+    let _ = done.recv_timeout(Duration::from_secs(2));
+}
+
+#[test]
+fn liveness_connection_refused_is_dead() {
+    // Bind then drop so the port is guaranteed free -> connect refused.
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind to grab a port");
+    let addr = listener.local_addr().unwrap().to_string();
+    drop(listener);
+
+    let v = probe_session_liveness(
+        &addr,
+        "key",
+        Duration::from_millis(300),
+        Duration::from_millis(200),
+    );
+
+    assert_eq!(v, SessionLiveness::Dead, "refused connect must be Dead");
+}
+
+#[test]
+fn liveness_connected_but_silent_is_dead() {
+    // A listener that accepts (via backlog) but never speaks our protocol.
+    // Bounded: we wait one read timeout, then declare it Dead (honors
+    // "no response within the timeout -> kill"); a real server self-heals.
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind silent listener");
+    let addr = listener.local_addr().unwrap().to_string();
+
+    let start = std::time::Instant::now();
+    let v = probe_session_liveness(
+        &addr,
+        "key",
+        Duration::from_millis(300),
+        Duration::from_millis(150),
+    );
+
+    assert_eq!(v, SessionLiveness::Dead, "silent peer must be Dead after timeout");
+    assert!(start.elapsed() < Duration::from_secs(2), "probe must stay bounded, not hang");
+    drop(listener);
+}

--- a/tests-rs/test_session.rs
+++ b/tests-rs/test_session.rs
@@ -225,7 +225,7 @@ fn stale_cleanup_removes_registry_only_when_probe_confirms_stale() {
     let dir = temp_psmux_dir("stale_cleanup_confirmed");
     let (port_path, key_path, sid_path) = write_registry_files(&dir, "dead", "54321");
 
-    cleanup_stale_port_files_in_with(&dir, |_| PortProbeResult::Stale);
+    cleanup_stale_port_files_in_with(&dir, |_, _| PortProbeResult::Stale);
 
     assert!(!port_path.exists(), "confirmed-stale .port file should be removed");
     assert!(!key_path.exists(), "matching .key file should be removed");
@@ -239,7 +239,7 @@ fn stale_cleanup_preserves_registry_when_probe_is_inconclusive() {
     let (port_path, key_path, sid_path) =
         write_registry_files(&dir, "maybe-live", "54322");
 
-    cleanup_stale_port_files_in_with(&dir, |_| PortProbeResult::Inconclusive);
+    cleanup_stale_port_files_in_with(&dir, |_, _| PortProbeResult::Inconclusive);
 
     assert!(port_path.exists(), "inconclusive probe must not remove .port");
     assert!(key_path.exists(), "inconclusive probe must not remove .key");
@@ -261,4 +261,84 @@ fn stale_cleanup_preserves_registry_for_live_listener() {
     assert!(sid_path.exists(), "live listener .sid should be preserved");
     drop(listener);
     let _ = fs::remove_dir_all(dir.parent().unwrap());
+}
+
+/// Read a single `\n`-terminated line from the stream (the probe's AUTH line),
+/// so the fake server's reply lands against the client's read.
+fn read_one_line(stream: &mut TcpStream) {
+    let mut buf = [0u8; 1];
+    loop {
+        match stream.read(&mut buf) {
+            Ok(0) => return,
+            Ok(_) if buf[0] == b'\n' => return,
+            Ok(_) => {}
+            Err(_) => return,
+        }
+    }
+}
+
+#[test]
+fn stale_cleanup_removes_session_when_port_reused_by_other_server() {
+    // After a crash/reboot the old port can be grabbed by a *different* live
+    // psmux server, which rejects our key. A bare TCP connect would call this
+    // "alive" and leave the dead session as a "(not responding)" zombie; the
+    // identity probe must classify the key rejection as Stale and reap it.
+    let (addr, done) = spawn_fake_server(|mut s| {
+        read_one_line(&mut s);
+        let _ = s.write_all(b"ERROR: Invalid session key\n");
+        let _ = s.flush();
+    });
+    let port = addr.rsplit(':').next().unwrap().to_string();
+    let dir = temp_psmux_dir("stale_cleanup_reused_port");
+    let (port_path, key_path, sid_path) = write_registry_files(&dir, "ghost", &port);
+
+    cleanup_stale_port_files_in(&dir);
+
+    assert!(!port_path.exists(), "key-rejected (reused) .port must be removed");
+    assert!(!key_path.exists(), "matching .key must be removed");
+    assert!(!sid_path.exists(), "matching .sid must be removed");
+    let _ = done.recv_timeout(Duration::from_secs(2));
+    let _ = fs::remove_dir_all(dir.parent().unwrap());
+}
+
+#[test]
+fn stale_cleanup_preserves_session_for_authenticated_server() {
+    // Our own live server accepts the key — it must never be reaped.
+    let (addr, done) = spawn_fake_server(|mut s| {
+        read_one_line(&mut s);
+        let _ = s.write_all(b"OK\n");
+        let _ = s.flush();
+        thread::sleep(Duration::from_millis(100));
+    });
+    let port = addr.rsplit(':').next().unwrap().to_string();
+    let dir = temp_psmux_dir("stale_cleanup_authed");
+    let (port_path, key_path, sid_path) = write_registry_files(&dir, "mine", &port);
+
+    cleanup_stale_port_files_in(&dir);
+
+    assert!(port_path.exists(), "authenticated .port must be preserved");
+    assert!(key_path.exists(), "authenticated .key must be preserved");
+    assert!(sid_path.exists(), "authenticated .sid must be preserved");
+    let _ = done.recv_timeout(Duration::from_secs(2));
+    let _ = fs::remove_dir_all(dir.parent().unwrap());
+}
+
+#[test]
+fn pre_boot_registry_is_reaped_regardless_of_port() {
+    use std::time::SystemTime;
+    let boot = SystemTime::now();
+    let margin = Duration::from_secs(10);
+
+    // Written well before boot (previous boot) -> reap.
+    let old = boot - Duration::from_secs(3600);
+    assert!(is_pre_boot(old, boot, margin), "pre-boot file must be reaped");
+
+    // Written within the boot grace window -> keep (could be a server that
+    // came up moments after boot).
+    let recent = boot - Duration::from_secs(2);
+    assert!(!is_pre_boot(recent, boot, margin), "just-after-boot file must be kept");
+
+    // Written after boot -> keep.
+    let fresh = boot + Duration::from_secs(30);
+    assert!(!is_pre_boot(fresh, boot, margin), "post-boot file must be kept");
 }


### PR DESCRIPTION
## What you see

After Windows reboots for an OS update, you reopen psmux and the session picker is full of old sessions stuck in `(not responding)`. They should be gone, because the psmux servers that ran those sessions died with the reboot. But their entries linger and you cannot get rid of them.

<img width="1198" height="301" alt="image" src="https://github.com/user-attachments/assets/2f7bc455-e9f2-4076-b48c-c68098db7a18" />

## Why every dead session still shows up

Two things combine here. Keep them separate, because they are different problems:

**A. The picker only labels, it never prunes.** The session picker builds its list straight from the leftover `<name>.port` files on disk. For each one it tries a single AUTH + `session-info` fetch, and if that fetch comes back with no usable info for *any* reason, it just prints `<name>: (not responding)`. It never deletes the file. So every dead session's leftover files show up in the list, no matter why the fetch failed.

**B. Startup cleanup was too weak to remove them first.** psmux does have a startup cleanup, but the old check was naive: it did a bare TCP connect to the port, and if anything answered it called the session "alive" and kept the files. Anything that was not a clean connection-refused was treated as "inconclusive" and also kept. So leftovers survived cleanup and reached the picker.

### What is actually on each old port after a reboot

Every session writes three files under `~/.psmux/`:

- `<name>.port` — the TCP port its server listens on
- `<name>.key` — a per-session secret for authentication
- `<name>.sid` — the session id

psmux servers do not use fixed ports; each asks the OS for a free ephemeral port at startup. After a reboot those files remain on disk but the servers are gone, and the OS starts handing out ephemeral ports again from the bottom of the range. So for each old `.port` the port number now usually points at one of:

1. **Nothing (free).** Most of them. A connect is refused.
2. **An unrelated program.** Some other app happens to listen on that number. A bare connect succeeds, so the old check wrongly called it "alive".
3. **A different, brand new psmux server.** Possible, but rare right after a reboot: psmux has only spawned a server or two by then (the warm standby plus whatever you just opened), so at most those one or two ports can land on an old session's number. The connect succeeds and it even speaks the psmux protocol, so the old check definitely called it "alive".

Cases 2 and 3 are why a bare "did the port answer?" test is wrong: it cannot tell our server from whoever else is on that port now. But none of these three is, by itself, why the whole list appears. That is problem A above.

## The "(not responding)" misnomer

The label is misleading: it suggests silence, but the port often did answer. Take case 3, the cleanest example. The picker connects and sends:

```
AUTH <old-key>
session-info
```

It expects back the server's `OK` followed by a session-info line like `mysession: 2 windows (created ...)`. But the server now on that reused port has a different key, so it replies:

```
ERROR: Invalid session key
```

The picker treats any `ERROR` as "no info" and prints `mysession: (not responding)`. So the port responded, it just rejected us.

### Detailed reason

`(not responding)` is just the fallback string the picker substitutes whenever the fetch returns "no info". So the real question is: what did the picker need to hear, and what did it actually get?

**What it sends** (per session): `AUTH <key>\n` then `session-info\n`.

**What it needs back:** the server's `OK` ack, followed by a real session-info payload line. That payload line is what would have been shown:

```
OK
mysession: 2 windows (created Mon Apr 20 11:10:58 2026)
```

**What counts as "no info":** the response reader returns nothing for any of these:

- empty line, EOF, or read timeout (true silence — e.g. an unrelated program that never speaks our protocol, case 2)
- the line is just `OK` with no payload after it
- the line starts with `ERROR:` (an explicit auth rejection — case 3)

So different leftover sessions hit "no info" for different reasons: free ports refuse the connect, unrelated programs stay silent, and a reused psmux port replies `ERROR`. The pre-fix picker collapsed all of them to the same `(not responding)` label and left the files in place. The `ERROR` path is the one worth calling out because it proves the point: that case is not silence, it is a definite rejection, which is hard proof the session is dead (a different server holds the port).

## The fix

Stop trusting "did the port answer?", require proof of identity (the AUTH key), and make the picker prune instead of just label.

1. **Identity-aware, bounded liveness probe.** For each session the picker does exactly one bounded probe: connect, AUTH with that session's own key, ask for `session-info`. One attempt, fixed timeouts (~50ms connect + ~250ms read), then a decision. It never retries forever.
   - `OK` + a real info line means it is our server -> **Alive**, shown with its info.
   - `ERROR` (a different server reused the port), connection failed (free port — on loopback any connect failure means nothing is listening), or connected-then-silent past the read timeout (unrelated program) -> **Dead**, files reaped, not shown.
   - No usable AUTH key on disk to verify with -> **Unreachable**, kept and shown honestly as `(not responding)` (ambiguous, so not deleted).

2. **Safe to reap on timeout.** Deleting a session's files is non-destructive even if we are briefly wrong: a live server rewrites its `.port`/`.key`/`.sid` every 5 seconds (`ensure_session_registry_files`). So a momentarily-slow live server self-heals; a truly dead one stays gone.

3. **Boot-time guard.** Any registry file last written before the machine booted cannot belong to a server running since startup, so startup cleanup deletes it unconditionally. No network, immune to port reuse. This clears reboot zombies the instant you run any psmux command.

4. **The picker lists and prunes in one parallel pass.** The probe above runs on one thread per session, so opening the picker is bounded by ~one probe window regardless of how many sessions exist. There is no separate sequential cleanup pass, so the picker stays responsive. Dead sessions simply do not appear; live ones show real info.

## The path, end to end

```
open picker
  -> classify_sessions_parallel()       (one bounded probe per session, in parallel)
       for each <name>.port:
         connect failed (free port)  --------> Dead        -> reap, omit
         AUTH -> OK + info           --------> Alive(info)  -> show real info
         AUTH -> ERROR (reused)      --------> Dead        -> reap, omit
         connected, silent > timeout --------> Dead        -> reap, omit
         no usable key on disk       --------> Unreachable -> keep, show "(not responding)"
  -> list shows live sessions; dead ones are gone, not zombies

startup (any psmux command)
  -> cleanup_stale_port_files()
       file older than last boot?    --------> delete .port/.key/.sid  (boot guard, no network)
       otherwise identity-probe the port (conservative belt-and-suspenders)
```

A live server that gets reaped by mistake reappears within 5s via its registry self-heal tick, so reaping is always safe.

## Observability

Added an env-gated logger, off by default, matching the existing `PSMUX_*_DEBUG` facility:

```
PSMUX_SESSION_DEBUG=1  ->  ~/.psmux/session_debug.log
```

It records each decision, for example:

```
[12:01:03.221][probe] port 50123: AUTH rejected by a different server (reused port) -> stale
[12:01:03.224][cleanup] reaping 'mysession': port file predates last boot (server died on restart)
[12:01:03.230][picker] reaping dead session 'oldsess' from chooser
```

So next time this happens you can see exactly which sessions were reaped and why, versus which were kept.

## Tests

- picker probe: authenticated server -> Alive; auth rejection -> Dead; connection refused -> Dead; connected-but-silent -> Dead (and the probe stays bounded, does not hang)
- startup cleanup: reused-port (key rejection) is reaped; authenticated server is preserved; pre-boot files are reaped while just-after-boot and post-boot files are kept
- existing stale/inconclusive cleanup behavior unchanged

