### PR TITLE
fix(conpty): detect ESC[6n split across parser read batches

### DIFF
--- a/src/pane.rs
+++ b/src/pane.rs
@@ -1199,6 +1199,54 @@ fn scan_cpr_query(data: &[u8]) -> bool {
     data.contains(&0x1b) && data.windows(CPR.len()).any(|w| w == CPR)
 }
 
+/// Detects ESC[6n across batch boundaries. The parser thread scans output in
+/// coalesced batches; a cursor-position request split across two batches is
+/// invisible to the per-batch `scan_cpr_query` (no carry-over), so `cpr_pending`
+/// is never set, the reply is never written, and whatever issued the request
+/// waits for it forever. The asker can be pwsh after a lock/unlock, or conhost
+/// at pane startup (PSUEDOCONSOLE_INHERIT_CURSOR) -- in that case the pane's
+/// child hangs permanently in ConsoleCreateConnectionObject, before any user
+/// code runs (reproduced deterministically: split the request and the per-batch
+/// scan misses it, the pane never starts on an idle machine). This scanner
+/// carries the last KEEP bytes between batches (one less than the sequence
+/// length -- the most a boundary can hide) and rescans the boundary region, so
+/// a split query is still detected.
+struct CprScanner {
+    tail: Vec<u8>,
+}
+
+impl CprScanner {
+    /// One less than the query length: a 4-byte sequence not contained in a
+    /// single batch has at most 3 bytes on either side of the boundary.
+    const KEEP: usize = 3;
+
+    fn new() -> Self {
+        Self {
+            tail: Vec::with_capacity(Self::KEEP),
+        }
+    }
+
+    fn scan(&mut self, batch: &[u8]) -> bool {
+        let mut hit = scan_cpr_query(batch);
+        if !hit && !self.tail.is_empty() {
+            // A match crossing the boundary has ≤KEEP bytes in the tail and
+            // ≤KEEP bytes at the start of this batch.
+            let mut boundary = self.tail.clone();
+            boundary.extend_from_slice(&batch[..batch.len().min(Self::KEEP)]);
+            hit = scan_cpr_query(&boundary);
+        }
+        if batch.len() >= Self::KEEP {
+            self.tail.clear();
+            self.tail.extend_from_slice(&batch[batch.len() - Self::KEEP..]);
+        } else {
+            self.tail.extend_from_slice(batch);
+            let excess = self.tail.len().saturating_sub(Self::KEEP);
+            self.tail.drain(..excess);
+        }
+        hit
+    }
+}
+
 // TODO: The 7 Arc parameters below should be grouped into a `ReaderSignals`
 // struct the next time a new signal is added, to keep the call-site manageable.
 pub fn spawn_reader_thread(
@@ -1290,6 +1338,7 @@ pub fn spawn_reader_thread(
 
     // ── Parser thread: coalesces staged bytes, processes under one lock ──
     thread::spawn(move || {
+        let mut cpr_scanner = CprScanner::new();
         loop {
             // Wait for at least one byte (or shutdown).
             {
@@ -1361,7 +1410,7 @@ pub fn spawn_reader_thread(
                 cursor_shape.store(shape, Ordering::Release);
             }
             let rmcup = scan_rmcup(&bytes);
-            let has_cpr_query = scan_cpr_query(&bytes);
+            let has_cpr_query = cpr_scanner.scan(&bytes);
 
             if let Ok(mut parser) = term_reader.lock() {
                 parser.process(&bytes);

--- a/tests-rs/test_cpr_responder.rs
+++ b/tests-rs/test_cpr_responder.rs
@@ -87,3 +87,58 @@ fn cpr_response_fallback_produces_valid_sequence() {
     let response = format!("\x1b[{};{}R", r + 1, c + 1);
     assert_eq!(response, "\x1b[1;1R");
 }
+
+// ── CprScanner — detection across batch boundaries ───────────────────────
+//
+// The parser thread scans output in coalesced batches. A query that straddles
+// a batch boundary is invisible to the per-batch scan_cpr_query (the
+// partial-sequence tests above pin that a lone prefix must NOT match), so the
+// boundary hides the query, cpr_pending is never set, and the reply is never
+// sent. An unanswered ESC[6n then leaves the asker waiting forever — for
+// conhost's PSUEDOCONSOLE_INHERIT_CURSOR startup query that means the pane's
+// child hangs permanently in ConsoleCreateConnectionObject (reproduced
+// deterministically). CprScanner carries the last bytes of the stream between
+// scans so a boundary cannot hide the query.
+
+#[test]
+fn scanner_detects_in_batch_query() {
+    let mut s = CprScanner::new();
+    assert!(s.scan(b"\x1b[6n"));
+}
+
+#[test]
+fn scanner_detects_query_split_at_every_boundary() {
+    let q = b"\x1b[6n";
+    for cut in 1..q.len() {
+        let mut s = CprScanner::new();
+        assert!(!s.scan(&q[..cut]), "prefix alone must not fire (cut={})", cut);
+        assert!(s.scan(&q[cut..]), "suffix must complete the query (cut={})", cut);
+    }
+}
+
+#[test]
+fn scanner_detects_query_split_across_four_batches() {
+    let mut s = CprScanner::new();
+    assert!(!s.scan(b"\x1b"));
+    assert!(!s.scan(b"["));
+    assert!(!s.scan(b"6"));
+    assert!(s.scan(b"n"));
+}
+
+#[test]
+fn scanner_partial_never_completed_does_not_fire() {
+    let mut s = CprScanner::new();
+    assert!(!s.scan(b"\x1b[6"));
+    assert!(!s.scan(b"hello world"));
+    assert!(!s.scan(b"n")); // the 'n' no longer completes anything
+}
+
+#[test]
+fn scanner_detects_query_split_after_long_noise_batches() {
+    let mut s = CprScanner::new();
+    assert!(!s.scan(&vec![b'X'; 1024]));
+    let mut batch = vec![b'Y'; 512];
+    batch.extend_from_slice(b"\x1b[6");
+    assert!(!s.scan(&batch));
+    assert!(s.scan(b"n"));
+}


### PR DESCRIPTION
I've observed additional robustness problems that this PR tries to fix. 

What we observed was that the initial command sometimes seems to hang somewhere during startup. After some debugging, process dumping and code reading it seems that one plausible cause matching what we see is the way that psmux scans for CPR query (Cursor Position Request) escape codes (ESC[6n) using scan_cpr_query. This is done in "batches" where the reader thread drains the ConPTY output pipe collecting some bytes, and (among other things) scans for a CPR to respond to.

However, a query that straddles a batch boundary (…ESC[6 ends one batch, n… begins the next) is in neither batch whole, so it is never detected: cpr_pending is never set, the reply is never sent, and whatever issued the request waits for it forever.

Now, why would that cause a startup hang? In short it is because psmux creates the psuedoconsole with the INHERIT_CURSOR flag, which according to [Microsoft's documentation for CreatePseudoConsole](https://learn.microsoft.com/en-us/windows/console/createpseudoconsole) requires the calling application to provide a cursor position response and "failure to [respond] may cause the calling application to hang while making another request of the pseudoconsole system", which matches what we see; when the pane command tries to open the console, it hangs.

Making the CPR query scanning detect escape codes even when split over two batches makes the hangs we observe go away. It will also respond correctly to a CPR query later in a process lifetime whenever this situation previously would cause psmux to ignore the request.