### PR TITLE
fix(attach): honour -t target instead of last_session (#408)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -671,15 +671,20 @@ fn run_main() -> io::Result<()> {
                 // otherwise argv[0] (the exe path or subcommand name) gets
                 // picked up as the target session name.
                 let sub_args: Vec<&String> = cmd_args.iter().skip(1).copied().collect();
-                let name = sub_args
+                // `-t` and its value are stripped from cmd_args (and therefore
+                // sub_args) by the global flag handling above, so resolve the
+                // target from the original argv. Without this, `attach -t NAME`
+                // fell through to the last_session fallback and ignored the
+                // requested target (#408).
+                let name = args
                     .iter()
-                    .position(|a| *a == "-t")
-                    .and_then(|i| sub_args.get(i + 1))
+                    .position(|a| a == "-t")
+                    .and_then(|i| args.get(i + 1))
                     .map(|s| {
                         if let Some(ref l) = l_socket_name {
                             format!("{}__{}", l, s)
                         } else {
-                            (*s).clone()
+                            s.clone()
                         }
                     })
                     .or_else(|| {

--- a/src/main.rs
+++ b/src/main.rs
@@ -672,21 +672,19 @@ fn run_main() -> io::Result<()> {
                 // picked up as the target session name.
                 let sub_args: Vec<&String> = cmd_args.iter().skip(1).copied().collect();
                 // `-t` and its value are stripped from cmd_args (and therefore
-                // sub_args) by the global flag handling above, so resolve the
-                // target from the original argv. Without this, `attach -t NAME`
-                // fell through to the last_session fallback and ignored the
-                // requested target (#408).
-                let name = args
-                    .iter()
-                    .position(|a| a == "-t")
-                    .and_then(|i| args.get(i + 1))
-                    .map(|s| {
-                        if let Some(ref l) = l_socket_name {
-                            format!("{}__{}", l, s)
-                        } else {
-                            s.clone()
-                        }
-                    })
+                // sub_args) by the global flag handling above, so the lookup
+                // below never saw it and `attach -t NAME` fell through to the
+                // last_session fallback (#408). When `-t` is present, prefer the
+                // target the global parser already resolved into
+                // PSMUX_TARGET_SESSION: it ran the value through parse_target,
+                // so `session:window`, `$id`, `=exact`, and the `-L` namespace
+                // prefix are all handled (a raw argv value would keep a
+                // `:window` suffix and fail the port-file lookup).
+                let name = (if args.iter().any(|a| a == "-t") {
+                    env::var("PSMUX_TARGET_SESSION").ok().filter(|s| !s.is_empty())
+                } else {
+                    None
+                })
                     .or_else(|| {
                         // Accept positional argument as target session name
                         // (e.g. "psmux attach work" without -t flag)

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -5228,6 +5228,10 @@ mod test_pane_title;
 mod test_issue202;
 
 #[cfg(test)]
+#[path = "../../tests-rs/test_issue408_attach_target.rs"]
+mod test_issue408_attach_target;
+
+#[cfg(test)]
 #[path = "../../tests-rs/test_new_session_env.rs"]
 mod test_new_session_env;
 

--- a/tests-rs/test_issue408_attach_target.rs
+++ b/tests-rs/test_issue408_attach_target.rs
@@ -1,0 +1,103 @@
+// Tests for issue #408: `attach-session -t <name>` ignored the requested
+// target and attached to last_session instead.
+//
+// Root cause: the global flag handling strips `-t` (and its value) from the
+// post-subcommand argv (`cmd_args` / `sub_args`). The attach handler then
+// looked for `-t` in those stripped args, never found it, and fell through
+// to the last_session fallback.
+//
+// Fix: resolve `-t` from the original argv. These tests replicate the
+// attach-target resolution logic from main.rs (same approach as
+// test_issue202_switch_client.rs) and prove the old code was buggy.
+
+/// Mirrors the post-fix attach-target resolution in main.rs:
+///   `-t` from the full argv  ->  positional name  ->  last_session  ->  "0"
+fn resolve_attach_target(
+    full_args: &[&str],
+    sub_args: &[&str],
+    l_socket: Option<&str>,
+    last_session: Option<&str>,
+) -> String {
+    let pref = |s: &str| match l_socket {
+        Some(l) => format!("{}__{}", l, s),
+        None => s.to_string(),
+    };
+    full_args
+        .iter()
+        .position(|a| *a == "-t")
+        .and_then(|i| full_args.get(i + 1))
+        .map(|s| pref(s))
+        // Positional target comes from the post-subcommand args.
+        .or_else(|| sub_args.iter().find(|a| !a.starts_with('-')).map(|a| pref(a)))
+        .or_else(|| last_session.map(|s| s.to_string()))
+        .unwrap_or_else(|| "0".to_string())
+}
+
+/// The OLD (buggy) logic looked for `-t` in the post-subcommand args, where
+/// it had already been stripped — so an explicit `-t` was lost.
+fn resolve_attach_target_old(
+    sub_args: &[&str],
+    last_session: Option<&str>,
+) -> String {
+    sub_args
+        .iter()
+        .position(|a| *a == "-t")
+        .and_then(|i| sub_args.get(i + 1))
+        .map(|s| s.to_string())
+        .or_else(|| sub_args.iter().find(|a| !a.starts_with('-')).map(|a| a.to_string()))
+        .or_else(|| last_session.map(|s| s.to_string()))
+        .unwrap_or_else(|| "0".to_string())
+}
+
+#[test]
+fn attach_t_honours_target_over_last_session() {
+    // `psmux attach -t A` with last_session = B must attach to A.
+    // The global handler strips `-t A`, so sub_args is empty here.
+    let result = resolve_attach_target(&["psmux", "attach", "-t", "A"], &[], None, Some("B"));
+    assert_eq!(result, "A", "attach -t A must honour the target, not last_session");
+}
+
+#[test]
+fn attach_positional_target_still_works() {
+    // `psmux attach A` (no -t): A is a positional in sub_args.
+    let result = resolve_attach_target(&["psmux", "attach", "A"], &["A"], None, Some("B"));
+    assert_eq!(result, "A");
+}
+
+#[test]
+fn attach_bare_falls_back_to_last_session() {
+    // `psmux attach` with no target uses last_session (unchanged behaviour).
+    let result = resolve_attach_target(&["psmux", "attach"], &[], None, Some("B"));
+    assert_eq!(result, "B");
+}
+
+#[test]
+fn attach_bare_no_last_session_uses_default_index() {
+    let result = resolve_attach_target(&["psmux", "attach"], &[], None, None);
+    assert_eq!(result, "0");
+}
+
+#[test]
+fn attach_t_applies_socket_namespace_prefix() {
+    // `psmux -L work attach -t A` resolves to the namespaced base name.
+    let result = resolve_attach_target(
+        &["psmux", "-L", "work", "attach", "-t", "A"],
+        &[],
+        Some("work"),
+        Some("B"),
+    );
+    assert_eq!(result, "work__A");
+}
+
+#[test]
+fn regression_old_code_attached_to_last_session() {
+    // Proof of the bug: with `-t A` stripped from sub_args, the old logic
+    // returned last_session (B) instead of A.
+    let old = resolve_attach_target_old(&[], Some("B"));
+    assert_eq!(old, "B", "old code ignored -t and used last_session");
+
+    // The fixed logic returns A for the same invocation.
+    let new = resolve_attach_target(&["psmux", "attach", "-t", "A"], &[], None, Some("B"));
+    assert_eq!(new, "A");
+    assert_ne!(old, new, "fix must change the resolved target");
+}

--- a/tests-rs/test_issue408_attach_target.rs
+++ b/tests-rs/test_issue408_attach_target.rs
@@ -6,39 +6,40 @@
 // looked for `-t` in those stripped args, never found it, and fell through
 // to the last_session fallback.
 //
-// Fix: resolve `-t` from the original argv. These tests replicate the
-// attach-target resolution logic from main.rs (same approach as
-// test_issue202_switch_client.rs) and prove the old code was buggy.
+// Fix: when `-t` is present, use the target the global parser already
+// resolved into PSMUX_TARGET_SESSION (it ran the value through parse_target,
+// so `session:window`, `$id`, `=exact`, and the `-L` namespace prefix are
+// handled). These tests replicate the resolution decision from main.rs
+// (same approach as test_issue202_switch_client.rs) and prove the old code
+// was buggy.
 
 /// Mirrors the post-fix attach-target resolution in main.rs:
-///   `-t` from the full argv  ->  positional name  ->  last_session  ->  "0"
+///   if `-t` present -> PSMUX_TARGET_SESSION  (parse_target result)
+///   else            -> positional name  ->  last_session  ->  "0"
+///
+/// `target_session` models PSMUX_TARGET_SESSION, which already holds the
+/// parse_target-resolved, `-L`-prefixed session base name.
 fn resolve_attach_target(
-    full_args: &[&str],
+    has_t_flag: bool,
+    target_session: Option<&str>,
     sub_args: &[&str],
-    l_socket: Option<&str>,
     last_session: Option<&str>,
 ) -> String {
-    let pref = |s: &str| match l_socket {
-        Some(l) => format!("{}__{}", l, s),
-        None => s.to_string(),
-    };
-    full_args
-        .iter()
-        .position(|a| *a == "-t")
-        .and_then(|i| full_args.get(i + 1))
-        .map(|s| pref(s))
-        // Positional target comes from the post-subcommand args.
-        .or_else(|| sub_args.iter().find(|a| !a.starts_with('-')).map(|a| pref(a)))
-        .or_else(|| last_session.map(|s| s.to_string()))
-        .unwrap_or_else(|| "0".to_string())
+    (if has_t_flag {
+        target_session.map(|s| s.to_string()).filter(|s| !s.is_empty())
+    } else {
+        None
+    })
+    // Positional target comes from the post-subcommand args.
+    .or_else(|| sub_args.iter().find(|a| !a.starts_with('-')).map(|a| a.to_string()))
+    .or_else(|| last_session.map(|s| s.to_string()))
+    .unwrap_or_else(|| "0".to_string())
 }
 
 /// The OLD (buggy) logic looked for `-t` in the post-subcommand args, where
-/// it had already been stripped — so an explicit `-t` was lost.
-fn resolve_attach_target_old(
-    sub_args: &[&str],
-    last_session: Option<&str>,
-) -> String {
+/// it had already been stripped — so an explicit `-t` was lost and it fell
+/// through to last_session.
+fn resolve_attach_target_old(sub_args: &[&str], last_session: Option<&str>) -> String {
     sub_args
         .iter()
         .position(|a| *a == "-t")
@@ -52,41 +53,55 @@ fn resolve_attach_target_old(
 #[test]
 fn attach_t_honours_target_over_last_session() {
     // `psmux attach -t A` with last_session = B must attach to A.
-    // The global handler strips `-t A`, so sub_args is empty here.
-    let result = resolve_attach_target(&["psmux", "attach", "-t", "A"], &[], None, Some("B"));
+    let result = resolve_attach_target(true, Some("A"), &[], Some("B"));
     assert_eq!(result, "A", "attach -t A must honour the target, not last_session");
+}
+
+#[test]
+fn attach_t_session_window_resolves_to_session_only() {
+    // `psmux attach -t A:1` — the global parser's parse_target extracts the
+    // session ("A") into PSMUX_TARGET_SESSION; the `:1` window suffix must NOT
+    // leak into the session name (a raw argv value would, breaking the port
+    // lookup).
+    let result = resolve_attach_target(true, Some("A"), &[], Some("B"));
+    assert_eq!(result, "A", "attach -t A:1 must resolve to session A");
 }
 
 #[test]
 fn attach_positional_target_still_works() {
     // `psmux attach A` (no -t): A is a positional in sub_args.
-    let result = resolve_attach_target(&["psmux", "attach", "A"], &["A"], None, Some("B"));
+    let result = resolve_attach_target(false, None, &["A"], Some("B"));
     assert_eq!(result, "A");
 }
 
 #[test]
 fn attach_bare_falls_back_to_last_session() {
     // `psmux attach` with no target uses last_session (unchanged behaviour).
-    let result = resolve_attach_target(&["psmux", "attach"], &[], None, Some("B"));
+    let result = resolve_attach_target(false, None, &[], Some("B"));
     assert_eq!(result, "B");
 }
 
 #[test]
 fn attach_bare_no_last_session_uses_default_index() {
-    let result = resolve_attach_target(&["psmux", "attach"], &[], None, None);
+    let result = resolve_attach_target(false, None, &[], None);
     assert_eq!(result, "0");
 }
 
 #[test]
 fn attach_t_applies_socket_namespace_prefix() {
-    // `psmux -L work attach -t A` resolves to the namespaced base name.
-    let result = resolve_attach_target(
-        &["psmux", "-L", "work", "attach", "-t", "A"],
-        &[],
-        Some("work"),
-        Some("B"),
-    );
+    // `psmux -L work attach -t A`: PSMUX_TARGET_SESSION is already the
+    // namespaced base name "work__A".
+    let result = resolve_attach_target(true, Some("work__A"), &[], Some("B"));
     assert_eq!(result, "work__A");
+}
+
+#[test]
+fn attach_t_pane_only_target_falls_through() {
+    // `psmux attach -t %2` has no explicit session, so PSMUX_TARGET_SESSION is
+    // never set — resolution falls through to last_session (unchanged, not a
+    // regression).
+    let result = resolve_attach_target(true, None, &[], Some("B"));
+    assert_eq!(result, "B");
 }
 
 #[test]
@@ -97,7 +112,7 @@ fn regression_old_code_attached_to_last_session() {
     assert_eq!(old, "B", "old code ignored -t and used last_session");
 
     // The fixed logic returns A for the same invocation.
-    let new = resolve_attach_target(&["psmux", "attach", "-t", "A"], &[], None, Some("B"));
+    let new = resolve_attach_target(true, Some("A"), &[], Some("B"));
     assert_eq!(new, "A");
     assert_ne!(old, new, "fix must change the resolved target");
 }


### PR DESCRIPTION
Fixes #408.

## Problem

`attach-session -t <name>` ignored the requested target and attached to whatever session was recorded in `~/.psmux/last_session`:

```
psmux new -d -s A
psmux new -d -s B        # last_session becomes B
psmux attach -t A        # -> attaches to B, not A
```

## Root cause

The global flag handling in `main()` strips `-t` **and its value** from the post-subcommand argv (`cmd_args`, and thus `sub_args`). The attach handler then looked for `-t` in those already-stripped args, never found it, and fell through to the `resolve_last_session_name_ns` fallback.

## Fix

When `-t` is present, use the target the global parser already resolved into `PSMUX_TARGET_SESSION`. That value comes from `parse_target`, so it correctly:

- extracts the session from a `session:window` form (`A:1` → `A`) — a raw argv value would keep the `:1` suffix and fail the `A:1.port` lookup,
- resolves `$id` and `=exact` targets, and
- carries the `-L` namespace prefix.

Both attach paths key the port-file lookup off `PSMUX_SESSION_NAME` (= this resolved name): remote/SSH at `client.rs` and local at `main.rs`. Positional (`attach NAME`), bare `attach` (→ last_session), and pane-only targets (`-t %2`, no explicit session → falls through) are unchanged.

## Tests

`tests-rs/test_issue408_attach_target.rs` replicates the resolution decision (same pattern as `test_issue202_switch_client.rs`): `-t` target, the `session:window` form, `-L` namespace, positional, bare, pane-only fall-through, and a regression test proving the old code returned `last_session` for `attach -t A`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)