### PR TITLE
fix(config): strip inline # comments from config lines (#416)

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -598,10 +598,58 @@ pub(crate) fn is_known_command(app: &AppState, name: &str) -> bool {
     })
 }
 
+/// Strip a trailing `# comment` from a single config line.
+///
+/// In tmux a `#` begins a comment only when it is unquoted and appears at the
+/// start of the line or immediately after whitespace. A `#` inside single or
+/// double quotes (e.g. a `"#{...}"` format or `'#H'`), one escaped with a
+/// backslash, or one in the middle of a word (e.g. `colour#aabbcc`) is left
+/// untouched. This lets configs use trailing comments such as:
+///
+/// ```text
+/// set -g base-index 1   # start windows at 1
+/// ```
+///
+/// Issue #416.
+fn strip_inline_comment(line: &str) -> &str {
+    let bytes = line.as_bytes();
+    let mut in_single = false;
+    let mut in_double = false;
+    let mut prev_ws = true; // start of line behaves like a word boundary
+    let mut i = 0;
+    while i < bytes.len() {
+        match bytes[i] {
+            // Backslash escapes the next byte (outside single quotes), matching
+            // tmux's tokeniser. Skip both bytes so an escaped `#` stays literal.
+            b'\\' if !in_single => {
+                i += 2;
+                prev_ws = false;
+                continue;
+            }
+            b'\'' if !in_double => in_single = !in_single,
+            b'"' if !in_single => in_double = !in_double,
+            b'#' if !in_single && !in_double && prev_ws => {
+                return line[..i].trim_end();
+            }
+            _ => {}
+        }
+        prev_ws = matches!(bytes[i], b' ' | b'\t');
+        i += 1;
+    }
+    line
+}
+
 pub fn parse_config_line(app: &mut AppState, line: &str) {
     let l = line.trim();
     if l.is_empty() || l.starts_with('#') { return; }
-    
+
+    // Strip a trailing inline `# comment` (issue #416). Done after the
+    // leading-`#` check above so whole-line comments are still skipped, and
+    // before any directive dispatch so trailing comments don't leak into
+    // command arguments.
+    let l = strip_inline_comment(l).trim_end();
+    if l.is_empty() { return; }
+
     let l = if l.ends_with('\\') {
         l.trim_end_matches('\\').trim()
     } else {
@@ -2077,3 +2125,7 @@ mod tests_issue362_config_new_session;
 #[cfg(test)]
 #[path = "../tests-rs/test_issue370_config_warnings.rs"]
 mod tests_issue370_config_warnings;
+
+#[cfg(test)]
+#[path = "../tests-rs/test_issue416_inline_comments.rs"]
+mod tests_issue416_inline_comments;

--- a/tests-rs/test_issue416_inline_comments.rs
+++ b/tests-rs/test_issue416_inline_comments.rs
@@ -1,0 +1,125 @@
+// Tests for issue #416: a trailing inline `# comment` on a config line
+// broke parsing.
+//
+// The config executor only skipped whole-line comments (lines whose first
+// non-whitespace char is `#`). A line like `set -g base-index 1   # test`
+// was handed verbatim to the option parser, so the directive never took
+// effect — while the same line without the comment worked.
+//
+// `strip_inline_comment` removes an unquoted, whitespace-preceded `#`
+// comment while preserving a `#` inside quotes (formats like "#{...}"),
+// an escaped `\#`, and a mid-word `#` (e.g. a `colour#aabbcc` token).
+
+use super::*;
+
+fn mock_app() -> AppState {
+    AppState::new("test_session".to_string())
+}
+
+// ── strip_inline_comment unit behaviour ───────────────────────────
+
+#[test]
+fn strips_trailing_comment_after_whitespace() {
+    assert_eq!(
+        strip_inline_comment("set -g base-index 1   # test"),
+        "set -g base-index 1"
+    );
+}
+
+#[test]
+fn strips_comment_with_single_space() {
+    assert_eq!(
+        strip_inline_comment("set -g base-index 1 #c"),
+        "set -g base-index 1"
+    );
+}
+
+#[test]
+fn keeps_line_without_comment() {
+    assert_eq!(
+        strip_inline_comment("set -g base-index 1"),
+        "set -g base-index 1"
+    );
+}
+
+#[test]
+fn preserves_hash_inside_double_quotes() {
+    let line = r#"set -g status-left "#H session""#;
+    assert_eq!(strip_inline_comment(line), line);
+}
+
+#[test]
+fn preserves_hash_inside_single_quotes() {
+    let line = "set -g status-right '#{session_name}'";
+    assert_eq!(strip_inline_comment(line), line);
+}
+
+#[test]
+fn strips_comment_after_quoted_value() {
+    assert_eq!(
+        strip_inline_comment(r#"set -g status-left "#H"   # hostname"#),
+        r#"set -g status-left "#H""#
+    );
+}
+
+#[test]
+fn preserves_mid_word_hash() {
+    // An unquoted `#` that is not preceded by whitespace is part of the token
+    // (matching tmux), so it is not a comment.
+    assert_eq!(
+        strip_inline_comment("set -g foo bar#baz"),
+        "set -g foo bar#baz"
+    );
+}
+
+#[test]
+fn preserves_escaped_hash() {
+    assert_eq!(
+        strip_inline_comment(r"send-keys \# Enter"),
+        r"send-keys \# Enter"
+    );
+}
+
+#[test]
+fn whole_line_comment_strips_to_empty() {
+    // Leading `#`: the start of line is treated as a word boundary, so the
+    // entire line is a comment.
+    assert_eq!(strip_inline_comment("# a comment"), "");
+}
+
+// ── end-to-end: directives take effect despite a trailing comment ──
+
+#[test]
+fn inline_comment_does_not_break_set_option() {
+    let mut app = mock_app();
+    parse_config_content(&mut app, "set -g base-index 1   # test\n");
+    assert_eq!(
+        app.window_base_index, 1,
+        "base-index should be 1 with a trailing inline comment"
+    );
+}
+
+#[test]
+fn inline_comment_matches_no_comment_behaviour() {
+    let mut with_comment = mock_app();
+    parse_config_content(&mut with_comment, "set -g pane-base-index 1  # comment\n");
+
+    let mut without_comment = mock_app();
+    parse_config_content(&mut without_comment, "set -g pane-base-index 1\n");
+
+    assert_eq!(with_comment.pane_base_index, without_comment.pane_base_index);
+    assert_eq!(with_comment.pane_base_index, 1);
+}
+
+#[test]
+fn quoted_format_value_survives_comment_stripping() {
+    let mut app = mock_app();
+    parse_config_content(
+        &mut app,
+        r#"set -g status-left "#{session_name}"  # show session"#,
+    );
+    assert_eq!(
+        app.status_left, "#{session_name}",
+        "a quoted #{{...}} format must not be truncated by comment stripping"
+    );
+}


### PR DESCRIPTION
Fixes #416.

## Problem

The config executor only skipped *whole-line* comments (lines whose first non-whitespace character is `#`). A line with a trailing comment such as:

```conf
set -g base-index 1   # test
```

was handed verbatim to the option parser, so the directive silently had no effect — while the same line without the comment worked.

## Fix

Add `strip_inline_comment`, applied in `parse_config_line` right after the leading-`#` check. It removes an **unquoted, whitespace-preceded** `#` comment while preserving, to match tmux's tokeniser:

- `#` inside single or double quotes (e.g. a `"#{...}"` format string),
- an escaped `\#`, and
- a mid-word `#` (e.g. a `colour#aabbcc` token).

Because `parse_config_line` is the single choke point for executing config directives (config load, `source-file`, brace `if-shell` blocks, and bind-dispatched commands), the fix applies consistently everywhere a config line is run.

## Tests

`tests-rs/test_issue416_inline_comments.rs` covers the stripper directly (quotes, escapes, mid-word `#`, whole-line comment) and the end-to-end case that `set -g base-index 1   # test` now takes effect and matches the no-comment behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)