### PR TITLE
fix(server): reap ghost clients by making ClientDetach idempotent + reaping from the writer Guard

### DIFF
--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -282,21 +282,31 @@ if line.trim() == "PERSISTENT" {
         Ok(s) => s,
         Err(_) => return,
     };
+    // Clone the CtrlReq sender so the writer thread's Guard can reap this
+    // client from the server's registry when the connection tears down —
+    // regardless of whether the reader loop or the writer noticed the death.
+    let tx_guard = tx.clone();
     std::thread::spawn(move || {
         // Deregister the frame channel and shut down the TCP connection when
         // this thread exits for any reason (write timeout, resp_rx disconnect,
         // etc.). The shutdown causes the client's reader thread to see EOF,
         // which triggers reconnect rather than leaving the client frozen.
-        struct Guard { client_id: u64, shutdown: std::net::TcpStream }
+        struct Guard { client_id: u64, shutdown: std::net::TcpStream, tx: mpsc::Sender<CtrlReq> }
         impl Drop for Guard {
             fn drop(&mut self) {
                 let _ = self.shutdown.shutdown(std::net::Shutdown::Both);
                 crate::types::deregister_frame_channel(self.client_id);
                 crate::types::remove_directive_channel(self.client_id);
                 crate::types::deregister_persistent_stream(self.client_id);
+                // Reap the client-registry entry. The reader loop also sends
+                // this on EOF; ClientDetach is idempotent (it no-ops when the
+                // entry is already gone), so doing it here too guarantees a
+                // ClientInfo is never orphaned when the writer is the thread
+                // that observes the disconnect (the ghost-client leak).
+                let _ = self.tx.send(CtrlReq::ClientDetach(self.client_id));
             }
         }
-        let _guard = Guard { client_id, shutdown: ws_shutdown };
+        let _guard = Guard { client_id, shutdown: ws_shutdown, tx: tx_guard };
 
         loop {
             // Each iteration drains all three sources in priority order

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1604,33 +1604,33 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                     }
                 }
                 CtrlReq::ClientDetach(cid) => {
-                    app.attached_clients = app.attached_clients.saturating_sub(1);
-                    app.client_sizes.remove(&cid);
-                    app.client_registry.remove(&cid);
-                    app.client_prefix_active = false;
-                    if app.latest_client_id == Some(cid) {
-                        app.latest_client_id = None;
-                    }
-                    // Recompute effective size from remaining clients
-                    if let Some((w, h)) = compute_effective_client_size(&app) {
-                        app.last_window_area = Rect { x: 0, y: 0, width: w, height: h };
-                        resize_all_panes(&mut app);
-                    }
-                    hook_event = Some("client-detached");
-                    if app.attached_clients == 0 && app.destroy_unattached {
-                        let home = env::var("USERPROFILE").or_else(|_| env::var("HOME")).unwrap_or_default();
-                        let regpath = format!("{}\\.psmux\\{}.port", home, app.port_file_base());
-                        let keypath = format!("{}\\.psmux\\{}.key", home, app.port_file_base());
-                        let _ = std::fs::remove_file(&regpath);
-                        let _ = std::fs::remove_file(&keypath);
-                        crate::session::remove_session_id_file(&app.port_file_base());
-                        crate::types::shutdown_persistent_streams();
-                        tree::kill_all_children_batch(&mut app.windows);
-                        if let Some(mut wp) = app.warm_pane.take() {
-                            wp.child.kill().ok();
+                    // Idempotent reap (see AppState::reap_client): only run the
+                    // detach side effects when this client was actually present,
+                    // so a duplicate detach (reader EOF + writer Guard teardown,
+                    // or a detach-client racing the socket close) can't
+                    // over-decrement attached_clients or fire destroy twice.
+                    if app.reap_client(cid) {
+                        // Recompute effective size from remaining clients
+                        if let Some((w, h)) = compute_effective_client_size(&app) {
+                            app.last_window_area = Rect { x: 0, y: 0, width: w, height: h };
+                            resize_all_panes(&mut app);
                         }
-                        std::thread::sleep(std::time::Duration::from_millis(10));
-                        std::process::exit(0);
+                        hook_event = Some("client-detached");
+                        if app.attached_clients == 0 && app.destroy_unattached {
+                            let home = env::var("USERPROFILE").or_else(|_| env::var("HOME")).unwrap_or_default();
+                            let regpath = format!("{}\\.psmux\\{}.port", home, app.port_file_base());
+                            let keypath = format!("{}\\.psmux\\{}.key", home, app.port_file_base());
+                            let _ = std::fs::remove_file(&regpath);
+                            let _ = std::fs::remove_file(&keypath);
+                            crate::session::remove_session_id_file(&app.port_file_base());
+                            crate::types::shutdown_persistent_streams();
+                            tree::kill_all_children_batch(&mut app.windows);
+                            if let Some(mut wp) = app.warm_pane.take() {
+                                wp.child.kill().ok();
+                            }
+                            std::thread::sleep(std::time::Duration::from_millis(10));
+                            std::process::exit(0);
+                        }
                     }
                 }
                 CtrlReq::DumpLayout(resp) => {

--- a/src/types.rs
+++ b/src/types.rs
@@ -702,6 +702,36 @@ pub struct AppState {
 }
 
 impl AppState {
+    /// Idempotently reap a client from the registry.
+    ///
+    /// Returns `true` iff the client was present (and thus `attached_clients`
+    /// and the prefix/latest-client bookkeeping were updated). A client's
+    /// connection is torn down by whichever of its two server-side threads
+    /// notices the disconnect first — the reader loop (socket EOF) OR the
+    /// writer thread's `Guard` — and a `detach-client` command can race the
+    /// socket close as well. Because this only mutates state when the entry is
+    /// actually removed, calling it more than once for the same `cid` is a safe
+    /// no-op: `attached_clients` can never be over-decremented (which used to
+    /// leave `attached=0` while real clients remained) and the caller's
+    /// destroy-unattached path can never fire twice. Conversely, a dropped
+    /// reap used to orphan a `ClientInfo` forever — the ghost-client leak —
+    /// which routing the reap through the always-firing `Guard` now prevents.
+    pub fn reap_client(&mut self, cid: u64) -> bool {
+        // client_sizes is always cleared (a stale size entry must never linger);
+        // the registry entry + counter bookkeeping only change when present.
+        self.client_sizes.remove(&cid);
+        if self.client_registry.remove(&cid).is_some() {
+            self.attached_clients = self.attached_clients.saturating_sub(1);
+            self.client_prefix_active = false;
+            if self.latest_client_id == Some(cid) {
+                self.latest_client_id = None;
+            }
+            true
+        } else {
+            false
+        }
+    }
+
     /// Create a new AppState with sensible defaults.
     /// Caller should set `session_name` and call `load_config()` after construction.
     pub fn new(session_name: String) -> Self {

--- a/tests-rs/test_issue275_detach_client.rs
+++ b/tests-rs/test_issue275_detach_client.rs
@@ -194,6 +194,154 @@ fn detach_last_client_without_destroy_unattached_does_not_signal_shutdown() {
 }
 
 // ════════════════════════════════════════════════════════════════════════════
+//  Idempotent reap (ghost-client leak fix) — exercises the REAL AppState method
+//  that the ClientDetach handler and the writer-thread Guard both call.
+// ════════════════════════════════════════════════════════════════════════════
+
+/// A first reap removes the client and decrements the counter, returning true.
+#[test]
+fn reap_client_first_call_removes_and_reports_present() {
+    let mut app = mock_app();
+    add_client(&mut app, 1, "/dev/pts/1");
+    add_client(&mut app, 2, "/dev/pts/2");
+
+    assert!(app.reap_client(2), "present client → reap reports true");
+    assert!(!app.client_registry.contains_key(&2));
+    assert_eq!(app.attached_clients, 1, "exactly one decrement");
+}
+
+/// Reaping the SAME client twice must be a safe no-op the second time — the
+/// core of the fix. A connection is torn down by whichever of its two threads
+/// (reader loop / writer Guard) notices death first; both call this. Without
+/// idempotency the second call would over-decrement attached_clients.
+#[test]
+fn reap_client_is_idempotent_no_double_decrement() {
+    let mut app = mock_app();
+    add_client(&mut app, 1, "/dev/pts/1");
+    add_client(&mut app, 2, "/dev/pts/2");
+
+    assert!(app.reap_client(1), "first reap of client 1 → true");
+    assert!(!app.reap_client(1), "second reap of client 1 → false (already gone)");
+
+    // client 2 must still be counted; attached_clients must not underflow past it.
+    assert_eq!(app.attached_clients, 1, "double reap must not over-decrement");
+    assert!(app.client_registry.contains_key(&2), "unrelated client untouched");
+}
+
+/// Regression for the counter/registry desync: a duplicate detach used to drop
+/// attached_clients to 0 while real client entries remained, so `list-clients`
+/// showed clients while `session_attached` read 0. With the guard, the count
+/// always matches the registry size.
+#[test]
+fn reap_client_keeps_counter_consistent_with_registry() {
+    let mut app = mock_app();
+    add_client(&mut app, 1, "/dev/pts/1");
+    add_client(&mut app, 2, "/dev/pts/2");
+    add_client(&mut app, 3, "/dev/pts/3");
+
+    // Client 2 dies; both of its threads fire a reap for the same cid.
+    let _ = app.reap_client(2);
+    let _ = app.reap_client(2);
+
+    assert_eq!(app.client_registry.len(), 2, "two real clients remain");
+    assert_eq!(app.attached_clients, app.client_registry.len(),
+        "attached_clients must equal registry size (never 0-while-clients-remain)");
+}
+
+/// Reaping a client that was never registered is a safe no-op that reports
+/// false and leaves all counters intact (e.g. a persistent connection whose
+/// writer Guard fires though the client never sent attach-session).
+#[test]
+fn reap_client_unknown_id_is_noop() {
+    let mut app = mock_app();
+    add_client(&mut app, 1, "/dev/pts/1");
+
+    assert!(!app.reap_client(999), "unknown client → reap reports false");
+    assert_eq!(app.client_registry.len(), 1);
+    assert_eq!(app.attached_clients, 1);
+}
+
+/// Reaping the latest_client_id clears it; reaping a different client leaves it.
+#[test]
+fn reap_client_clears_latest_client_id_only_for_that_client() {
+    let mut app = mock_app();
+    add_client(&mut app, 1, "/dev/pts/1");
+    add_client(&mut app, 2, "/dev/pts/2");
+    app.latest_client_id = Some(2);
+
+    assert!(app.reap_client(1));
+    assert_eq!(app.latest_client_id, Some(2), "reaping a different client keeps latest");
+
+    assert!(app.reap_client(2));
+    assert_eq!(app.latest_client_id, None, "reaping the latest client clears it");
+}
+
+/// A real reap clears the shared client_prefix_active flag; a no-op reap of an
+/// absent client leaves it untouched (documents the flag's guarded semantics).
+#[test]
+fn reap_client_clears_prefix_flag_only_on_real_reap() {
+    let mut app = mock_app();
+    add_client(&mut app, 1, "/dev/pts/1");
+    app.client_prefix_active = true;
+    assert!(!app.reap_client(99), "absent client -> no-op");
+    assert!(app.client_prefix_active, "no-op reap must not touch the prefix flag");
+    assert!(app.reap_client(1), "present client -> real reap");
+    assert!(!app.client_prefix_active, "real reap clears the prefix flag");
+}
+
+/// The fix's core promise via reap_client's return value: the destroy-unattached
+/// exit is gated on a REAL reap, so a duplicate detach of the last client cannot
+/// re-satisfy the `attached_clients == 0 && destroy_unattached` condition twice.
+#[test]
+fn reap_client_gates_destroy_unattached_to_a_single_real_reap() {
+    let mut app = mock_app();
+    app.destroy_unattached = true;
+    add_client(&mut app, 1, "/dev/pts/1");
+
+    // First reap is real -> the caller would run the destroy path here.
+    assert!(app.reap_client(1));
+    assert_eq!(app.attached_clients, 0);
+    // The handler's exit gate: attached_clients == 0 && destroy_unattached.
+    assert!(app.attached_clients == 0 && app.destroy_unattached,
+        "first (real) reap leaves the session destroy-eligible");
+
+    // Second reap of the same cid is a no-op -> the caller must NOT re-run destroy.
+    assert!(!app.reap_client(1), "duplicate reap is a no-op (gate not re-triggered by a real reap)");
+    assert_eq!(app.attached_clients, 0, "counter stays at 0, not underflowed");
+}
+
+/// Models the actual connection-teardown path this fix targets: BOTH the reader
+/// loop (socket EOF) and the writer thread's Guard now enqueue `ClientDetach`
+/// for the SAME registered client. The server processes them as two
+/// `reap_client` calls in sequence. This asserts the whole contract the handler
+/// relies on: exactly one registry removal, exactly one `attached_clients`
+/// decrement, and — because the destroy-unattached / `client-detached` hook side
+/// effects run only on a `true` return — those fire exactly once, never twice.
+/// (A full server-loop integration test of the Guard is impractical because the
+/// missed-reap race is timing-dependent; this pins the invariant the fix rests on.)
+#[test]
+fn reap_client_reader_and_writer_duplicate_detach_reaps_once() {
+    let mut app = mock_app();
+    app.destroy_unattached = true;
+    add_client(&mut app, 1, "/dev/pts/1"); // survivor
+    add_client(&mut app, 2, "/dev/pts/2"); // the client whose connection tears down
+    assert_eq!(app.attached_clients, 2);
+
+    // Reader loop observes EOF and enqueues ClientDetach(2).
+    let reader_side_effects = app.reap_client(2);
+    // Writer Guard also enqueues ClientDetach(2) for the same connection.
+    let writer_side_effects = app.reap_client(2);
+
+    assert!(reader_side_effects, "first (reader) reap is real -> side effects run once");
+    assert!(!writer_side_effects, "second (writer Guard) reap is a no-op -> side effects do NOT run again");
+    assert_eq!(app.client_registry.len(), 1, "exactly one registry removal");
+    assert!(app.client_registry.contains_key(&1), "survivor untouched");
+    assert_eq!(app.attached_clients, 1, "exactly one decrement; survivor still counted (not 0, no destroy)");
+    assert!(!(app.attached_clients == 0 && app.destroy_unattached),
+        "survivor remains -> destroy-unattached gate is NOT satisfied");
+}
+
+// ════════════════════════════════════════════════════════════════════════════
 //  CLI flag-parsing tests (mirror the parser in main.rs detach-client branch)
 // ════════════════════════════════════════════════════════════════════════════
 


### PR DESCRIPTION
## What

Reaps **ghost clients** and fixes an `attached_clients` **over-decrement** desync. Closes #434.

A persistent attach connection is served by a reader loop (reaps the client on socket EOF) and a
writer thread whose `Guard` tears the connection down on any writer exit. Only the reader enqueued
`ClientDetach`, so when a teardown was observed only by the writer path the client's `ClientInfo` was
left **orphaned** and lingered in `list-clients` forever (a "ghost client"; reconnect churn amplifies
it since each new connection gets a fresh `client_id`). Separately, `ClientDetach` decremented
`attached_clients` unconditionally, so a duplicate detach could drop the count to `0` while real
clients remained (`#{session_attached}` reads `0` while `list-clients` shows clients).

## Changes

- **`AppState::reap_client(cid) -> bool`** (`src/types.rs`): idempotently remove a client from the
  registry and update `attached_clients` / `client_prefix_active` / `latest_client_id` **only when the
  entry was actually present** (`client_sizes` is always cleared). Returns whether a reap happened; a
  second call for the same `cid` is a safe no-op.
- **`CtrlReq::ClientDetach`** (`src/server/mod.rs`): route through `reap_client`; run the detach side
  effects (resize recompute, `client-detached` hook, destroy-unattached) only on a real reap, so a
  duplicate detach can't over-decrement the counter or fire destroy twice. Two intentional
  consequences of moving the bookkeeping inside the present-only guard (both benign): `client_prefix_active`
  is now cleared only on a real reap (a single global render-invalidation flag), and `latest_client_id`
  is no longer clobbered by a no-op detach — its value on a real reap is unchanged from before (`None`
  when the reaped client was the latest; this matches the prior `ClientDetach`, not the
  survivor-promotion that the force-detach handlers use).
- **Writer-thread `Guard::drop`** (`src/server/connection.rs`): also enqueue `ClientDetach(client_id)`,
  so a connection torn down via the writer path is reaped too, not just the reader-EOF path. The reader
  loop and this Guard may both enqueue it for the same `cid`; the idempotency above makes the pair reap
  exactly once. This is low-risk because the Guard already `shutdown(Both)`s the socket — the client
  reconnects under a *new* `client_id`, so reaping the old id does not remove the live reconnected
  client.
- **Tests** (`tests-rs/test_issue275_detach_client.rs`): 8 new cases exercising the real
  `reap_client` — first-reap removes + decrements, second-reap no-op, double-reap keeps the counter
  consistent with the registry (the `attached=0`-while-clients-remain regression), unknown-id no-op,
  latest-client clearing, prefix-flag clearing only on a real reap, destroy-unattached gated to a
  single real reap, and a **reader+writer duplicate-detach teardown** case asserting one registry
  removal + one decrement + side effects (hook/destroy) firing exactly once for the modelled
  connection-teardown path.

Scope note: only `ClientDetach` is refactored through `reap_client`; the explicit `detach-client` /
force-detach handlers already guarded their decrement correctly (they were the template
`ClientDetach` failed to follow), so they never had the over-decrement bug and are left unchanged to
keep this fix minimal.

On a clean detach the existing `client-detach` / EOF path reaps the client; any later Guard
`ClientDetach` for the same `cid` is an idempotent no-op, so hooks / counters / destroy-unattached do
not run twice. With `destroy-unattached on`, a writer-detected teardown of the last client now follows
the same destroy path a reader-detected EOF already used (intentional consistency; default off).

## Testing

- `cargo build --release` on `x86_64` / `i686` / `aarch64-pc-windows-msvc` — all green (CI).
- `cargo test --all-targets` — green (executed on the x64 job), including the 8 new tests + smoke.
- Behavioral ConPTY smoke / no-regression harness on the built binary: attach two clients → kill one
  abnormally → survivor stays counted (`attached=1`, no desync), re-attach works — 8/8 invariants,
  identical on stock 3.3.6 (a regression/sanity check). The idempotency + gating are covered by the new
  unit tests (incl. the reader+writer duplicate-detach case); the end-to-end leak is documented from the
  live observation in the issue. A full server-loop integration test of the writer-Guard reap is
  impractical (the missed-reap race is timing-dependent), so the invariant it relies on is pinned at the
  unit level instead.

## Related

- Partially addresses the client-state-cleanup aspect of #274's *second suggested fix* (release
  server-side client state on death) for the client registry — does **not** tackle #274's deeper
  pane-I/O wedge.
- Conceptually separate from #389 / #420 (intentional `detach-client` sending `DETACH`): that changes
  the *intentional* detach path (force-detach block, ~`server/mod.rs:3692+`); this touches
  `ClientDetach` (~`server/mod.rs:1606`) and abnormal/writer teardown. No hard conflict — happy to
  rebase over #420 if it lands first.


