### PR TITLE
fix: detach-client without -P cleanly detaches instead of reconnecting (#386)

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -3699,6 +3699,11 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                     if app.latest_client_id == Some(target_cid) {
                         app.latest_client_id = app.client_registry.keys().max().copied();
                     }
+                    // Tell the client to detach cleanly so it exits instead of
+                    // reconnecting. Without a DETACH directive the client treats the
+                    // dropped stream as a transient disconnect and reconnects.
+                    crate::types::send_directive_to_client(target_cid, "DETACH");
+                    std::thread::sleep(Duration::from_millis(50));
                     // Shut down the TCP stream to force disconnect
                     crate::types::shutdown_client_stream(target_cid);
                     // Recompute effective size from remaining clients
@@ -3733,10 +3738,14 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                         .find(|(_, ci)| ci.tty_name == tty)
                         .map(|(cid, _)| *cid);
                     if let Some(cid) = target_cid {
+                        // Send a clean detach directive first so the client exits
+                        // instead of reconnecting on a bare stream drop.
                         if kill_parent {
                             crate::types::send_directive_to_client(cid, "DETACH-KILL-PARENT");
-                            std::thread::sleep(Duration::from_millis(50));
+                        } else {
+                            crate::types::send_directive_to_client(cid, "DETACH");
                         }
+                        std::thread::sleep(Duration::from_millis(50));
                         app.client_sizes.remove(&cid);
                         let was_present = app.client_registry.remove(&cid).is_some();
                         if was_present {
@@ -3764,11 +3773,15 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                         .map(|(cid, ci)| (*cid, ci.tty_name.clone()))
                         .collect();
                     for (cid, _tty) in &targets {
+                        // Clean detach directive so each client exits instead of
+                        // reconnecting on a bare stream drop.
                         if kill_parent {
                             crate::types::send_directive_to_client(*cid, "DETACH-KILL-PARENT");
+                        } else {
+                            crate::types::send_directive_to_client(*cid, "DETACH");
                         }
                     }
-                    if kill_parent && !targets.is_empty() {
+                    if !targets.is_empty() {
                         std::thread::sleep(Duration::from_millis(50));
                     }
                     for (cid, tty) in &targets {
@@ -3813,11 +3826,15 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                         .map(|(cid, ci)| (*cid, ci.tty_name.clone()))
                         .collect();
                     for (cid, _) in &targets {
+                        // Clean detach directive so each client exits instead of
+                        // reconnecting on a bare stream drop.
                         if kill_parent {
                             crate::types::send_directive_to_client(*cid, "DETACH-KILL-PARENT");
+                        } else {
+                            crate::types::send_directive_to_client(*cid, "DETACH");
                         }
                     }
-                    if kill_parent && !targets.is_empty() {
+                    if !targets.is_empty() {
                         std::thread::sleep(Duration::from_millis(50));
                     }
                     for (cid, tty) in &targets {


### PR DESCRIPTION
## What

`detach-client` (without `-P`) now actually detaches the targeted client(s) instead of letting them reconnect.

Fixes #386.

## Why

The non-`-P` detach handlers in `src/server/mod.rs` (`ForceDetachClient`, `ForceDetachClientByTty`, `DetachAllOtherClients`, `DetachAllClients`) force-closed the client's TCP stream via `shutdown_client_stream` **without first sending a clean `"DETACH"` directive**. Only the `-P` branch sent a directive (`"DETACH-KILL-PARENT"`).

On the client side (`src/client.rs`), a client only sets `quit=true` (clean exit) when it receives a `"DETACH"`/`"DETACH-KILL-PARENT"` directive; on a bare stream drop it treats the disconnect as transient and spawns a reconnect thread (since the port file still exists). So a non-`-P` detach made the client **reconnect** (new tty, same process) — `detach-client` returned exit 0 but had no effect. The only working CLI detach was `-P`, which also kills the parent process.

This diverges from tmux, whose `detach-client` cleanly exits the attached client while the session persists.

## How

Send a `"DETACH"` directive to each targeted client before `shutdown_client_stream` in the non-`-P` paths, mirroring the existing `-P` flow but without kill-parent. The client then sets `quit=true` and exits cleanly. `-P` behavior is unchanged.

## Verification

- `cargo check` passes.
- Manual repro (psmux 3.3.6, isolated `-L` socket): before the fix, `detach-client -s <session>` left the client attached with a changed tty (reconnect); the same flow on tmux 3.2a cleanly detaches. With this change the psmux client exits and the session persists detached, matching tmux.

Invariants preserved: `prefix+d` / `prefix+:detach-client` still detach the current client; `detach-client -a` from inside a client still does not exit the calling client; the session/panes survive a detach.
