### PR TITLE
fix(#389): detach-client without -P cleanly detaches instead of reconnecting

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -3699,13 +3699,14 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                     if app.latest_client_id == Some(target_cid) {
                         app.latest_client_id = app.client_registry.keys().max().copied();
                     }
-                    // Send a clean DETACH directive first so the client exits cleanly
-                    // instead of treating the stream drop as a transient disconnect and
-                    // reconnecting. Give it a moment to act on the directive.
-let sent = crate::types::send_directive_to_client(target_cid, "DETACH");
-if sent {
-    std::thread::sleep(Duration::from_millis(50));
-}
+                    // Send a clean DETACH directive first so the client exits instead
+                    // of treating the stream drop as a transient disconnect and
+                    // reconnecting. Only wait if the directive was actually queued; a
+                    // failed send means the client is already gone, so blocking the
+                    // server loop would buy nothing.
+                    if crate::types::send_directive_to_client(target_cid, "DETACH") {
+                        std::thread::sleep(Duration::from_millis(50));
+                    }
                     // Shut down the TCP stream to force disconnect
                     crate::types::shutdown_client_stream(target_cid);
                     // Recompute effective size from remaining clients
@@ -3740,14 +3741,14 @@ if sent {
                         .find(|(_, ci)| ci.tty_name == tty)
                         .map(|(cid, _)| *cid);
                     if let Some(cid) = target_cid {
-                        if kill_parent {
-                            crate::types::send_directive_to_client(cid, "DETACH-KILL-PARENT");
-                        } else {
-                            // Clean detach: tell the client to exit so it does not treat
-                            // the stream drop as a transient disconnect and reconnect.
-                            crate::types::send_directive_to_client(cid, "DETACH");
+                        // Send a clean directive first so the client exits instead of
+                        // reconnecting on the stream drop. -P also kills the parent.
+                        // Only wait if the directive was actually queued; a failed send
+                        // means the client is already gone.
+                        let directive = if kill_parent { "DETACH-KILL-PARENT" } else { "DETACH" };
+                        if crate::types::send_directive_to_client(cid, directive) {
+                            std::thread::sleep(Duration::from_millis(50));
                         }
-                        std::thread::sleep(Duration::from_millis(50));
                         app.client_sizes.remove(&cid);
                         let was_present = app.client_registry.remove(&cid).is_some();
                         if was_present {
@@ -3774,16 +3775,15 @@ if sent {
                         .filter(|(cid, _)| **cid != except_cid)
                         .map(|(cid, ci)| (*cid, ci.tty_name.clone()))
                         .collect();
-                    for (cid, _tty) in &targets {
-                        if kill_parent {
-                            crate::types::send_directive_to_client(*cid, "DETACH-KILL-PARENT");
-                        } else {
-                            // Clean detach: tell each client to exit so it does not treat
-                            // the stream drop as a transient disconnect and reconnect.
-                            crate::types::send_directive_to_client(*cid, "DETACH");
-                        }
+                    // Send a clean directive to each target first so they exit instead
+                    // of reconnecting on the stream drop. -P also kills the parent.
+                    let directive = if kill_parent { "DETACH-KILL-PARENT" } else { "DETACH" };
+                    let mut any_sent = false;
+                    for (cid, _) in &targets {
+                        any_sent |= crate::types::send_directive_to_client(*cid, directive);
                     }
-                    if !targets.is_empty() {
+                    // Only wait if at least one directive was actually queued.
+                    if any_sent {
                         std::thread::sleep(Duration::from_millis(50));
                     }
                     for (cid, tty) in &targets {
@@ -3827,16 +3827,15 @@ if sent {
                     let targets: Vec<(u64, String)> = app.client_registry.iter()
                         .map(|(cid, ci)| (*cid, ci.tty_name.clone()))
                         .collect();
+                    // Send a clean directive to each client first so they exit instead
+                    // of reconnecting on the stream drop. -P also kills the parent.
+                    let directive = if kill_parent { "DETACH-KILL-PARENT" } else { "DETACH" };
+                    let mut any_sent = false;
                     for (cid, _) in &targets {
-                        if kill_parent {
-                            crate::types::send_directive_to_client(*cid, "DETACH-KILL-PARENT");
-                        } else {
-                            // Clean detach: tell each client to exit so it does not treat
-                            // the stream drop as a transient disconnect and reconnect.
-                            crate::types::send_directive_to_client(*cid, "DETACH");
-                        }
+                        any_sent |= crate::types::send_directive_to_client(*cid, directive);
                     }
-                    if !targets.is_empty() {
+                    // Only wait if at least one directive was actually queued.
+                    if any_sent {
                         std::thread::sleep(Duration::from_millis(50));
                     }
                     for (cid, tty) in &targets {

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -3699,6 +3699,11 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                     if app.latest_client_id == Some(target_cid) {
                         app.latest_client_id = app.client_registry.keys().max().copied();
                     }
+                    // Send a clean DETACH directive first so the client exits cleanly
+                    // instead of treating the stream drop as a transient disconnect and
+                    // reconnecting. Give it a moment to act on the directive.
+                    crate::types::send_directive_to_client(target_cid, "DETACH");
+                    std::thread::sleep(Duration::from_millis(50));
                     // Shut down the TCP stream to force disconnect
                     crate::types::shutdown_client_stream(target_cid);
                     // Recompute effective size from remaining clients
@@ -3735,8 +3740,12 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                     if let Some(cid) = target_cid {
                         if kill_parent {
                             crate::types::send_directive_to_client(cid, "DETACH-KILL-PARENT");
-                            std::thread::sleep(Duration::from_millis(50));
+                        } else {
+                            // Clean detach: tell the client to exit so it does not treat
+                            // the stream drop as a transient disconnect and reconnect.
+                            crate::types::send_directive_to_client(cid, "DETACH");
                         }
+                        std::thread::sleep(Duration::from_millis(50));
                         app.client_sizes.remove(&cid);
                         let was_present = app.client_registry.remove(&cid).is_some();
                         if was_present {
@@ -3766,9 +3775,13 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                     for (cid, _tty) in &targets {
                         if kill_parent {
                             crate::types::send_directive_to_client(*cid, "DETACH-KILL-PARENT");
+                        } else {
+                            // Clean detach: tell each client to exit so it does not treat
+                            // the stream drop as a transient disconnect and reconnect.
+                            crate::types::send_directive_to_client(*cid, "DETACH");
                         }
                     }
-                    if kill_parent && !targets.is_empty() {
+                    if !targets.is_empty() {
                         std::thread::sleep(Duration::from_millis(50));
                     }
                     for (cid, tty) in &targets {
@@ -3815,9 +3828,13 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                     for (cid, _) in &targets {
                         if kill_parent {
                             crate::types::send_directive_to_client(*cid, "DETACH-KILL-PARENT");
+                        } else {
+                            // Clean detach: tell each client to exit so it does not treat
+                            // the stream drop as a transient disconnect and reconnect.
+                            crate::types::send_directive_to_client(*cid, "DETACH");
                         }
                     }
-                    if kill_parent && !targets.is_empty() {
+                    if !targets.is_empty() {
                         std::thread::sleep(Duration::from_millis(50));
                     }
                     for (cid, tty) in &targets {

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -3702,8 +3702,10 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                     // Send a clean DETACH directive first so the client exits cleanly
                     // instead of treating the stream drop as a transient disconnect and
                     // reconnecting. Give it a moment to act on the directive.
-                    crate::types::send_directive_to_client(target_cid, "DETACH");
-                    std::thread::sleep(Duration::from_millis(50));
+let sent = crate::types::send_directive_to_client(target_cid, "DETACH");
+if sent {
+    std::thread::sleep(Duration::from_millis(50));
+}
                     // Shut down the TCP stream to force disconnect
                     crate::types::shutdown_client_stream(target_cid);
                     // Recompute effective size from remaining clients

--- a/tests-rs/test_issue275_detach_client.rs
+++ b/tests-rs/test_issue275_detach_client.rs
@@ -194,6 +194,45 @@ fn detach_last_client_without_destroy_unattached_does_not_signal_shutdown() {
 }
 
 // ════════════════════════════════════════════════════════════════════════════
+//  Directive-channel gating (grace-sleep precondition)
+// ════════════════════════════════════════════════════════════════════════════
+//
+// The detach handlers take the 50 ms grace sleep only when
+// `send_directive_to_client` reports the directive was queued.  A client with no
+// registered channel is already gone, so the send reports false and the handler
+// skips the sleep instead of stalling the server loop for nothing.  These tests
+// pin that true/false contract directly, without spinning up a server.
+
+/// Absent channel → the directive cannot be queued, so the send reports false
+/// and the handler skips the grace sleep.
+#[test]
+fn send_directive_reports_false_without_channel() {
+    use crate::types::{remove_directive_channel, send_directive_to_client};
+    let cid = 0xDEAD_0001u64;
+    remove_directive_channel(cid); // drop any entry a prior run might have left
+    assert!(!send_directive_to_client(cid, "DETACH"),
+        "absent channel must report not-queued so the handler skips the sleep");
+}
+
+/// Registered channel → the directive is queued (send reports true) and the
+/// exact string is delivered; after removal the send reports false again.
+#[test]
+fn send_directive_delivers_then_stops_after_removal() {
+    use crate::types::{register_directive_channel, remove_directive_channel, send_directive_to_client};
+    let cid = 0xDEAD_0002u64;
+    let rx = register_directive_channel(cid);
+
+    assert!(send_directive_to_client(cid, "DETACH"),
+        "registered channel must report queued so the handler takes the grace sleep");
+    assert_eq!(rx.recv().ok().as_deref(), Some("DETACH"),
+        "the exact directive string must reach the client's writer thread");
+
+    remove_directive_channel(cid);
+    assert!(!send_directive_to_client(cid, "DETACH"),
+        "after channel removal the send must report not-queued again");
+}
+
+// ════════════════════════════════════════════════════════════════════════════
 //  CLI flag-parsing tests (mirror the parser in main.rs detach-client branch)
 // ════════════════════════════════════════════════════════════════════════════
 


### PR DESCRIPTION
Fixes #389

## Problem

`psmux detach-client` (without `-P`) returns exit `0` but does **not** actually detach an attached client — the client immediately **reconnects** (new tty, same process), so it stays attached. Only `detach-client -P` detached, but `-P` also kills the client's parent process. Real tmux detaches cleanly: the client exits, the session and panes persist, no reconnect.

## Root cause

In `src/server/mod.rs`, the non-`-P` detach handlers force-close the client's TCP stream via `shutdown_client_stream(...)` **without** first sending a clean `"DETACH"` directive. Only the `kill_parent` (`-P`) branch sent a directive (`"DETACH-KILL-PARENT"`).

In `src/client.rs`, a client sets `quit = true` (clean exit) only on receiving a `"DETACH"` / `"DETACH-KILL-PARENT"` directive. On a bare stream drop, if `!quit && port_file_exists`, it spawns a reconnect thread. So a non-`-P` detach looks like a transient disconnect, and the client reconnects with a new tty.

The four affected handlers: `CtrlReq::ForceDetachClient`, `CtrlReq::ForceDetachClientByTty`, `CtrlReq::DetachAllOtherClients`, `CtrlReq::DetachAllClients`.

## Fix

In each handler, on the non-`-P` path, send a clean `"DETACH"` directive to each targeted client **before** `shutdown_client_stream(...)` — mirroring the `-P` branch but using `"DETACH"` (no parent kill) — with a 50 ms grace so the client acts on the directive before its stream is torn down.

- `ForceDetachClient` (no `kill_parent` param): always send `"DETACH"` + sleep before shutdown. Its `-P` callers send `"DETACH-KILL-PARENT"` upstream first, so the client reads that, kills the parent, and quits; the later `"DETACH"` is a harmless no-op on an already-quitting client — `-P` behavior unchanged.
- `ForceDetachClientByTty` / `DetachAllOtherClients` / `DetachAllClients`: the existing `if kill_parent { ...DETACH-KILL-PARENT... }` now has an `else { ...DETACH... }` branch, and the grace sleep fires whenever a directive was sent.

`-P` behavior is unchanged. Preserved invariants: `prefix+d` / `prefix+:detach-client` still detach the current client; `detach-client -a` from inside a client still does not exit the calling client (it routes to `DetachAllOtherClients`, which excludes the caller); the session and panes survive.

## tmux parity

Matches tmux 3.2a, where `detach-client` detaches the client cleanly while the session persists and there is no reconnect.

## Verification

`cargo check` passes.
