### PR TITLE
Fix <Esc> (and CPR replies) being swallowed under PSEUDOCONSOLE_WIN32_INPUT_MODE

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -2102,6 +2102,42 @@ pub fn forward_key_to_active(app: &mut AppState, key: KeyEvent) -> io::Result<()
                 return Ok(());
             }
         }
+
+        // Bare <Esc>: deliver it as a VK_ESCAPE key event via WriteConsoleInputW
+        // instead of writing a lone \x1b to the PTY pipe.  Once the child app
+        // (Neovim, Claude Code, ...) turns on VT / Win32 input mode a moment
+        // after launch, ConPTY treats a piped \x1b as the start of a CSI
+        // sequence and buffers it, so the keypress never reaches the child and
+        // <Esc> appears dead.  Direct console-input injection bypasses that
+        // parser, mirroring the Ctrl+letter path above (#305).  Fall back to the
+        // pipe only when no child pid is known.
+        if matches!(key.code, KeyCode::Esc) && key.modifiers.is_empty() {
+            fn deliver_esc(p: &mut Pane) {
+                let injected = p.child_pid
+                    .map(|pid| crate::platform::mouse_inject::send_modified_key_event(pid, '\u{1b}', false, false, false))
+                    .unwrap_or(false);
+                if !injected {
+                    let _ = p.writer.write_all(b"\x1b");
+                    let _ = p.writer.flush();
+                }
+                crate::debug_log::input_log("esc",
+                    &format!("deliver_esc injected={} pid={:?}", injected, p.child_pid));
+            }
+            let win = &mut app.windows[app.active_idx];
+            if app.sync_input {
+                fn esc_all(node: &mut Node) {
+                    match node {
+                        Node::Leaf(p) if !p.dead => deliver_esc(p),
+                        Node::Leaf(_) => {}
+                        Node::Split { children, .. } => { for c in children { esc_all(c); } }
+                    }
+                }
+                esc_all(&mut win.root);
+            } else if let Some(active) = active_pane_mut(&mut win.root, &win.active_path) {
+                if !active.dead { deliver_esc(active); }
+            }
+            return Ok(());
+        }
     }
 
     let encoded = match encode_key_event(&key) {

--- a/src/server/helpers.rs
+++ b/src/server/helpers.rs
@@ -386,8 +386,32 @@ fn check_pane_bells(node: &Node) -> bool {
 /// Injects ESC[row;colR into any pane whose reader thread detected ESC[6n.
 /// pwsh re-issues the CPR query after lock/unlock; without this response it
 /// blocks indefinitely since the preemptive write at spawn time is long gone.
+/// Deliver a CPR (cursor-position-report) reply to a child process.
+///
+/// The child ConPTY is created with `PSEUDOCONSOLE_WIN32_INPUT_MODE`, whose
+/// input parser only accepts win32 key sequences terminated with `_`.  Writing
+/// a raw VT CPR reply (terminated with `R`) to the PTY pipe leaves that parser
+/// in a half-state that swallows the next keystroke -- notably a lone <Esc>,
+/// which is why <Esc> stops working a few seconds after an app such as Neovim
+/// issues its `ESC[6n` probe.  This is the reactive twin of the spawn-time DSR
+/// bug fixed in #313.  Inject the reply straight into the child's console input
+/// buffer (bypassing ConPTY's VT input parser); only fall back to the PTY pipe
+/// when no child pid is known or on non-Windows, where the issue does not apply.
+pub(crate) fn deliver_cpr_reply<W: std::io::Write>(
+    child_pid: Option<u32>,
+    writer: &mut W,
+    response: &str,
+) {
+    let injected = child_pid
+        .map(|pid| crate::platform::mouse_inject::send_vt_sequence(pid, response.as_bytes()))
+        .unwrap_or(false);
+    if !injected {
+        let _ = writer.write_all(response.as_bytes());
+        let _ = writer.flush();
+    }
+}
+
 pub(crate) fn drain_cpr_pending(node: &mut crate::types::Node) {
-    use std::io::Write as _;
     match node {
         crate::types::Node::Leaf(p) => {
             if p.cpr_pending
@@ -399,8 +423,7 @@ pub(crate) fn drain_cpr_pending(node: &mut crate::types::Node) {
                     .map(|g| g.screen().cursor_position())
                     .unwrap_or((0, 0));
                 let response = format!("\x1b[{};{}R", r + 1, c + 1);
-                let _ = p.writer.write_all(response.as_bytes());
-                let _ = p.writer.flush();
+                deliver_cpr_reply(p.child_pid, &mut p.writer, &response);
             }
         }
         crate::types::Node::Split { children, .. } => {

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1090,9 +1090,7 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                             .map(|g| g.screen().cursor_position())
                             .unwrap_or((0, 0));
                         let response = format!("\x1b[{};{}R", r + 1, c + 1);
-                        use std::io::Write as _;
-                        let _ = wp.writer.write_all(response.as_bytes());
-                        let _ = wp.writer.flush();
+                        helpers::deliver_cpr_reply(wp.child_pid, &mut wp.writer, &response);
                     }
                 }
                 // Also answer CPR queries for an active popup PTY pane. Like the
@@ -1105,9 +1103,7 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                             .map(|g| g.screen().cursor_position())
                             .unwrap_or((0, 0));
                         let response = format!("\x1b[{};{}R", r + 1, c + 1);
-                        use std::io::Write as _;
-                        let _ = pane.writer.write_all(response.as_bytes());
-                        let _ = pane.writer.flush();
+                        helpers::deliver_cpr_reply(pane.child_pid, &mut pane.writer, &response);
                     }
                 }
             }


### PR DESCRIPTION
## Summary

Fixes `<Esc>` becoming unresponsive in TUI apps (Neovim, Claude Code, …) a few seconds after they launch and never recovering — the open bug #380. The root cause is the same `WIN32_INPUT_MODE` ConPTY input-parser hazard that #313 / #305 already addressed for other keys; this PR covers the bare-`<Esc>` keypress path and the reactive CPR responder.

## Root cause

Panes are created with `PSEUDOCONSOLE_WIN32_INPUT_MODE`, whose input parser expects win32 key sequences (underscore-terminated). Two code paths still wrote raw VT to that pipe:

1. **Bare `<Esc>` keypress** — `forward_key_to_active` fell through to `encode_key_event`, which writes a lone `ESC` byte to the PTY pipe. ConPTY treats it as the start of a CSI sequence and buffers it, so once the child enables VT / Win32 input mode (a moment after launch) the key never arrives, and it never recovers. The Ctrl+letter path already injects to avoid exactly this — see the comment it left in `src/input.rs`.
2. **CPR reply** — the reactive `ESC[6n` responder wrote a raw `…R`-terminated cursor-position report into the same pipe, corrupting the parser. This is the reactive twin of the spawn-time DSR bug fixed in #313 (the spawn-time response was made a no-op there, but the reactive path was not).

## Changes

- **`src/input.rs`** — deliver bare `<Esc>` as a `VK_ESCAPE` key event via `WriteConsoleInputW` (`mouse_inject::send_modified_key_event`), bypassing ConPTY's VT input parser. Falls back to the PTY pipe only when no child pid is known. Mirrors the Ctrl+letter approach from #305.
- **`src/server/helpers.rs`, `src/server/mod.rs`** — route CPR replies for the active, warm, and popup panes through `send_vt_sequence` (direct console-input injection) via a shared `deliver_cpr_reply` helper; the raw PTY-pipe write is kept only as a fallback.

## Testing

- Built on `x86_64-pc-windows-gnu`. With the bare-`<Esc>` fix, `<Esc>` works reliably in `nvim --clean` and Claude Code under a fresh server, where it was previously permanently dead within seconds of launch. Verified with `PSMUX_INPUT_DEBUG=1`.
- The CPR change is a code-correctness fix matching the #313 root-cause analysis; no behavior change on non-Windows or when no child pid is available (the pipe fallback path is unchanged there).

Fixes #380. Related: #313, #305.
