### PR TITLE
Fix intermittent first-pane startup stall under load (drop ConPTY INHERIT_CURSOR)

### DIFF
--- a/crates/portable-pty-psmux/src/win/psuedocon.rs
+++ b/crates/portable-pty-psmux/src/win/psuedocon.rs
@@ -119,12 +119,26 @@ fn supports_passthrough_mode() -> bool {
     ver.dwBuildNumber >= 22621
 }
 
+/// The flag set passed to every CreatePseudoConsole call (passthrough is
+/// OR'ed on separately where supported).
+///
+/// PSUEDOCONSOLE_INHERIT_CURSOR is deliberately NOT set. With it, conhost emits
+/// an ESC[6n cursor-position request at startup and will not service a child's
+/// console connection until the host answers it. So if that reply is sent later
+/// than the child's connect attempt, the child blocks in
+/// ConsoleCreateConnectionObject during process initialization (a single
+/// thread, before any user code runs) until the reply arrives: a temporary
+/// stall if it is merely late, indefinite if it never comes. A multiplexer pane
+/// always starts on a fresh screen, so inheriting the host cursor row buys
+/// nothing here.
+fn base_flags() -> DWORD {
+    PSEUDOCONSOLE_RESIZE_QUIRK | PSEUDOCONSOLE_WIN32_INPUT_MODE
+}
+
 impl PsuedoCon {
     pub fn new(size: COORD, input: FileDescriptor, output: FileDescriptor) -> Result<Self, Error> {
         let mut con: HPCON = INVALID_HANDLE_VALUE;
-        let base_flags = PSUEDOCONSOLE_INHERIT_CURSOR
-            | PSEUDOCONSOLE_RESIZE_QUIRK
-            | PSEUDOCONSOLE_WIN32_INPUT_MODE;
+        let base_flags = base_flags();
 
         // Use PSEUDOCONSOLE_PASSTHROUGH_MODE on Windows 11 22H2+ to relay
         // VT sequences (including DECSCUSR cursor shapes) from child processes
@@ -172,9 +186,7 @@ impl PsuedoCon {
     /// rejects the passthrough ConPTY handle.
     pub fn new_without_passthrough(size: COORD, input: FileDescriptor, output: FileDescriptor) -> Result<Self, Error> {
         let mut con: HPCON = INVALID_HANDLE_VALUE;
-        let base_flags = PSUEDOCONSOLE_INHERIT_CURSOR
-            | PSEUDOCONSOLE_RESIZE_QUIRK
-            | PSEUDOCONSOLE_WIN32_INPUT_MODE;
+        let base_flags = base_flags();
 
         let result = unsafe {
             (CONPTY.CreatePseudoConsole)(
@@ -271,5 +283,29 @@ impl PsuedoCon {
         Ok(WinChild {
             proc: Mutex::new(proc),
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn conpty_flags_do_not_include_inherit_cursor() {
+        // PSUEDOCONSOLE_INHERIT_CURSOR makes the new conhost emit ESC[6n at
+        // startup and block its own initialization until the host replies; an
+        // unanswered query leaves conhost unable to service the child's
+        // console connect, so the child hangs inside process initialization
+        // (single thread parked in ConsoleCreateConnectionObject). A
+        // multiplexer pane always starts on a fresh screen, so inheriting the
+        // host cursor row has no value here.
+        assert_eq!(
+            base_flags() & PSUEDOCONSOLE_INHERIT_CURSOR,
+            0,
+            "INHERIT_CURSOR must not be set: it makes conhost block startup waiting for an ESC[6n reply"
+        );
+        // The other flags are load-bearing and must stay.
+        assert_ne!(base_flags() & PSEUDOCONSOLE_RESIZE_QUIRK, 0);
+        assert_ne!(base_flags() & PSEUDOCONSOLE_WIN32_INPUT_MODE, 0);
     }
 }

--- a/src/pane.rs
+++ b/src/pane.rs
@@ -1247,6 +1247,26 @@ pub fn spawn_reader_thread(
     let reader_done_r = reader_done.clone();
     let output_ring_r = output_ring.clone();
     thread::spawn(move || {
+        // TEST-ONLY (PSMUX_TEST_READER_DELAY_MS): hold off this reader's first
+        // read by a fixed duration. The reader is what drains conhost's startup
+        // ESC[6n cursor-position request; with PSEUDOCONSOLE_INHERIT_CURSOR set,
+        // conhost will not service the child's console connection until that
+        // request is read and answered, so delaying the reader stalls the child
+        // in ConsoleCreateConnectionObject for the duration -- the exact race
+        // otherwise hit only under concurrent load. Without the flag conhost
+        // issues no such request, so the delay only postpones psmux's parse of
+        // the pane while the child comes up promptly. Placed here, not in
+        // create_window, so it delays only the reader and not window
+        // registration. Inert unless the env var is set; compiled out of release
+        // builds. REMOVE with tests/test_first_pane_cpr_hang.ps1.
+        #[cfg(debug_assertions)]
+        {
+            if let Ok(ms) = std::env::var("PSMUX_TEST_READER_DELAY_MS") {
+                if let Ok(ms) = ms.parse::<u64>() {
+                    if ms > 0 { thread::sleep(Duration::from_millis(ms)); }
+                }
+            }
+        }
         let mut local = vec![0u8; 65536];
         let mut zero_reads: u32 = 0;
         loop {

--- a/tests/stress_new_session_readiness.ps1
+++ b/tests/stress_new_session_readiness.ps1
@@ -24,6 +24,19 @@ param(
 $ErrorActionPreference = "Continue"
 if (-not $PsmuxExe) { $PsmuxExe = (Get-Command psmux -EA Stop).Source }
 if (-not (Test-Path $PsmuxExe)) { Write-Host "FATAL: psmux not found: $PsmuxExe" -ForegroundColor Red; exit 2 }
+$PsmuxExe = (Resolve-Path -LiteralPath $PsmuxExe).Path   # absolute, so the straggler backstop's ExecutablePath match is reliable
+
+# Refuse to run from inside a live multiplexer session. The inherited
+# PSMUX_SESSION / TMUX (and PSMUX_TARGET_SESSION) override the per-session -L/-s,
+# so list-windows queries the ambient server instead of the one just created,
+# which reads back as a spurious 100% readiness race. Run from a clean shell, or
+# scrub those vars before invoking.
+if ($env:PSMUX_SESSION -or $env:TMUX) {
+    Write-Host "FATAL: refusing to run inside an active psmux/tmux session" -ForegroundColor Red
+    Write-Host "       (PSMUX_SESSION='$env:PSMUX_SESSION' TMUX='$env:TMUX')." -ForegroundColor Red
+    Write-Host "       Run from a clean shell, or clear PSMUX_SESSION/PSMUX_TARGET_SESSION/TMUX/TMUX_PANE first." -ForegroundColor Red
+    exit 3
+}
 
 # Isolate into a throwaway HOME so we never touch the real ~/.psmux and any
 # orphaned server is fully contained and countable.
@@ -31,8 +44,19 @@ $tmpHome = Join-Path $env:TEMP ("psmux_stress_" + [guid]::NewGuid().ToString("N"
 New-Item -ItemType Directory -Path $tmpHome -Force | Out-Null
 $psmuxDir = Join-Path $tmpHome ".psmux"
 New-Item -ItemType Directory -Path $psmuxDir -Force | Out-Null
+# Pane-liveness markers live OUTSIDE .psmux so they never collide with the
+# *.port discovery files the teardown sweep globs.
+$liveDir = Join-Path $tmpHome "live"
+New-Item -ItemType Directory -Path $liveDir -Force | Out-Null
 $env:USERPROFILE = $tmpHome
 $env:HOME = $tmpHome
+
+# Liveness poll timeout: must exceed any injected reader delay so a baseline
+# build's stalled first panes are still captured (timed at ~delay) rather than
+# counted as never-lived.
+$readerDelayMs = 0
+if ($env:PSMUX_TEST_READER_DELAY_MS) { [void][int]::TryParse($env:PSMUX_TEST_READER_DELAY_MS, [ref]$readerDelayMs) }
+$liveTimeoutMs = [Math]::Max(8000, $readerDelayMs + 5000)
 
 Write-Host ""
 Write-Host ("=" * 70) -ForegroundColor Cyan
@@ -47,6 +71,8 @@ $orphan = 0      # rc!=0 but live server left behind
 $rcFail = 0      # rc!=0 total
 $ok     = 0      # rc=0 AND window present
 $lat    = [System.Collections.Generic.List[double]]::new()
+$liveLat = [System.Collections.Generic.List[double]]::new()  # per-session time-to-first-output (pane liveness)
+$liveNever = 0                                               # sessions whose marker never appeared within $liveTimeoutMs
 $raceDetails   = [System.Collections.Generic.List[string]]::new()
 $orphanDetails = [System.Collections.Generic.List[string]]::new()
 
@@ -89,14 +115,20 @@ $swAll = [System.Diagnostics.Stopwatch]::StartNew()
 for ($round = 0; $round -lt $Rounds; $round++) {
     $procs = @()
     for ($b = 0; $b -lt $Batch; $b++) {
-        $sname = "s_{0}_{1}" -f $round, $b
-        # Use -L namespace == session name so discovery files are deterministic.
+        # -L namespace == session name so discovery files are deterministic;
+        # prefixed with this run's PID so the names are unique to this run and the
+        # straggler backstop can match exactly our own processes.
+        $sname = "s_{0}_{1}_{2}" -f $PID, $round, $b
+        # Initial command writes a liveness marker the moment the pane's child
+        # actually runs, then idles. Time-to-marker is the pane-liveness metric.
+        $liveFile = Join-Path $liveDir "$sname.live"
+        $cmd = "Set-Content -LiteralPath '$liveFile' -Value ok; Start-Sleep 30"
         $sw = [System.Diagnostics.Stopwatch]::StartNew()
         $p = Start-Process -FilePath $PsmuxExe `
-                -ArgumentList @("-L", $sname, "new-session", "-d", "-s", $sname) `
+                -ArgumentList @("-L", $sname, "new-session", "-d", "-s", $sname, $cmd) `
                 -PassThru -WindowStyle Hidden
         # With `-L ns -s session` the discovery files are named ns__session.*
-        $procs += [pscustomobject]@{ Name=$sname; Proc=$p; Sw=$sw; PortBase="${sname}__${sname}" }
+        $procs += [pscustomobject]@{ Name=$sname; Proc=$p; Sw=$sw; PortBase="${sname}__${sname}"; LiveFile=$liveFile; LiveMs=$null }
     }
 
     foreach ($e in $procs) {
@@ -105,8 +137,7 @@ for ($round = 0; $round -lt $Rounds; $round++) {
             $rcFail++; $orphanDetails.Add("$($e.Name): client HUNG >30s") | Out-Null
             continue
         }
-        $e.Sw.Stop()
-        [void]$lat.Add($e.Sw.Elapsed.TotalMilliseconds)
+        [void]$lat.Add($e.Sw.Elapsed.TotalMilliseconds)   # client-return latency; Sw keeps running for the liveness poll
         $rc = $e.Proc.ExitCode
         if ($rc -eq 0) {
             # rc=0 contract: a window MUST already exist. Check immediately.
@@ -127,6 +158,27 @@ for ($round = 0; $round -lt $Rounds; $round++) {
         }
     }
 
+    # Pane-liveness: poll for each session's marker BEFORE teardown (teardown
+    # kills the pane, so a not-yet-written marker would never appear). With the
+    # reader-start delay injected this is the metric that exposes the first-pane
+    # hang -- a baseline build stalls ~delay until the reader drains the cursor
+    # request, a fixed build comes up promptly.
+    do {
+        $pending = $false
+        foreach ($e in $procs) {
+            if ($null -eq $e.LiveMs) {
+                if (Test-Path $e.LiveFile) {
+                    $e.LiveMs = [int]$e.Sw.Elapsed.TotalMilliseconds
+                    [void]$liveLat.Add([double]$e.LiveMs)
+                } elseif ($e.Sw.Elapsed.TotalMilliseconds -lt $liveTimeoutMs) {
+                    $pending = $true
+                }
+            }
+        }
+        if ($pending) { Start-Sleep -Milliseconds 50 }
+    } while ($pending)
+    foreach ($e in $procs) { if ($null -eq $e.LiveMs) { $liveNever++ } }
+
     # Teardown this round's sessions to keep the machine sane. Each -L namespace
     # has its own server, so kill the whole server per namespace.
     foreach ($e in $procs) {
@@ -136,14 +188,20 @@ for ($round = 0; $round -lt $Rounds; $round++) {
 }
 $swAll.Stop()
 
-# Final sweep: any psmux server processes still alive under our isolated home?
+# Final sweep: count servers still alive under our isolated home (per-round
+# teardown leaks), then tear each down scoped by its -L namespace. We never run
+# a bare `kill-server`: with no -L it falls back to an image-name kill of every
+# psmux/pmux/tmux process on the machine, which would take down pre-existing
+# unrelated sessions. Counting BEFORE the kill makes leftoverAlive a real leak
+# signal rather than "survived a nuclear kill".
 Start-Sleep -Milliseconds 500
-& $PsmuxExe kill-server 2>&1 | Out-Null
 $leftoverPorts = @(Get-ChildItem -Path $psmuxDir -Filter "*.port" -EA SilentlyContinue)
 $leftoverAlive = 0
 foreach ($pf in $leftoverPorts) {
-    $base = $pf.BaseName
+    $base = $pf.BaseName                 # <ns>__<session>
     if (Test-ServerAlive $base) { $leftoverAlive++ }
+    $ns = ($base -split '__', 2)[0]      # namespace == part before __
+    & $PsmuxExe -L $ns kill-server 2>&1 | Out-Null
 }
 
 function Pct($arr, $p) {
@@ -167,6 +225,9 @@ Write-Host ""
 Write-Host "  PERFORMANCE (per new-session -d, ms):" -ForegroundColor Cyan
 Write-Host ("    p50={0} p90={1} p99={2} max={3}" -f (Pct $lat 50), (Pct $lat 90), (Pct $lat 99), (Pct $lat 100))
 Write-Host ("    wall={0:N1}s  throughput={1:N1} sessions/s" -f $swAll.Elapsed.TotalSeconds, ($total / $swAll.Elapsed.TotalSeconds))
+Write-Host ""
+Write-Host "  PANE LIVENESS (time-to-first-output, ms):" -ForegroundColor Cyan
+Write-Host ("    p50={0} p90={1} p99={2} max={3}  never={4}" -f (Pct $liveLat 50), (Pct $liveLat 90), (Pct $liveLat 99), (Pct $liveLat 100), $liveNever) -ForegroundColor $(if ($liveNever -gt 0) {"Red"} else {"Gray"})
 Write-Host ("=" * 70) -ForegroundColor Cyan
 
 if ($raceDetails.Count -gt 0) {
@@ -178,9 +239,14 @@ if ($orphanDetails.Count -gt 0) {
     $orphanDetails | Select-Object -First 10 | ForEach-Object { Write-Host "    $_" -ForegroundColor Red }
 }
 
-# Cleanup isolated home.
-& $PsmuxExe kill-server 2>&1 | Out-Null
-Get-Process psmux -EA SilentlyContinue | Where-Object { $_.Path -eq $PsmuxExe } | Stop-Process -Force -EA SilentlyContinue
+# Cleanup isolated home. The per-namespace sweep above already reaped (and
+# removed the .port files of) this run's servers. Backstop: force-kill only a
+# straggler that is BOTH this exact binary AND carries THIS run's unique marker
+# ("s_<pid>_") in its command line -- never a bare kill-server, never another
+# run's or a pre-existing session's process.
+Get-CimInstance Win32_Process -Filter "Name='psmux.exe'" -EA SilentlyContinue |
+    Where-Object { $_.ExecutablePath -eq $PsmuxExe -and $_.CommandLine -match "s_${PID}_" } |
+    ForEach-Object { Stop-Process -Id $_.ProcessId -Force -EA SilentlyContinue }
 Start-Sleep -Milliseconds 300
 Remove-Item -Recurse -Force $tmpHome -EA SilentlyContinue
 

--- a/tests/stress_new_session_readiness.ps1
+++ b/tests/stress_new_session_readiness.ps1
@@ -31,9 +31,10 @@ $PsmuxExe = (Resolve-Path -LiteralPath $PsmuxExe).Path   # absolute, so the stra
 # so list-windows queries the ambient server instead of the one just created,
 # which reads back as a spurious 100% readiness race. Run from a clean shell, or
 # scrub those vars before invoking.
-if ($env:PSMUX_SESSION -or $env:TMUX) {
+if ($env:PSMUX_SESSION -or $env:TMUX -or $env:PSMUX_TARGET_SESSION -or $env:TMUX_PANE) {
     Write-Host "FATAL: refusing to run inside an active psmux/tmux session" -ForegroundColor Red
-    Write-Host "       (PSMUX_SESSION='$env:PSMUX_SESSION' TMUX='$env:TMUX')." -ForegroundColor Red
+    Write-Host ("       (PSMUX_SESSION='{0}' TMUX='{1}' PSMUX_TARGET_SESSION='{2}' TMUX_PANE='{3}')." -f `
+        $env:PSMUX_SESSION, $env:TMUX, $env:PSMUX_TARGET_SESSION, $env:TMUX_PANE) -ForegroundColor Red
     Write-Host "       Run from a clean shell, or clear PSMUX_SESSION/PSMUX_TARGET_SESSION/TMUX/TMUX_PANE first." -ForegroundColor Red
     exit 3
 }

--- a/tests/test_first_pane_cpr_hang.ps1
+++ b/tests/test_first_pane_cpr_hang.ps1
@@ -31,14 +31,29 @@
 # PSMUX_TEST_READER_DELAY_MS hook is deleted from src/pane.rs, delete this test.
 
 $ErrorActionPreference = "Stop"
-# Prefer the local build under test; the injection hook exists only in
-# debug_assertions builds, so do NOT fall back to a psmux on PATH (an installed
-# release binary would make the injection a no-op and the test pass for free).
+# Resolve the binary under test. The injection hook is #[cfg(debug_assertions)],
+# so it exists only in a debug build; against a release build no reader delay is
+# injected and the pane comes up promptly regardless of the regression -- a false
+# GREEN. The shared runner (run_all_integration.ps1) prefers a release build and
+# exports it as PSMUX_EXE, so we cannot assume PSMUX_EXE is a debug binary.
 $PSMUX = $env:PSMUX_EXE
 if (-not $PSMUX -or -not (Test-Path $PSMUX)) { $PSMUX = "$PSScriptRoot\..\target\debug\psmux.exe" }
 if (-not (Test-Path $PSMUX)) { $PSMUX = "$PSScriptRoot\..\target\release\psmux.exe" }
 if (-not (Test-Path $PSMUX)) { Write-Host "FATAL: could not resolve psmux ($PSMUX)" -ForegroundColor Red; exit 1 }
 $PSMUX = (Resolve-Path -LiteralPath $PSMUX).Path   # absolute, so the straggler backstop's ExecutablePath match is reliable
+
+# Guard against a false GREEN on a non-debug build. The delay hook is compiled out
+# of release builds, so without it this test would pass for free. PowerShell can't
+# read the binary's cfg flags, so this is a PATH HEURISTIC: a binary whose path
+# contains \debug\ is treated as a debug build, otherwise we SKIP. Tradeoffs: it
+# closes the PSMUX_EXE=>release path the runner creates (the real false-green risk),
+# but it leans on the build layout -- a debug binary at an unconventional path would
+# be skipped here (an error toward SKIP, never a false green or a false red). SKIP
+# (exit 0), not FATAL, so a release-only run leaves the suite green rather than red.
+if ($PSMUX -notmatch '\\debug\\') {
+    Write-Host "SKIPPED: requires a debug build (PSMUX_TEST_READER_DELAY_MS hook is #[cfg(debug_assertions)]); got $PSMUX" -ForegroundColor Yellow
+    exit 0
+}
 
 $DELAY_MS = 10000                  # injected reader-start delay (reader thread sleeps this long)
 $MAX_LIVENESS_MS = $DELAY_MS / 2   # post-fix the pane must come up well under the delay;

--- a/tests/test_first_pane_cpr_hang.ps1
+++ b/tests/test_first_pane_cpr_hang.ps1
@@ -1,0 +1,120 @@
+# Regression test: a session's first pane must come up even when psmux is slow
+# to drain the pseudoconsole's startup cursor-position request.
+#
+# ROOT CAUSE: psmux created every ConPTY with PSEUDOCONSOLE_INHERIT_CURSOR.
+# Per Microsoft's CreatePseudoConsole docs, that flag makes conhost emit an
+# ESC[6n cursor-position request at startup and the host must answer it
+# asynchronously on a background thread, or it "may cause the calling
+# application to hang while making another request of the pseudoconsole
+# system." psmux answered only from the server's main loop (not yet running
+# when a session's first window is created), so under load the request went
+# unanswered and the pane's child process hung during startup in
+# ConsoleCreateConnectionObject -- a live pane that never ran. The fix removes
+# the flag (a multiplexer pane renders into its own fresh screen, so cursor
+# inheritance buys nothing); conhost then issues no startup request.
+#
+# DETERMINISTIC RED via reader-start latency injection: the pane's output-pipe
+# reader sleeps PSMUX_TEST_READER_DELAY_MS before its first read. The reader is
+# what drains conhost's startup ESC[6n; with INHERIT_CURSOR present conhost will
+# not service the child's console connection until that request is read and
+# answered, so the child stays blocked for the whole delay. Without the flag
+# conhost issues no request, so the child connects and runs its command
+# immediately while the reader harmlessly sleeps. The hook sits inside the reader
+# thread, not create_window, so new-session -d returns promptly on both builds;
+# the discriminator is TIME-TO-FIRST-OUTPUT, a liveness file the initial command
+# writes:
+#   - pre-fix : liveness file appears no earlier than ~PSMUX_TEST_READER_DELAY_MS
+#               (child blocked on the unanswered cursor request).
+#   - post-fix: liveness file appears promptly, well under the delay.
+# Launched via Start-Process (not a background job) so the measured time is the
+# pane's real liveness, not job spin-up. Removal recipe: when the
+# PSMUX_TEST_READER_DELAY_MS hook is deleted from src/pane.rs, delete this test.
+
+$ErrorActionPreference = "Stop"
+# Prefer the local build under test; the injection hook exists only in
+# debug_assertions builds, so do NOT fall back to a psmux on PATH (an installed
+# release binary would make the injection a no-op and the test pass for free).
+$PSMUX = $env:PSMUX_EXE
+if (-not $PSMUX -or -not (Test-Path $PSMUX)) { $PSMUX = "$PSScriptRoot\..\target\debug\psmux.exe" }
+if (-not (Test-Path $PSMUX)) { $PSMUX = "$PSScriptRoot\..\target\release\psmux.exe" }
+if (-not (Test-Path $PSMUX)) { Write-Host "FATAL: could not resolve psmux ($PSMUX)" -ForegroundColor Red; exit 1 }
+$PSMUX = (Resolve-Path -LiteralPath $PSMUX).Path   # absolute, so the straggler backstop's ExecutablePath match is reliable
+
+$DELAY_MS = 10000                  # injected reader-start delay (reader thread sleeps this long)
+$MAX_LIVENESS_MS = $DELAY_MS / 2   # post-fix the pane must come up well under the delay;
+                                   # wide margin so a loaded machine's shell cold-start cannot cross it
+
+# Isolate into a throwaway HOME so the run never touches the real ~/.psmux.
+# Set in THIS process so the launched psmux inherits it AND cleanup below
+# resolves the session inside the throwaway home. Each session is its own
+# server; we tear it down by name (never a bare kill-server).
+$tmpHome = Join-Path $env:TEMP ("psmux_cpr_" + [guid]::NewGuid().ToString("N").Substring(0, 8))
+New-Item -ItemType Directory -Path (Join-Path $tmpHome ".psmux") -Force | Out-Null
+$env:USERPROFILE = $tmpHome
+$env:HOME = $tmpHome
+$env:PSMUX_NO_WARM = "1"
+$env:PSMUX_CONFIG_FILE = "NUL"
+$env:PSMUX_TEST_READER_DELAY_MS = "$DELAY_MS"
+foreach ($v in 'PSMUX_SESSION', 'PSMUX_TARGET_SESSION', 'PSMUX_NAMESPACE', 'TMUX', 'TMUX_PANE') {
+    Remove-Item "Env:\$v" -ErrorAction SilentlyContinue
+}
+$session = "cpr_$($PID)_$(Get-Random -Maximum 99999)"
+$liveFile = Join-Path $tmpHome "live.txt"
+
+$pass = 0; $fail = 0
+function Write-Result($name, $ok, $msg) {
+    if ($ok) { Write-Host "  [PASS] $name" -ForegroundColor Green; $script:pass++ }
+    else { Write-Host "  [FAIL] $name : $msg" -ForegroundColor Red; $script:fail++ }
+}
+
+Write-Host ""
+Write-Host "=== first-pane startup must survive a slow ESC[6n drain ===" -ForegroundColor Cyan
+Write-Host "  psmux  : $PSMUX" -ForegroundColor DarkGray
+Write-Host "  home   : $tmpHome" -ForegroundColor DarkGray
+
+try {
+    # Launch new-session -d with an initial command that writes a liveness file,
+    # then poll for that file to time when the pane's child actually ran. The hook
+    # delays only the reader thread, so new-session returns promptly; Start-Process
+    # (not Start-Job) keeps the measured time free of background-job spin-up.
+    $cmd = "Set-Content -LiteralPath '$liveFile' -Value ok; Start-Sleep 30"
+    $sw = [System.Diagnostics.Stopwatch]::StartNew()
+    $p = Start-Process -FilePath $PSMUX `
+            -ArgumentList @("new-session", "-d", "-s", $session, $cmd) `
+            -PassThru -WindowStyle Hidden
+
+    $fileMs = $null; $retMs = $null
+    while ($sw.Elapsed.TotalMilliseconds -lt ($DELAY_MS + 4000)) {
+        if (-not $retMs -and $p.HasExited) { $retMs = [int]$sw.Elapsed.TotalMilliseconds }
+        if (Test-Path $liveFile) { $fileMs = [int]$sw.Elapsed.TotalMilliseconds; break }
+        Start-Sleep -Milliseconds 25
+    }
+    if (-not $retMs -and $p.WaitForExit(3000)) { $retMs = [int]$sw.Elapsed.TotalMilliseconds }
+
+    Write-Host ("  new-session returned: {0}" -f $(if ($retMs) { "${retMs}ms" } else { "?" })) -ForegroundColor DarkGray
+    Write-Host ("  liveness file after : {0}" -f $(if ($null -ne $fileMs) { "${fileMs}ms" } else { "NEVER" })) -ForegroundColor DarkGray
+    Write-Host ("  injected delay      : ${DELAY_MS}ms  (liveness threshold ${MAX_LIVENESS_MS}ms)") -ForegroundColor DarkGray
+
+    # THE assertion: the pane's child ran well before the injected reader delay
+    # would force it -- it connected to its console without waiting on the
+    # (delayed) cursor-request drain, so INHERIT_CURSOR is gone. Pre-fix the child
+    # stays blocked until the reader wakes at ~$DELAY_MS, so the liveness file
+    # appears no earlier than the delay.
+    Write-Result "first pane ran well before the injected reader delay (not blocked on the cursor request)" `
+        (($null -ne $fileMs) -and ($fileMs -lt $MAX_LIVENESS_MS)) "liveness ${fileMs}ms >= ${MAX_LIVENESS_MS}ms (pane stayed blocked until the reader drained the cursor request)"
+}
+finally {
+    & $PSMUX kill-session -t $session 2>&1 | Out-Null   # session-scoped; never a bare kill-server
+    if ($p -and -not $p.HasExited) { try { $p.Kill() } catch {} }
+    # Backstop: kill only a straggler that is BOTH this exact binary AND carries
+    # our unique session name. Never an image-name kill.
+    Get-CimInstance Win32_Process -Filter "Name='psmux.exe'" -EA SilentlyContinue |
+        Where-Object { $_.ExecutablePath -eq $PSMUX -and $_.CommandLine -match $session } |
+        ForEach-Object { Stop-Process -Id $_.ProcessId -Force -EA SilentlyContinue }
+    Start-Sleep -Milliseconds 300
+    Remove-Item -Recurse -Force $tmpHome -EA SilentlyContinue
+}
+
+Write-Host ""
+Write-Host "  $pass passed, $fail failed" -ForegroundColor $(if ($fail -gt 0) { "Red" } else { "Green" })
+exit $(if ($fail -gt 0) { 1 } else { 0 })


### PR DESCRIPTION
This PR drops the use of the ConPTY INHERIT_CURSOR flag which does not seem to be needed, and which complicates ConPTY initialization. 

The PR is an independent companion to #385 and the two issues together (ConPTY startup with the INHERIT_CURSOR flag, requiring a cursor position response before continuing, and sometimes not responding to the cursor position request) caused a deadlock of the first pane command for a few percent of sessions when creating multiple sessions under load. 

After merge of #385 we will avoid the deadlock, but even in isolation we probably want to get rid of the INHERIT_CURSOR flag.

## Symptom

Under concurrent `new-session -d` on a busy machine, a freshly created session's **first** pane intermittently stalls during process startup: for a stretch it produces nothing — no prompt, no output — though its command line is already in the PEB. It eventually recovers, but the stall lasts seconds, and under heavy load up to minutes — long enough to look hung. Later panes are unaffected; it is always the session's first window.

During the stall, a minidump shows the pane's single thread parked in early process initialization, before `main`:

```
ntdll!NtCreateFile
KERNELBASE!ConsoleCreateConnectionObject
KERNELBASE!ConsoleInitialize
KERNELBASE!_KernelBaseBaseDllInitialize
ntdll!LdrpInitializeProcess
```

The child is blocked connecting to its console (ConDrv) while KERNELBASE initializes.

## Root cause

Every ConPTY is created with `PSUEDOCONSOLE_INHERIT_CURSOR`. Per Microsoft's [`CreatePseudoConsole` documentation][doc], that flag makes the new conhost emit a cursor-position request (`ESC[6n`) during its own startup, and:

> If using `PSEUDOCONSOLE_INHERIT_CURSOR`, the calling application should be prepared to respond to the request for the cursor state in an asynchronous fashion on a background thread by forwarding or interpreting the request for cursor information that will be received on `hOutput` and replying on `hInput`. **Failure to do so may cause the calling application to hang while making another request of the pseudoconsole system.**

psmux's reply is written only by the server's main request loop — its periodic `drain_cpr_pending`, which writes `ESC[row;colR` back on the pane's input pipe. For a session's **first** window that loop is not yet running: the initial window is created during server startup, before the request loop begins, and under load the loop is slow to get going. So while conhost waits for the reply, the pane child's own console-connect attempt — racing that wait — is not serviced, and it stalls in `ConsoleCreateConnectionObject` (the dump above) until psmux finally writes the reply. The server itself stays responsive throughout; it is just late to answer. Under concurrent load the gap widens (slower startup, threads contending for CPU), which is when the stall grows long enough to look like a dead pane.

## Fix

Drop `PSUEDOCONSOLE_INHERIT_CURSOR` (`base_flags()` in `crates/portable-pty-psmux/src/win/psuedocon.rs`). A multiplexer pane renders into its own fresh screen, so inheriting the host's cursor row gains psmux nothing — and without the flag conhost issues no startup `ESC[6n`, so there is no request to answer and the stall cannot occur. `RESIZE_QUIRK` and `WIN32_INPUT_MODE` are kept.

We drop the flag rather than answer the request earlier or re-time the responder. A preemptive cursor-position reply at spawn time was tried for this (`72b7998`) and reverted in `b4bd81b` (#313): written to the pane's input pipe before any request arrived, under `PSEUDOCONSOLE_WIN32_INPUT_MODE` it was mis-parsed as terminal input and consumed the user's first keystroke. Dropping the flag removes the request entirely, so no reply is needed at all — avoiding both the stall and that regression, and leaving #313's keystroke fix in place. The `ESC[6n` queries a real shell issues *later* (e.g. pwsh after lock/unlock) are unaffected by this change and continue to go through the existing reactive responder.

The inherited cursor row is moreover _never consumed_. Each pane gets a fresh `vt100::Parser` and renders from its own grid origin, and psmux answers any `ESC[6n` from that grid's own cursor (`drain_cpr_pending` in `src/server/helpers.rs`), never from the inherited host row — nothing in psmux reads the value the flag would set. So the flag's only live effect is the harmful startup handshake. Verified empirically too: a psmux pane started in a bottom-right WezTerm split, plus a few newlines (host cursor at a non-zero offset) still positions its cursor correctly.

## Validation

### Deterministic regression test

`tests/test_first_pane_cpr_hang.ps1`, with no dependence on machine load. A debug-only (`#[cfg(debug_assertions)]`) hook, `PSMUX_TEST_READER_DELAY_MS`, sleeps a pane's output-pipe reader for a fixed duration before its first read — the reader is what drains conhost's startup `ESC[6n`. With `INHERIT_CURSOR` present, conhost will not service the child's console connection until that request is read and answered, so the delayed reader stalls the child for the whole duration; without the flag conhost issues no request, so the child connects and runs immediately while the reader harmlessly sleeps. The hook lives inside the reader thread, not `create_window`, so `new-session -d` returns promptly on both builds — the pane's time-to-first-output is the sole discriminator.

The test launches `new-session -d` via `Start-Process` (so the measured time is the pane's real liveness, not background-job spin-up) and times when the pane's initial command writes a liveness file. With the fix the file appears well under the delay; pre-fix the child is blocked until the reader wakes, so it appears no earlier than the delay. Confirmed both ways: the fix is GREEN; re-adding `INHERIT_CURSOR` turns it RED. The hook compiles out of release builds; its removal recipe is in the source banner.

### Scaled differential

`tests/stress_new_session_readiness.ps1` is the existing readiness/orphan stress harness (from the new-session readiness work) that launches many concurrent `new-session -d`. We adapted it for this PR: each session's initial command now writes a marker file the moment its pane's child actually runs, and the harness records, per session, the time from launch to that marker — the pane's time-to-first-output. Here "output" means that marker: a filesystem write by the initial command, not terminal output, so it fires the instant the child runs any code at all — exactly what the first-pane hang delays, since the hung child is parked in console init *before* `main`. Its teardown was also scoped to `-L`-namespaced kills and it now refuses to run inside a live multiplexer, so it is safe to run beside real sessions; neither change affects the measurement.

Run on the same machine against a build with the flag and a build without, under natural concurrent load with no delay injected, 320 sessions each:

|                               | without INHERIT_CURSOR | with INHERIT_CURSOR |
| ----------------------------- | ---------------------- | ------------------- |
| `new-session -d` p50          | 0.4 s                  | 0.4 s               |
| `new-session -d` p99          | 0.6 s                  | 5.3 s               |
| time-to-first-output p50            | 1.5 s            | 1.3 s               |
| time-to-first-output p99            | 1.8 s            | 5.4 s               |
| first panes still blocked after 8 s | 0 / 320          | 18 / 320            |

(Debug build under heavy concurrent spawning, so absolute latencies run high; the same-machine relative gap is the signal.) The medians (p50) are identical, so the flag costs nothing in the common case — it only creates the tail: with the flag, 18 of 320 first panes had still not run their command after 8 s and the p99 blows out; without it, none. Injecting the reader delay (above) makes the same stall deterministic on every first pane.

Full Rust workspace test suite green (2120 binary tests + 8 portable-pty crate tests), including a `psuedocon.rs` unit test asserting `INHERIT_CURSOR` is not set, with the reason.

## Notes

- This branch is based on `master`; the change is self-contained ConPTY code.
- Commits: (1) the fix + a unit test asserting the flag is unset; (2) the deterministic regression test and its reader-delay hook; (3) pane-liveness measurement in the readiness stress harness, plus scoping its teardown so it is safe to run beside live sessions.

[doc]: https://learn.microsoft.com/en-us/windows/console/createpseudoconsole
