### PR TITLE
fix: tighten swap-pane target handling and in-app error feedback

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1262,21 +1262,11 @@ fn execute_command_string_single(app: &mut AppState, cmd: &str) -> io::Result<()
                 if let Some(port) = app.control_port {
                     let _ = send_control_to_port(port, &format!("swap-pane -t {}\n", tgt), &app.session_key);
                 } else {
-                    let path = if tgt.starts_with('{') {
-                        // Layout position token like {top-right} — resolve to
-                        // whatever pane currently occupies that corner.
-                        crate::window_ops::pane_path_at_position(app, &tgt)
-                    } else {
-                        let parsed = crate::cli::parse_target(&tgt);
-                        let win = &app.windows[app.active_idx];
-                        match parsed.pane {
-                            Some(p) if parsed.pane_is_id => crate::tree::find_path_by_id(&win.root, p),
-                            Some(p) => crate::tree::path_by_position(&win.root, p.saturating_sub(app.pane_base_index)),
-                            None => None,
-                        }
-                    };
+                    let path = resolve_swap_pane_target_path(app, &tgt);
                     if let Some(path) = path {
                         crate::window_ops::swap_pane_with_path(app, path);
+                    } else {
+                        app.status_message = Some((format!("swap-pane: can't find pane: {}", tgt), Instant::now(), None));
                     }
                 }
             } else if let Some(port) = app.control_port {
@@ -2375,6 +2365,23 @@ fn execute_command_string_single(app: &mut AppState, cmd: &str) -> io::Result<()
     Ok(())
 }
 
+fn resolve_swap_pane_target_path(app: &AppState, target: &str) -> Option<Vec<usize>> {
+    if target.starts_with('{') {
+        return crate::window_ops::pane_path_at_position(app, target);
+    }
+    if app.windows.is_empty() {
+        return None;
+    }
+    let parsed = crate::cli::parse_target(target);
+    let win = &app.windows[app.active_idx];
+    match parsed.pane {
+        Some(p) if parsed.pane_is_id => crate::tree::find_path_by_id(&win.root, p),
+        Some(p) => p.checked_sub(app.pane_base_index)
+            .and_then(|idx| crate::tree::path_by_position(&win.root, idx)),
+        None => None,
+    }
+}
+
 #[cfg(test)]
 #[path = "../tests-rs/test_commands.rs"]
 mod tests;
@@ -2474,3 +2481,7 @@ mod tests_named_buffers;
 #[cfg(test)]
 #[path = "../tests-rs/test_issue273_send_prefix.rs"]
 mod tests_issue273_send_prefix;
+
+#[cfg(test)]
+#[path = "../tests-rs/test_issue383_swap_pane_targets.rs"]
+mod tests_issue383_swap_pane_targets;

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -2868,15 +2868,17 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                 CtrlReq::SwapPane(dir) => {
                     // tmux: swap-pane without -Z permanently unzooms (#82)
                     unzoom_if_zoomed(&mut app);
-                    match dir.as_str() {
-                        "U" => { swap_pane(&mut app, FocusDir::Up); }
-                        "D" => { swap_pane(&mut app, FocusDir::Down); }
-                        "L" => { swap_pane(&mut app, FocusDir::Left); }
-                        "R" => { swap_pane(&mut app, FocusDir::Right); }
-                        _ => { swap_pane(&mut app, FocusDir::Down); }
+                    let swapped = match dir.as_str() {
+                        "U" => swap_pane(&mut app, FocusDir::Up),
+                        "D" => swap_pane(&mut app, FocusDir::Down),
+                        "L" => swap_pane(&mut app, FocusDir::Left),
+                        "R" => swap_pane(&mut app, FocusDir::Right),
+                        _ => swap_pane(&mut app, FocusDir::Down),
+                    };
+                    if swapped {
+                        meta_dirty = true;
+                        hook_event = Some("after-swap-pane");
                     }
-                    meta_dirty = true;
-                    hook_event = Some("after-swap-pane");
                 }
                 CtrlReq::SwapPaneTarget(target, is_id) => {
                     // tmux: swap-pane without -Z permanently unzooms (#82)
@@ -2886,23 +2888,32 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                         if is_id {
                             crate::tree::find_path_by_id(&win.root, target)
                         } else {
-                            crate::tree::path_by_position(&win.root, target.saturating_sub(app.pane_base_index))
+                            match target.checked_sub(app.pane_base_index) {
+                                Some(idx) => crate::tree::path_by_position(&win.root, idx),
+                                None => None,
+                            }
                         }
                     };
                     if let Some(path) = path {
-                        swap_pane_with_path(&mut app, path);
+                        if swap_pane_with_path(&mut app, path) {
+                            meta_dirty = true;
+                            hook_event = Some("after-swap-pane");
+                        }
+                    } else {
+                        app.status_message = Some((format!("swap-pane: can't find pane: {}", target), std::time::Instant::now(), None));
                     }
-                    meta_dirty = true;
-                    hook_event = Some("after-swap-pane");
                 }
                 CtrlReq::SwapPanePosition(token) => {
                     // tmux: swap-pane without -Z permanently unzooms (#82)
                     unzoom_if_zoomed(&mut app);
                     if let Some(path) = crate::window_ops::pane_path_at_position(&app, &token) {
-                        swap_pane_with_path(&mut app, path);
+                        if swap_pane_with_path(&mut app, path) {
+                            meta_dirty = true;
+                            hook_event = Some("after-swap-pane");
+                        }
+                    } else {
+                        app.status_message = Some((format!("swap-pane: can't find pane: {}", token), std::time::Instant::now(), None));
                     }
-                    meta_dirty = true;
-                    hook_event = Some("after-swap-pane");
                 }
                 CtrlReq::ResizePane(dir, amount) => {
                     unzoom_if_zoomed(&mut app);

--- a/src/types.rs
+++ b/src/types.rs
@@ -1034,7 +1034,8 @@ pub enum CtrlReq {
     SwapPane(String),
     /// swap-pane -t <target>: swap the active pane with the pane identified by
     /// (target, pane_is_id).  When `pane_is_id` is true the value is a pane id
-    /// (`%N`); otherwise it is a 0-based positional pane index.
+    /// (`%N`); otherwise it is a user-facing pane index that is normalized
+    /// using pane-base-index before resolving a positional pane path.
     SwapPaneTarget(usize, bool),
     /// swap-pane -t <token>: swap the active pane with the pane at a layout
     /// position token (e.g. `{top-right}`).  Layout-independent.

--- a/src/window_ops.rs
+++ b/src/window_ops.rs
@@ -1072,7 +1072,7 @@ pub fn handle_split_resize_done(app: &mut AppState) {
     resize_all_panes(app);
 }
 
-pub fn swap_pane(app: &mut AppState, dir: FocusDir) {
+pub fn swap_pane(app: &mut AppState, dir: FocusDir) -> bool {
     let win = &mut app.windows[app.active_idx];
     let mut rects: Vec<(Vec<usize>, Rect)> = Vec::new();
     compute_rects(&win.root, app.last_window_area, &mut rects);
@@ -1081,7 +1081,7 @@ pub fn swap_pane(app: &mut AppState, dir: FocusDir) {
     for (i, (path, _)) in rects.iter().enumerate() { 
         if *path == win.active_path { active_idx = Some(i); break; } 
     }
-    let Some(ai) = active_idx else { return; };
+    let Some(ai) = active_idx else { return false; };
     let (_, arect) = &rects[ai];
     
     // Collect pane IDs for MRU-based tie-breaking (issue #70)
@@ -1099,38 +1099,41 @@ pub fn swap_pane(app: &mut AppState, dir: FocusDir) {
         // sizes) instead of merely moving focus.  This is the real swap-pane
         // behaviour expected from tmux.
         if crate::tree::swap_nodes(&mut win.root, &active_path, &target_path) {
-            if let Some(new_pane_id) = pane_ids.get(ni) {
-                crate::tree::touch_mru(&mut win.pane_mru, *new_pane_id);
-            }
             // Focus follows the pane that was just moved into the new slot.
             win.active_path = target_path;
+            if let Some(focused_id) = crate::tree::get_active_pane_id(&win.root, &win.active_path) {
+                crate::tree::touch_mru(&mut win.pane_mru, focused_id);
+            }
             swapped = true;
         }
     }
     // Resize the moved panes' PTYs to fit their new slots (tmux re-lays-out
     // after a swap).  Without this the program keeps its old terminal size.
     if swapped { crate::tree::resize_all_panes(app); }
+    swapped
 }
 
 /// Swap the active pane with the pane at an explicit tree `path`
 /// (used by `swap-pane -t <target>`).  Geometry is preserved; focus follows
 /// the moved pane to its new slot.
-pub fn swap_pane_with_path(app: &mut AppState, target_path: Vec<usize>) {
+pub fn swap_pane_with_path(app: &mut AppState, target_path: Vec<usize>) -> bool {
     let swapped = {
         let win = &mut app.windows[app.active_idx];
         let active_path = win.active_path.clone();
         if active_path == target_path { false }
         else {
-            let new_id = crate::tree::get_active_pane_id(&win.root, &target_path);
             if crate::tree::swap_nodes(&mut win.root, &active_path, &target_path) {
-                if let Some(id) = new_id { crate::tree::touch_mru(&mut win.pane_mru, id); }
                 win.active_path = target_path;
+                if let Some(focused_id) = crate::tree::get_active_pane_id(&win.root, &win.active_path) {
+                    crate::tree::touch_mru(&mut win.pane_mru, focused_id);
+                }
                 true
             } else { false }
         }
     };
     // Resize moved panes to fit their new slots (see swap_pane).
     if swapped { crate::tree::resize_all_panes(app); }
+    swapped
 }
 
 /// Resolve a tmux-style position token (e.g. `{top-right}`) to the path of the
@@ -1202,6 +1205,79 @@ mod position_token_tests {
     fn unknown_token_is_none() {
         let (area, rects) = layout();
         assert_eq!(resolve_position_token("{active}", area, &rects), None);
+    }
+}
+
+#[cfg(test)]
+mod swap_mru_tests {
+    use super::swap_pane_with_path;
+    use crate::proxy_pane::create_proxy_pane;
+    use crate::types::{AppState, LayoutKind, Node, Window};
+    use ratatui::layout::Rect;
+    use std::net::{TcpListener, TcpStream};
+
+    fn tcp_pair() -> (TcpStream, TcpStream) {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind listener");
+        let addr = listener.local_addr().expect("listener addr");
+        let accept_thr = std::thread::spawn(move || listener.accept().expect("accept").0);
+        let client = TcpStream::connect(addr).expect("connect");
+        let server = accept_thr.join().expect("join accept thread");
+        (client, server)
+    }
+
+    fn proxy_pane(id: usize, rows: u16, cols: u16) -> crate::types::Pane {
+        let (reader, _peer1) = tcp_pair();
+        let (writer, _peer2) = tcp_pair();
+        create_proxy_pane(
+            reader,
+            writer,
+            "127.0.0.1:1".to_string(),
+            "test-key".to_string(),
+            "test-session".to_string(),
+            id as u64,
+            None,
+            format!("pane-{}", id),
+            rows,
+            cols,
+            id,
+            None,
+        ).expect("create proxy pane")
+    }
+
+    fn make_window_with_two_panes(left_id: usize, right_id: usize) -> Window {
+        Window {
+            root: Node::Split {
+                kind: LayoutKind::Horizontal,
+                sizes: vec![1, 1],
+                children: vec![Node::Leaf(proxy_pane(left_id, 10, 5)), Node::Leaf(proxy_pane(right_id, 10, 5))],
+            },
+            active_path: vec![0],
+            name: "w0".to_string(),
+            id: 0,
+            activity_flag: false,
+            bell_flag: false,
+            silence_flag: false,
+            last_output_time: std::time::Instant::now(),
+            last_seen_version: 0,
+            manual_rename: false,
+            layout_index: 0,
+            pane_mru: vec![right_id, left_id],
+            zoom_saved: None,
+            linked_from: None,
+        }
+    }
+
+    #[test]
+    fn swap_with_path_updates_mru_for_focused_pane_after_swap() {
+        let mut app = AppState::new("swap-mru".to_string());
+        app.last_window_area = Rect { x: 0, y: 0, width: 10, height: 10 };
+        app.windows.push(make_window_with_two_panes(11, 22));
+        app.active_idx = 0;
+
+        let swapped = swap_pane_with_path(&mut app, vec![1]);
+        assert!(swapped, "swap should succeed");
+        assert_eq!(app.windows[0].active_path, vec![1], "focus should follow moved active pane");
+        assert_eq!(app.windows[0].pane_mru.first().copied(), Some(11), "MRU should be the focused pane id after swap");
     }
 }
 

--- a/tests-rs/test_issue383_swap_pane_targets.rs
+++ b/tests-rs/test_issue383_swap_pane_targets.rs
@@ -1,0 +1,32 @@
+use super::*;
+
+fn make_window(name: &str, id: usize) -> crate::types::Window {
+    crate::types::Window {
+        root: Node::Split { kind: LayoutKind::Horizontal, sizes: vec![], children: vec![] },
+        active_path: vec![],
+        name: name.to_string(),
+        id,
+        activity_flag: false,
+        bell_flag: false,
+        silence_flag: false,
+        last_output_time: std::time::Instant::now(),
+        last_seen_version: 0,
+        manual_rename: false,
+        layout_index: 0,
+        pane_mru: vec![],
+        zoom_saved: None,
+        linked_from: None,
+    }
+}
+
+#[test]
+fn swap_pane_target_below_pane_base_index_is_invalid() {
+    let mut app = AppState::new("issue383".to_string());
+    app.pane_base_index = 1;
+    app.windows.push(make_window("w0", 0));
+    app.active_idx = 0;
+
+    // Regression guard: `.0` must not saturate to pane 0 when pane-base-index=1.
+    let path = resolve_swap_pane_target_path(&app, ".0");
+    assert!(path.is_none(), "target below pane-base-index should be rejected");
+}


### PR DESCRIPTION
## Summary
- prevent invalid `swap-pane -t` pane indexes from silently mapping to pane 0 by using checked base-index normalization
- update swap MRU behavior to track the pane that remains focused after swap, and only fire swap metadata/hook updates when a swap actually occurs
- surface unresolved `swap-pane -t` errors through `status_message` so failures are visible in TUI mode, and add a regression test for pane-base-index underflow

## Test plan
- [ ] Run CI pipeline for this branch
- [ ] Verify `swap-pane -t .0` with `pane-base-index 1` reports an error and does not swap
- [ ] Verify MRU ordering follows focused pane after both directional swap and `-t` swap
- [ ] Verify unresolved `-t` target error is visible in the psmux status line

Made with [Cursor](https://cursor.com)