### PR TITLE
fix(input): handle Ctrl+/ from VT terminals on Windows

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -1797,8 +1797,15 @@ pub fn encode_key_event(key: &KeyEvent) -> Option<Vec<u8>> {
             format!("\x1b{}", c).into_bytes()
         }
         KeyCode::Char(c) if key.modifiers.contains(KeyModifiers::CONTROL) => {
-            let ctrl_char = (c as u8) & 0x1F;
-            vec![ctrl_char]
+            // Use ctrl_char_send_keys_byte for correct tmux-parity mapping.
+            // Naive `c & 0x1F` is wrong for punctuation: C-/ gives 0x0F (^O)
+            // instead of 0x1F (^_). See #226.
+            if let Some(b) = ctrl_char_send_keys_byte(c) {
+                vec![b]
+            } else {
+                let ctrl_char = (c as u8) & 0x1F;
+                vec![ctrl_char]
+            }
         }
         KeyCode::Char(c) if (c as u32) >= 0x01 && (c as u32) <= 0x1A => {
             vec![c as u8]
@@ -3326,7 +3333,8 @@ pub fn send_key_to_active(app: &mut AppState, k: &str) -> io::Result<()> {
             }
             s if s.starts_with("C-") && s.len() == 3 => {
                 let c = s.chars().nth(2).unwrap_or('c');
-                let ctrl_char = (c.to_ascii_lowercase() as u8) & 0x1F;
+                let ctrl_char = ctrl_char_send_keys_byte(c)
+                    .unwrap_or((c.to_ascii_lowercase() as u8) & 0x1F);
                 // Always write the raw control byte so ConPTY can generate
                 // console control events (e.g. CTRL_C_EVENT for \x03).
                 // Raw bytes do NOT start with \x1b so they never corrupt

--- a/src/ssh_input.rs
+++ b/src/ssh_input.rs
@@ -202,9 +202,38 @@ pub fn is_ssh_session() -> bool {
 /// The fix: use the same VT input parser as SSH sessions to properly decode
 /// X10/SGR mouse sequences from stdin.
 pub fn needs_vt_input() -> bool {
-    is_ssh_session()
-        || std::env::var("TERMINAL_EMULATOR")
-            .map_or(false, |v| v.contains("JetBrains"))
+    if is_ssh_session() {
+        return true;
+    }
+    // JetBrains IDEs (JediTerm) send VT mouse sequences through ConPTY.
+    if std::env::var("TERMINAL_EMULATOR")
+        .map_or(false, |v| v.contains("JetBrains"))
+    {
+        return true;
+    }
+    // Alacritty and WezTerm on Windows route input through ConPTY and send
+    // VT escape sequences (e.g. \x1b[27;5;47~ for Ctrl+/).
+    //
+    // Detection by env vars each terminal sets on Windows:
+    //   Alacritty  → ALACRITTY_LOG (e.g. C:\...\Alacritty-NNNN.log)
+    //   WezTerm    → WEZTERM_LOG   (e.g. "warn")
+    //   TERM_PROGRAM → set by some terminals on other platforms
+    //
+    // Windows Terminal sets WT_SESSION and delivers native Win32 INPUT_RECORDs,
+    // so it does NOT need VT mode.
+    if std::env::var_os("ALACRITTY_LOG").is_some() {
+        return true;
+    }
+    if std::env::var_os("WEZTERM_LOG").is_some() {
+        return true;
+    }
+    if let Ok(term_program) = std::env::var("TERM_PROGRAM") {
+        let tp = term_program.to_lowercase();
+        if tp.contains("alacritty") || tp.contains("wezterm") {
+            return true;
+        }
+    }
+    false
 }
 
 /// Returns the Windows build number (e.g. 19045 for Win10 22H2, 22631 for
@@ -818,6 +847,19 @@ impl VtParser {
     /// Dispatch CSI `~` (tilde) sequences: `\x1b[N~` or `\x1b[N;mod~`.
     fn dispatch_tilde<F: FnMut(Event)>(&self, mods: KeyModifiers, emit: &mut F) {
         let n = self.params[0];
+
+        // modifyOtherKeys format 1: \x1b[27;mod;unicode~
+        // params[0]=27, params[1]=modifier, params[2]=Unicode codepoint.
+        // Sent by Alacritty, XTerm with modifyOtherKeys=1, etc.
+        // Example: Ctrl+/ → \x1b[27;5;47~
+        if n == 27 && self.pidx >= 3 {
+            let key_mods = decode_modifiers(self.params[1]);
+            if let Some(c) = char::from_u32(self.params[2] as u32) {
+                emit(make_key(KeyCode::Char(c), key_mods));
+            }
+            return;
+        }
+
         let code = match n {
             1 | 7 => KeyCode::Home,
             2 => KeyCode::Insert,


### PR DESCRIPTION
## What

Fix `Ctrl+/` not working in psmux when using Alacritty or WezTerm on Windows.

## Why it broke

psmux disables `ENABLE_VIRTUAL_TERMINAL_INPUT` on stdin, forcing crossterm into
Win32 `INPUT_RECORD` mode. Windows Terminal works fine because it delivers native
Win32 key events. Alacritty and WezTerm instead send modified keys as VT escape
sequences through ConPTY — those are never translated into Win32 events and get
silently dropped.

There was also a bug in Ctrl-key byte encoding: the naive `c & 0x1F` bitmask
gives the wrong result for punctuation. `'/' & 0x1F = 0x0F` (`^O`), but
`Ctrl+/` should produce `0x1F` (`^_`).

## Changes

**`src/ssh_input.rs` — `needs_vt_input()`**
Detect Alacritty (`ALACRITTY_LOG`) and WezTerm (`WEZTERM_LOG`) and keep VT input
enabled for them, the same way SSH and JetBrains sessions already do.

**`src/ssh_input.rs` — `dispatch_tilde()`**
Handle modifyOtherKeys format 1 (`CSI 27;mod;unicode~`). Alacritty sends
`Ctrl+/` as `\x1b[27;5;47~`; this was previously unrecognised.

**`src/input.rs` — `encode_key_event()` and `write_named_key_to_pane()`**
Use the existing `ctrl_char_send_keys_byte()` helper instead of `c & 0x1F` so
Ctrl+punctuation follows the same tmux-compatible mapping table used by
`send-keys`.

## Testing

```
cargo test ctrl_slash
# 14 passed, 0 failed
```

Manually verified in Alacritty → psmux → WSL: `Ctrl+/` now triggers comment
toggle in Neovim as expected.
