### PR TITLE
fix(ssh): decode ESC+CR as Alt+Enter so Shift+Enter inserts a newline over SSH

### DIFF
--- a/src/ssh_input.rs
+++ b/src/ssh_input.rs
@@ -661,6 +661,15 @@ impl VtParser {
                 self.osc.clear();
                 self.state = PS::Osc;
             }
+            '\r' | '\n' => {
+                // ESC+CR / ESC+LF → Alt+Enter, emitted as a single event.
+                // Windows Terminal sends ESC+CR for Shift+Enter; forwarding one
+                // \x1b\r (re-emitted by encode_key_event) lets TUI apps such as
+                // the Copilot and Claude CLIs insert a newline instead of
+                // submitting the prompt.
+                emit(make_key(KeyCode::Enter, KeyModifiers::ALT));
+                self.state = PS::Ground;
+            }
             c if c >= ' ' && c <= '~' => {
                 // Alt + printable character.
                 emit(make_key(KeyCode::Char(c), KeyModifiers::ALT));

--- a/tests-rs/test_ssh_vt_paste.rs
+++ b/tests-rs/test_ssh_vt_paste.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crossterm::event::Event;
+use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers};
 
 // ── Helpers ──────────────────────────────────────────────────────────────
 
@@ -502,4 +502,77 @@ fn dispatch_tilde_ignores_param_201() {
     assert!(csi_events.is_empty(),
         "CSI 201~ should be silently ignored, got {:?}", csi_events);
     assert_eq!(p.state, PS::Ground);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 7. Modified Enter over SSH (ESC+CR / ESC+LF → Alt+Enter)
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// Extract the KeyEvent from an Event::Key variant.
+fn key_event(evt: &Event) -> Option<&KeyEvent> {
+    match evt {
+        Event::Key(k) => Some(k),
+        _ => None,
+    }
+}
+
+#[test]
+fn esc_cr_decodes_as_alt_enter() {
+    // Windows Terminal sends ESC+CR (\x1b\r) for Shift+Enter.  The SSH VT
+    // parser must decode it as a single Alt+Enter event so encode_key_event
+    // re-emits \x1b\r and TUI apps insert a newline instead of submitting.
+    // Regression: previously this split into a standalone Esc + plain Enter,
+    // which submitted the prompt.
+    let events = parse("\x1b\r");
+    assert_eq!(events.len(), 1, "expected exactly one event, got {:?}", events);
+    let k = key_event(&events[0]).expect("expected a Key event");
+    assert_eq!(k.code, KeyCode::Enter);
+    assert_eq!(k.modifiers, KeyModifiers::ALT);
+}
+
+#[test]
+fn esc_lf_decodes_as_alt_enter() {
+    let events = parse("\x1b\n");
+    assert_eq!(events.len(), 1, "expected exactly one event, got {:?}", events);
+    let k = key_event(&events[0]).expect("expected a Key event");
+    assert_eq!(k.code, KeyCode::Enter);
+    assert_eq!(k.modifiers, KeyModifiers::ALT);
+}
+
+#[test]
+fn esc_cr_returns_to_ground_and_passes_following_text() {
+    // After Alt+Enter the parser must be back in Ground and decode the
+    // following characters normally.
+    let mut p = VtParser::new();
+    let events = feed_str(&mut p, "\x1b\rhi");
+    assert_eq!(p.state, PS::Ground);
+    assert_eq!(events.len(), 3, "Alt+Enter + 'h' + 'i', got {:?}", events);
+
+    let k = key_event(&events[0]).expect("first event should be a Key");
+    assert_eq!(k.code, KeyCode::Enter);
+    assert_eq!(k.modifiers, KeyModifiers::ALT);
+
+    assert_eq!(key_event(&events[1]).unwrap().code, KeyCode::Char('h'));
+    assert_eq!(key_event(&events[2]).unwrap().code, KeyCode::Char('i'));
+}
+
+#[test]
+fn bare_cr_without_esc_is_plain_enter() {
+    // A CR not preceded by ESC must remain an unmodified Enter so ordinary
+    // prompt submission still works.
+    let events = parse("\r");
+    assert_eq!(events.len(), 1);
+    let k = key_event(&events[0]).expect("expected a Key event");
+    assert_eq!(k.code, KeyCode::Enter);
+    assert_eq!(k.modifiers, KeyModifiers::empty());
+}
+
+#[test]
+fn esc_printable_still_decodes_as_alt_char() {
+    // The new Enter arm must not disturb Alt+<printable> handling.
+    let events = parse("\x1bx");
+    assert_eq!(events.len(), 1);
+    let k = key_event(&events[0]).expect("expected a Key event");
+    assert_eq!(k.code, KeyCode::Char('x'));
+    assert_eq!(k.modifiers, KeyModifiers::ALT);
 }


### PR DESCRIPTION
## What

Over SSH, **Shift+Enter** (and Alt+Enter) in TUI apps such as the GitHub Copilot CLI and Claude Code submitted the prompt instead of inserting a newline. This maps `ESC`+`CR` / `ESC`+`LF` to a single `Alt`+`Enter` event in the SSH VT input parser, so the keystroke round-trips as one `\x1b\r` and the app inserts a newline.

Fixes #396.

## Root cause

Windows Terminal encodes Shift+Enter as the two bytes `ESC` + `CR` (`\x1b\r`). In `src/ssh_input.rs`, `on_escape()` only mapped `ESC`+printable (`' '..='~'`) to `Alt`+char; `ESC` followed by a C0 control byte such as `CR` (`0x0D`) fell into the catch-all, which emitted a standalone `Esc` and re-processed the `CR` as an unmodified `Enter`. The inner app therefore received `Escape` + a plain `Enter` (a submit) instead of a single modified `Enter`. psmux already fixes the equivalent ConPTY mis-report on the local crossterm path via `platform::augment_enter_shift()`, but the SSH VT input path had no counterpart.

## The change

`src/ssh_input.rs`: add an `'\r' | '\n'` arm to `on_escape()` that emits a single `Alt`+`Enter` event instead of falling into the `Esc` + re-process catch-all.

Why `Alt`+`Enter` specifically:

- It is the conventional decode of an ESC-prefixed key and matches the existing `ESC`+printable → `Alt`+char arm in the same function.
- `encode_key_event()` already special-cases Shift/Alt+Enter (no Ctrl) to `\x1b\r` on Windows, so the keystroke round-trips to exactly the bytes the client sent.
- `augment_enter_shift()` only upgrades `Alt`→`Shift` when a physical Shift is held; on the SSH server no physical key is held, so it leaves the event as `Alt`+`Enter` — the same canonical form the crossterm path produces.

Scope is intentionally limited to Enter. Other `ESC`+C0 combinations are left unchanged: `Alt`+`Backspace` must stay `\x1b` + `\x7f`/`\x08` (the encode side drops Backspace modifiers, so converting it would regress word-delete), and `ESC` + `Ctrl`+letter already round-trips to identical bytes.

## Tests

Added to `tests-rs/test_ssh_vt_paste.rs`:

- `esc_cr_decodes_as_alt_enter`, `esc_lf_decodes_as_alt_enter` — `ESC`+`CR`/`ESC`+`LF` each produce a single `Alt`+`Enter` event.
- `esc_cr_returns_to_ground_and_passes_following_text` — the parser returns to `Ground` and decodes following input normally.
- `bare_cr_without_esc_is_plain_enter` — an unprefixed `CR` stays an unmodified `Enter`, so ordinary prompt submission still works.
- `esc_printable_still_decodes_as_alt_char` — `Alt`+`<printable>` handling is unaffected.

All 33 `ssh_input` parser tests pass: `cargo test --bin psmux -- ssh_input::`.

## Verification

Built a release binary, installed it on a Windows SSH host, and confirmed Shift+Enter now inserts a newline in the GitHub Copilot CLI over the SSH session, while plain Enter still submits.
