### PR TITLE
(fix: swap-pane:) actually swap panes; add -t targets, position tokens, and post-swap resize

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1253,11 +1253,43 @@ fn execute_command_string_single(app: &mut AppState, cmd: &str) -> io::Result<()
             }
         }
         "swap-pane" | "swapp" => {
-            if let Some(port) = app.control_port {
-                let dir = if parts.iter().any(|p| *p == "-U") { "-U" } else { "-D" };
+            // `-t <target>` swaps the active pane with an explicit target pane
+            // (e.g. `swap-pane -t :.4` or `swap-pane -t %2`).  Without -t, fall
+            // back to the directional -U/-D/-L/-R swap.
+            let target = parts.iter().position(|p| *p == "-t")
+                .and_then(|i| parts.get(i + 1)).map(|s| s.to_string());
+            if let Some(tgt) = target {
+                if let Some(port) = app.control_port {
+                    let _ = send_control_to_port(port, &format!("swap-pane -t {}\n", tgt), &app.session_key);
+                } else {
+                    let path = if tgt.starts_with('{') {
+                        // Layout position token like {top-right} — resolve to
+                        // whatever pane currently occupies that corner.
+                        crate::window_ops::pane_path_at_position(app, &tgt)
+                    } else {
+                        let parsed = crate::cli::parse_target(&tgt);
+                        let win = &app.windows[app.active_idx];
+                        match parsed.pane {
+                            Some(p) if parsed.pane_is_id => crate::tree::find_path_by_id(&win.root, p),
+                            Some(p) => crate::tree::path_by_position(&win.root, p.saturating_sub(app.pane_base_index)),
+                            None => None,
+                        }
+                    };
+                    if let Some(path) = path {
+                        crate::window_ops::swap_pane_with_path(app, path);
+                    }
+                }
+            } else if let Some(port) = app.control_port {
+                let dir = if parts.iter().any(|p| *p == "-U") { "-U" }
+                    else if parts.iter().any(|p| *p == "-L") { "-L" }
+                    else if parts.iter().any(|p| *p == "-R") { "-R" }
+                    else { "-D" };
                 let _ = send_control_to_port(port, &format!("swap-pane {}\n", dir), &app.session_key);
             } else {
-                let dir = if parts.iter().any(|p| *p == "-U") { FocusDir::Up } else { FocusDir::Down };
+                let dir = if parts.iter().any(|p| *p == "-L") { FocusDir::Left }
+                    else if parts.iter().any(|p| *p == "-R") { FocusDir::Right }
+                    else if parts.iter().any(|p| *p == "-U") { FocusDir::Up }
+                    else { FocusDir::Down };
                 crate::window_ops::swap_pane(app, dir);
             }
         }

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -588,7 +588,10 @@ if control_echo || control_noecho {
                 } else {
                     let _ = tx_ctrl.send(CtrlReq::FocusPaneByIndex(pid));
                 }
-            } else {
+            } else if !matches!(cmd_name, "swap-pane" | "swapp") {
+                // swap-pane resolves its own target and swaps it with the *current*
+                // active pane.  Temporarily focusing the target here would make
+                // active == target, turning the swap into a no-op (so skip it).
                 if ctrl_pane_is_id {
                     let _ = tx_ctrl.send(CtrlReq::FocusPaneTemp(pid));
                 } else {
@@ -823,7 +826,9 @@ let targeted_kill_pane_id = if matches!(cmd, "kill-pane" | "killp") && pane_is_i
 } else {
     None
 };
-let skip_pane_focus = matches!(cmd, "display-message" | "display") || skip_target_focus;
+// swap-pane swaps the target with the *current* active pane; focusing the
+// target first would make active == target and turn the swap into a no-op.
+let skip_pane_focus = matches!(cmd, "display-message" | "display" | "swap-pane" | "swapp") || skip_target_focus;
 if !skip_pane_focus && targeted_kill_pane_id.is_none() {
     if let Some(pid) = target_pane {
         if is_focus_cmd {
@@ -1393,10 +1398,21 @@ match cmd {
         }
     }
     "swap-pane" | "swapp" => {
-        let dir = if args.iter().any(|a| *a == "-U") { "U" }
-            else if args.iter().any(|a| *a == "-D") { "D" }
-            else { "D" };
-        let _ = tx.send(CtrlReq::SwapPane(dir.to_string()));
+        let raw_t = args.iter().position(|a| *a == "-t")
+            .and_then(|i| args.get(i + 1).copied())
+            .or_else(|| raw_target.as_deref());
+        if let Some(tok) = raw_t.filter(|t| t.starts_with('{')) {
+            // Layout position token like {top-right} — layout-independent.
+            let _ = tx.send(CtrlReq::SwapPanePosition(tok.to_string()));
+        } else if let Some((p, is_id)) = raw_t.map(parse_target).and_then(|pt| pt.pane.map(|p| (p, pt.pane_is_id))) {
+            let _ = tx.send(CtrlReq::SwapPaneTarget(p, is_id));
+        } else {
+            let dir = if args.iter().any(|a| *a == "-U") { "U" }
+                else if args.iter().any(|a| *a == "-L") { "L" }
+                else if args.iter().any(|a| *a == "-R") { "R" }
+                else { "D" };
+            let _ = tx.send(CtrlReq::SwapPane(dir.to_string()));
+        }
     }
     "resize-pane" | "resizep" => {
         // Check for zoom toggle first (issue #35)
@@ -3423,10 +3439,27 @@ fn dispatch_control_command(
             true
         }
         "swap-pane" | "swapp" => {
-            let direction = if args.iter().any(|a| *a == "-U") { "-U".to_string() }
-                           else if args.iter().any(|a| *a == "-D") { "-D".to_string() }
-                           else { "-D".to_string() };
-            let _ = tx.send(CtrlReq::SwapPane(direction));
+            // A `{...}` position token (e.g. {top-right}) resolves to whatever
+            // pane currently sits there — layout-independent.  Otherwise resolve
+            // an inline `-t <target>` / pre-parsed control target; else directional.
+            if let Some(tok) = _raw_target.filter(|t| t.starts_with('{')) {
+                let _ = tx.send(CtrlReq::SwapPanePosition(tok.to_string()));
+            } else {
+                let inline = args.iter().position(|a| *a == "-t")
+                    .and_then(|i| args.get(i + 1).copied())
+                    .map(parse_target)
+                    .and_then(|pt| pt.pane.map(|p| (p, pt.pane_is_id)));
+                let resolved = inline.or_else(|| target_pane.map(|p| (p, pane_is_id)));
+                if let Some((p, is_id)) = resolved {
+                    let _ = tx.send(CtrlReq::SwapPaneTarget(p, is_id));
+                } else {
+                    let direction = if args.iter().any(|a| *a == "-U") { "U".to_string() }
+                                   else if args.iter().any(|a| *a == "-L") { "L".to_string() }
+                                   else if args.iter().any(|a| *a == "-R") { "R".to_string() }
+                                   else { "D".to_string() };
+                    let _ = tx.send(CtrlReq::SwapPane(direction));
+                }
+            }
             let _ = resp_tx.send(String::new());
             true
         }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -33,7 +33,7 @@ use crate::layout::{dump_layout_json, dump_layout_json_fast, apply_layout, cycle
     cycle_layout_reverse};
 use crate::window_ops::{toggle_zoom, remote_mouse_down, remote_mouse_drag, remote_mouse_up,
     remote_mouse_button, remote_mouse_motion, remote_scroll_up, remote_scroll_down,
-    swap_pane, break_pane_to_window, unzoom_if_zoomed, resize_pane_vertical,
+    swap_pane, swap_pane_with_path, break_pane_to_window, unzoom_if_zoomed, resize_pane_vertical,
     resize_pane_horizontal, resize_pane_absolute, rotate_panes, respawn_active_pane,
     handle_pane_mouse, handle_pane_scroll, handle_split_set_sizes, handle_split_resize_done};
 use crate::config::{load_config, parse_key_string, format_key_binding, normalize_key_for_binding,
@@ -2871,8 +2871,37 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                     match dir.as_str() {
                         "U" => { swap_pane(&mut app, FocusDir::Up); }
                         "D" => { swap_pane(&mut app, FocusDir::Down); }
+                        "L" => { swap_pane(&mut app, FocusDir::Left); }
+                        "R" => { swap_pane(&mut app, FocusDir::Right); }
                         _ => { swap_pane(&mut app, FocusDir::Down); }
                     }
+                    meta_dirty = true;
+                    hook_event = Some("after-swap-pane");
+                }
+                CtrlReq::SwapPaneTarget(target, is_id) => {
+                    // tmux: swap-pane without -Z permanently unzooms (#82)
+                    unzoom_if_zoomed(&mut app);
+                    let path = {
+                        let win = &app.windows[app.active_idx];
+                        if is_id {
+                            crate::tree::find_path_by_id(&win.root, target)
+                        } else {
+                            crate::tree::path_by_position(&win.root, target.saturating_sub(app.pane_base_index))
+                        }
+                    };
+                    if let Some(path) = path {
+                        swap_pane_with_path(&mut app, path);
+                    }
+                    meta_dirty = true;
+                    hook_event = Some("after-swap-pane");
+                }
+                CtrlReq::SwapPanePosition(token) => {
+                    // tmux: swap-pane without -Z permanently unzooms (#82)
+                    unzoom_if_zoomed(&mut app);
+                    if let Some(path) = crate::window_ops::pane_path_at_position(&app, &token) {
+                        swap_pane_with_path(&mut app, path);
+                    }
+                    meta_dirty = true;
                     hook_event = Some("after-swap-pane");
                 }
                 CtrlReq::ResizePane(dir, amount) => {

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -528,6 +528,87 @@ fn collect_leaf_paths(node: &Node, path: &mut Vec<usize>, out: &mut Vec<(usize, 
     }
 }
 
+/// Return the tree path of the pane at positional index `pos` (DFS order).
+pub fn path_by_position(node: &Node, pos: usize) -> Option<Vec<usize>> {
+    let mut out: Vec<(usize, Vec<usize>)> = Vec::new();
+    collect_leaf_paths(node, &mut Vec::new(), &mut out);
+    out.get(pos).map(|(_, p)| p.clone())
+}
+
+/// Get a mutable reference to the node at `path` (following Split children).
+pub fn node_at_mut<'a>(node: &'a mut Node, path: &[usize]) -> Option<&'a mut Node> {
+    let mut cur = node;
+    for &idx in path {
+        match cur {
+            Node::Split { children, .. } => { cur = children.get_mut(idx)?; }
+            Node::Leaf(_) => return None,
+        }
+    }
+    Some(cur)
+}
+
+/// Swap the two subtrees located at `a` and `b` within `root`.
+/// Returns true on success.  The paths must be distinct and neither may be a
+/// prefix of the other — which always holds for two distinct leaf paths.
+/// The split `sizes` are untouched, so only the pane *contents* change slots.
+pub fn swap_nodes(root: &mut Node, a: &[usize], b: &[usize]) -> bool {
+    if a == b || a.is_empty() || b.is_empty() { return false; }
+    let min = a.len().min(b.len());
+    if a[..min] == b[..min] { return false; } // one path is an ancestor of the other
+    let pa = match node_at_mut(root, a) { Some(n) => n as *mut Node, None => return false };
+    let pb = match node_at_mut(root, b) { Some(n) => n as *mut Node, None => return false };
+    if pa == pb { return false; }
+    // SAFETY: `pa` and `pb` point to distinct, non-overlapping nodes (the paths
+    // are distinct and neither is a prefix of the other), so the swap cannot
+    // create aliasing.
+    unsafe { std::ptr::swap(pa, pb); }
+    true
+}
+
+#[cfg(test)]
+mod swap_node_tests {
+    use crate::types::{Node, LayoutKind};
+    // Use empty Splits as distinguishable markers (avoids constructing a Pane).
+    fn marker(n: u16) -> Node {
+        Node::Split { kind: LayoutKind::Vertical, sizes: vec![n], children: vec![] }
+    }
+    fn sz(n: &Node) -> Vec<u16> {
+        match n { Node::Split { sizes, .. } => sizes.clone(), _ => vec![] }
+    }
+    #[test]
+    fn swap_nonsibling_positions() {
+        // H[ A(10), V[ B(20), C(30) ] ] ; swap [0] <-> [1,1]
+        let mut root = Node::Split { kind: LayoutKind::Horizontal, sizes: vec![1, 1], children: vec![
+            marker(10),
+            Node::Split { kind: LayoutKind::Vertical, sizes: vec![1, 1], children: vec![marker(20), marker(30)] },
+        ]};
+        assert!(super::swap_nodes(&mut root, &[0], &[1, 1]));
+        if let Node::Split { children, .. } = &root {
+            assert_eq!(sz(&children[0]), vec![30], "slot [0] should now hold C(30)");
+            if let Node::Split { children: c2, .. } = &children[1] {
+                assert_eq!(sz(&c2[0]), vec![20], "B(20) unchanged");
+                assert_eq!(sz(&c2[1]), vec![10], "slot [1,1] should now hold A(10)");
+            } else { panic!("expected inner split"); }
+        } else { panic!("expected split"); }
+    }
+    #[test]
+    fn swap_siblings() {
+        let mut root = Node::Split { kind: LayoutKind::Horizontal, sizes: vec![1, 1], children: vec![marker(1), marker(2)] };
+        assert!(super::swap_nodes(&mut root, &[0], &[1]));
+        if let Node::Split { children, .. } = &root {
+            assert_eq!(sz(&children[0]), vec![2]);
+            assert_eq!(sz(&children[1]), vec![1]);
+        } else { panic!(); }
+    }
+    #[test]
+    fn swap_rejects_invalid() {
+        let mut root = Node::Split { kind: LayoutKind::Horizontal, sizes: vec![1], children: vec![marker(1)] };
+        assert!(!super::swap_nodes(&mut root, &[0], &[0]));    // identical paths
+        assert!(!super::swap_nodes(&mut root, &[], &[0]));     // empty path
+        assert!(!super::swap_nodes(&mut root, &[0], &[0, 0])); // ancestor/descendant
+    }
+}
+
 /// Public wrapper for collect_leaf_paths (used by join-pane to resolve pane index to path).
 pub fn collect_leaf_paths_pub(node: &Node, path: &mut Vec<usize>, out: &mut Vec<(usize, Vec<usize>)>) {
     collect_leaf_paths(node, path, out);

--- a/src/types.rs
+++ b/src/types.rs
@@ -1032,6 +1032,13 @@ pub enum CtrlReq {
     /// Fields: session name, optional client CWD, response sender.
     ClaimSession(String, Option<String>, mpsc::Sender<String>),
     SwapPane(String),
+    /// swap-pane -t <target>: swap the active pane with the pane identified by
+    /// (target, pane_is_id).  When `pane_is_id` is true the value is a pane id
+    /// (`%N`); otherwise it is a 0-based positional pane index.
+    SwapPaneTarget(usize, bool),
+    /// swap-pane -t <token>: swap the active pane with the pane at a layout
+    /// position token (e.g. `{top-right}`).  Layout-independent.
+    SwapPanePosition(String),
     ResizePane(String, u16),
     SetBuffer(String),
     /// Set a named buffer: (name, content)

--- a/src/window_ops.rs
+++ b/src/window_ops.rs
@@ -1091,11 +1091,117 @@ pub fn swap_pane(app: &mut AppState, dir: FocusDir) {
     // Try direct neighbour first, then wrap to opposite edge (tmux parity #61)
     let target = crate::input::find_best_pane_in_direction(&rects, ai, arect, dir, &pane_ids, &win.pane_mru)
         .or_else(|| crate::input::find_wrap_target(&rects, ai, arect, dir, &pane_ids, &win.pane_mru));
+    let mut swapped = false;
     if let Some(ni) = target {
-        if let Some(new_pane_id) = pane_ids.get(ni) {
-            crate::tree::touch_mru(&mut win.pane_mru, *new_pane_id);
+        let active_path = rects[ai].0.clone();
+        let target_path = rects[ni].0.clone();
+        // Actually exchange the two panes in the layout tree (keeping the split
+        // sizes) instead of merely moving focus.  This is the real swap-pane
+        // behaviour expected from tmux.
+        if crate::tree::swap_nodes(&mut win.root, &active_path, &target_path) {
+            if let Some(new_pane_id) = pane_ids.get(ni) {
+                crate::tree::touch_mru(&mut win.pane_mru, *new_pane_id);
+            }
+            // Focus follows the pane that was just moved into the new slot.
+            win.active_path = target_path;
+            swapped = true;
         }
-        win.active_path = rects[ni].0.clone();
+    }
+    // Resize the moved panes' PTYs to fit their new slots (tmux re-lays-out
+    // after a swap).  Without this the program keeps its old terminal size.
+    if swapped { crate::tree::resize_all_panes(app); }
+}
+
+/// Swap the active pane with the pane at an explicit tree `path`
+/// (used by `swap-pane -t <target>`).  Geometry is preserved; focus follows
+/// the moved pane to its new slot.
+pub fn swap_pane_with_path(app: &mut AppState, target_path: Vec<usize>) {
+    let swapped = {
+        let win = &mut app.windows[app.active_idx];
+        let active_path = win.active_path.clone();
+        if active_path == target_path { false }
+        else {
+            let new_id = crate::tree::get_active_pane_id(&win.root, &target_path);
+            if crate::tree::swap_nodes(&mut win.root, &active_path, &target_path) {
+                if let Some(id) = new_id { crate::tree::touch_mru(&mut win.pane_mru, id); }
+                win.active_path = target_path;
+                true
+            } else { false }
+        }
+    };
+    // Resize moved panes to fit their new slots (see swap_pane).
+    if swapped { crate::tree::resize_all_panes(app); }
+}
+
+/// Resolve a tmux-style position token (e.g. `{top-right}`) to the path of the
+/// pane occupying that corner/edge of the current window.  Layout-independent:
+/// always finds whatever pane currently sits there.
+pub fn pane_path_at_position(app: &AppState, token: &str) -> Option<Vec<usize>> {
+    if app.windows.is_empty() { return None; }
+    let area = app.last_window_area;
+    let win = &app.windows[app.active_idx];
+    let mut rects: Vec<(Vec<usize>, Rect)> = Vec::new();
+    compute_rects(&win.root, area, &mut rects);
+    resolve_position_token(token, area, &rects)
+}
+
+/// Map a tmux-style position token to the path of the pane covering that
+/// corner/edge point.  Pure geometry, separated out so it can be unit-tested.
+pub fn resolve_position_token(token: &str, area: Rect, rects: &[(Vec<usize>, Rect)]) -> Option<Vec<usize>> {
+    if area.width == 0 || area.height == 0 { return None; }
+    let x0 = area.x;
+    let y0 = area.y;
+    let xmax = area.x + area.width - 1;
+    let ymax = area.y + area.height - 1;
+    let xmid = area.x + area.width / 2;
+    let ymid = area.y + area.height / 2;
+    let (px, py) = match token {
+        "{top-left}"     => (x0, y0),
+        "{top-right}"    => (xmax, y0),
+        "{bottom-left}"  => (x0, ymax),
+        "{bottom-right}" => (xmax, ymax),
+        "{top}"          => (xmid, y0),
+        "{bottom}"       => (xmid, ymax),
+        "{left}"         => (x0, ymid),
+        "{right}"        => (xmax, ymid),
+        _ => return None,
+    };
+    rects.iter()
+        .find(|(_, r)| px >= r.x && px < r.x + r.width && py >= r.y && py < r.y + r.height)
+        .map(|(p, _)| p.clone())
+}
+
+#[cfg(test)]
+mod position_token_tests {
+    use super::resolve_position_token;
+    use ratatui::layout::Rect;
+    fn layout() -> (Rect, Vec<(Vec<usize>, Rect)>) {
+        // ABTOP top-left, SMALL bottom-left, BIG right (mirrors the user's panel).
+        let area = Rect { x: 0, y: 0, width: 160, height: 40 };
+        let rects = vec![
+            (vec![0, 0], Rect { x: 0,  y: 0,  width: 79, height: 19 }),
+            (vec![0, 1], Rect { x: 0,  y: 20, width: 79, height: 20 }),
+            (vec![1],    Rect { x: 80, y: 0,  width: 80, height: 40 }),
+        ];
+        (area, rects)
+    }
+    #[test]
+    fn top_right_finds_big_pane() {
+        let (area, rects) = layout();
+        assert_eq!(resolve_position_token("{top-right}", area, &rects), Some(vec![1]));
+        assert_eq!(resolve_position_token("{bottom-right}", area, &rects), Some(vec![1]));
+        assert_eq!(resolve_position_token("{right}", area, &rects), Some(vec![1]));
+    }
+    #[test]
+    fn corners_left() {
+        let (area, rects) = layout();
+        assert_eq!(resolve_position_token("{top-left}", area, &rects), Some(vec![0, 0]));
+        assert_eq!(resolve_position_token("{bottom-left}", area, &rects), Some(vec![0, 1]));
+    }
+    #[test]
+    fn unknown_token_is_none() {
+        let (area, rects) = layout();
+        assert_eq!(resolve_position_token("{active}", area, &rects), None);
     }
 }
 


### PR DESCRIPTION
# swap-pane: actually swap panes; add -t targets, position tokens, and post-swap resize

## Summary
`swap-pane` only moved the active-pane marker instead of exchanging the two panes
in the window layout, so it was effectively a no-op. This PR makes `swap-pane`
actually swap the panes (matching tmux), adds the `-t` targeting tmux supports
(pane id/index and `{position}` tokens), and resizes the swapped panes to their
new cells.

## The bug
`window_ops::swap_pane()` located the neighbour pane in the requested direction
and then only set `win.active_path` to it — it never exchanged the two panes in
the layout tree. Consequences:
- `swap-pane -U`/`-D` (and `swapp`) did nothing visible — they just moved focus.
- `rotate-window` was a no-op too, and same-window `join-pane`/`move-pane` are
  rejected, so there was no working way to reorder panes.

In tmux, `swap-pane` swaps the two panes' positions in the window
(man page: *"swap-pane … Swap two panes."*).

## Changes

### Real swap
- `tree::swap_nodes(root, a, b)` exchanges the two subtrees at two distinct leaf
  paths via `std::ptr::swap` (because `Pane` is not `Clone`), keeping split kinds
  and `sizes`. Guards against equal paths and ancestor/descendant paths.
- `window_ops::swap_pane` and the new `swap_pane_with_path` call `swap_nodes`
  and move focus to follow the swapped-in pane.

### Resize after swap (tmux parity)
- After a successful swap, call `resize_all_panes()` so each pane's PTY and
  `vt100` size is updated to its new cell. tmux keeps the layout cells fixed and
  resizes the swapped panes into them; without this the program inside the moved
  pane keeps its old terminal size.

### `-t` target support
- `swap-pane -t <target>` now works for `session:window.pane`, pane index, and
  `%id` (via `parse_target` → `find_path_by_id` / `path_by_position`), routed
  through a new `CtrlReq::SwapPaneTarget`.
- Added tmux's pane **position tokens** as targets: `{top-left}`, `{top-right}`,
  `{bottom-left}`, `{bottom-right}`, `{top}`, `{bottom}`, `{left}`, `{right}`
  (`window_ops::resolve_position_token`, `CtrlReq::SwapPanePosition`). Each
  resolves to whatever pane currently occupies that corner/edge, so e.g.
  `bind -n M-w swap-pane -t '{top-right}'` is layout-independent. tmux's
  `target-pane` grammar already defines these tokens.
- Added `swap-pane -L`/`-R` alongside the existing `-U`/`-D`.
- Excluded `swap-pane` from the control path's "focus the `-t` target before
  running the command" step — otherwise the active pane became the target and
  the swap was a self-swap (no-op).

## Test plan
- Unit tests added: `tree::swap_node_tests` (non-sibling / sibling swap,
  invalid-path rejection) and `window_ops::position_token_tests` (corner/edge
  resolution).
- Manual (Windows 11, PowerShell): in a 3-pane layout, `swap-pane -t <big-pane>`
  exchanges the focused pane with the target, focus follows, and the swapped-in
  pane is resized to the target cell; `swap-pane -t '{top-right}'` hits the
  top-right pane regardless of pane order.

## Notes / scope
- Relative tokens `{up-of}` / `{down-of}` / `{left-of}` / `{right-of}` are not
  added here (only the absolute corner/edge tokens).
- A one-shot CLI on a custom `-L` socket can mis-route a `{...}` target as a
  session name; the key-binding / in-server path resolves it correctly (the
  common use). Can be addressed in a follow-up if desired.
