### PR TITLE
fix(attach): honour -t target instead of last_session (#408)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -671,15 +671,26 @@ fn run_main() -> io::Result<()> {
                 // otherwise argv[0] (the exe path or subcommand name) gets
                 // picked up as the target session name.
                 let sub_args: Vec<&String> = cmd_args.iter().skip(1).copied().collect();
-                let name = sub_args
+                // Explicit -t target takes precedence over every fallback (issue #408).
+                // The global argument scan above STRIPS -t (and its value) out of
+                // cmd_args, so re-reading it from sub_args here always missed and the
+                // resolution fell through to resolve_last_session_name_ns — meaning
+                // `attach-session -t NAME` reattached to whatever session was used
+                // last instead of NAME. Read -t from the full, unstripped argv so the
+                // requested target always wins. Works for both subcommand-position
+                // (`attach-session -t s2`) and global-position (`-t s2 attach-session`).
+                let name = args
                     .iter()
-                    .position(|a| *a == "-t")
-                    .and_then(|i| sub_args.get(i + 1))
-                    .map(|s| {
+                    .position(|a| a == "-t")
+                    .and_then(|i| args.get(i + 1))
+                    .map(|target| {
+                        let session = crate::cli::parse_target(target)
+                            .session
+                            .unwrap_or_else(|| target.clone());
                         if let Some(ref l) = l_socket_name {
-                            format!("{}__{}", l, s)
+                            format!("{}__{}", l, session)
                         } else {
-                            (*s).clone()
+                            session
                         }
                     })
                     .or_else(|| {

--- a/tests/test_issue408_attach_target_last_session.ps1
+++ b/tests/test_issue408_attach_target_last_session.ps1
@@ -1,0 +1,93 @@
+# Issue #408 / discussion #430: attach-session -t <name> must honour the target
+# instead of reattaching to the `last_session` marker.
+#
+# Root cause: the global arg scan strips -t out of cmd_args, so the attach branch
+# re-parsed -t from the stripped args (found none) and fell through to
+# resolve_last_session_name_ns. Whenever last_session pointed at a DIFFERENT
+# session, `attach-session -t s2` silently landed on last_session (e.g. s1).
+#
+# Deterministic proof without an interactive TTY: launch the attach client with
+# Start-Process, then ask the server (via list-clients) which session the client
+# actually joined. list-clients prints "<pts>: <session>: ...".
+
+$ErrorActionPreference = "Continue"
+$PSMUX = (Get-Command psmux -EA Stop).Source
+$psmuxDir = "$env:USERPROFILE\.psmux"
+$lastSessionFile = Join-Path $psmuxDir "last_session"
+$script:TestsPassed = 0
+$script:TestsFailed = 0
+
+function Write-Pass($msg) { Write-Host "  [PASS] $msg" -ForegroundColor Green; $script:TestsPassed++ }
+function Write-Fail($msg) { Write-Host "  [FAIL] $msg" -ForegroundColor Red; $script:TestsFailed++ }
+
+function Reset-Server {
+    & $PSMUX kill-server 2>&1 | Out-Null
+    Get-Process psmux -EA SilentlyContinue | Stop-Process -Force -EA SilentlyContinue
+    Start-Sleep -Milliseconds 700
+}
+
+# Returns the session name that the newest attach client is bound to, or "" if none.
+function Get-AttachedSession {
+    param([string[]]$ArgList, [string]$ForceLastSession)
+    if ($ForceLastSession) { Set-Content $lastSessionFile -Value $ForceLastSession -NoNewline }
+    $proc = Start-Process -FilePath $PSMUX -ArgumentList $ArgList -WindowStyle Minimized -PassThru
+    Start-Sleep -Seconds 2
+    $clients = & $PSMUX list-clients 2>&1 | Out-String
+    try { Stop-Process -Id $proc.Id -Force -EA SilentlyContinue } catch {}
+    Start-Sleep -Milliseconds 400
+    # Parse the most recently active client line: "/dev/pts/N: <session>: cmd ..."
+    $line = ($clients -split "`n" | Where-Object { $_ -match ':\s*\S+:\s' } | Select-Object -Last 1)
+    if ($line -match '^\S+:\s*(\S+):') { return $Matches[1] }
+    return ""
+}
+
+function New-TwoDetachedSessions {
+    Reset-Server
+    & $PSMUX new-session -d -s s1 -- cmd.exe; Start-Sleep -Milliseconds 600
+    & $PSMUX new-session -d -s s2 -- cmd.exe; Start-Sleep -Milliseconds 600
+}
+
+Write-Host "`n=== Issue #408 attach target regression ===" -ForegroundColor Cyan
+
+# --- Test 1: subcommand -t, last_session points elsewhere (the reported bug) ---
+Write-Host "`n[Test 1] attach-session -t s2 with last_session=s1" -ForegroundColor Yellow
+New-TwoDetachedSessions
+$landed = Get-AttachedSession -ArgList @('attach-session','-t','s2') -ForceLastSession 's1'
+if ($landed -eq 's2') { Write-Pass "Client attached to s2 (target honoured)" }
+else { Write-Fail "Client attached to '$landed', expected s2 (BUG: last_session won)" }
+
+# --- Test 2: global -t placement, last_session points elsewhere ---
+Write-Host "`n[Test 2] -t s2 attach-session with last_session=s1" -ForegroundColor Yellow
+New-TwoDetachedSessions
+$landed = Get-AttachedSession -ArgList @('-t','s2','attach-session') -ForceLastSession 's1'
+if ($landed -eq 's2') { Write-Pass "Client attached to s2 (global -t honoured)" }
+else { Write-Fail "Client attached to '$landed', expected s2" }
+
+# --- Test 3: symmetric - target s1 while last_session=s2 ---
+Write-Host "`n[Test 3] attach-session -t s1 with last_session=s2" -ForegroundColor Yellow
+New-TwoDetachedSessions
+$landed = Get-AttachedSession -ArgList @('attach-session','-t','s1') -ForceLastSession 's2'
+if ($landed -eq 's1') { Write-Pass "Client attached to s1 (target honoured)" }
+else { Write-Fail "Client attached to '$landed', expected s1" }
+
+# --- Test 4: bare `attach` (no -t) still falls back to last_session (tmux parity) ---
+Write-Host "`n[Test 4] bare attach with last_session=s1 falls back to s1" -ForegroundColor Yellow
+New-TwoDetachedSessions
+$landed = Get-AttachedSession -ArgList @('attach') -ForceLastSession 's1'
+if ($landed -eq 's1') { Write-Pass "Bare attach used last_session=s1 (fallback intact)" }
+else { Write-Fail "Bare attach landed on '$landed', expected s1" }
+
+# --- Test 5: positional target `attach s2` still works (no regression) ---
+Write-Host "`n[Test 5] positional 'attach s2' with last_session=s1" -ForegroundColor Yellow
+New-TwoDetachedSessions
+$landed = Get-AttachedSession -ArgList @('attach','s2') -ForceLastSession 's1'
+if ($landed -eq 's2') { Write-Pass "Positional attach to s2 honoured" }
+else { Write-Fail "Positional attach landed on '$landed', expected s2" }
+
+# --- Teardown ---
+Reset-Server
+
+Write-Host "`n=== Results ===" -ForegroundColor Cyan
+Write-Host "  Passed: $($script:TestsPassed)" -ForegroundColor Green
+Write-Host "  Failed: $($script:TestsFailed)" -ForegroundColor $(if ($script:TestsFailed -gt 0) { "Red" } else { "Green" })
+exit $script:TestsFailed


### PR DESCRIPTION
## Problem

`attach-session -t NAME` reattaches to the `last_session` marker instead of `NAME` whenever a different session was used last. Reported in discussion #430, tracked as #408 (dup of #393).

Same root cause as the existing PR #418. Opening this as an alternative fix with a deterministic regression test; close whichever you prefer.

## Root cause

The global argument scan strips `-t` (and its value) out of `cmd_args` before the `attach-session` handler runs. The handler re-parsed `-t` from those already-stripped args, found nothing, and fell through `resolve_default_session_name` -> `resolve_last_session_name_ns`, so `last_session` overrode the explicit target.

## Fix

Read `-t` from the full, unstripped argv in the attach branch (via `crate::cli::parse_target`) as first priority. Works for both subcommand-position (`attach-session -t s2`) and global-position (`-t s2 attach-session`). Bare `attach` (falls back to last_session) and positional `attach s2` are unchanged.

```
attach-session -t s2   ->  s2   (was: last_session)
-t s2 attach-session   ->  s2   (was: last_session)
attach                 ->  last_session   (unchanged)
attach s2              ->  s2   (unchanged)
```

## Verification

- New regression test `tests/test_issue408_attach_target_last_session.ps1` launches the attach client and asks the server via `list-clients` which session it actually joined. The 3 targeting cases fail before this change and pass after; 2 guard cases cover the fallback and positional paths.
- Reporter's original steps resolve correctly end to end: `capture-pane -t s2` and `attach-session -t s2` both land on s2 even with `last_session=s1`.
- Full suite: `cargo test --bin psmux` 2144 passed, 0 failed.