### PR TITLE
feat(choose-tree): kill highlighted window with 'x' (#410)

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -3032,6 +3032,32 @@ pub fn run_remote(terminal: &mut Terminal<CrosstermBackend<crate::platform::Psmu
                                 KeyCode::Char('p') if tree_chooser => {
                                     preview_enabled = !preview_enabled;
                                 }
+                                // 'x' kills the highlighted window, mirroring the
+                                // session chooser's 'x' (issue #410). The window is
+                                // focused first so the kill targets it. Scoped to a
+                                // window row in the current session — session headers
+                                // (wid == usize::MAX), pane rows, and rows from other
+                                // sessions fall through to the catch-all below.
+                                KeyCode::Char('x') if tree_chooser => {
+                                    let sel_idx: Option<usize> = if tree_num_buffer.is_empty() {
+                                        Some(tree_selected)
+                                    } else {
+                                        match tree_num_buffer.parse::<usize>() {
+                                            Ok(n) if n >= 1 && n <= tree_entries.len() => Some(n - 1),
+                                            _ => None,
+                                        }
+                                    };
+                                    if let Some((is_win, wid, _pid, _label, sess_name)) =
+                                        sel_idx.and_then(|i| tree_entries.get(i))
+                                    {
+                                        if *is_win && *wid != usize::MAX && *sess_name == current_session {
+                                            cmd_batch.push(format!("focus-window {}\n", wid));
+                                            cmd_batch.push("kill-window\n".into());
+                                            tree_chooser = false;
+                                            tree_num_buffer.clear();
+                                        }
+                                    }
+                                }
                                 KeyCode::Char(c) if tree_chooser && c.is_ascii_digit() => {
                                     // Append to the digit-jump buffer; Enter consumes it.
                                     if tree_num_buffer.len() < 6 {


### PR DESCRIPTION
Fixes #410.

## Problem

The window picker (`choose-tree`) absorbed every non-navigation key, so there was no way to kill a window from it — only the **session** chooser had an `x` binding (which kills sessions). Users could navigate windows but not delete them.

## Fix

Add an `x` arm to the tree chooser, mirroring the existing session-chooser `x`: it focuses the highlighted window and then kills it (`focus-window <id>` + `kill-window`, since there is no kill-window-by-id control verb but `focus-window <id>` is already wired and `kill-window` targets the active window).

Scope and behaviour:
- Acts only on a **window row in the current session**. Session headers (`wid == usize::MAX`), pane rows, and rows belonging to other sessions fall through to the existing catch-all and are ignored (killing across sessions would require routing to another server — left for a follow-up).
- Honours the digit-jump buffer for target selection, same as `Enter`.
- Closes the picker after the kill.

## Testing

This lives in the client's inline key-event loop (no pure handler to unit-test, consistent with the rest of the chooser logic), so it is verified by compilation + manual use: open `choose-tree`, highlight a window, press `x`, and the window is removed. The change only adds a new match arm ahead of the existing no-op catch-all, so navigation and `Enter` behaviour are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)