### PR TITLE
feat(warm-pane): honor -c on new-window/split via silent re-home

### DIFF
--- a/src/pane.rs
+++ b/src/pane.rs
@@ -71,6 +71,43 @@ fn default_shell_name(command: Option<&str>, configured_shell: Option<&str>) -> 
     }
 }
 
+/// Build the command injected to silently re-home a pane's shell to `dir`.
+///
+/// The trailing clear (`cls` on Windows, `clear` elsewhere) wipes the visible
+/// echo; single quotes in the path are doubled so the single-quoted string
+/// stays well-formed; the trailing `\r` submits it as one command line. The
+/// leading space asks shells that ignore space-prefixed commands to skip the
+/// history entry (best-effort — not every shell honours it).
+pub(crate) fn rehome_command(dir: &str) -> String {
+    let escaped = dir.replace('\'', "''");
+    let clear = if cfg!(windows) { "cls" } else { "clear" };
+    format!(" cd '{}'; {}\r", escaped, clear)
+}
+
+/// Silently re-home an already-running pane's shell to `dir`: inject
+/// [`rehome_command`] and squelch the pane's rendering until the resulting
+/// screen-clear (CSI 2J) fires or a 500ms safety timeout elapses, so the user
+/// never sees the injected command or its echo.
+///
+/// A pre-spawned shell (warm pane or warm server) starts in the server CWD;
+/// since a running process's CWD cannot be set externally, the shell moves
+/// itself with `cd`. The shell must be at a fresh prompt so the injected line
+/// runs immediately.
+pub(crate) fn silent_rehome(pane: &mut Pane, dir: &str) {
+    use std::io::Write as _;
+    let cd_cmd = rehome_command(dir);
+    // Tell the vt100 parser to watch for the next screen-clear (CSI 2J/3J);
+    // its arrival tells the layout serialiser the clear finished (event-driven).
+    if let Ok(mut parser) = pane.term.lock() {
+        parser.screen_mut().set_squelch_clear_pending(true);
+    }
+    // Reveal the pane when that clear arrives, or after 500ms as a fallback for
+    // shells that never emit one — whichever happens first.
+    pane.squelch_until = Some(Instant::now() + Duration::from_millis(500));
+    let _ = pane.writer.write_all(cd_cmd.as_bytes());
+    let _ = pane.writer.flush();
+}
+
 pub fn create_window(pty_system: &dyn portable_pty::PtySystem, app: &mut AppState, command: Option<&str>, start_dir: Option<&str>, empty: bool) -> io::Result<()> {
     // ── Empty window (tmux new-window -E): a new window whose single pane has
     // no command/process. It renders blank until respawn-pane gives it one. ──
@@ -91,7 +128,9 @@ pub fn create_window(pty_system: &dyn portable_pty::PtySystem, app: &mut AppStat
     // ── Fast path: use pre-spawned warm pane when creating a default shell ──
     // The warm pane has its shell already loaded (~470ms for pwsh), so the
     // prompt appears instantly — matching wezterm's "instant tab" feel.
-    if command.is_none() && start_dir.is_none() && app.warm_pane.is_some() {
+    // A `-c <dir>` is honoured by re-homing the transplanted shell (below), so
+    // the warm pane is used even when start_dir is set (#107).
+    if command.is_none() && app.warm_pane.is_some() {
         let mut wp = app.warm_pane.take().unwrap();
         // Resize to current terminal dimensions if they changed since pre-spawn
         let area = app.last_window_area;
@@ -123,7 +162,11 @@ pub fn create_window(pty_system: &dyn portable_pty::PtySystem, app: &mut AppStat
             }
             let epoch = std::time::Instant::now() - Duration::from_secs(2);
             let configured_shell = if app.default_shell.is_empty() { None } else { Some(app.default_shell.as_str()) };
-            let pane = Pane { master: wp.master, writer: wp.writer, child: wp.child, term: wp.term, last_rows: rows, last_cols: cols, id: wp.pane_id, title: hostname_cached(), title_locked: false, child_pid: wp.child_pid, data_version: wp.data_version, last_title_check: epoch, last_infer_title: epoch, dead: false, last_text_input: None, last_special_key: None, vt_bridge_cache: None, vti_mode_cache: None, mouse_input_cache: None, cursor_shape: wp.cursor_shape, bell_pending: wp.bell_pending, cpr_pending: wp.cpr_pending, copy_state: None, pane_style: None, squelch_until: None, output_ring: wp.output_ring };
+            let mut pane = Pane { master: wp.master, writer: wp.writer, child: wp.child, term: wp.term, last_rows: rows, last_cols: cols, id: wp.pane_id, title: hostname_cached(), title_locked: false, child_pid: wp.child_pid, data_version: wp.data_version, last_title_check: epoch, last_infer_title: epoch, dead: false, last_text_input: None, last_special_key: None, vt_bridge_cache: None, vti_mode_cache: None, mouse_input_cache: None, cursor_shape: wp.cursor_shape, bell_pending: wp.bell_pending, cpr_pending: wp.cpr_pending, copy_state: None, pane_style: None, squelch_until: None, output_ring: wp.output_ring };
+            // Honour `-c <dir>`: silently re-home the transplanted warm shell.
+            if let Some(dir) = start_dir {
+                silent_rehome(&mut pane, dir);
+            }
             let win_name = default_shell_name(None, configured_shell);
             let initial_pane_id = wp.pane_id;
             app.windows.push(Window { root: Node::Leaf(pane), active_path: vec![], name: win_name, id: app.next_win_id, activity_flag: false, bell_flag: false, silence_flag: false, last_output_time: std::time::Instant::now(), last_seen_version: 0, manual_rename: false, layout_index: 0, pane_mru: vec![initial_pane_id], zoom_saved: None, linked_from: None, floating: Vec::new(), floating_focus: None });
@@ -410,9 +453,9 @@ pub fn split_active_with_command(app: &mut AppState, kind: LayoutKind, command: 
     // though its ConPTY was created at full-window size, resizing to the
     // split dimensions only costs a ConPTY repaint (~10-50ms) vs a full
     // cold spawn (~500ms).  Net result: split feels nearly instant.
-    // Skip warm pane when start_dir is set — the warm pane was spawned
-    // in the server's CWD, not the requested directory (#107).
-    if command.is_none() && start_dir.is_none() && app.warm_pane.is_some() {
+    // A `-c <dir>` is honoured by re-homing the transplanted shell (below), so
+    // the warm pane is used even when start_dir is set (#107).
+    if command.is_none() && app.warm_pane.is_some() {
         let mut wp = app.warm_pane.take().unwrap();
         let need_resize = rows != wp.rows || cols != wp.cols;
         // #450: never transplant a spare whose shell died in the pool —
@@ -434,7 +477,12 @@ pub fn split_active_with_command(app: &mut AppState, kind: LayoutKind, command: 
             }
             let epoch = std::time::Instant::now() - Duration::from_secs(2);
             let new_pane_id = wp.pane_id;
-            let new_leaf = Node::Leaf(Pane { master: wp.master, writer: wp.writer, child: wp.child, term: wp.term, last_rows: rows, last_cols: cols, id: new_pane_id, title: hostname_cached(), title_locked: false, child_pid: wp.child_pid, data_version: wp.data_version, last_title_check: epoch, last_infer_title: epoch, dead: false, last_text_input: None, last_special_key: None, vt_bridge_cache: None, vti_mode_cache: None, mouse_input_cache: None, cursor_shape: wp.cursor_shape, bell_pending: wp.bell_pending, cpr_pending: wp.cpr_pending, copy_state: None, pane_style: None, squelch_until: None, output_ring: wp.output_ring });
+            let mut new_pane = Pane { master: wp.master, writer: wp.writer, child: wp.child, term: wp.term, last_rows: rows, last_cols: cols, id: new_pane_id, title: hostname_cached(), title_locked: false, child_pid: wp.child_pid, data_version: wp.data_version, last_title_check: epoch, last_infer_title: epoch, dead: false, last_text_input: None, last_special_key: None, vt_bridge_cache: None, vti_mode_cache: None, mouse_input_cache: None, cursor_shape: wp.cursor_shape, bell_pending: wp.bell_pending, cpr_pending: wp.cpr_pending, copy_state: None, pane_style: None, squelch_until: None, output_ring: wp.output_ring };
+            // Honour `-c <dir>`: silently re-home the transplanted warm shell.
+            if let Some(dir) = start_dir {
+                silent_rehome(&mut new_pane, dir);
+            }
+            let new_leaf = Node::Leaf(new_pane);
             let win = &mut app.windows[app.active_idx];
             replace_leaf_with_split(&mut win.root, &win.active_path, kind, new_leaf);
             let mut new_path = win.active_path.clone();
@@ -1754,3 +1802,7 @@ mod test_parser_audible_bell {
 #[cfg(test)]
 #[path = "../tests-rs/test_issue450_dead_warm_pane.rs"]
 mod tests_issue450_dead_warm_pane;
+
+#[cfg(test)]
+#[path = "../tests-rs/test_warm_pane_start_dir.rs"]
+mod tests_warm_pane_start_dir;

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1319,13 +1319,9 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                     let start_dir = start_dir.map(|d| expand_format(&d, &app)).filter(|d| !d.is_empty());
                     let saved_dir = if start_dir.is_some() { env::current_dir().ok() } else { None };
                     if let Some(dir) = &start_dir { env::set_current_dir(dir).ok(); }
-                    // Hide the warm pane when an explicit start dir is requested
-                    // so create_window spawns a fresh shell in the correct CWD.
-                    let stashed_warm = if start_dir.is_some() { app.warm_pane.take() } else { None };
                     if let Err(e) = create_window(&*pty_system, &mut app, cmd.as_deref(), start_dir.as_deref(), empty) {
                         eprintln!("psmux: new-window error: {e}");
                     }
-                    if let Some(wp) = stashed_warm { app.warm_pane = Some(wp); }
                     if let Some(prev) = saved_dir { env::set_current_dir(prev).ok(); }
                     if let Some(n) = name { app.windows.last_mut().map(|w| { w.name = n; w.manual_rename = true; }); }
                     // -T: set the new pane's title at creation (tmux new-window -T).
@@ -1353,11 +1349,9 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                     let start_dir = start_dir.map(|d| expand_format(&d, &app)).filter(|d| !d.is_empty());
                     let saved_dir = if start_dir.is_some() { env::current_dir().ok() } else { None };
                     if let Some(dir) = &start_dir { env::set_current_dir(dir).ok(); }
-                    let stashed_warm = if start_dir.is_some() { app.warm_pane.take() } else { None };
                     if let Err(e) = create_window(&*pty_system, &mut app, cmd.as_deref(), start_dir.as_deref(), empty) {
                         eprintln!("psmux: new-window error: {e}");
                     }
-                    if let Some(wp) = stashed_warm { app.warm_pane = Some(wp); }
                     if let Some(prev) = saved_dir { env::set_current_dir(prev).ok(); }
                     if let Some(n) = name { app.windows.last_mut().map(|w| { w.name = n; w.manual_rename = true; }); }
                     if let Some(t) = title {
@@ -1418,8 +1412,6 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                     let saved_dir = if start_dir.is_some() { env::current_dir().ok() } else { None };
                     if let Some(dir) = &start_dir { env::set_current_dir(dir).ok(); }
                     let prev_path = app.windows[app.active_idx].active_path.clone();
-                    // Hide warm pane when explicit start_dir is given (wrong CWD)
-                    let stashed_warm = if start_dir.is_some() { app.warm_pane.take() } else { None };
                     if let Err(e) = split_active_with_command(&mut app, k, cmd.as_deref(), Some(&*pty_system), start_dir.as_deref()) {
                         let msg = format!("split-window: {e}");
                         app.status_message = Some((msg.clone(), std::time::Instant::now(), None));
@@ -1427,7 +1419,6 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                     } else {
                         let _ = resp.send(String::new());
                     }
-                    if let Some(wp) = stashed_warm { app.warm_pane = Some(wp); }
                     // Apply size if specified: (value, true) = percentage, (value, false) = cell count
                     if let Some((val, is_pct)) = split_size {
                         let pct = if is_pct {
@@ -1495,12 +1486,10 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                     let saved_dir = if start_dir.is_some() { env::current_dir().ok() } else { None };
                     if let Some(dir) = &start_dir { env::set_current_dir(dir).ok(); }
                     let prev_path = app.windows[app.active_idx].active_path.clone();
-                    let stashed_warm = if start_dir.is_some() { app.warm_pane.take() } else { None };
                     if let Err(e) = split_active_with_command(&mut app, k, cmd.as_deref(), Some(&*pty_system), start_dir.as_deref()) {
                         app.status_message = Some((format!("split-window: {e}"), std::time::Instant::now(), None));
                         eprintln!("psmux: split-window error: {e}");
                     }
-                    if let Some(wp) = stashed_warm { app.warm_pane = Some(wp); }
                     // Apply size if specified: (value, true) = percentage, (value, false) = cell count
                     if let Some((val, is_pct)) = split_size {
                         let pct = if is_pct {
@@ -3036,30 +3025,12 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                                 .unwrap_or(true);
                             if server_cwd_differs {
                                 env::set_current_dir(cwd_path).ok();
-                                // Inject cd + clear into the active pane so
-                                // the directory change is invisible to the
-                                // user.  Leading space keeps it out of shell
-                                // history; the clear wipes visible traces.
-                                //
-                                // The vt100 parser watches for the CSI 2J
-                                // that cls/clear generates, which tells the
-                                // layout serialiser the clear finished
-                                // (event-driven, no guessing).  A safety
-                                // timeout is a fallback for unusual shells.
+                                // Silently re-home the warm server's active pane
+                                // to the client's CWD (invisible cd + clear), so
+                                // the shell it pre-spawned adopts the right dir.
                                 if let Some(win) = app.windows.last_mut() {
                                     if let Some(p) = active_pane_mut(&mut win.root, &win.active_path) {
-                                        use std::io::Write as _;
-                                        let escaped = cwd.replace('\'', "''");
-                                        let clear = if cfg!(windows) { "cls" } else { "clear" };
-                                        let cd_cmd = format!(" cd '{}'; {}\r", escaped, clear);
-                                        // Tell the vt100 parser to watch for the
-                                        // next screen-clear event (CSI 2J/3J).
-                                        if let Ok(mut parser) = p.term.lock() {
-                                            parser.screen_mut().set_squelch_clear_pending(true);
-                                        }
-                                        p.squelch_until = Some(Instant::now() + Duration::from_millis(500));
-                                        let _ = p.writer.write_all(cd_cmd.as_bytes());
-                                        let _ = p.writer.flush();
+                                        crate::pane::silent_rehome(p, cwd);
                                     }
                                 }
                             }

--- a/tests-rs/test_warm_pane_start_dir.rs
+++ b/tests-rs/test_warm_pane_start_dir.rs
@@ -1,0 +1,215 @@
+// Warm-pane `-c <dir>` re-home: the fast paths (create_window / split) now
+// transplant the warm pane even when a start_dir is requested, then silently
+// re-home the pre-spawned shell to that directory via `silent_rehome`.
+//
+// These unit tests cover the pure command-construction half (`rehome_command`),
+// which is the security-sensitive part (single-quote escaping). The full
+// behavioural path — warm pane actually consumed for `new-window -c` and the
+// shell landing in the requested dir — needs real ConPTY/shell scaffolding and
+// is covered by tests/test_warm_pane_start_dir.ps1.
+
+use super::*;
+
+/// The injected command must: start with a space (kept out of shell history),
+/// `cd` into the requested directory, chain a clear to hide the echo, and end
+/// with a single CR so it submits as exactly one command line.
+#[test]
+fn rehome_command_wraps_dir_and_clears() {
+    let cmd = rehome_command(r"C:\code\project");
+    assert!(cmd.starts_with(' '), "must start with a space, got {cmd:?}");
+    assert!(cmd.ends_with('\r'), "must end with CR, got {cmd:?}");
+    assert!(
+        cmd.contains(r"cd 'C:\code\project'"),
+        "must cd into the dir, got {cmd:?}"
+    );
+    let clear = if cfg!(windows) { "cls" } else { "clear" };
+    assert!(cmd.contains(clear), "must chain {clear}, got {cmd:?}");
+    assert_eq!(cmd.matches('\r').count(), 1, "exactly one line, got {cmd:?}");
+}
+
+/// A single quote in the path must be doubled so the single-quoted string stays
+/// well-formed — otherwise the `cd` breaks (or a crafted path could inject a
+/// second command). Precondition: the input actually contains a lone quote.
+#[test]
+fn rehome_command_escapes_single_quotes() {
+    let input = r"C:\weird'dir";
+    assert_eq!(input.matches('\'').count(), 1, "precondition: one lone quote");
+
+    let cmd = rehome_command(input);
+    assert!(
+        cmd.contains(r"cd 'C:\weird''dir'"),
+        "lone quote must be doubled, got {cmd:?}"
+    );
+    // Still exactly one command line — the quote didn't terminate it early.
+    assert_eq!(cmd.matches('\r').count(), 1, "got {cmd:?}");
+}
+
+/// Full contract lock on Windows: documents the precise bytes injected so a
+/// future refactor can't silently change the wire format.
+#[test]
+fn rehome_command_exact_windows_form() {
+    if cfg!(windows) {
+        assert_eq!(rehome_command(r"C:\x"), " cd 'C:\\x'; cls\r");
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Behavioural: the `-c <dir>` fast path with real ConPTY spawns.
+//
+// These prove #436 composes with #450's dead-spare liveness gate: the warm-pane
+// guard admits `-c` requests, on the path #450's gate protects. A LIVE spare must
+// be transplanted AND re-homed for `-c`; a DEAD spare must never be transplanted
+// (the #450 bug), falling through to a cold spawn that still honours `-c` via
+// `shell_cmd.cwd`.
+//
+// Discriminators are structural, not timing-based: transplant ⇔ the delivered
+// pane keeps the warm pane's id; re-home ⇔ `silent_rehome` set `squelch_until`.
+// Landing the *cold* spawn in the requested dir is verified end-to-end by
+// tests/test_warm_pane_start_dir.ps1 (a running process's CWD isn't cheaply
+// observable in-process).
+
+fn test_app() -> AppState {
+    let mut app = AppState::new("warm_start_dir_test".to_string());
+    app.warm_enabled = true;
+    app.last_window_area = ratatui::prelude::Rect { x: 0, y: 0, width: 100, height: 30 };
+    app
+}
+
+/// Kill the warm pane's child and wait until the OS reports it exited
+/// (TerminateProcess is asynchronous; try_wait flips within milliseconds).
+fn kill_warm_child(wp: &mut crate::types::WarmPane) {
+    wp.child.kill().ok();
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while Instant::now() < deadline {
+        if !matches!(wp.child.try_wait(), Ok(None)) {
+            return;
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+    panic!("warm child did not report exit within 5s of kill()");
+}
+
+fn active_pane_of(win: &mut Window) -> &mut Pane {
+    let path = win.active_path.clone();
+    active_pane_mut(&mut win.root, &path).expect("active pane")
+}
+
+fn cleanup(app: &mut AppState) {
+    for win in app.windows.iter_mut() {
+        crate::tree::kill_all_children(&mut win.root);
+    }
+    if let Some(mut wp) = app.warm_pane.take() {
+        wp.child.kill().ok();
+    }
+}
+
+/// Control / precondition: a live spare consumed WITHOUT `-c` is transplanted
+/// but NOT re-homed, so `squelch_until` stays `None`. This is what makes the
+/// `is_some()` check in `create_window_live_spare_with_start_dir_transplants_and_rehomes`
+/// meaningful — without it, that assertion could pass vacuously.
+#[test]
+fn create_window_live_spare_without_start_dir_does_not_rehome() {
+    let pty = native_pty_system();
+    let mut app = test_app();
+    let wp = spawn_warm_pane(&*pty, &mut app).expect("spawn warm pane");
+    let warm_id = wp.pane_id;
+    app.warm_pane = Some(wp);
+
+    create_window(&*pty, &mut app, None, None, false).expect("create_window");
+
+    let pane = active_pane_of(&mut app.windows[0]);
+    assert_eq!(pane.id, warm_id, "live spare must be transplanted (warm fast path)");
+    assert!(
+        pane.squelch_until.is_none(),
+        "no start_dir means no silent_rehome, so squelch_until must be None"
+    );
+    cleanup(&mut app);
+}
+
+/// #436 core: a live spare consumed WITH `-c <dir>` is STILL transplanted (warm
+/// reuse — the whole point) and additionally re-homed, so `silent_rehome` runs
+/// and sets `squelch_until`.
+#[test]
+fn create_window_live_spare_with_start_dir_transplants_and_rehomes() {
+    let pty = native_pty_system();
+    let mut app = test_app();
+    let dir = std::env::temp_dir();
+    let dir = dir.to_str().expect("temp dir path");
+    let wp = spawn_warm_pane(&*pty, &mut app).expect("spawn warm pane");
+    let warm_id = wp.pane_id;
+    app.warm_pane = Some(wp);
+
+    create_window(&*pty, &mut app, None, Some(dir), false).expect("create_window");
+
+    let pane = active_pane_of(&mut app.windows[0]);
+    assert_eq!(
+        pane.id, warm_id,
+        "#436: the warm spare must be transplanted even with -c (not cold-spawned)"
+    );
+    assert!(
+        pane.squelch_until.is_some(),
+        "#436: -c must silently re-home the transplanted shell (squelch_until set)"
+    );
+    assert!(
+        matches!(pane.child.try_wait(), Ok(None)),
+        "the transplanted shell must be alive"
+    );
+    cleanup(&mut app);
+}
+
+/// #450 gate under #436's looser guard: a DEAD spare must not be transplanted
+/// just because `-c` makes the warm pane eligible. #450's liveness gate must
+/// still reject it and fall through to a cold spawn.
+#[test]
+fn create_window_dead_spare_with_start_dir_cold_spawns() {
+    let pty = native_pty_system();
+    let mut app = test_app();
+    let dir = std::env::temp_dir();
+    let dir = dir.to_str().expect("temp dir path");
+    let mut wp = spawn_warm_pane(&*pty, &mut app).expect("spawn warm pane");
+    let warm_id = wp.pane_id;
+    kill_warm_child(&mut wp);
+    app.warm_pane = Some(wp);
+
+    create_window(&*pty, &mut app, None, Some(dir), false).expect("create_window");
+
+    assert!(app.warm_pane.is_none(), "the dead spare must be discarded, not restored");
+    let pane = active_pane_of(&mut app.windows[0]);
+    assert_ne!(
+        pane.id, warm_id,
+        "dead spare (id {warm_id}) was transplanted for -c — the #450 bug #436 must not reopen"
+    );
+    assert!(
+        matches!(pane.child.try_wait(), Ok(None)),
+        "the cold-spawned shell must be alive"
+    );
+    cleanup(&mut app);
+}
+
+/// Same gate on the split path: a dead spare must not be transplanted into a
+/// `split-window -c`; the split still succeeds via cold spawn.
+#[test]
+fn split_dead_spare_with_start_dir_cold_spawns() {
+    let pty = native_pty_system();
+    let mut app = test_app();
+    let dir = std::env::temp_dir();
+    let dir = dir.to_str().expect("temp dir path");
+    create_window(&*pty, &mut app, None, None, false).expect("create_window");
+    let mut wp = spawn_warm_pane(&*pty, &mut app).expect("spawn warm pane");
+    let warm_id = wp.pane_id;
+    kill_warm_child(&mut wp);
+    app.warm_pane = Some(wp);
+
+    split_active_with_command(&mut app, LayoutKind::Vertical, None, Some(&*pty), Some(dir))
+        .expect("split");
+
+    let win = &mut app.windows[0];
+    assert!(matches!(win.root, Node::Split { .. }), "split must still happen");
+    let pane = active_pane_of(win);
+    assert_ne!(pane.id, warm_id, "dead spare transplanted into the -c split (#450 bug)");
+    assert!(
+        matches!(pane.child.try_wait(), Ok(None)),
+        "the split's cold-spawned shell must be alive"
+    );
+    cleanup(&mut app);
+}

--- a/tests/test_warm_pane.ps1
+++ b/tests/test_warm_pane.ps1
@@ -458,44 +458,50 @@ Kill-TestSession $session
 Write-Host ""
 
 # =============================================================================
-# TEST 9: Start-dir stash — warm pane preserved when -c specified
+# TEST 9: Start-dir re-home — warm pane honours -c (transplant + silent cd)
 # =============================================================================
-Write-Host "--- TEST 9: Start-dir stash (warm pane preserved for later) ---" -ForegroundColor Yellow
+Write-Host "--- TEST 9: Start-dir re-home (warm pane honours -c) ---" -ForegroundColor Yellow
 $session = "wp_test_9"
 $proc = Start-Process -FilePath $PSMUX -ArgumentList "new-session", "-s", $session, "-d", "-x", "120", "-y", "30" -PassThru -WindowStyle Hidden
 $null = Wait-ServerReady -SessionName $session -TimeoutSec 15
 $null = Wait-PanePrompt -SessionName $session -TimeoutMs ($PromptTimeoutSec * 1000)
-Start-Sleep -Milliseconds 600   # Warm pane replenishment + loading
+Start-Sleep -Milliseconds 1500   # let the warm pane finish loading before we consume it
 
-# Create window with -c (custom start dir) — warm pane should be STASHED, not consumed
+# new-window -c transplants the warm pane and silently re-homes its shell to the
+# requested dir.
 $testDir = $env:USERPROFILE
 $sw = [System.Diagnostics.Stopwatch]::StartNew()
 & $PSMUX new-window -t $session -c $testDir 2>&1 | Out-Null
 $dirResult = Wait-PanePrompt -SessionName $session -TimeoutMs ($PromptTimeoutSec * 1000)
 $sw.Stop()
 if ($dirResult.Found) {
-    # This should be a cold spawn (warm pane was stashed due to -c)
-    Write-Metric "  new-window -c (cold, stash)" $sw.ElapsedMilliseconds
-    Write-Pass "new-window with -c completed in $($sw.ElapsedMilliseconds)ms"
+    Write-Metric "  new-window -c (warm re-home)" $sw.ElapsedMilliseconds
+    # The shell's prompt should reflect the requested directory (re-home worked).
+    if ($dirResult.Output -match [regex]::Escape($testDir.TrimEnd('\'))) {
+        Write-Pass "new-window -c re-homed the shell to $testDir ($($sw.ElapsedMilliseconds)ms)"
+    } else {
+        Write-Fail "new-window -c prompt not at ${testDir}: $($dirResult.Output.Trim())"
+    }
 } else {
     Write-Fail "new-window with -c — prompt never appeared"
 }
 
-# Now create a DEFAULT window — the warm pane should be RESTORED and used
-Start-Sleep -Milliseconds 100  # Warm pane was stashed, should be ready immediately
+# The -c consumed the warm pane; a replenished warm pane should still serve the
+# next default window quickly (replenishment chain intact).
+Start-Sleep -Milliseconds 1500
 $sw2 = [System.Diagnostics.Stopwatch]::StartNew()
 & $PSMUX new-window -t $session 2>&1 | Out-Null
 $defaultResult = Wait-PanePrompt -SessionName $session -TimeoutMs ($PromptTimeoutSec * 1000)
 $sw2.Stop()
 if ($defaultResult.Found) {
-    Write-Metric "  new-window default (stashed warm)" $sw2.ElapsedMilliseconds
+    Write-Metric "  new-window default (replenished warm)" $sw2.ElapsedMilliseconds
     if ($sw2.ElapsedMilliseconds -lt 2000) {
-        Write-Pass "Stashed warm pane consumed on default new-window ($($sw2.ElapsedMilliseconds)ms)"
+        Write-Pass "Replenished warm pane consumed on default new-window ($($sw2.ElapsedMilliseconds)ms)"
     } else {
-        Write-Fail "Default new-window after stash took $($sw2.ElapsedMilliseconds)ms (stash may have failed)"
+        Write-Fail "Default new-window after -c took $($sw2.ElapsedMilliseconds)ms (replenish may have failed)"
     }
 } else {
-    Write-Fail "Default new-window after stash — prompt never appeared"
+    Write-Fail "Default new-window after -c — prompt never appeared"
 }
 Kill-TestSession $session
 Write-Host ""

--- a/tests/test_warm_pane_start_dir.ps1
+++ b/tests/test_warm_pane_start_dir.ps1
@@ -1,0 +1,119 @@
+# test_warm_pane_start_dir.ps1 — warm pane honours `new-window -c <dir>` (and splits)
+#
+# The warm-pane fast path transplants the pre-spawned warm pane for `-c <dir>`
+# and silently re-homes its shell to that dir, so `new-window -c` and
+# `split-window -c` are instant (warm reuse) and land in the requested directory.
+#
+# Discriminator = time-to-prompt (the method psmux's other warm tests use):
+#   FIXED  -> `-c` reuses the loaded warm pane: prompt in well under a second.
+#   UNFIXED-> `-c` cold-spawns a fresh shell: prompt after a full profile load
+#             (seconds). Measured 5646ms cold vs 53ms warm on my machine.
+# We also assert the pane's prompt shows the requested dir.
+#
+# SAFETY: fully isolated — runs the binary with USERPROFILE pointed at a
+# throwaway temp dir (its ~/.psmux state can't collide with a live server) and an
+# -L namespace, and cleans up by PID. It does NOT use name-based process kills or
+# a global kill-server, so it is safe to run while a real psmux session is active.
+#
+# NOTE: relies on the warm pane being FULLY loaded before it is consumed (the
+# re-home cd is injected at a fresh prompt). The test waits generously; on a very
+# cold AV cache the warm-load can exceed the wait and the `-c` timing will
+# regress toward cold (the underlying readiness race an OSC-133 prompt gate would
+# remove). The directory assertion still holds regardless.
+
+param(
+    [string]$Psmux = (Join-Path $PSScriptRoot "..\target\release\psmux.exe"),
+    [string]$TargetDir = "C:\Windows",   # must exist and differ from the server CWD
+    [int]$WarmLoadMs = 4000,             # generous wait for the warm pane to load (NoProfile is fast)
+    [int]$WarmMaxMs = 1200               # absolute cap; the real check is relative to the cold window-0 time
+)
+
+$ErrorActionPreference = "Continue"
+if (-not (Test-Path $Psmux)) {
+    Write-Host "ERROR: psmux binary not found at $Psmux (cargo build --release)" -ForegroundColor Red
+    exit 2
+}
+$Psmux = (Resolve-Path $Psmux).Path
+$NS = "wpsd" + ([guid]::NewGuid().ToString('N').Substring(0,6))
+$TempHome = Join-Path $env:TEMP "psmux-$NS"
+New-Item -ItemType Directory -Force -Path (Join-Path $TempHome ".psmux") | Out-Null
+Set-Content -Path (Join-Path $TempHome ".psmux.conf") -Value ('set -g default-shell "pwsh -NoProfile"' + "`n") -Encoding ascii
+
+$savedUP = $env:USERPROFILE; $savedCfg = $env:PSMUX_CONFIG_FILE
+$savedTgt = $env:PSMUX_TARGET_SESSION; $savedSess = $env:PSMUX_SESSION; $savedTmux = $env:TMUX
+$testStart = Get-Date
+$pass = 0; $fail = 0
+function Result($name, [bool]$ok, $detail="") {
+    if ($ok) { $script:pass++; Write-Host "  [PASS] $name" -ForegroundColor Green }
+    else     { $script:fail++; Write-Host "  [FAIL] $name $(if($detail){"— $detail"})" -ForegroundColor Red }
+}
+# A plain (`pwsh -NoProfile`) prompt is `PS X:\...>` — that marks "prompt ready".
+# NoProfile keeps loads fast and load-stable so the warm-vs-cold gap is reliable.
+$PromptPat = "PS [A-Z]:\\"
+function Wait-Prompt([int]$TimeoutMs) {
+    $sw = [Diagnostics.Stopwatch]::StartNew()
+    while ($sw.ElapsedMilliseconds -lt $TimeoutMs) {
+        $o = (& $Psmux -L $NS capture-pane -t probe -p 2>&1) -join "`n"
+        if ($o -match $PromptPat) { return @{ Found = $true; Ms = $sw.ElapsedMilliseconds } }
+        Start-Sleep -Milliseconds 40
+    }
+    return @{ Found = $false; Ms = $sw.ElapsedMilliseconds }
+}
+
+try {
+    $env:USERPROFILE = $TempHome
+    $env:PSMUX_CONFIG_FILE = (Join-Path $TempHome ".psmux.conf")
+    $env:PSMUX_TARGET_SESSION = "${NS}__probe"
+    Remove-Item Env:\PSMUX_SESSION, Env:\TMUX, Env:\PSMUX_SESSION_NAME -ErrorAction SilentlyContinue
+
+    Write-Host "`n--- Isolated server (-L $NS, HOME=$TempHome) ---" -ForegroundColor Cyan
+    & $Psmux -L $NS new-session -d -s probe -x 120 -y 30 2>&1 | Out-Null
+    $port = Join-Path $TempHome ".psmux\${NS}__probe.port"
+    $sw = [Diagnostics.Stopwatch]::StartNew()
+    while ($sw.ElapsedMilliseconds -lt 15000 -and -not (Test-Path $port)) { Start-Sleep -Milliseconds 50 }
+    Result "isolated session created" (Test-Path $port)
+
+    $w0 = Wait-Prompt 20000
+    # Warm reuse (no shell spawn) must be well under a cold spawn. Use a relative
+    # threshold off the cold window-0 time so the check is stable under machine load.
+    $warmThresh = [Math]::Min($WarmMaxMs, [int]($w0.Ms * 0.6))
+    Write-Host "    window-0 (cold) prompt ready in $($w0.Ms) ms; warm threshold = ${warmThresh}ms; waiting ${WarmLoadMs}ms for warm pane..." -ForegroundColor DarkGray
+    Start-Sleep -Milliseconds $WarmLoadMs
+
+    # ── new-window -c ──
+    & $Psmux -L $NS new-window -t probe -c $TargetDir 2>&1 | Out-Null
+    $rc = Wait-Prompt 20000
+    Start-Sleep -Milliseconds 1500   # let the injected cd settle
+    $cap = (& $Psmux -L $NS capture-pane -t probe -p 2>&1) -join "`n"
+    $dirOk = $cap -match [regex]::Escape($TargetDir)
+    Write-Host "    new-window -c: prompt in $($rc.Ms) ms, prompt-at-target=$dirOk" -ForegroundColor DarkGray
+    Result "new-window -c is warm (reused warm pane, <${warmThresh}ms)" ($rc.Found -and $rc.Ms -lt $warmThresh) "took $($rc.Ms)ms (cold?)"
+    Result "new-window -c re-homed to target dir (prompt at $TargetDir)" $dirOk "prompt not at target"
+
+    Start-Sleep -Milliseconds $WarmLoadMs   # let the replenished warm pane load
+
+    # ── split-window -c ──
+    & $Psmux -L $NS split-window -t probe -h -c $TargetDir 2>&1 | Out-Null
+    $rs = Wait-Prompt 20000
+    Start-Sleep -Milliseconds 1500
+    $scap = (& $Psmux -L $NS capture-pane -t probe -p 2>&1) -join "`n"
+    $sdirOk = $scap -match [regex]::Escape($TargetDir)
+    Write-Host "    split-window -c: prompt in $($rs.Ms) ms, prompt-at-target=$sdirOk" -ForegroundColor DarkGray
+    Result "split-window -c is warm (reused warm pane, <${warmThresh}ms)" ($rs.Found -and $rs.Ms -lt $warmThresh) "took $($rs.Ms)ms (cold?)"
+    Result "split-window -c re-homed to target dir (prompt at $TargetDir)" $sdirOk "prompt not at target"
+}
+finally {
+    & $Psmux -L $NS kill-server 2>&1 | Out-Null
+    Start-Sleep -Milliseconds 500
+    Get-Process psmux, pwsh -ErrorAction SilentlyContinue |
+        Where-Object { $_.StartTime -ge $testStart } |
+        ForEach-Object { Stop-Process -Id $_.Id -Force -ErrorAction SilentlyContinue }
+    $env:USERPROFILE = $savedUP; $env:PSMUX_CONFIG_FILE = $savedCfg
+    $env:PSMUX_TARGET_SESSION = $savedTgt
+    if ($null -ne $savedSess) { $env:PSMUX_SESSION = $savedSess }
+    if ($null -ne $savedTmux) { $env:TMUX = $savedTmux }
+    Remove-Item -Recurse -Force $TempHome -ErrorAction SilentlyContinue
+}
+
+Write-Host "`n  RESULTS: $pass passed, $fail failed" -ForegroundColor $(if ($fail -eq 0) { "Green" } else { "Red" })
+if ($fail -gt 0) { exit 1 } else { exit 0 }


### PR DESCRIPTION
## Problem

Binding `new-window -c '#{pane_current_path}'` (open the new window in the current pane's directory) is a common setup. But `new-window -c <dir>` and `split-window -c <dir>` skip the pre-spawned warm pane whenever a start dir is requested, cold-spawning a fresh shell every time. A cold spawn with a heavy shell profile is several seconds per pane, so the warm pane is effectively never used for the one binding that needs it most.

This is the #107 workaround: the fast path guarded on `start_dir.is_none()`, and four `CtrlReq` handlers stashed the warm pane aside whenever a start dir was set.

## Fix

Server claim already has a similar code path, where it pre-starts the server, then uses a "silent rehome" command to switch to the current directory (inject ` cd '<dir>'; cls` and squelch the pane's rendering until the resulting screen-clear (CSI 2J) arrives or 500ms elapses).

This change extracts that to its own function, wires it to `-c` for new windows and panes, then removes the four now-unnecessary stash/restore workarounds in the handlers. 

## Result

`new-window -c` and `split-window -c`: ~5,600 ms cold-spawn -> ~50 ms warm reuse and opened in the correct directory.

## Tests

- `tests-rs/test_warm_pane_start_dir.rs` - unit tests for `rehome_command`
  (single-quote escaping, platform clear command, trailing submit).
- `tests/test_warm_pane_start_dir.ps1` - isolated behavioral timing test; green
  on the fix, red on the pre-fix stash behavior.
- `tests/test_warm_pane.ps1` TEST 9 updated for the re-home behavior.

## Risks

This is injecting commands into the user's shell, which we were already doing before, but in a new code path.

Refs #107