### PR TITLE
fix(#381) Improve fullscreen TUI detection by excluding shell processes

### DIFF
--- a/src/window_ops.rs
+++ b/src/window_ops.rs
@@ -158,6 +158,17 @@ pub(crate) fn is_fullscreen_tui(pane: &Pane) -> bool {
         if screen.alternate_screen() {
             return true;
         }
+
+        // Check if forground process is a shell program
+        let forground_is_shell = pane
+            .child_pid
+            .and_then(crate::platform::process_info::foreground_is_shell)
+            .is_some();
+
+        if forground_is_shell {
+            return false;
+        }
+
         // Heuristic: check if many of the last rows are non-blank AND the
         // cursor is near the bottom.  Fullscreen TUI apps fill the entire
         // screen and keep the cursor near the bottom (status bars, menus).


### PR DESCRIPTION
This fixes an issue where Git Bash was incorrectly detected as a fullscreen TUI application. I added a check to see if the foreground process is a shell program before the heuristic logic is run. This way shell programs cannot be misclassified as full screen TUI apps.  

fixes #381 