### PR TITLE
fix: resolve #{session_path} to the server working directory

### DIFF
--- a/src/format.rs
+++ b/src/format.rs
@@ -1046,6 +1046,9 @@ pub fn expand_var(var: &str, app: &AppState, win_idx: usize) -> String {
                 "session_name" => app.session_name.clone(),
                 "session_windows" => app.windows.len().to_string(),
                 "session_id" => format!("${}", app.session_id),
+                "session_path" => std::env::current_dir()
+                    .map(|d| d.to_string_lossy().into_owned())
+                    .unwrap_or_default(),
                 "pid" | "server_pid" => std::process::id().to_string(),
                 "version" => VERSION.to_string(),
                 "host" | "hostname" => hostname_cached(),
@@ -1095,7 +1098,9 @@ pub fn expand_var(var: &str, app: &AppState, win_idx: usize) -> String {
         }
         "session_grouped" => if app.session_group.is_some() { "1".into() } else { "0".into() },
         "session_format" | "session_many_attached" => if app.attached_clients > 1 { "1".into() } else { "0".into() },
-        "session_path" => env::var("HOME").or_else(|_| env::var("USERPROFILE")).unwrap_or_default(),
+        "session_path" => std::env::current_dir()
+            .map(|d| d.to_string_lossy().into_owned())
+            .unwrap_or_default(),
 
         // ── Window ──
         "window_index" => (win_idx + app.window_base_index).to_string(),

--- a/tests-rs/test_format.rs
+++ b/tests-rs/test_format.rs
@@ -610,3 +610,17 @@ fn test_expand_format_complex_style() {
     assert_eq!(result, "#[fg=yellow,bg=blue,bold]Styled Text",
         "Complex style directives must be preserved");
 }
+
+#[test]
+fn test_session_path_is_server_cwd() {
+    // tmux: #{session_path} is the working directory of the session. psmux has
+    // no per-session cwd, so it resolves to the server's current directory --
+    // the same source #{pane_current_path} falls back to. It must NOT be the
+    // user's home directory.
+    let app = mock_app();
+    let expected = std::env::current_dir()
+        .map(|d| d.to_string_lossy().into_owned())
+        .unwrap_or_default();
+    assert_eq!(expand_format("#{session_path}", &app), expected,
+        "#{{session_path}} must resolve to the session (server) working directory");
+}


### PR DESCRIPTION
This PR fixes `#{session_path}` to resolve to the session working directory (which is the server working directory as of #369)

- It returned the user home directory. tmux defines `#{session_path}` as the
  working directory of the session.
- Now resolves to the server's current directory (`std::env::current_dir()`),
  the same source `#{pane_current_path}` already falls back to. Fixed in both
  `expand_var` arms — the windowed match and the no-window early-return path.
- TDD: a `test_format` test asserts it expands to the server cwd, not home.

**Observable change:** `#{session_path}` now reports the session (server)
working directory instead of the home directory.

## Repro

```shell
$ tmux new -d -c C:\WINDOWS
# should return C:\WINDOWS + C:\WINDOWS but returns the value of $USERPROFILE (or $HOME) + C:\WINDOWS
$ tmux ls -F "#{session_path} + #{pane_current_path}" 
C:\Users\your.name + C:\WINDOWS
```