### PR TITLE
refactor: centralize psmux data-dir path construction into paths.rs

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1366,13 +1366,12 @@ fn try_reconnect(addr: &str, key: &str) -> Option<Connection> {
 
 pub fn run_remote(terminal: &mut Terminal<CrosstermBackend<crate::platform::PsmuxWriter>>, input: &crate::ssh_input::InputSource) -> io::Result<()> {
     let name = env::var("PSMUX_SESSION_NAME").unwrap_or_else(|_| "default".to_string());
-    let home = env::var("USERPROFILE").or_else(|_| env::var("HOME")).unwrap_or_default();
-    let path = format!("{}\\.psmux\\{}.port", home, name);
+    let path = crate::paths::port_file(&name);
     let port = std::fs::read_to_string(&path).ok().and_then(|s| s.trim().parse::<u16>().ok())
         .ok_or_else(|| io::Error::new(io::ErrorKind::Other, format!("can't find session '{}' (no server running)", name)))?;
     let addr = format!("127.0.0.1:{}", port);
     let session_key = read_session_key(&name).unwrap_or_default();
-    let last_path = format!("{}\\.psmux\\last_session", home);
+    let last_path = crate::paths::psmux_dir_file("last_session");
     if !crate::session::is_warm_session(&name) {
         let _ = std::fs::write(&last_path, &name);
     }
@@ -1893,8 +1892,7 @@ pub fn run_remote(terminal: &mut Terminal<CrosstermBackend<crate::platform::Psmu
     // Diagnostic latency log: set PSMUX_LATENCY_LOG=1 to enable
     let latency_log_enabled = env::var("PSMUX_LATENCY_LOG").unwrap_or_default() == "1";
     let mut latency_log: Option<std::fs::File> = if latency_log_enabled {
-        let home = env::var("USERPROFILE").or_else(|_| env::var("HOME")).unwrap_or_default();
-        let path = format!("{}\\.psmux\\latency.log", home);
+        let path = crate::paths::psmux_dir_file("latency.log");
         std::fs::File::create(&path).ok()
     } else { None };
     let mut loop_count: u64 = 0;
@@ -2856,7 +2854,7 @@ pub fn run_remote(terminal: &mut Terminal<CrosstermBackend<crate::platform::Psmu
                                 popup_rect_last = None;
                                 if choose_tree_preview_default { preview_enabled = true; }
                                 // Query ALL sessions (like tmux choose-tree)
-                                let dir = format!("{}\\.psmux", home);
+                                let dir = crate::paths::psmux_dir();
                                 if let Ok(entries) = std::fs::read_dir(&dir) {
                                     let mut sessions: Vec<(String, Vec<(usize, String, bool, Vec<(usize, String)>, usize)>)> = Vec::new();
                                     for e in entries.flatten() {
@@ -2954,7 +2952,7 @@ pub fn run_remote(terminal: &mut Terminal<CrosstermBackend<crate::platform::Psmu
                                 popup_dragging = false;
                                 popup_rect_last = None;
                                 if choose_tree_preview_default { preview_enabled = true; }
-                                let dir = format!("{}\\.psmux", home);
+                                let dir = crate::paths::psmux_dir();
                                 // Collect (label, addr, key) for every port file, then run ONE
                                 // bounded liveness probe per session in parallel. This both lists
                                 // and prunes: total wall time is ~one probe window regardless of
@@ -3022,7 +3020,7 @@ pub fn run_remote(terminal: &mut Terminal<CrosstermBackend<crate::platform::Psmu
                                 buffer_scroll = 0;
                                 buffer_num_buffer.clear();
                                 // Fetch buffer list from server via TCP
-                                let port_file = format!("{}\\.psmux\\{}.port", home, current_session);
+                                let port_file = crate::paths::port_file(&current_session);
                                 if let Ok(port_str) = std::fs::read_to_string(&port_file) {
                                     if let Ok(p) = port_str.trim().parse::<u16>() {
                                         let sess_key = read_session_key(&current_session).unwrap_or_default();
@@ -3068,7 +3066,7 @@ pub fn run_remote(terminal: &mut Terminal<CrosstermBackend<crate::platform::Psmu
                                 }
                             }
                             if let Some(dir_next) = do_session_nav {
-                                let dir = format!("{}\\.psmux", home);
+                                let dir = crate::paths::psmux_dir();
                                 let mut names: Vec<String> = Vec::new();
                                 if let Ok(entries) = std::fs::read_dir(&dir) {
                                     for e in entries.flatten() {
@@ -3191,9 +3189,8 @@ pub fn run_remote(terminal: &mut Terminal<CrosstermBackend<crate::platform::Psmu
                                             quit = true;
                                         } else {
                                             // Kill another session by connecting to it
-                                            let h = env::var("USERPROFILE").or_else(|_| env::var("HOME")).unwrap_or_default();
-                                            let port_path = format!("{}\\.psmux\\{}.port", h, sname);
-                                            let key_path = format!("{}\\.psmux\\{}.key", h, sname);
+                                            let port_path = crate::paths::port_file(&sname);
+                                            let key_path = crate::paths::key_file(&sname);
                                             if let Ok(port_str) = std::fs::read_to_string(&port_path) {
                                                 if let Ok(port) = port_str.trim().parse::<u16>() {
                                                     let addr = format!("127.0.0.1:{}", port);
@@ -3488,7 +3485,7 @@ pub fn run_remote(terminal: &mut Terminal<CrosstermBackend<crate::platform::Psmu
                                             buffer_selected = 0;
                                             buffer_scroll = 0;
                                             buffer_num_buffer.clear();
-                                            let port_file = format!("{}\\.psmux\\{}.port", home, current_session);
+                                            let port_file = crate::paths::port_file(&current_session);
                                             if let Ok(port_str) = std::fs::read_to_string(&port_file) {
                                                 if let Ok(p) = port_str.trim().parse::<u16>() {
                                                     let sess_key = read_session_key(&current_session).unwrap_or_default();
@@ -5108,7 +5105,7 @@ pub fn run_remote(terminal: &mut Terminal<CrosstermBackend<crate::platform::Psmu
                             } else { None }
                         } else { None };
                         let win_id = win_id.or_else(|| {
-                            let port_path = format!("{}\\.psmux\\{}.port", home, sname);
+                            let port_path = crate::paths::port_file(sname);
                             let port: u16 = std::fs::read_to_string(&port_path).ok()?.trim().parse().ok()?;
                             let key = crate::session::read_session_key(sname).ok()?;
                             let resp = crate::session::fetch_authed_response_multi(
@@ -5126,7 +5123,7 @@ pub fn run_remote(terminal: &mut Terminal<CrosstermBackend<crate::platform::Psmu
 
                         if let Some(wid) = win_id {
                             if let Some(layout) = crate::preview::get_or_fetch_dump(
-                                &mut dump_cache, &home, sname, wid,
+                                &mut dump_cache, sname, wid,
                             ) {
                                 crate::preview::render_dump_tree(
                                     f,
@@ -5153,7 +5150,7 @@ pub fn run_remote(terminal: &mut Terminal<CrosstermBackend<crate::platform::Psmu
                                     } else { None }
                                 } else { None };
                                 let wid = win_id?;
-                                crate::preview::get_or_fetch(&mut preview_cache, &home, sname, wid, usize::MAX)
+                                crate::preview::get_or_fetch(&mut preview_cache, sname, wid, usize::MAX)
                             });
                         let pv: Vec<Line> = match preview_text {
                             Some(t) => crate::preview::parse_ansi_lines(&t, parea.width, parea.height),
@@ -5311,7 +5308,7 @@ pub fn run_remote(terminal: &mut Terminal<CrosstermBackend<crate::platform::Psmu
 
                         if let Some(twid) = target_win {
                             if let Some(layout) = crate::preview::get_or_fetch_dump(
-                                &mut dump_cache, &home, &sess, twid,
+                                &mut dump_cache, &sess, twid,
                             ) {
                                 // Highlight which pane the user is hovering on
                                 // (for pane-level entries). Active pane gets a
@@ -5335,11 +5332,11 @@ pub fn run_remote(terminal: &mut Terminal<CrosstermBackend<crate::platform::Psmu
                             let preview_text: Option<String> = if is_win && wid == usize::MAX {
                                 tree_entries.iter()
                                     .find(|(iw, w, _p, _l, s)| *iw && *w != usize::MAX && s == &sess)
-                                    .and_then(|(_, w, _p, _l, s)| crate::preview::get_or_fetch(&mut preview_cache, &home, s, *w, usize::MAX))
+                                    .and_then(|(_, w, _p, _l, s)| crate::preview::get_or_fetch(&mut preview_cache, s, *w, usize::MAX))
                             } else if is_win {
-                                crate::preview::get_or_fetch(&mut preview_cache, &home, &sess, wid, usize::MAX)
+                                crate::preview::get_or_fetch(&mut preview_cache, &sess, wid, usize::MAX)
                             } else {
-                                crate::preview::get_or_fetch(&mut preview_cache, &home, &sess, wid, pid)
+                                crate::preview::get_or_fetch(&mut preview_cache, &sess, wid, pid)
                             };
                             let pv: Vec<Line> = match preview_text {
                                 Some(t) => crate::preview::parse_ansi_lines(&t, parea.width, parea.height),

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -2175,8 +2175,7 @@ fn execute_command_string_single(app: &mut AppState, cmd: &str) -> io::Result<()
             };
 
             // Check if session already exists
-            let home = std::env::var("USERPROFILE").or_else(|_| std::env::var("HOME")).unwrap_or_default();
-            let port_path = format!("{}\\.psmux\\{}.port", home, port_file_base);
+            let port_path = crate::paths::port_file(&port_file_base);
             if std::path::Path::new(&port_path).exists() {
                 if let Ok(port_str) = std::fs::read_to_string(&port_path) {
                     if let Ok(port) = port_str.trim().parse::<u16>() {
@@ -2203,7 +2202,7 @@ fn execute_command_string_single(app: &mut AppState, cmd: &str) -> io::Result<()
                 } else {
                     "__warm__".to_string()
                 };
-                let warm_port_path = format!("{}\\.psmux\\{}.port", home, warm_base);
+                let warm_port_path = crate::paths::port_file(&warm_base);
                 if std::path::Path::new(&warm_port_path).exists() {
                     if let Ok(warm_port_str) = std::fs::read_to_string(&warm_port_path) {
                         if let Ok(warm_port) = warm_port_str.trim().parse::<u16>() {

--- a/src/cross_session.rs
+++ b/src/cross_session.rs
@@ -20,10 +20,7 @@ use std::time::Duration;
 
 /// Resolve a session name to (port, key).
 pub fn resolve_session(session_name: &str) -> io::Result<(u16, String)> {
-    let home = std::env::var("USERPROFILE")
-        .or_else(|_| std::env::var("HOME"))
-        .unwrap_or_default();
-    let port_path = format!("{}\\.psmux\\{}.port", home, session_name);
+    let port_path = crate::paths::port_file(session_name);
     let port: u16 = std::fs::read_to_string(&port_path)
         .map_err(|_| io::Error::new(io::ErrorKind::NotFound,
             format!("no server for session '{}'", session_name)))?

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,6 +34,7 @@ mod control;
 mod proxy_pane;
 mod cross_session;
 mod cross_session_server;
+mod paths;
 
 use std::io::{self, Write, Read as _, BufRead as _, IsTerminal};
 use std::time::Duration;
@@ -166,8 +167,7 @@ fn cli_pane_index_exists(idx_spec: &str) -> Option<bool> {
 /// returns true — conservative on purpose, so a busy server is never wrongly
 /// declared dead (used by kill-session to decide when the kill has landed).
 fn probe_session_alive(session_name: &str) -> bool {
-    let home = env::var("USERPROFILE").or_else(|_| env::var("HOME")).unwrap_or_default();
-    let path = format!("{}\\.psmux\\{}.port", home, session_name);
+    let path = crate::paths::port_file(session_name);
     let port = match std::fs::read_to_string(&path).ok().and_then(|s| s.trim().parse::<u16>().ok()) {
         Some(p) => p,
         None => return false, // no port file → gone
@@ -319,8 +319,7 @@ fn run_main() -> io::Result<()> {
         // (set inside every psmux pane) names the current server; the `-L`
         // namespace and the most-recent-session fallback are applied inside
         // resolve_routing_target.
-        let home = env::var("USERPROFILE").or_else(|_| env::var("HOME")).unwrap_or_default();
-        let psmux_dir = std::path::PathBuf::from(format!("{}\\.psmux", home));
+        let psmux_dir = std::path::PathBuf::from(crate::paths::psmux_dir());
         let tmux_env = env::var("TMUX").ok();
         if let Some(name) = crate::session::resolve_routing_target(
             l_socket_name.as_deref(),
@@ -400,8 +399,7 @@ fn run_main() -> io::Result<()> {
             let win_id: usize = cmd_args[2].parse().expect("win_id must be a number");
             let w: u16 = cmd_args[3].parse().expect("width must be a number");
             let h: u16 = cmd_args[4].parse().expect("height must be a number");
-            let home = env::var("USERPROFILE").or_else(|_| env::var("HOME")).unwrap_or_default();
-            let layout = match crate::preview::fetch_window_dump(&home, &sess, win_id) {
+            let layout = match crate::preview::fetch_window_dump(&sess, win_id) {
                 Some(l) => l,
                 None => { eprintln!("failed to fetch window-dump for {}:@{}", sess, win_id); std::process::exit(3); }
             };
@@ -461,8 +459,7 @@ fn run_main() -> io::Result<()> {
     match cmd {
         // kill-server MUST be handled early before any potential fall-through
         "kill-server" => {
-            let home = env::var("USERPROFILE").or_else(|_| env::var("HOME")).unwrap_or_default();
-            let psmux_dir = format!("{}\\.psmux", home);
+            let psmux_dir = crate::paths::psmux_dir();
             // Compute namespace prefix for -L filtering (matches list-sessions behavior)
             let ns_prefix = l_socket_name.as_ref().map(|l| format!("{l}__"));
             let mut targets: Vec<(std::path::PathBuf, u16, String)> = Vec::new();
@@ -571,8 +568,7 @@ fn run_main() -> io::Result<()> {
                         i += 1;
                     }
                 }
-                let home = env::var("USERPROFILE").or_else(|_| env::var("HOME")).unwrap_or_default();
-                let dir = format!("{}\\.psmux", home);
+                let dir = crate::paths::psmux_dir();
                 // Compute namespace prefix for -L filtering
                 let ns_prefix = l_socket_name.as_ref().map(|l| format!("{l}__"));
                 if let Ok(entries) = std::fs::read_dir(&dir) {
@@ -619,7 +615,7 @@ fn run_main() -> io::Result<()> {
                                                 // while still detecting dead sessions quickly.
                                                 let _ = s.set_read_timeout(Some(Duration::from_millis(500)));
                                                 // Read session key and authenticate
-                                                let key_path = format!("{}\\.psmux\\{}.key", home, base);
+                                                let key_path = crate::paths::key_file(&base);
                                                 if let Ok(key) = std::fs::read_to_string(&key_path) {
                                                     let _ = std::io::Write::write_all(&mut s, format!("AUTH {}\n", key.trim()).as_bytes());
                                                 }
@@ -957,8 +953,8 @@ fn run_main() -> io::Result<()> {
                 };
                 
                 // Check if session already exists AND is actually running
-                let home = env::var("USERPROFILE").or_else(|_| env::var("HOME")).unwrap_or_default();
-                let port_path = format!("{}\\.psmux\\{}.port", home, port_file_base);
+                let psmux_dir = crate::paths::psmux_dir();
+                let port_path = crate::paths::port_file(&port_file_base);
                 // PID of the server we spawn on the cold path (None when we adopt
                 // a warm server or attach to a remote one). The readiness gate
                 // below uses it to fail fast if the freshly spawned server dies.
@@ -1012,7 +1008,7 @@ fn run_main() -> io::Result<()> {
                     } else {
                         "__warm__".to_string()
                     };
-                    let warm_port_path = format!("{}\\.psmux\\{}.port", home, warm_base);
+                    let warm_port_path = crate::paths::port_file(&warm_base);
                     // Atomically CLAIM the warm server before connecting. The
                     // __warm__.port file is a shared handoff: under rapid
                     // new-session, several clients could read the SAME file (and
@@ -1023,7 +1019,7 @@ fn run_main() -> io::Result<()> {
                     let warm_port_opt = std::fs::read_to_string(&warm_port_path)
                         .ok()
                         .and_then(|s| s.trim().parse::<u16>().ok());
-                    let claim_path = format!("{}\\.psmux\\{}.claiming.{}", home, warm_base, std::process::id());
+                    let claim_path = format!("{}\\{}.claiming.{}", psmux_dir, warm_base, std::process::id());
                     if let Some(warm_port) = warm_port_opt {
                         if std::fs::rename(&warm_port_path, &claim_path).is_ok() {
                             let warm_addr = format!("127.0.0.1:{}", warm_port);
@@ -1784,8 +1780,7 @@ fn run_main() -> io::Result<()> {
 
                 if all_sessions {
                     // Iterate over all session port files (like list-sessions does)
-                    let home = env::var("USERPROFILE").or_else(|_| env::var("HOME")).unwrap_or_default();
-                    let dir = format!("{}\\.psmux", home);
+                    let dir = crate::paths::psmux_dir();
                     let ns_prefix = l_socket_name.as_ref().map(|l| format!("{l}__"));
                     if let Ok(entries) = std::fs::read_dir(&dir) {
                         for e in entries.flatten() {
@@ -1808,7 +1803,7 @@ fn run_main() -> io::Result<()> {
                                             let refused = matches!(&conn, Err(e) if e.kind() == io::ErrorKind::ConnectionRefused);
                                             if let Ok(mut s) = conn {
                                                 let _ = s.set_read_timeout(Some(Duration::from_millis(500)));
-                                                let key_path = format!("{}\\.psmux\\{}.key", home, base);
+                                                let key_path = crate::paths::key_file(&base);
                                                 if let Ok(key) = std::fs::read_to_string(&key_path) {
                                                     let _ = std::io::Write::write_all(&mut s, format!("AUTH {}\n", key.trim()).as_bytes());
                                                 }
@@ -1904,8 +1899,7 @@ fn run_main() -> io::Result<()> {
 
                 if all_sessions {
                     // Iterate over all session port files (like list-sessions does)
-                    let home = env::var("USERPROFILE").or_else(|_| env::var("HOME")).unwrap_or_default();
-                    let dir = format!("{}\\.psmux", home);
+                    let dir = crate::paths::psmux_dir();
                     let ns_prefix = l_socket_name.as_ref().map(|l| format!("{l}__"));
                     if let Ok(entries) = std::fs::read_dir(&dir) {
                         for e in entries.flatten() {
@@ -1928,7 +1922,7 @@ fn run_main() -> io::Result<()> {
                                             let refused = matches!(&conn, Err(e) if e.kind() == io::ErrorKind::ConnectionRefused);
                                             if let Ok(mut s) = conn {
                                                 let _ = s.set_read_timeout(Some(Duration::from_millis(500)));
-                                                let key_path = format!("{}\\.psmux\\{}.key", home, base);
+                                                let key_path = crate::paths::key_file(&base);
                                                 if let Ok(key) = std::fs::read_to_string(&key_path) {
                                                     let _ = std::io::Write::write_all(&mut s, format!("AUTH {}\n", key.trim()).as_bytes());
                                                 }
@@ -2140,8 +2134,7 @@ fn run_main() -> io::Result<()> {
                 // reliable. Crucially, a mere timeout must NOT be treated as
                 // "server dead" — that used to delete a live-but-busy server's
                 // port file, orphaning it and triggering relaunch storms.
-                let home = env::var("USERPROFILE").or_else(|_| env::var("HOME")).unwrap_or_default();
-                let port_path = format!("{}\\.psmux\\{}.port", home, session_name);
+                let port_path = crate::paths::port_file(&session_name);
                 let deadline = std::time::Instant::now() + Duration::from_secs(5);
                 let mut gone = !probe_session_alive(&session_name);
                 let mut refused = false;
@@ -2202,8 +2195,7 @@ fn run_main() -> io::Result<()> {
                 if crate::session::is_warm_session(&target) {
                     std::process::exit(1);
                 }
-                let home = env::var("USERPROFILE").or_else(|_| env::var("HOME")).unwrap_or_default();
-                let path = format!("{}\\.psmux\\{}.port", home, target);
+                let path = crate::paths::port_file(&target);
                 if let Ok(port_str) = std::fs::read_to_string(&path) {
                     if let Ok(port) = port_str.trim().parse::<u16>() {
                         let addr = format!("127.0.0.1:{}", port);
@@ -3586,13 +3578,12 @@ fn run_main() -> io::Result<()> {
                 // Pre-spawn a warm __warm__ server so the next new-session is
                 // instant.  Also triggers Windows Defender's scan cache on the
                 // binary, eliminating the ~200-400ms first-run penalty.
-                let home = env::var("USERPROFILE").or_else(|_| env::var("HOME")).unwrap_or_default();
                 let warm_base = if let Some(ref l) = l_socket_name {
                     format!("{}____warm__", l)
                 } else {
                     "__warm__".to_string()
                 };
-                let warm_port_path = format!("{}\\.psmux\\{}.port", home, warm_base);
+                let warm_port_path = crate::paths::port_file(&warm_base);
                 // Check if warm server is already running
                 let already_running = if std::path::Path::new(&warm_port_path).exists() {
                     if let Ok(port_str) = std::fs::read_to_string(&warm_port_path) {
@@ -3767,7 +3758,7 @@ fn run_main() -> io::Result<()> {
     // starts the server and creates a session automatically; we do the same.
 
     if env::var("PSMUX_REMOTE_ATTACH").ok().as_deref() != Some("1") {
-        let home = env::var("USERPROFILE").or_else(|_| env::var("HOME")).unwrap_or_default();
+        let psmux_dir = crate::paths::psmux_dir();
         let session_name = env::var("PSMUX_SESSION_NAME").unwrap_or_else(|_| {
             crate::session::next_session_name(l_socket_name.as_deref())
         });
@@ -3776,7 +3767,7 @@ fn run_main() -> io::Result<()> {
         } else {
             session_name.clone()
         };
-        let port_path = format!("{}\\.psmux\\{}.port", home, port_file_base);
+        let port_path = crate::paths::port_file(&port_file_base);
 
         // Try warm server claim first (fast path)
         // Skipped when PSMUX_NO_WARM=1 is set or config has 'set -g warm off'.
@@ -3787,7 +3778,7 @@ fn run_main() -> io::Result<()> {
         } else {
             "__warm__".to_string()
         };
-        let warm_port_path = format!("{}\\.psmux\\{}.port", home, warm_base);
+        let warm_port_path = crate::paths::port_file(&warm_base);
         let mut warm_claimed = false;
         // Atomically CLAIM the warm server before connecting (see the detached
         // path above for the full rationale): renaming the shared __warm__.port
@@ -3797,7 +3788,7 @@ fn run_main() -> io::Result<()> {
         let warm_port_opt = if warm_disabled { None } else {
             std::fs::read_to_string(&warm_port_path).ok().and_then(|s| s.trim().parse::<u16>().ok())
         };
-        let warm_claim_path = format!("{}\\.psmux\\{}.claiming.{}", home, warm_base, std::process::id());
+        let warm_claim_path = format!("{}\\{}.claiming.{}", psmux_dir, warm_base, std::process::id());
         if let Some(port) = warm_port_opt {
             if std::fs::rename(&warm_port_path, &warm_claim_path).is_ok() {
             let warm_key = crate::session::read_session_key(&warm_base).unwrap_or_default();
@@ -3984,8 +3975,7 @@ fn run_main() -> io::Result<()> {
             env::remove_var("PSMUX_SWITCH_TO");
             env::set_var("PSMUX_SESSION_NAME", &switch_to);
             // Update last_session file
-            let home = env::var("USERPROFILE").or_else(|_| env::var("HOME")).unwrap_or_default();
-            let last_path = format!("{}\\.psmux\\last_session", home);
+            let last_path = crate::paths::psmux_dir_file("last_session");
             let _ = std::fs::write(&last_path, &switch_to);
             // Continue loop to attach to new session
             continue;
@@ -4025,10 +4015,9 @@ fn run_control_mode(mode: u8) -> io::Result<()> {
     use std::net::TcpStream;
 
     // Create diagnostic log FIRST, before anything else, so we can see failures.
-    let home = env::var("USERPROFILE").or_else(|_| env::var("HOME")).unwrap_or_default();
-    let psmux_dir = format!("{}\\.psmux", home);
+    let psmux_dir = crate::paths::psmux_dir();
     let _ = std::fs::create_dir_all(&psmux_dir);
-    let cc_log_path = format!("{}\\cc_debug.log", psmux_dir);
+    let cc_log_path = crate::paths::psmux_dir_file("cc_debug.log");
     let mut log_file = std::fs::File::create(&cc_log_path).ok();
     macro_rules! cclog {
         ($($arg:tt)*) => {
@@ -4141,8 +4130,8 @@ fn run_control_mode(mode: u8) -> io::Result<()> {
     cclog!("session: {}", session_name);
 
     // Read port and key
-    let port_path = format!("{}\\{}.port", psmux_dir, session_name);
-    let key_path = format!("{}\\{}.key", psmux_dir, session_name);
+    let port_path = crate::paths::port_file(&session_name);
+    let key_path = crate::paths::key_file(&session_name);
     cclog!("port_path: {}", port_path);
     cclog!("key_path: {}", key_path);
     cclog!("port_path exists: {}", std::path::Path::new(&port_path).exists());

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -1,0 +1,107 @@
+//! Single source of truth for psmux's home and data directories.
+//!
+//! Every `.port`/`.key`/`.sid`/warm-pool/log path routes through [`psmux_dir`]
+//! (or [`psmux_dir_opt`]), so client and server can never disagree about where
+//! the bookkeeping lives.
+
+/// User home directory: `USERPROFILE`, then `HOME`. Empty string if neither is
+/// set (matches the historical `.unwrap_or_default()` behavior at every call
+/// site).
+pub fn home_dir() -> String {
+    std::env::var("USERPROFILE")
+        .or_else(|_| std::env::var("HOME"))
+        .unwrap_or_default()
+}
+
+/// psmux data directory, without a trailing separator. Fallible variant for
+/// call sites that early-exit when home is missing (`.ok()?` /
+/// `Err(_) => return …`). `None` when no home directory is available.
+pub fn psmux_dir_opt() -> Option<String> {
+    let home = home_dir();
+    if home.is_empty() {
+        None
+    } else {
+        Some(format!("{}\\.psmux", home))
+    }
+}
+
+/// psmux data directory, without a trailing separator. Infallible variant for
+/// call sites that today use `.unwrap_or_default()`.
+///
+/// When no home directory is set, returns `\.psmux` — byte-identical to the
+/// historical `format!("{}\.psmux", "")`. It does not panic: the historical
+/// behavior is to proceed and let the filesystem call fail gracefully, and a
+/// crash on an unset `USERPROFILE` would be worse.
+pub fn psmux_dir() -> String {
+    psmux_dir_opt().unwrap_or_else(|| "\\.psmux".to_string())
+}
+
+/// Path to a fixed-name file directly under the data directory (e.g.
+/// `latency.log`, `last_session`, `next_session_id`, `crash.log`).
+pub fn psmux_dir_file(name: impl AsRef<str>) -> String {
+    format!("{}\\{}", psmux_dir(), name.as_ref())
+}
+
+/// Path to a session's `.port` file (the TCP port its server listens on).
+pub fn port_file(session: impl AsRef<str>) -> String {
+    format!("{}\\{}.port", psmux_dir(), session.as_ref())
+}
+
+/// Fallible variant of [`port_file`]: `None` when no data directory can be
+/// determined. Lets a call site early-exit on the same condition without having
+/// to know that `port_file` routes through `psmux_dir`.
+pub fn port_file_opt(session: impl AsRef<str>) -> Option<String> {
+    psmux_dir_opt().map(|dir| format!("{}\\{}.port", dir, session.as_ref()))
+}
+
+/// Path to a session's `.key` file (the auth key for its server).
+pub fn key_file(session: impl AsRef<str>) -> String {
+    format!("{}\\{}.key", psmux_dir(), session.as_ref())
+}
+
+/// Path to a session's `.sid` file (its stable session id).
+pub fn sid_file(session: impl AsRef<str>) -> String {
+    format!("{}\\{}.sid", psmux_dir(), session.as_ref())
+}
+
+/// Path to a session's `.pid` file (the liveness anchor: the server pid).
+pub fn pid_file(session: impl AsRef<str>) -> String {
+    format!("{}\\{}.pid", psmux_dir(), session.as_ref())
+}
+
+/// Path to a session's `.spawnlock` file (the warm-pool spawn lock).
+pub fn spawnlock_file(session: impl AsRef<str>) -> String {
+    format!("{}\\{}.spawnlock", psmux_dir(), session.as_ref())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn psmux_dir_is_home_relative_dot_psmux() {
+        // The test environment always has a home, so the data dir resolves to
+        // {home}\.psmux and the two accessors agree.
+        let dir = psmux_dir();
+        assert!(dir.ends_with("\\.psmux"), "got {dir:?}");
+        assert_eq!(psmux_dir_opt().as_deref(), Some(dir.as_str()));
+    }
+
+    #[test]
+    fn per_session_helpers_append_name_and_suffix_to_data_dir() {
+        let dir = psmux_dir();
+        assert_eq!(port_file("foo"), format!("{}\\foo.port", dir));
+        assert_eq!(key_file("foo"), format!("{}\\foo.key", dir));
+        assert_eq!(sid_file("foo"), format!("{}\\foo.sid", dir));
+        assert_eq!(pid_file("foo"), format!("{}\\foo.pid", dir));
+        assert_eq!(spawnlock_file("foo"), format!("{}\\foo.spawnlock", dir));
+    }
+
+    #[test]
+    fn psmux_dir_file_appends_fixed_name() {
+        assert_eq!(
+            psmux_dir_file("latency.log"),
+            format!("{}\\latency.log", psmux_dir())
+        );
+    }
+}

--- a/src/preview.rs
+++ b/src/preview.rs
@@ -31,8 +31,8 @@ pub fn cache_key(sess: &str, win_id: usize, pane_id: usize) -> String {
 ///
 /// `pane_id == usize::MAX` => target the window only (server captures the
 /// active pane). Otherwise targets a specific pane id within the window.
-pub fn fetch_pane_preview(home: &str, sess: &str, win_id: usize, pane_id: usize) -> Option<String> {
-    let port_path = format!("{}\\.psmux\\{}.port", home, sess);
+pub fn fetch_pane_preview(sess: &str, win_id: usize, pane_id: usize) -> Option<String> {
+    let port_path = crate::paths::port_file(sess);
     let port: u16 = std::fs::read_to_string(&port_path).ok()?.trim().parse().ok()?;
     let key = read_session_key(sess).ok()?;
     let target = if pane_id == usize::MAX {
@@ -60,7 +60,6 @@ pub fn fetch_pane_preview(home: &str, sess: &str, win_id: usize, pane_id: usize)
 /// Get a preview, using the cache if fresh, fetching otherwise.
 pub fn get_or_fetch(
     cache: &mut PreviewCache,
-    home: &str,
     sess: &str,
     win_id: usize,
     pane_id: usize,
@@ -71,7 +70,7 @@ pub fn get_or_fetch(
             return Some(text.clone());
         }
     }
-    let text = fetch_pane_preview(home, sess, win_id, pane_id)?;
+    let text = fetch_pane_preview(sess, win_id, pane_id)?;
     cache.insert(key, (text.clone(), Instant::now()));
     Some(text)
 }
@@ -284,8 +283,8 @@ pub type LayoutCache = HashMap<String, (LayoutSimple, Instant)>;
 pub const LAYOUT_TTL: Duration = Duration::from_millis(2500);
 
 /// Fetch the simplified layout for a window in any session via TCP.
-pub fn fetch_window_layout(home: &str, sess: &str, win_id: usize) -> Option<LayoutSimple> {
-    let port_path = format!("{}\\.psmux\\{}.port", home, sess);
+pub fn fetch_window_layout(sess: &str, win_id: usize) -> Option<LayoutSimple> {
+    let port_path = crate::paths::port_file(sess);
     let port: u16 = std::fs::read_to_string(&port_path).ok()?.trim().parse().ok()?;
     let key = read_session_key(sess).ok()?;
     let cmd = format!("window-layout {}\n", win_id);
@@ -305,7 +304,6 @@ pub fn fetch_window_layout(home: &str, sess: &str, win_id: usize) -> Option<Layo
 
 pub fn get_or_fetch_layout(
     cache: &mut LayoutCache,
-    home: &str,
     sess: &str,
     win_id: usize,
 ) -> Option<LayoutSimple> {
@@ -315,7 +313,7 @@ pub fn get_or_fetch_layout(
             return Some(layout.clone());
         }
     }
-    let layout = fetch_window_layout(home, sess, win_id)?;
+    let layout = fetch_window_layout(sess, win_id)?;
     cache.insert(key, (layout.clone(), Instant::now()));
     Some(layout)
 }
@@ -461,8 +459,8 @@ pub const DUMP_TTL: Duration = Duration::from_millis(1500);
 
 /// Fetch the full styled layout (rows_v2) for a window in any session
 /// via TCP using the new `window-dump` command.
-pub fn fetch_window_dump(home: &str, sess: &str, win_id: usize) -> Option<crate::layout::LayoutJson> {
-    let port_path = format!("{}\\.psmux\\{}.port", home, sess);
+pub fn fetch_window_dump(sess: &str, win_id: usize) -> Option<crate::layout::LayoutJson> {
+    let port_path = crate::paths::port_file(sess);
     let port: u16 = std::fs::read_to_string(&port_path).ok()?.trim().parse().ok()?;
     let key = read_session_key(sess).ok()?;
     let cmd = format!("window-dump {}\n", win_id);
@@ -482,7 +480,6 @@ pub fn fetch_window_dump(home: &str, sess: &str, win_id: usize) -> Option<crate:
 
 pub fn get_or_fetch_dump(
     cache: &mut DumpCache,
-    home: &str,
     sess: &str,
     win_id: usize,
 ) -> Option<crate::layout::LayoutJson> {
@@ -492,7 +489,7 @@ pub fn get_or_fetch_dump(
             return Some(layout.clone());
         }
     }
-    let layout = fetch_window_dump(home, sess, win_id)?;
+    let layout = fetch_window_dump(sess, win_id)?;
     cache.insert(key, (layout.clone(), Instant::now()));
     Some(layout)
 }

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -1411,8 +1411,7 @@ match cmd {
         // path is missing we ask our own server for its session name and
         // fall through to KillSession when raw_target matches us.
         if let Some(ref tgt) = raw_target {
-            let home = std::env::var("USERPROFILE").or_else(|_| std::env::var("HOME")).unwrap_or_default();
-            let port_path = format!("{}\\.psmux\\{}.port", home, tgt);
+            let port_path = crate::paths::port_file(tgt);
             let mut handled = false;
             if let Ok(port_str) = std::fs::read_to_string(&port_path) {
                 if let Ok(port) = port_str.trim().parse::<u16>() {
@@ -2863,8 +2862,7 @@ match cmd {
 
             let port_file_base = name.clone();
 
-            let home = std::env::var("USERPROFILE").or_else(|_| std::env::var("HOME")).unwrap_or_default();
-            let port_path = format!("{}\\.psmux\\{}.port", home, port_file_base);
+            let port_path = crate::paths::port_file(&port_file_base);
 
             // Check if session already exists
             let already_exists = if std::path::Path::new(&port_path).exists() {

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -75,15 +75,15 @@ fn should_spawn_warm_server(app: &AppState) -> bool {
     app.warm_enabled && app.session_name != "__warm__" && !app.destroy_unattached
 }
 
-fn ensure_session_registry_files(home: &str, app: &AppState) {
+fn ensure_session_registry_files(app: &AppState) {
     let Some(port) = app.control_port else { return; };
-    let dir = format!("{}\\.psmux", home);
+    let dir = crate::paths::psmux_dir();
     let _ = std::fs::create_dir_all(&dir);
 
     let base = app.port_file_base();
-    let port_path = format!("{}\\{}.port", dir, base);
-    let key_path = format!("{}\\{}.key", dir, base);
-    let sid_path = format!("{}\\{}.sid", dir, base);
+    let port_path = crate::paths::port_file(&base);
+    let key_path = crate::paths::key_file(&base);
+    let sid_path = crate::paths::sid_file(&base);
     let port_value = port.to_string();
     let sid_value = app.session_id.to_string();
 
@@ -112,7 +112,7 @@ fn ensure_session_registry_files(home: &str, app: &AppState) {
     // port/key/sid so a live server is never listening without a PID anchor, and
     // re-ensured periodically so the entry self-heals after rename/claim. This is
     // what lets startup reap live-but-orphaned duplicate servers by identity.
-    let pid_path = format!("{}\\{}.pid", dir, base);
+    let pid_path = crate::paths::pid_file(&base);
     let pid_value = std::process::id().to_string();
     if std::fs::read_to_string(&pid_path)
         .map(|s| s.trim() != pid_value)
@@ -214,18 +214,17 @@ fn spawn_warm_server(app: &AppState) {
         return;
     }
     // Skip if a warm server already exists
-    let home = env::var("USERPROFILE").or_else(|_| env::var("HOME")).unwrap_or_default();
     let warm_base = if let Some(ref sn) = app.socket_name {
         format!("{}____warm__", sn)
     } else {
         "__warm__".to_string()
     };
-    let warm_port_path = format!("{}\\.psmux\\{}.port", home, warm_base);
+    let warm_port_path = crate::paths::port_file(&warm_base);
     warm_debug(&format!("spawn_warm_server entry base={} port_exists={}", warm_base, std::path::Path::new(&warm_port_path).exists()));
     // Serialize the check->spawn window: without this, two callers can both see
     // "no warm" (a freshly-spawned warm hasn't written its port yet) and each
     // spawn one, orphaning all but the last. This is the primary process-leak source.
-    let warm_lock_path = format!("{}\\.psmux\\{}.spawnlock", home, warm_base);
+    let warm_lock_path = crate::paths::spawnlock_file(&warm_base);
     let spawn_lock = match acquire_warm_spawn_lock(&warm_lock_path) {
         Some(g) => g,
         None => { warm_debug("another warm spawn in progress -- skipping"); return; }
@@ -246,7 +245,7 @@ fn spawn_warm_server(app: &AppState) {
                     Duration::from_millis(100),
                 ).is_ok() {
                     // TCP is up — verify the session name via AUTH.
-                    let warm_key_path = format!("{}\\.psmux\\{}.key", home, warm_base);
+                    let warm_key_path = crate::paths::key_file(&warm_base);
                     if let Ok(key) = std::fs::read_to_string(&warm_key_path) {
                         let key = key.trim().to_string();
                         if !key.is_empty() {
@@ -282,9 +281,9 @@ fn spawn_warm_server(app: &AppState) {
         // Stale or wrong-server port file — remove it (and matching key/sid files)
         warm_debug("removing STALE warm port/key/sid (unreachable or not a warm server)");
         let _ = std::fs::remove_file(&warm_port_path);
-        let warm_key_path = format!("{}\\.psmux\\{}.key", home, warm_base);
+        let warm_key_path = crate::paths::key_file(&warm_base);
         let _ = std::fs::remove_file(&warm_key_path);
-        let warm_sid_path = format!("{}\\.psmux\\{}.sid", home, warm_base);
+        let warm_sid_path = crate::paths::sid_file(&warm_base);
         let _ = std::fs::remove_file(&warm_sid_path);
     }
     warm_debug("SPAWNING new warm server");
@@ -526,13 +525,9 @@ fn drain_plugin_req(
 /// Best-effort: any error writing the log is swallowed (we are already
 /// reporting the original failure up the call chain).
 pub(crate) fn write_startup_error_log(err: &dyn std::fmt::Display) {
-    let home = std::env::var("USERPROFILE")
-        .or_else(|_| std::env::var("HOME"))
-        .unwrap_or_default();
-    if home.is_empty() {
+    let Some(dir) = crate::paths::psmux_dir_opt() else {
         return;
-    }
-    let dir = format!("{}\\.psmux", home);
+    };
     let _ = std::fs::create_dir_all(&dir);
     let path = format!("{}\\server-startup.log", dir);
 
@@ -603,13 +598,7 @@ pub(crate) fn write_startup_error_log(err: &dyn std::fmt::Display) {
 
 /// Absolute path to `~/.psmux/server-startup.log`, or None if no home dir.
 pub(crate) fn startup_error_log_path() -> Option<String> {
-    let home = std::env::var("USERPROFILE")
-        .or_else(|_| std::env::var("HOME"))
-        .unwrap_or_default();
-    if home.is_empty() {
-        return None;
-    }
-    Some(format!("{}\\.psmux\\server-startup.log", home))
+    Some(format!("{}\\server-startup.log", crate::paths::psmux_dir_opt()?))
 }
 
 /// Read the real failure reason out of a *fresh* `server-startup.log`.
@@ -669,13 +658,7 @@ fn read_fresh_startup_error_at(path: &str, since_epoch: u64) -> Option<(String, 
 
 /// Absolute path to `~/.psmux/config-warnings.log`, or None if no home dir.
 pub(crate) fn config_warnings_log_path() -> Option<String> {
-    let home = std::env::var("USERPROFILE")
-        .or_else(|_| std::env::var("HOME"))
-        .unwrap_or_default();
-    if home.is_empty() {
-        return None;
-    }
-    Some(format!("{}\\.psmux\\config-warnings.log", home))
+    Some(format!("{}\\config-warnings.log", crate::paths::psmux_dir_opt()?))
 }
 
 /// Persist non-fatal config parse warnings so the attaching client can echo
@@ -728,8 +711,7 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
     let panic_session_name = session_name.clone();
     let panic_socket_name = socket_name.clone();
     std::panic::set_hook(Box::new(move |info| {
-        let home = std::env::var("USERPROFILE").or_else(|_| std::env::var("HOME")).unwrap_or_default();
-        let path = format!("{}\\.psmux\\crash.log", home);
+        let path = crate::paths::psmux_dir_file("crash.log");
         let bt = std::backtrace::Backtrace::force_capture();
         let _ = std::fs::write(&path, format!("{info}\n\nBacktrace:\n{bt}"));
         // Remove port/key files to prevent stale entries after a panic
@@ -738,10 +720,10 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
         } else {
             panic_session_name.clone()
         };
-        let _ = std::fs::remove_file(format!("{}\\.psmux\\{}.port", home, base));
-        let _ = std::fs::remove_file(format!("{}\\.psmux\\{}.key", home, base));
-        let _ = std::fs::remove_file(format!("{}\\.psmux\\{}.sid", home, base));
-        let _ = std::fs::remove_file(format!("{}\\.psmux\\{}.pid", home, base));
+        let _ = std::fs::remove_file(crate::paths::port_file(&base));
+        let _ = std::fs::remove_file(crate::paths::key_file(&base));
+        let _ = std::fs::remove_file(crate::paths::sid_file(&base));
+        let _ = std::fs::remove_file(crate::paths::pid_file(&base));
     }));
     // Install console control handler to prevent termination on client detach
     install_console_ctrl_handler();
@@ -791,8 +773,7 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
     // config or creating windows.  run-shell scripts (e.g. PPM) need the
     // port file to discover the server, and the client polls for it to know
     // the server is ready.
-    let home = env::var("USERPROFILE").or_else(|_| env::var("HOME")).unwrap_or_default();
-    let dir = format!("{}\\.psmux", home);
+    let dir = crate::paths::psmux_dir();
     let _ = std::fs::create_dir_all(&dir);
 
     // Generate a random session key for security
@@ -824,7 +805,7 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
         }
     }
 
-    ensure_session_registry_files(&home, &app);
+    ensure_session_registry_files(&app);
 
     // TEST-ONLY fault injection — compiled out of release builds entirely.
     // Simulates the server dying AFTER writing its .port file but WITHOUT the
@@ -838,8 +819,8 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
         }
     }
 
-    let regpath = format!("{}\\{}.port", dir, app.port_file_base());
-    let keypath = format!("{}\\{}.key", dir, app.port_file_base());
+    let regpath = crate::paths::port_file(&app.port_file_base());
+    let keypath = crate::paths::key_file(&app.port_file_base());
 
     // Expose the server identity via env var so that child processes spawned
     // by run-shell (from hooks, keybindings, etc.) can find this server when
@@ -1129,7 +1110,7 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
         }
         if last_registry_check.elapsed() >= Duration::from_secs(5) {
             last_registry_check = Instant::now();
-            ensure_session_registry_files(&home, &app);
+            ensure_session_registry_files(&app);
         }
 
         // Adaptive timeout: ramps from 1ms (active typing/echo) through
@@ -1814,9 +1795,8 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                         }
                         hook_event = Some("client-detached");
                         if app.attached_clients == 0 && app.destroy_unattached {
-                            let home = env::var("USERPROFILE").or_else(|_| env::var("HOME")).unwrap_or_default();
-                            let regpath = format!("{}\\.psmux\\{}.port", home, app.port_file_base());
-                            let keypath = format!("{}\\.psmux\\{}.key", home, app.port_file_base());
+                            let regpath = crate::paths::port_file(&app.port_file_base());
+                            let keypath = crate::paths::key_file(&app.port_file_base());
                             let _ = std::fs::remove_file(&regpath);
                             let _ = std::fs::remove_file(&keypath);
                             crate::session::remove_session_id_file(&app.port_file_base());
@@ -2925,9 +2905,8 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                     if let Some(cmds) = app.hooks.get("session-closed") { let cmds = cmds.clone(); for cmd in &cmds { let _ = execute_command_string(&mut app, cmd); } }
                     // Remove port/key/sid files FIRST so clients see the session
                     // as gone immediately, then kill processes.
-                    let home = env::var("USERPROFILE").or_else(|_| env::var("HOME")).unwrap_or_default();
-                    let regpath = format!("{}\\.psmux\\{}.port", home, app.port_file_base());
-                    let keypath = format!("{}\\.psmux\\{}.key", home, app.port_file_base());
+                    let regpath = crate::paths::port_file(&app.port_file_base());
+                    let keypath = crate::paths::key_file(&app.port_file_base());
                     let _ = std::fs::remove_file(&regpath);
                     let _ = std::fs::remove_file(&keypath);
                     crate::session::remove_session_id_file(&app.port_file_base());
@@ -2948,17 +2927,16 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                 }
                 CtrlReq::RenameSession(name) => {
                     if let Some(cmds) = app.hooks.get("before-rename-session") { let cmds = cmds.clone(); for cmd in &cmds { let _ = execute_command_string(&mut app, cmd); } }
-                    let home = env::var("USERPROFILE").or_else(|_| env::var("HOME")).unwrap_or_default();
-                    let old_path = format!("{}\\.psmux\\{}.port", home, app.port_file_base());
-                    let old_keypath = format!("{}\\.psmux\\{}.key", home, app.port_file_base());
+                    let old_path = crate::paths::port_file(&app.port_file_base());
+                    let old_keypath = crate::paths::key_file(&app.port_file_base());
                     // Compute new port file base with socket_name prefix
                     let new_base = if let Some(ref sn) = app.socket_name {
                         format!("{}__{}" , sn, name)
                     } else {
                         name.clone()
                     };
-                    let new_path = format!("{}\\.psmux\\{}.port", home, new_base);
-                    let new_keypath = format!("{}\\.psmux\\{}.key", home, new_base);
+                    let new_path = crate::paths::port_file(&new_base);
+                    let new_keypath = crate::paths::key_file(&new_base);
                     if let Some(port) = app.control_port {
                         let _ = std::fs::remove_file(&old_path);
                         let _ = std::fs::write(&new_path, port.to_string());
@@ -2999,16 +2977,15 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                     warm_debug(&format!("CLAIM ACCEPT: __warm__ (port={:?}) -> '{}'", app.control_port, name));
                     // Same as RenameSession but with a synchronous response
                     // so the CLI knows the rename completed before attaching.
-                    let home = env::var("USERPROFILE").or_else(|_| env::var("HOME")).unwrap_or_default();
-                    let old_path = format!("{}\\.psmux\\{}.port", home, app.port_file_base());
-                    let old_keypath = format!("{}\\.psmux\\{}.key", home, app.port_file_base());
+                    let old_path = crate::paths::port_file(&app.port_file_base());
+                    let old_keypath = crate::paths::key_file(&app.port_file_base());
                     let new_base = if let Some(ref sn) = app.socket_name {
                         format!("{}__{}" , sn, name)
                     } else {
                         name.clone()
                     };
-                    let new_path = format!("{}\\.psmux\\{}.port", home, new_base);
-                    let new_keypath = format!("{}\\.psmux\\{}.key", home, new_base);
+                    let new_path = crate::paths::port_file(&new_base);
+                    let new_keypath = crate::paths::key_file(&new_base);
                     if let Some(port) = app.control_port {
                         let _ = std::fs::remove_file(&old_path);
                         let _ = std::fs::write(&new_path, port.to_string());
@@ -4138,9 +4115,8 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                     });
                     hook_event = Some("client-detached");
                     if app.attached_clients == 0 && app.destroy_unattached {
-                        let home = env::var("USERPROFILE").or_else(|_| env::var("HOME")).unwrap_or_default();
-                        let regpath = format!("{}\\.psmux\\{}.port", home, app.port_file_base());
-                        let keypath = format!("{}\\.psmux\\{}.key", home, app.port_file_base());
+                        let regpath = crate::paths::port_file(&app.port_file_base());
+                        let keypath = crate::paths::key_file(&app.port_file_base());
                         let _ = std::fs::remove_file(&regpath);
                         let _ = std::fs::remove_file(&keypath);
                         crate::session::remove_session_id_file(&app.port_file_base());
@@ -4225,9 +4201,8 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                         hook_event = Some("client-detached");
                     }
                     if app.attached_clients == 0 && app.destroy_unattached {
-                        let home = env::var("USERPROFILE").or_else(|_| env::var("HOME")).unwrap_or_default();
-                        let regpath = format!("{}\\.psmux\\{}.port", home, app.port_file_base());
-                        let keypath = format!("{}\\.psmux\\{}.key", home, app.port_file_base());
+                        let regpath = crate::paths::port_file(&app.port_file_base());
+                        let keypath = crate::paths::key_file(&app.port_file_base());
                         let _ = std::fs::remove_file(&regpath);
                         let _ = std::fs::remove_file(&keypath);
                         crate::session::remove_session_id_file(&app.port_file_base());
@@ -4276,9 +4251,8 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                         hook_event = Some("client-detached");
                     }
                     if app.attached_clients == 0 && app.destroy_unattached {
-                        let home = env::var("USERPROFILE").or_else(|_| env::var("HOME")).unwrap_or_default();
-                        let regpath = format!("{}\\.psmux\\{}.port", home, app.port_file_base());
-                        let keypath = format!("{}\\.psmux\\{}.key", home, app.port_file_base());
+                        let regpath = crate::paths::port_file(&app.port_file_base());
+                        let keypath = crate::paths::key_file(&app.port_file_base());
                         let _ = std::fs::remove_file(&regpath);
                         let _ = std::fs::remove_file(&keypath);
                         crate::session::remove_session_id_file(&app.port_file_base());
@@ -4327,8 +4301,7 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                         }
                         'l' => {
                             // Last session (read from last_session file)
-                            let home = env::var("USERPROFILE").or_else(|_| env::var("HOME")).unwrap_or_default();
-                            let last_path = format!("{}\\.psmux\\last_session", home);
+                            let last_path = crate::paths::psmux_dir_file("last_session");
                             std::fs::read_to_string(&last_path).ok()
                                 .map(|s| s.trim().to_string())
                                 .filter(|s| !s.is_empty() && s != &current && all_sessions.contains(s))
@@ -4492,9 +4465,8 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                     }
                     // Remove port/key files FIRST so clients see the session
                     // as gone immediately, then kill processes.
-                    let home = env::var("USERPROFILE").or_else(|_| env::var("HOME")).unwrap_or_default();
-                    let regpath = format!("{}\\.psmux\\{}.port", home, app.port_file_base());
-                    let keypath = format!("{}\\.psmux\\{}.key", home, app.port_file_base());
+                    let regpath = crate::paths::port_file(&app.port_file_base());
+                    let keypath = crate::paths::key_file(&app.port_file_base());
                     let _ = std::fs::remove_file(&regpath);
                     let _ = std::fs::remove_file(&keypath);
                     crate::types::send_directive_to_all_clients("DETACH");
@@ -4775,8 +4747,7 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                         app.windows.len(),
                         (chrono::Local::now() - app.created_at).num_seconds(),
                         {
-                            let home = env::var("USERPROFILE").or_else(|_| env::var("HOME")).unwrap_or_default();
-                            format!("{}\\.psmux\\{}.port", home, app.port_file_base())
+                            crate::paths::port_file(&app.port_file_base())
                         }
                     );
                     let _ = resp.send(info);
@@ -5743,9 +5714,8 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                     // the DCS stream before we tear down the process.
                     std::thread::sleep(std::time::Duration::from_millis(80));
                 }
-                let home = env::var("USERPROFILE").or_else(|_| env::var("HOME")).unwrap_or_default();
-                let regpath = format!("{}\\.psmux\\{}.port", home, app.port_file_base());
-                let keypath = format!("{}\\.psmux\\{}.key", home, app.port_file_base());
+                let regpath = crate::paths::port_file(&app.port_file_base());
+                let keypath = crate::paths::key_file(&app.port_file_base());
                 let _ = std::fs::remove_file(&regpath);
                 let _ = std::fs::remove_file(&keypath);
                 crate::types::send_directive_to_all_clients("DETACH");

--- a/src/server/options.rs
+++ b/src/server/options.rs
@@ -468,15 +468,12 @@ pub(crate) fn apply_set_option(app: &mut AppState, option: &str, value: &str, _q
                     wp.child.kill().ok();
                 }
                 // Kill the background warm server process
-                let home = std::env::var("USERPROFILE")
-                    .or_else(|_| std::env::var("HOME"))
-                    .unwrap_or_default();
                 let warm_base = if let Some(ref sn) = app.socket_name {
                     format!("{}____warm__", sn)
                 } else {
                     "__warm__".to_string()
                 };
-                let warm_port_path = format!("{}\\.psmux\\{}.port", home, warm_base);
+                let warm_port_path = crate::paths::port_file(&warm_base);
                 if let Ok(port_str) = std::fs::read_to_string(&warm_port_path) {
                     if let Ok(port) = port_str.trim().parse::<u16>() {
                         let addr = format!("127.0.0.1:{}", port);
@@ -490,7 +487,7 @@ pub(crate) fn apply_set_option(app: &mut AppState, option: &str, value: &str, _q
                     }
                 }
                 let _ = std::fs::remove_file(&warm_port_path);
-                let warm_key_path = format!("{}\\.psmux\\{}.key", home, warm_base);
+                let warm_key_path = crate::paths::key_file(&warm_base);
                 let _ = std::fs::remove_file(&warm_key_path);
             }
         }

--- a/src/session.rs
+++ b/src/session.rs
@@ -34,11 +34,9 @@ pub fn is_warm_session(base: &str) -> bool {
 /// the lowest non-negative integer not already in use.
 /// When `ns_prefix` is Some("foo"), names are checked as "foo__0", "foo__1", etc.
 pub fn next_session_name(ns_prefix: Option<&str>) -> String {
-    let home = match env::var("USERPROFILE").or_else(|_| env::var("HOME")) {
-        Ok(h) => h,
-        Err(_) => return "0".to_string(),
+    let Some(psmux_dir) = crate::paths::psmux_dir_opt() else {
+        return "0".to_string();
     };
-    let psmux_dir = format!("{}\\.psmux", home);
     let mut used: std::collections::HashSet<u32> = std::collections::HashSet::new();
     if let Ok(entries) = std::fs::read_dir(&psmux_dir) {
         for entry in entries.flatten() {
@@ -133,8 +131,7 @@ impl Drop for CounterLock {
 /// never observe the same `current` and return duplicate ids.
 pub fn allocate_session_id() -> usize {
     let _guard = SESSION_ID_ALLOC.lock().unwrap_or_else(|e| e.into_inner());
-    let home = env::var("USERPROFILE").or_else(|_| env::var("HOME")).unwrap_or_default();
-    let counter_path = format!("{}\\.psmux\\next_session_id", home);
+    let counter_path = crate::paths::psmux_dir_file("next_session_id");
     let _xlock = CounterLock::acquire(format!("{}.lock", counter_path));
     let current = std::fs::read_to_string(&counter_path)
         .ok()
@@ -146,8 +143,7 @@ pub fn allocate_session_id() -> usize {
 
 /// Write a `.sid` file recording the session ID for this session.
 pub fn write_session_id_file(port_file_base: &str, session_id: usize) {
-    let home = env::var("USERPROFILE").or_else(|_| env::var("HOME")).unwrap_or_default();
-    let sid_path = format!("{}\\.psmux\\{}.sid", home, port_file_base);
+    let sid_path = crate::paths::sid_file(port_file_base);
     let _ = std::fs::write(&sid_path, session_id.to_string());
 }
 
@@ -157,8 +153,7 @@ pub fn write_session_id_file(port_file_base: &str, session_id: usize) {
 /// calls this, so piggybacking `.pid` cleanup here keeps the registry consistent
 /// without touching each teardown call site.
 pub fn remove_session_id_file(port_file_base: &str) {
-    let home = env::var("USERPROFILE").or_else(|_| env::var("HOME")).unwrap_or_default();
-    let sid_path = format!("{}\\.psmux\\{}.sid", home, port_file_base);
+    let sid_path = crate::paths::sid_file(port_file_base);
     let _ = std::fs::remove_file(&sid_path);
     remove_session_pid_file(port_file_base);
 }
@@ -169,23 +164,20 @@ pub fn remove_session_id_file(port_file_base: &str) {
 /// targeted by identity at all. The PID gives every registry entry a stable
 /// process anchor.
 pub fn write_session_pid_file(port_file_base: &str, pid: u32) {
-    let home = env::var("USERPROFILE").or_else(|_| env::var("HOME")).unwrap_or_default();
-    let pid_path = format!("{}\\.psmux\\{}.pid", home, port_file_base);
+    let pid_path = crate::paths::pid_file(port_file_base);
     let _ = std::fs::write(&pid_path, pid.to_string());
 }
 
 /// Remove the `.pid` file for a session.
 pub fn remove_session_pid_file(port_file_base: &str) {
-    let home = env::var("USERPROFILE").or_else(|_| env::var("HOME")).unwrap_or_default();
-    let pid_path = format!("{}\\.psmux\\{}.pid", home, port_file_base);
+    let pid_path = crate::paths::pid_file(port_file_base);
     let _ = std::fs::remove_file(&pid_path);
 }
 
 /// Resolve a tmux session ID (`$N`) to the port file base name of the
 /// session that owns that ID. Returns `None` if no session has that ID.
 pub fn resolve_session_by_id(id: usize) -> Option<String> {
-    let home = env::var("USERPROFILE").or_else(|_| env::var("HOME")).ok()?;
-    let psmux_dir = format!("{}\\.psmux", home);
+    let psmux_dir = crate::paths::psmux_dir_opt()?;
     if let Ok(entries) = std::fs::read_dir(&psmux_dir) {
         for entry in entries.flatten() {
             let path = entry.path();
@@ -195,7 +187,7 @@ pub fn resolve_session_by_id(id: usize) -> Option<String> {
                         if file_id == id {
                             if let Some(base) = path.file_stem().and_then(|s| s.to_str()) {
                                 // Verify the session is actually alive
-                                let port_path = format!("{}\\.psmux\\{}.port", home, base);
+                                let port_path = crate::paths::port_file(base);
                                 if std::path::Path::new(&port_path).exists() {
                                     return Some(base.to_string());
                                 }
@@ -211,11 +203,9 @@ pub fn resolve_session_by_id(id: usize) -> Option<String> {
 
 /// Clean up any stale port files (where server is not actually running)
 pub fn cleanup_stale_port_files() {
-    let home = match env::var("USERPROFILE").or_else(|_| env::var("HOME")) {
-        Ok(h) => h,
-        Err(_) => return,
+    let Some(psmux_dir) = crate::paths::psmux_dir_opt() else {
+        return;
     };
-    let psmux_dir = format!("{}\\.psmux", home);
     cleanup_stale_port_files_in(Path::new(&psmux_dir));
 }
 
@@ -321,11 +311,9 @@ fn read_tracked_registry(psmux_dir: &Path)
 /// server) and reaps the process itself, bounding the process count regardless
 /// of how the duplicate arose.
 pub fn reap_orphaned_servers() {
-    let home = match env::var("USERPROFILE").or_else(|_| env::var("HOME")) {
-        Ok(h) => h,
-        Err(_) => return,
+    let Some(psmux_dir) = crate::paths::psmux_dir_opt() else {
+        return;
     };
-    let psmux_dir = format!("{}\\.psmux", home);
     reap_orphaned_servers_in(Path::new(&psmux_dir));
 }
 
@@ -680,8 +668,7 @@ fn probe_session_for_cleanup(key: &str, port: u16) -> PortProbeResult {
 
 /// Read the session key from the key file
 pub fn read_session_key(session: &str) -> io::Result<String> {
-    let home = env::var("USERPROFILE").or_else(|_| env::var("HOME")).unwrap_or_default();
-    let keypath = format!("{}\\.psmux\\{}.key", home, session);
+    let keypath = crate::paths::key_file(session);
     std::fs::read_to_string(&keypath).map(|s| s.trim().to_string())
 }
 
@@ -1074,8 +1061,7 @@ pub fn classify_sessions_parallel(
 /// TCP connect timeout per dead entry. Some(false) = definitively dead
 /// (reap + skip), Some(true) = live, None = no anchor (probe as usual).
 pub fn registry_pid_anchor_alive(base: &str) -> Option<bool> {
-    let home = env::var("USERPROFILE").or_else(|_| env::var("HOME")).ok()?;
-    let port_path = format!("{}\\.psmux\\{}.port", home, base);
+    let port_path = crate::paths::port_file_opt(base)?;
     pid_anchor_verdict(Path::new(&port_path))
 }
 
@@ -1084,16 +1070,13 @@ pub fn registry_pid_anchor_alive(base: &str) -> Option<bool> {
 /// Used when a probe proves the session is dead. Safe against a live server:
 /// it re-creates these files on its next 5s registry tick.
 pub fn remove_session_registry(base: &str) {
-    let home = match env::var("USERPROFILE").or_else(|_| env::var("HOME")) {
-        Ok(h) => h,
-        Err(_) => return,
+    let Some(port_path) = crate::paths::port_file_opt(base) else {
+        return;
     };
-    let port_path = format!("{}\\.psmux\\{}.port", home, base);
     remove_session_registry_files(Path::new(&port_path));
 }
 
 pub fn send_control(line: String) -> io::Result<()> {
-    let home = env::var("USERPROFILE").or_else(|_| env::var("HOME")).unwrap_or_default();
     let mut target = env::var("PSMUX_TARGET_SESSION").ok().unwrap_or_else(|| "default".to_string());
     // Never target a warm (standby) session — resolve to a real session instead
     if is_warm_session(&target) {
@@ -1102,7 +1085,7 @@ pub fn send_control(line: String) -> io::Result<()> {
         target = resolve_last_session_name_ns(ns.as_deref()).unwrap_or_else(|| "default".to_string());
     }
     let full_target = env::var("PSMUX_TARGET_FULL").ok();
-    let path = format!("{}\\.psmux\\{}.port", home, target);
+    let path = crate::paths::port_file(&target);
     let port = std::fs::read_to_string(&path).ok().and_then(|s| s.trim().parse::<u16>().ok()).ok_or_else(|| io::Error::new(io::ErrorKind::Other, format!("no server running on session '{}'", target)))?.clone();
     let session_key = read_session_key(&target).unwrap_or_default();
     let addr: std::net::SocketAddr = format!("127.0.0.1:{}", port).parse().unwrap();
@@ -1138,7 +1121,6 @@ pub fn send_control(line: String) -> io::Result<()> {
 }
 
 pub fn send_control_with_response(line: String) -> io::Result<String> {
-    let home = env::var("USERPROFILE").or_else(|_| env::var("HOME")).unwrap_or_default();
     let mut target = env::var("PSMUX_TARGET_SESSION").ok().unwrap_or_else(|| "default".to_string());
     // Never target a warm (standby) session — resolve to a real session instead
     if is_warm_session(&target) {
@@ -1146,7 +1128,7 @@ pub fn send_control_with_response(line: String) -> io::Result<String> {
         target = resolve_last_session_name_ns(ns.as_deref()).unwrap_or_else(|| "default".to_string());
     }
     let full_target = env::var("PSMUX_TARGET_FULL").ok();
-    let path = format!("{}\\.psmux\\{}.port", home, target);
+    let path = crate::paths::port_file(&target);
     let port = std::fs::read_to_string(&path).ok().and_then(|s| s.trim().parse::<u16>().ok()).ok_or_else(|| io::Error::new(io::ErrorKind::Other, format!("no server running on session '{}'", target)))?.clone();
     let session_key = read_session_key(&target).unwrap_or_default();
     // Bounded connect: against a saturated listen backlog, a bare connect()
@@ -1223,8 +1205,8 @@ pub fn resolve_last_session_name() -> Option<String> {
 /// and the returned name includes the prefix (e.g. "foo__dev").
 /// When `ns` is None, only non-namespaced sessions (no "__" in name) are considered.
 pub fn resolve_last_session_name_ns(ns: Option<&str>) -> Option<String> {
-    let home = env::var("USERPROFILE").or_else(|_| env::var("HOME")).ok()?;
-    resolve_last_session_name_ns_in(std::path::Path::new(&format!("{}\\.psmux", home)), ns)
+    let psmux_dir = crate::paths::psmux_dir_opt()?;
+    resolve_last_session_name_ns_in(std::path::Path::new(&psmux_dir), ns)
 }
 
 /// Registry-directory-parameterized variant of [`resolve_last_session_name_ns`]:
@@ -1325,17 +1307,18 @@ fn session_base_owning_tmux_port(tmux_val: &str, psmux_dir: &std::path::Path) ->
 
 pub fn resolve_default_session_name() -> Option<String> {
     if let Ok(name) = env::var("PSMUX_DEFAULT_SESSION") {
-        let home = env::var("USERPROFILE").or_else(|_| env::var("HOME")).ok()?;
-        let p = format!("{}\\.psmux\\{}.port", home, name);
+        let p = crate::paths::port_file(&name);
         if std::path::Path::new(&p).exists() { return Some(name); }
     }
-    let home = env::var("USERPROFILE").or_else(|_| env::var("HOME")).ok()?;
-    let candidates = [format!("{}\\.psmuxrc", home), format!("{}\\.psmux\\pmuxrc", home)];
+    // `.psmuxrc` is a home-relative config file, not part of the data dir, so it
+    // stays under home_dir(); `pmuxrc` and the port files live in the data dir.
+    let home = crate::paths::home_dir();
+    let candidates = [format!("{}\\.psmuxrc", home), format!("{}\\pmuxrc", crate::paths::psmux_dir())];
     for cfg in candidates.iter() {
         if let Ok(text) = std::fs::read_to_string(cfg) {
             let line = text.lines().find(|l| !l.trim().is_empty())?;
             let name = if let Some(rest) = line.strip_prefix("default-session ") { rest.trim().to_string() } else { line.trim().to_string() };
-            let p = format!("{}\\.psmux\\{}.port", home, name);
+            let p = crate::paths::port_file(&name);
             if std::path::Path::new(&p).exists() { return Some(name); }
         }
     }
@@ -1351,8 +1334,7 @@ pub fn list_session_names() -> Vec<String> {
 
 /// Return session names filtered by namespace (same logic as resolve_last_session_name_ns).
 pub fn list_session_names_ns(ns: Option<&str>) -> Vec<String> {
-    let home = std::env::var("USERPROFILE").or_else(|_| std::env::var("HOME")).unwrap_or_default();
-    let dir = format!("{}\\.psmux", home);
+    let dir = crate::paths::psmux_dir();
     let mut names = Vec::new();
     if let Ok(entries) = std::fs::read_dir(&dir) {
         for e in entries.flatten() {
@@ -1396,11 +1378,9 @@ pub struct TreeEntry {
 /// List all running sessions and their windows for choose-tree display.
 /// Queries each running server via its TCP port for window list info.
 pub fn list_all_sessions_tree(current_session: &str, current_windows: &[(String, usize, String, bool, usize)]) -> Vec<TreeEntry> {
-    let home = match env::var("USERPROFILE").or_else(|_| env::var("HOME")) {
-        Ok(h) => h,
-        Err(_) => return vec![],
+    let Some(psmux_dir) = crate::paths::psmux_dir_opt() else {
+        return vec![];
     };
-    let psmux_dir = format!("{}\\.psmux", home);
     let mut sessions: Vec<(String, u16, std::time::SystemTime)> = Vec::new();
 
     if let Ok(entries) = std::fs::read_dir(&psmux_dir) {


### PR DESCRIPTION
This PR is a refactoring that centralizes the psmux data-dir path construction into `paths.rs`. This makes future changes to the exact name and location of the data dir or the port/key/sid files trivial.

This PR introduces `src/paths.rs` as the single source of truth for the psmux data directory and the files under it, and routes every call site through it.

- New helpers: `home_dir()`, `psmux_dir()` / `psmux_dir_opt()`,
  `port_file()` / `key_file()` / `sid_file()` / `port_file_opt()`,
  `psmux_dir_file()`.
- Converts all load-bearing sites (`.port`/`.key`/`.sid`, `next_session_id`, `last_session`, warm-pool/claim files, `latency.log`/ `crash.log`/ `cc_debug.log`) across session, main, server, client, preview, commands and cross_session.
- Drops the now-dead `home` parameter from `preview::fetch_*`/`get_or_fetch*` and `server::ensure_session_registry_files`.

Forward-slash sites (`debug_log.rs`, `ssh_input.rs`, `util.rs`, `#{socket_path}`) are intentionally left inline here — routing them through `psmux_dir_file` would normalize the separator (an observable change), so that is left for a later PR.

**No observable change.** `psmux_dir()` returns exactly the previous inline `format!("{}\.psmux", home)`, so every produced path is byte-identical. Verified by the full unit suite staying green.
