### PR TITLE
fix(kill-server): scope the force-kill fallback to the data dir, by pid

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -51,7 +51,7 @@ use crate::platform::enable_virtual_terminal_processing;
 use crate::cli::{print_help, print_version, print_commands};
 use crate::session::{cleanup_stale_port_files, reap_orphaned_servers, read_session_key, send_control,
     send_control_with_response, resolve_default_session_name,
-    kill_remaining_server_processes};
+    force_kill_targets, confirms_identity};
 use crate::rendering::apply_cursor_style;
 use crate::server::run_server;
 use crate::client::run_remote;
@@ -462,6 +462,11 @@ fn run_main() -> io::Result<()> {
             let psmux_dir = crate::paths::psmux_dir();
             // Compute namespace prefix for -L filtering (matches list-sessions behavior)
             let ns_prefix = l_socket_name.as_ref().map(|l| format!("{l}__"));
+            // Snapshot the force-kill candidates from this data dir's .pid files
+            // BEFORE the graceful pass removes them. Scoped to this dir and (with
+            // -L) this namespace, so the fallback can never reach another instance.
+            let fk_targets =
+                force_kill_targets(std::path::Path::new(&psmux_dir), ns_prefix.as_deref());
             let mut targets: Vec<(std::path::PathBuf, u16, String)> = Vec::new();
             let mut stale_ports: Vec<std::path::PathBuf> = Vec::new();
             if let Ok(entries) = std::fs::read_dir(&psmux_dir) {
@@ -512,25 +517,31 @@ fn run_main() -> io::Result<()> {
                             }
                         }
                     }
-                    // Remove port/key files regardless
+                    // Remove port/key/pid files regardless
                     let _ = std::fs::remove_file(&path);
-                    let key_path = path.with_extension("key");
-                    let _ = std::fs::remove_file(&key_path);
+                    let _ = std::fs::remove_file(path.with_extension("key"));
+                    let _ = std::fs::remove_file(path.with_extension("pid"));
                 })
             }).collect();
             // Wait for all threads to complete
             for h in handles { let _ = h.join(); }
-            // Clean up stale port/key files
+            // Clean up stale port/key/pid files
             for path in &stale_ports {
                 let _ = std::fs::remove_file(path);
-                let key_path = path.with_extension("key");
-                let _ = std::fs::remove_file(&key_path);
+                let _ = std::fs::remove_file(path.with_extension("key"));
+                let _ = std::fs::remove_file(path.with_extension("pid"));
             }
-            // Brief wait then verify no processes remain; if any do, force-kill them.
-            // Only do the nuclear fallback when not using -L namespace filtering.
+            // Force-kill any wedged server that ignored the graceful kill. The
+            // candidates were read from this data dir's (and, with -L, this
+            // namespace's) own .pid files before the graceful pass removed them,
+            // so nothing outside this instance is ever reached. The identity gate
+            // (exact process-creation-time match) skips any pid that has already
+            // exited or been recycled — no machine-wide, name-based scan.
             std::thread::sleep(Duration::from_millis(50));
-            if ns_prefix.is_none() {
-                kill_remaining_server_processes();
+            for t in fk_targets {
+                if confirms_identity(crate::platform::process_kill::process_creation_time(t.pid), t.creation_time) {
+                    crate::platform::process_kill::terminate_server_pid(t.pid, None);
+                }
             }
             return Ok(());
         }

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -1956,25 +1956,25 @@ pub mod process_kill {
         descendants
     }
 
-    /// Force-terminate a single process by PID, but ONLY if its creation time is
-    /// no later than `max_creation_ft` (issue #447 PID-reuse guard).
+    /// Force-terminate a single process by PID, guarded against PID reuse by
+    /// process creation time (issue #447).
     ///
-    /// The caller captures `max_creation_ft` (via `now_filetime()`) immediately
-    /// BEFORE taking the process snapshot that identified `pid`. Any process
-    /// that was legitimately enumerated in that snapshot must have been created
-    /// at or before the cutoff. If the PID has since been reused by an unrelated
-    /// process, that new process was created AFTER the cutoff, so its creation
-    /// time exceeds `max_creation_ft` and we refuse to terminate it.
+    /// `max_creation_ft` is `Some(cutoff)` for callers that identified `pid` from
+    /// a process snapshot: they capture the cutoff (via `now_filetime()`)
+    /// immediately BEFORE snapshotting, so any legitimately enumerated process
+    /// was created at or before it. A pid since reused by an unrelated process
+    /// was created AFTER the cutoff, so its creation time exceeds it and we refuse
+    /// to kill; a pid we cannot query is skipped too (fail safe).
     ///
-    /// Pass `u64::MAX` to disable the guard (unconditional kill) for callers that
-    /// terminate a process they hold a first-class reference to rather than a
-    /// snapshot-derived PID.
-    fn terminate_pid(pid: u32, max_creation_ft: u64) {
+    /// `None` is for callers that have already settled identity another way — an
+    /// exact creation-time match (kill-server's `confirms_identity`) or a
+    /// first-class child handle — so no snapshot cutoff applies.
+    fn terminate_pid(pid: u32, max_creation_ft: Option<u64>) {
         // PID-reuse guard: verify identity by creation time before killing.
-        if max_creation_ft != u64::MAX {
+        if let Some(cutoff) = max_creation_ft {
             match process_creation_filetime(pid) {
                 // Created after our snapshot cutoff -> PID was reused. Do NOT kill.
-                Some(created) if created > max_creation_ft => return,
+                Some(created) if created > cutoff => return,
                 // Could not confirm identity (gone / foreign context). Skip to
                 // stay on the safe side of the false-kill race.
                 None => return,
@@ -2032,8 +2032,8 @@ pub mod process_kill {
             if ppid == 0 || ppid == 4 { return false; }
             // detach-client -P intentionally targets the caller's own parent
             // shell; there is no snapshot cutoff to verify against, so kill
-            // unconditionally (u64::MAX disables the PID-reuse guard).
-            terminate_pid(ppid, u64::MAX);
+            // unconditionally.
+            terminate_pid(ppid, None);
             true
         } else {
             false
@@ -2070,12 +2070,12 @@ pub mod process_kill {
                 }
                 descs.reverse();
                 for &dpid in &descs {
-                    terminate_pid(dpid, cutoff);
+                    terminate_pid(dpid, Some(cutoff));
                 }
             }
             // Kill the root process last. Its PID also gets the reuse guard,
             // gated on the entry cutoff captured while root was still alive.
-            terminate_pid(root_pid, entry_cutoff);
+            terminate_pid(root_pid, Some(entry_cutoff));
         }
 
         // Fallback: tell portable_pty to kill the direct child process.
@@ -2108,9 +2108,9 @@ pub mod process_kill {
                 let mut descs = collect_descendants_from_table(&entries, *root_pid);
                 descs.reverse();
                 for &dpid in &descs {
-                    terminate_pid(dpid, cutoff);
+                    terminate_pid(dpid, Some(cutoff));
                 }
-                terminate_pid(*root_pid, cutoff);
+                terminate_pid(*root_pid, Some(cutoff));
             }
             let _ = children[i].kill();
         }
@@ -2250,10 +2250,13 @@ pub mod process_kill {
         process_creation_filetime(pid)
     }
 
-    /// Terminate an orphaned server PID, guarded by the #447 PID-reuse check:
-    /// the process is killed only if its creation time is no later than
-    /// `max_creation_ft` (captured before the enumeration that found it).
-    pub fn terminate_server_pid(pid: u32, max_creation_ft: u64) {
+    /// Terminate a psmux server PID, guarded against PID reuse by process
+    /// creation time (issue #447). Pass `Some(cutoff)` (the reaper's path) to
+    /// reject a pid reused by a process created after the snapshot that found it;
+    /// pass `None` when the caller has already matched creation time exactly
+    /// (kill-server's `confirms_identity` against the stored `.pid` value), which
+    /// settles identity and makes the cutoff heuristic redundant.
+    pub fn terminate_server_pid(pid: u32, max_creation_ft: Option<u64>) {
         terminate_pid(pid, max_creation_ft);
     }
 
@@ -2280,7 +2283,7 @@ pub mod process_kill {
     pub fn loopback_listener_pids() -> Vec<(u32, u16)> { Vec::new() }
     pub fn now_process_filetime() -> u64 { 0 }
     pub fn process_creation_time(_pid: u32) -> Option<u64> { None }
-    pub fn terminate_server_pid(_pid: u32, _max_creation_ft: u64) {}
+    pub fn terminate_server_pid(_pid: u32, _max_creation_ft: Option<u64>) {}
 }
 
 // ---------------------------------------------------------------------------

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -112,8 +112,16 @@ fn ensure_session_registry_files(app: &AppState) {
     // port/key/sid so a live server is never listening without a PID anchor, and
     // re-ensured periodically so the entry self-heals after rename/claim. This is
     // what lets startup reap live-but-orphaned duplicate servers by identity.
+    //
+    // The body is `pid:creation_filetime`: the creation time lets kill-server's
+    // force-kill fallback confirm identity (exact match) before terminating, so a
+    // recycled pid is never killed. Readers tolerate a bare pid too.
     let pid_path = crate::paths::pid_file(&base);
-    let pid_value = std::process::id().to_string();
+    let self_pid = std::process::id();
+    let pid_value = crate::session::format_pid_file_contents(
+        self_pid,
+        crate::platform::process_kill::process_creation_time(self_pid).unwrap_or(0),
+    );
     if std::fs::read_to_string(&pid_path)
         .map(|s| s.trim() != pid_value)
         .unwrap_or(true)

--- a/src/session.rs
+++ b/src/session.rs
@@ -165,7 +165,10 @@ pub fn remove_session_id_file(port_file_base: &str) {
 /// process anchor.
 pub fn write_session_pid_file(port_file_base: &str, pid: u32) {
     let pid_path = crate::paths::pid_file(port_file_base);
-    let _ = std::fs::write(&pid_path, pid.to_string());
+    // `pid:creation_filetime` — same body as ensure_session_registry_files, so a
+    // freshly renamed session is force-kill-identifiable before the next re-ensure.
+    let creation = crate::platform::process_kill::process_creation_time(pid).unwrap_or(0);
+    let _ = std::fs::write(&pid_path, format_pid_file_contents(pid, creation));
 }
 
 /// Remove the `.pid` file for a session.
@@ -293,7 +296,8 @@ fn read_tracked_registry(psmux_dir: &Path)
                     let port_sibling = path.with_extension("port");
                     if port_sibling.exists() {
                         if let Ok(s) = std::fs::read_to_string(&path) {
-                            if let Ok(pid) = s.trim().parse::<u32>() { tracked_pids.insert(pid); }
+                            // Tolerate both `pid` and `pid:creation_filetime` bodies.
+                            if let Some((pid, _)) = parse_pid_file_contents(&s) { tracked_pids.insert(pid); }
                         }
                     }
                 }
@@ -302,6 +306,82 @@ fn read_tracked_registry(psmux_dir: &Path)
         }
     }
     (tracked_ports, tracked_pids)
+}
+
+// --- kill-server force-kill fallback: data-dir-scoped, identity-checked -------
+// tmux's kill-server is socket-scoped. psmux's bare kill-server sends a graceful
+// kill-server to every session in scope; a wedged server that ignores it must be
+// force-killed. The old fallback scanned every process on the machine by image
+// name (psmux/pmux/tmux) and TerminateProcess'd them — machine-wide, reaching
+// unrelated servers and other namespaces. These helpers replace that with a
+// selection scoped by construction to this data dir's `.pid` files, gated by an
+// exact process-creation-time match so a recycled pid is never killed.
+
+/// A force-kill target read from a data dir's registry: the recorded server pid
+/// and the creation FILETIME it had when it wrote the pid file. The pair is what
+/// defeats pid reuse — a recycled pid will not carry the same creation time.
+#[derive(Debug, PartialEq)]
+pub struct PidTarget {
+    pub pid: u32,
+    pub creation_time: u64,
+}
+
+/// Parse a `.pid` file body. Two forms are accepted: a bare `pid` (the #448
+/// liveness anchor as first written) and `pid:creation_filetime` (extended so
+/// kill-server can verify identity). Returns `(pid, Option<creation_time>)`, or
+/// `None` when the pid itself is unparseable. One parser so every reader
+/// (`force_kill_targets`, the orphan reaper, the pid anchor) stays in step.
+pub fn parse_pid_file_contents(s: &str) -> Option<(u32, Option<u64>)> {
+    let s = s.trim();
+    match s.split_once(':') {
+        Some((pid_str, time_str)) => Some((pid_str.trim().parse().ok()?, time_str.trim().parse().ok())),
+        None => Some((s.parse().ok()?, None)),
+    }
+}
+
+/// The `.pid` body the server writes: `pid:creation_filetime`. Kept as one
+/// function so the producer and `parse_pid_file_contents` cannot drift apart.
+pub fn format_pid_file_contents(pid: u32, creation_time: u64) -> String {
+    format!("{pid}:{creation_time}")
+}
+
+/// Force-kill candidates for `kill-server`'s fallback, scoped by construction to
+/// a single data dir: the `pid:creation_filetime` `.pid` files in `dir`. When
+/// `ns_prefix` is `Some`, only files whose base starts with it are considered —
+/// mirroring the graceful pass's `-L` filter, so a namespaced kill-server never
+/// reaches another namespace. Bare-pid and malformed files are skipped (no
+/// recorded creation time means no identity gate, so they are not force-kill
+/// candidates). This selects targets; it does not kill.
+pub fn force_kill_targets(dir: &std::path::Path, ns_prefix: Option<&str>) -> Vec<PidTarget> {
+    let mut targets = Vec::new();
+    let Ok(entries) = std::fs::read_dir(dir) else { return targets; };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().map(|e| e == "pid").unwrap_or(false) {
+            if let Some(pfx) = ns_prefix {
+                let stem = path.file_stem().and_then(|s| s.to_str()).unwrap_or("");
+                if !stem.starts_with(pfx) { continue; }
+            }
+            if let Ok(contents) = std::fs::read_to_string(&path) {
+                // A recorded creation time is required: it is the identity gate.
+                // Bare-pid files carry none, so they are not force-kill candidates.
+                if let Some((pid, Some(creation_time))) = parse_pid_file_contents(&contents) {
+                    targets.push(PidTarget { pid, creation_time });
+                }
+            }
+        }
+    }
+    targets
+}
+
+/// The exact-match identity gate for the force-kill fallback: terminate only when
+/// the live process at the pid still carries the creation time recorded in the
+/// pid file. `queried` is the process's current creation FILETIME (None if it
+/// could not be read); `expected` is the value from the pid file. A recycled pid
+/// carries a different creation time and is rejected; an unreadable process is
+/// rejected too, so the fallback fails safe and never kills on uncertainty.
+pub fn confirms_identity(queried: Option<u64>, expected: u64) -> bool {
+    queried == Some(expected)
 }
 
 /// Terminate live psmux *server* processes that no registry entry accounts for
@@ -356,7 +436,7 @@ fn reap_orphaned_servers_in(psmux_dir: &Path) {
             crate::debug_log::session_log("reaper", &format!(
                 "terminating orphaned psmux server pid {} (no registry entry references it)", pid));
         }
-        process_kill::terminate_server_pid(pid, now_ft);
+        process_kill::terminate_server_pid(pid, Some(now_ft));
     }
 }
 
@@ -397,7 +477,9 @@ fn pid_anchor_verdict(port_path: &Path) -> Option<bool> {
         return None;
     }
     let pid_path = port_path.with_extension("pid");
-    let pid: u32 = std::fs::read_to_string(&pid_path).ok()?.trim().parse().ok()?;
+    // Tolerate both `pid` and `pid:creation_filetime` bodies (the latter written
+    // so kill-server can verify identity); the anchor only needs the pid.
+    let (pid, _creation) = parse_pid_file_contents(&std::fs::read_to_string(&pid_path).ok()?)?;
     let name = match crate::platform::process_info::get_process_name(pid) {
         // No such process (a same-user psmux server is always openable with
         // QUERY_LIMITED_INFORMATION, so an unopenable PID is not our server).
@@ -1468,93 +1550,6 @@ pub fn list_all_sessions_tree(current_session: &str, current_windows: &[(String,
         }
     }
     tree
-}
-
-/// Force-kill any remaining psmux/pmux/tmux server processes that didn't
-/// exit via the TCP kill-server command.  This is the nuclear fallback that
-/// guarantees kill-server always succeeds.
-///
-/// On Windows, uses CreateToolhelp32Snapshot to enumerate processes and
-/// TerminateProcess to kill them.  Skips the current process.
-#[cfg(windows)]
-pub fn kill_remaining_server_processes() {
-    const TH32CS_SNAPPROCESS: u32 = 0x00000002;
-    const PROCESS_TERMINATE: u32 = 0x0001;
-    const PROCESS_QUERY_LIMITED_INFORMATION: u32 = 0x1000;
-    const INVALID_HANDLE: isize = -1;
-
-    #[repr(C)]
-    struct PROCESSENTRY32W {
-        dw_size: u32,
-        cnt_usage: u32,
-        th32_process_id: u32,
-        th32_default_heap_id: usize,
-        th32_module_id: u32,
-        cnt_threads: u32,
-        th32_parent_process_id: u32,
-        pc_pri_class_base: i32,
-        dw_flags: u32,
-        sz_exe_file: [u16; 260],
-    }
-
-    #[link(name = "kernel32")]
-    extern "system" {
-        fn CreateToolhelp32Snapshot(dw_flags: u32, th32_process_id: u32) -> isize;
-        fn Process32FirstW(h_snapshot: isize, lppe: *mut PROCESSENTRY32W) -> i32;
-        fn Process32NextW(h_snapshot: isize, lppe: *mut PROCESSENTRY32W) -> i32;
-        fn OpenProcess(desired_access: u32, inherit_handle: i32, process_id: u32) -> isize;
-        fn TerminateProcess(h_process: isize, exit_code: u32) -> i32;
-        fn CloseHandle(handle: isize) -> i32;
-    }
-
-    let my_pid = std::process::id();
-
-    unsafe {
-        let snap = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
-        if snap == INVALID_HANDLE || snap == 0 { return; }
-
-        let mut pe: PROCESSENTRY32W = std::mem::zeroed();
-        pe.dw_size = std::mem::size_of::<PROCESSENTRY32W>() as u32;
-
-        let target_names: &[&str] = &["psmux.exe", "pmux.exe", "tmux.exe"];
-        let mut pids_to_kill: Vec<u32> = Vec::new();
-
-        if Process32FirstW(snap, &mut pe) != 0 {
-            loop {
-                let pid = pe.th32_process_id;
-                if pid != my_pid {
-                    // Extract exe name from wide string
-                    let len = pe.sz_exe_file.iter().position(|&c| c == 0).unwrap_or(260);
-                    let name = String::from_utf16_lossy(&pe.sz_exe_file[..len]);
-                    let name_lower = name.to_lowercase();
-                    for target in target_names {
-                        if name_lower == *target || name_lower.ends_with(&format!("\\{}", target)) {
-                            pids_to_kill.push(pid);
-                            break;
-                        }
-                    }
-                }
-                if Process32NextW(snap, &mut pe) == 0 { break; }
-            }
-        }
-        CloseHandle(snap);
-
-        for pid in &pids_to_kill {
-            let h = OpenProcess(PROCESS_TERMINATE | PROCESS_QUERY_LIMITED_INFORMATION, 0, *pid);
-            if h != 0 && h != INVALID_HANDLE {
-                let _ = TerminateProcess(h, 1);
-                CloseHandle(h);
-            }
-        }
-    }
-}
-
-#[cfg(not(windows))]
-pub fn kill_remaining_server_processes() {
-    // On non-Windows, use signal-based killing
-    let _ = std::process::Command::new("pkill")
-        .args(&["-f", "psmux|pmux"])
-        .status();
 }
 
 #[cfg(test)]

--- a/tests-rs/test_issue447_kill_pid_reuse.rs
+++ b/tests-rs/test_issue447_kill_pid_reuse.rs
@@ -65,7 +65,7 @@ fn wait_until_dead(pid: u32, timeout_ms: u64) -> bool {
     !pid_alive(pid)
 }
 
-/// The raw primitive (guard DISABLED via u64::MAX) kills an unrelated process
+/// The raw primitive (guard DISABLED via None) kills an unrelated process
 /// purely by PID. This documents the underlying capability the PID-reuse race
 /// weaponizes, and is the exact mode used by detach-client -P (kill_parent).
 #[test]
@@ -73,8 +73,8 @@ fn terminate_pid_unguarded_kills_by_raw_pid() {
     let (mut bystander, pid) = spawn_bystander();
     assert!(pid_alive(pid), "bystander should be alive right after spawn");
 
-    // u64::MAX disables the reuse guard -> unconditional kill.
-    terminate_pid(pid, u64::MAX);
+    // None disables the reuse guard -> unconditional kill.
+    terminate_pid(pid, None);
 
     assert!(
         wait_until_dead(pid, 3000),
@@ -105,7 +105,7 @@ fn guarded_terminate_rejects_pid_reused_after_cutoff() {
 
     // The sweep asks to kill this PID believing it was a descendant, but the
     // real process was created after the cutoff -> guard must skip it.
-    terminate_pid(pid, cutoff);
+    terminate_pid(pid, Some(cutoff));
 
     // Give any (erroneous) termination time to take effect, then assert SURVIVAL.
     std::thread::sleep(std::time::Duration::from_millis(300));
@@ -115,7 +115,7 @@ fn guarded_terminate_rejects_pid_reused_after_cutoff() {
     );
 
     // Cleanup: kill it for real with the guard disabled.
-    terminate_pid(pid, u64::MAX);
+    terminate_pid(pid, None);
     let _ = wait_until_dead(pid, 3000);
     let _ = innocent.wait();
 }
@@ -132,7 +132,7 @@ fn guarded_terminate_still_kills_genuine_descendant() {
     std::thread::sleep(std::time::Duration::from_millis(200));
     let cutoff = now_filetime();
 
-    terminate_pid(pid, cutoff);
+    terminate_pid(pid, Some(cutoff));
 
     assert!(
         wait_until_dead(pid, 3000),
@@ -157,7 +157,7 @@ fn creation_filetime_ordering_is_monotonic() {
     assert!(created > before, "creation time must be after a pre-spawn cutoff");
     assert!(created <= after, "creation time must be at/before a post-spawn instant");
 
-    terminate_pid(pid, u64::MAX);
+    terminate_pid(pid, None);
     let _ = wait_until_dead(pid, 3000);
     let _ = child.wait();
 }

--- a/tests-rs/test_session.rs
+++ b/tests-rs/test_session.rs
@@ -424,3 +424,129 @@ fn liveness_connected_but_silent_is_dead() {
     assert!(start.elapsed() < Duration::from_secs(2), "probe must stay bounded, not hang");
     drop(listener);
 }
+
+// --- .pid body parsing: one parser shared by every reader --------------------
+// `.pid` is written as `pid:creation_filetime`, but a bare `pid` (the #448 anchor
+// as first written, or an older server mid-upgrade) must still parse so the
+// orphan reaper never loses track of a live server.
+
+#[test]
+fn parse_pid_file_contents_reads_both_forms() {
+    assert_eq!(parse_pid_file_contents("1234:567890"), Some((1234, Some(567890))));
+    assert_eq!(parse_pid_file_contents("1234"), Some((1234, None)));
+    assert_eq!(parse_pid_file_contents("  1234:567890 \n"), Some((1234, Some(567890))));
+    // Unparseable pid -> not a record at all.
+    assert_eq!(parse_pid_file_contents("notanumber"), None);
+    // Valid pid, unparseable creation time -> pid is kept, creation dropped.
+    assert_eq!(parse_pid_file_contents("12:notatime"), Some((12, None)));
+}
+
+#[test]
+fn format_pid_file_contents_round_trips() {
+    let s = format_pid_file_contents(4321, 987654);
+    assert_eq!(s, "4321:987654");
+    assert_eq!(parse_pid_file_contents(&s), Some((4321, Some(987654))));
+}
+
+// --- force_kill_targets: the data-dir-scoped force-kill selector -------------
+// kill-server's force-kill fallback must target only PIDs recorded in *this*
+// data dir's registry, never a machine-wide scan by image name.
+
+#[test]
+fn force_kill_targets_reads_pid_files_in_its_dir() {
+    let dir = temp_psmux_dir("fkt_basic");
+    fs::write(dir.join("ns__a.pid"), "1234:567890").unwrap();
+
+    let targets = force_kill_targets(&dir, None);
+
+    assert_eq!(
+        targets,
+        vec![PidTarget { pid: 1234, creation_time: 567890 }],
+        "the .pid file's pid and creation time must be parsed and returned"
+    );
+    let _ = fs::remove_dir_all(dir.parent().unwrap());
+}
+
+#[test]
+fn force_kill_targets_is_scoped_to_its_dir() {
+    // The whole point of the fix: a kill-server in dir A must never reach a
+    // server registered under dir B.
+    let dir_a = temp_psmux_dir("fkt_a");
+    let dir_b = temp_psmux_dir("fkt_b");
+    fs::write(dir_a.join("a.pid"), "111:1").unwrap();
+    fs::write(dir_b.join("b.pid"), "999:2").unwrap();
+
+    let targets = force_kill_targets(&dir_a, None);
+
+    assert_eq!(targets, vec![PidTarget { pid: 111, creation_time: 1 }]);
+    assert!(
+        !targets.iter().any(|t| t.pid == 999),
+        "dir A's selection must not include dir B's pid"
+    );
+    let _ = fs::remove_dir_all(dir_a.parent().unwrap());
+    let _ = fs::remove_dir_all(dir_b.parent().unwrap());
+}
+
+#[test]
+fn force_kill_targets_skips_bare_and_malformed_pid_files() {
+    let dir = temp_psmux_dir("fkt_malformed");
+    fs::write(dir.join("good.pid"), "5:6").unwrap();
+    fs::write(dir.join("bare.pid"), "12345").unwrap();          // no creation time -> no gate
+    fs::write(dir.join("bad_pid.pid"), "notanumber:6").unwrap();
+    fs::write(dir.join("bad_time.pid"), "7:notatime").unwrap();
+
+    let targets = force_kill_targets(&dir, None);
+
+    assert_eq!(
+        targets,
+        vec![PidTarget { pid: 5, creation_time: 6 }],
+        "only well-formed pid:creation files are force-kill candidates"
+    );
+    let _ = fs::remove_dir_all(dir.parent().unwrap());
+}
+
+#[test]
+fn force_kill_targets_honors_ns_prefix() {
+    // Many namespaces share one data dir (-L only changes the filename prefix).
+    // A namespaced kill-server must force-kill only its own namespace's wedged
+    // servers, never another namespace's, even though all .pid files sit side by
+    // side in the same dir.
+    let dir = temp_psmux_dir("fkt_ns");
+    fs::write(dir.join("ns1__a.pid"), "11:1").unwrap();
+    fs::write(dir.join("ns1__b.pid"), "12:2").unwrap();
+    fs::write(dir.join("ns2__c.pid"), "21:3").unwrap();
+    fs::write(dir.join("plain.pid"), "30:4").unwrap();
+
+    let ns1 = force_kill_targets(&dir, Some("ns1__"));
+
+    assert!(
+        ns1.iter().all(|t| t.pid == 11 || t.pid == 12),
+        "ns1 selection must contain only ns1's pids, got {ns1:?}"
+    );
+    assert!(
+        !ns1.iter().any(|t| t.pid == 21 || t.pid == 30),
+        "ns1 selection must not reach ns2's or the default namespace's pids"
+    );
+    assert_eq!(ns1.len(), 2, "ns1 has exactly two sessions");
+    let _ = fs::remove_dir_all(dir.parent().unwrap());
+}
+
+// --- confirms_identity: the exact-match gate that defeats pid reuse ----------
+
+#[test]
+fn confirms_identity_matches_exact_creation_time() {
+    assert!(confirms_identity(Some(567890), 567890));
+}
+
+#[test]
+fn confirms_identity_rejects_recycled_pid() {
+    // A different creation time at the same pid means the pid was reused by an
+    // unrelated process. It must never be killed.
+    assert!(!confirms_identity(Some(567891), 567890));
+}
+
+#[test]
+fn confirms_identity_rejects_unqueryable_process() {
+    // Process gone, or OpenProcess/GetProcessTimes failed: fail safe, no kill.
+    assert!(!confirms_identity(None, 567890));
+}

--- a/tests/test_kill_server_scoped.ps1
+++ b/tests/test_kill_server_scoped.ps1
@@ -1,0 +1,135 @@
+# Integration: kill-server's force-kill fallback is scoped to its own data dir
+# and namespace, and verifies process identity (pid + creation time) before
+# terminating. It no longer scans the machine by executable name.
+#
+# The test exploits the very property under test: because the fallback no longer
+# checks the name, an ordinary unrelated process serves as a stand-in for a
+# "wedged" server. We start a harmless long-lived pwsh (Start-Sleep), write a
+# {pid}:{creation_filetime} pid file for it, run kill-server, and observe whether
+# it is terminated. The probe never speaks the control protocol, so the graceful
+# pass cannot stop it -- only the force-kill fallback can.
+#
+# SAFE TO RUN ALONGSIDE REAL psmux SESSIONS: precisely because the name scan is
+# gone, kill-server here touches only this temp HOME's registry plus the probe
+# pid we authored. (Against a pre-fix binary the bare kill-server below would
+# TerminateProcess every psmux.exe on the machine -- do NOT run this on one.)
+#
+# Removal recipe: delete if force_kill_targets / confirms_identity are removed.
+
+$ErrorActionPreference = "Stop"
+
+# This test issues a REAL kill-server. If it is pointed at a binary that still
+# has the old name-based sweep -- a stale build, or the psmux on PATH -- that
+# bare kill-server terminates every psmux/pmux/tmux process on the machine.
+# Refuse to run unless the caller has confirmed a throwaway environment, exactly
+# as run_all_tests.ps1 does. The Docker dev image / CI set this automatically.
+# This gate MUST stay before any kill-server call.
+if ($env:PSMUX_TEST_SANDBOX -ne '1') {
+    Write-Host ''
+    Write-Host 'REFUSING TO RUN: this test issues a real kill-server.' -ForegroundColor Red
+    Write-Host 'Against a pre-fix or PATH psmux that would terminate every' -ForegroundColor Yellow
+    Write-Host 'psmux/pmux/tmux process on the machine. Run only in a sandbox.' -ForegroundColor Yellow
+    Write-Host 'To confirm a sandbox and run against a freshly built binary:' -ForegroundColor Yellow
+    Write-Host '    $env:PSMUX_TEST_SANDBOX = "1"; $env:PSMUX_EXE = "<freshly built psmux.exe>"' -ForegroundColor Cyan
+    Write-Host '    pwsh -File tests\test_kill_server_scoped.ps1' -ForegroundColor Cyan
+    Write-Host ''
+    exit 2
+}
+
+$PSMUX = $env:PSMUX_EXE
+if (-not $PSMUX -or -not (Test-Path $PSMUX)) { $PSMUX = "$PSScriptRoot\..\target\debug\psmux.exe" }
+if (-not (Test-Path $PSMUX)) { Write-Host "FATAL: psmux not found ($PSMUX)" -ForegroundColor Red; exit 1 }
+
+$shell = if (Get-Command pwsh -EA SilentlyContinue) { 'pwsh' } else { 'powershell' }
+
+$tmpHome = Join-Path $env:TEMP ("psmux_killscope_" + [guid]::NewGuid().ToString("N").Substring(0,8))
+$psmuxDir = Join-Path $tmpHome ".psmux"
+New-Item -ItemType Directory $psmuxDir -Force | Out-Null
+
+# Isolate HOME and scrub session vars so a runner inside a psmux session does not
+# retarget commands or trip the nesting guard.
+$savedUP = $env:USERPROFILE; $savedHOME = $env:HOME
+$savedSession = $env:PSMUX_SESSION; $savedTarget = $env:PSMUX_TARGET_SESSION
+$savedTmux = $env:TMUX; $savedTmuxPane = $env:TMUX_PANE
+$env:USERPROFILE = $tmpHome; $env:HOME = $tmpHome
+Remove-Item Env:\PSMUX_SESSION,Env:\PSMUX_TARGET_SESSION,Env:\TMUX,Env:\TMUX_PANE -EA SilentlyContinue
+
+$probes = @()
+$pass = 0; $fail = 0
+function Write-Result($name, $ok, $msg) {
+    if ($ok) { Write-Host "  [PASS] $name" -ForegroundColor Green; $script:pass++ }
+    else     { Write-Host "  [FAIL] $name : $msg" -ForegroundColor Red; $script:fail++ }
+}
+
+# Start a harmless long-lived process we fully control; return its pid and the
+# creation FILETIME exactly as our pid file records it. .NET StartTime ->
+# ToFileTimeUtc is the same 100ns-ticks-since-1601-UTC value psmux reads from
+# GetProcessTimes, so the recorded pid file matches what the fallback queries.
+function Start-Probe {
+    $p = Start-Process $shell -ArgumentList '-NoProfile','-Command','Start-Sleep -Seconds 60' `
+        -PassThru -WindowStyle Hidden
+    $script:probes += $p.Id
+    $ft = (Get-Process -Id $p.Id).StartTime.ToFileTimeUtc()
+    return [pscustomobject]@{ Pid = $p.Id; FileTime = $ft }
+}
+
+function Test-Alive($procId) { $null -ne (Get-Process -Id $procId -EA SilentlyContinue) }
+
+function Wait-Dead($procId, $ms) {
+    $sw = [System.Diagnostics.Stopwatch]::StartNew()
+    while ($sw.ElapsedMilliseconds -lt $ms) {
+        if (-not (Test-Alive $procId)) { return $true }
+        Start-Sleep -Milliseconds 50
+    }
+    return -not (Test-Alive $procId)
+}
+
+function Reset-PidFiles { Get-ChildItem $psmuxDir -Filter *.pid -EA SilentlyContinue | Remove-Item -Force }
+function Write-PidFile($base, $procId, $fileTime) {
+    Set-Content -Path (Join-Path $psmuxDir "$base.pid") -Value ("{0}:{1}" -f $procId, $fileTime) -NoNewline
+}
+
+Write-Host ""
+Write-Host "=== kill-server force-kill fallback: scoped + identity-checked ===" -ForegroundColor Cyan
+Write-Host "  psmux: $PSMUX" -ForegroundColor DarkGray
+
+try {
+    # Case 1: in-scope wedged server with a matching identity -> reaped.
+    Reset-PidFiles
+    $p1 = Start-Probe
+    Write-PidFile "scoped__victim" $p1.Pid $p1.FileTime
+    & $PSMUX kill-server 2>&1 | Out-Null
+    Write-Result "in-scope probe with matching identity is force-killed" (Wait-Dead $p1.Pid 4000) `
+        "probe $($p1.Pid) still alive after kill-server"
+
+    # Case 2: same pid but wrong creation time (simulated pid reuse) -> spared.
+    Reset-PidFiles
+    $p2 = Start-Probe
+    Write-PidFile "scoped__reuse" $p2.Pid ($p2.FileTime + 99999)
+    & $PSMUX kill-server 2>&1 | Out-Null
+    Start-Sleep -Milliseconds 400
+    Write-Result "probe with a mismatched creation time (pid reuse) is spared" (Test-Alive $p2.Pid) `
+        "probe $($p2.Pid) was killed despite a creation-time mismatch"
+
+    # Case 3: probe registered under namespace 'a', kill-server -L b -> spared.
+    Reset-PidFiles
+    $p3 = Start-Probe
+    Write-PidFile "a__victim" $p3.Pid $p3.FileTime
+    & $PSMUX -L b kill-server 2>&1 | Out-Null
+    Start-Sleep -Milliseconds 400
+    Write-Result "probe in another namespace is spared by -L b kill-server" (Test-Alive $p3.Pid) `
+        "probe $($p3.Pid) in namespace 'a' was killed by -L b kill-server"
+}
+finally {
+    foreach ($id in $probes) { Stop-Process -Id $id -Force -EA SilentlyContinue }
+    $env:USERPROFILE = $savedUP; $env:HOME = $savedHOME
+    if ($null -ne $savedSession) { $env:PSMUX_SESSION = $savedSession }
+    if ($null -ne $savedTarget)  { $env:PSMUX_TARGET_SESSION = $savedTarget }
+    if ($null -ne $savedTmux)     { $env:TMUX = $savedTmux }
+    if ($null -ne $savedTmuxPane) { $env:TMUX_PANE = $savedTmuxPane }
+    Remove-Item -Recurse -Force $tmpHome -EA SilentlyContinue
+}
+
+Write-Host ""
+Write-Host "=== Results: $pass passed, $fail failed ===" -ForegroundColor Cyan
+if ($fail -gt 0) { exit 1 } else { exit 0 }


### PR DESCRIPTION
This PR stops `kill-server` from killing potentially unrelated processes that happen to be named `psmux.exe` it will now only terminate known pids (with a re-used pid guard based on process creation time) - but beware, it will still happily kill your own namespaced work sessions when running a bare `kill-server` (without -L). Tmux-faithful scoping of that remaining over-reach is a follow-up.

## Problem

After its graceful pass, a bare `kill-server` (without -L) ran a force-kill fallback that enumerated *every process on the machine* and `TerminateProcess`'d anything whose exe name was `psmux.exe` / `pmux.exe` / `tmux.exe`. It matched on the *name*, not on whether the process was actually one of our servers, and it ignored the data dir and namespace entirely. tmux's `kill-server` is socket-scoped and never crosses to another socket's server.

## Repro

```
# Start the super important MindServer
C:\Program Files\PSy Mind Upload Xplorer\psmux.exe --with-lifesupport --critical --redundancy 3
LOG: MindServer started with 3x redundancy. I'd like to see the bug that brings THIS down!
                      # meanwhile, in a different terminal
                      cd C:\dev
                      psmux new-session -s hacking
                      ...
                      psmux kill-server
LOG: MindServer #1 terminated
LOG: MindServer #2 terminated
LOG: MindServer #3 terminated
LOG: Lifesupport disabled, flatlining
```

Hypothetical 3-way redundancy is no help when the reaper matches on the *name* — all three live on one machine, all three are `psmux.exe`. (Same user here; a non-elevated `kill-server` is bounded by `OpenProcess` rights to your own processes — but across all your sessions, namespaces, and data dirs. Run elevated, it reaches other users' processes too.)

A harmless, actually-runnable version:

```
mkdir %TEMP%\unrelated && copy C:\Windows\System32\calc.exe %TEMP%\unrelated\psmux.exe
& %TEMP%\unrelated\psmux.exe
psmux kill-server          # in a separate session
# Before: %TEMP%\unrelated\psmux.exe is terminated (exit code 1).
# After:  untouched — only this data dir's own servers are reaped.
```

## Fix

A fallback scoped by construction to the registry:

- The server records `{pid}:{creation_filetime}` in `{base}.pid` alongside `.port`/`.key`/`.sid`.
- `force_kill_targets(dir, ns_prefix)` selects candidates only from *this* data dir's `.pid` files, filtered by the same `-L` prefix as the graceful pass — a namespaced `kill-server` never reaches another namespace.
- Before terminating, `confirms_identity` requires the live process's creation time to *exactly* match the recorded one. A recycled pid has a different creation time and is rejected; an unqueryable process is rejected too — fail-safe, no kill on uncertainty. No name matching anywhere.

With 3 sessions in each of 3 namespaces + default (12 servers, one data dir): `-L ns1 kill-server` reaps exactly ns1's 3 (force-killing only the wedged ones); bare `kill-server` reaps the 12 in this data dir — and nothing outside it, ever.

**Not full tmux parity yet.** A bare `kill-server` still graceful-kills every namespace in *this* data dir, where tmux would scope to the default socket only (see follow-up). What this change fixes is the dangerous part: `kill-server` no longer kills *unrelated* processes — nothing outside this data dir, and never by exe name. The over-reach that remains is confined to your own psmux sessions in your own data dir; it can no longer flatline the MindServer next door.

## Testing

Unit tests cover the selection and the gate: dir scoping, namespace scoping, exact-match, fail-safe-on-`None`, FILETIME packing, and a pid-file producer/consumer round trip. A ps1 integration test drives a real `kill-server` against an unrelated `pwsh` sleep used as a stand-in wedged server (exploiting that we no longer name-check), confirming the real `GetProcessTimes` path: in-scope + matching → killed; creation-time mismatch (pid reuse) → spared; other namespace → spared. Both the "kill" and "spare" directions were verified non-vacuous via edit-to-red. The integration test refuses to run unless `PSMUX_TEST_SANDBOX=1` (and is pointed at the build under test via `PSMUX_EXE`), since a real `kill-server` against a pre-fix or PATH binary is destructive.

## Follow-up (separate work)

- The ps1 tests cite bare `kill-server`'s "kill-all-by-image-name fallback" as the reason to avoid it. That sweep is gone — a bare `kill-server` will no longer terminate *unrelated* processes (the MindServer next door is safe). But the helpers should still avoid bare `kill-server`, for a sharper reason: it still graceful-kills *every one of your own* psmux sessions in the data dir (all namespaces). In practice that has repeatedly wiped my own live sessions when an agent or test fired a bare `kill-server`. Tests and tooling should use `-L <ns>`, never bare. 

The structural fix to only kill servers within a named (or default) namespace is in the works, and PR #403 will make that change safe and trivial.
