### PR TITLE
fix(input): deliver Ctrl+/ as 0x1f under ConPTY terminals (#394)

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1402,6 +1402,24 @@ fn execute_command_string_single(app: &mut AppState, cmd: &str) -> io::Result<()
                                         key.to_string()
                                     }
                                 }
+                                // Ctrl+Shift+<punctuation/digit> collapsing to a C0 byte,
+                                // e.g. Ctrl+/ arriving as "C-S--" -> 0x1f (^_), matching
+                                // Ctrl+_ and tmux (issue #394).  Must precede the generic
+                                // C- arm, whose nth(2) would read the 'S' and mis-send Ctrl+S.
+                                s if (s.starts_with("C-S-") || s.starts_with("C-s-"))
+                                    && s.chars().count() == 5
+                                    && s.chars().nth(4).map_or(false, |c| !c.is_ascii_alphabetic()) =>
+                                {
+                                    if let Some(c) = s.chars().nth(4) {
+                                        if let Some(ctrl) = crate::input::ctrl_char_send_keys_byte(c) {
+                                            String::from(ctrl as char)
+                                        } else {
+                                            String::new()
+                                        }
+                                    } else {
+                                        key.to_string()
+                                    }
+                                }
                                 s if s.starts_with("C-") => {
                                     if let Some(c) = s.chars().nth(2) {
                                         if let Some(ctrl) = crate::input::ctrl_char_send_keys_byte(c) {

--- a/src/input.rs
+++ b/src/input.rs
@@ -1797,7 +1797,12 @@ pub fn encode_key_event(key: &KeyEvent) -> Option<Vec<u8>> {
             format!("\x1b{}", c).into_bytes()
         }
         KeyCode::Char(c) if key.modifiers.contains(KeyModifiers::CONTROL) => {
-            let ctrl_char = (c as u8) & 0x1F;
+            // Use the tmux-parity control mapping so punctuation collapses to the
+            // correct C0 byte: C-/ -> 0x1f (^_), C-- (Ctrl+Shift+-) -> 0x1f, etc.
+            // The naive `c & 0x1f` mis-mapped these (e.g. '/' -> 0x0f ^O, issue
+            // #226) and broke neovim's Ctrl+/ comment-toggle under ConPTY
+            // terminals like Alacritty/WezTerm (issue #394).
+            let ctrl_char = ctrl_char_send_keys_byte(c).unwrap_or((c as u8) & 0x1F);
             vec![ctrl_char]
         }
         KeyCode::Char(c) if (c as u32) >= 0x01 && (c as u32) <= 0x1A => {
@@ -3324,9 +3329,32 @@ pub fn send_key_to_active(app: &mut AppState, k: &str) -> io::Result<()> {
                     let _ = p.writer.write_all(&[ctrl_char]);
                 }
             }
+            // Ctrl+Shift+<punctuation/digit> that collapses to a single C0 byte.
+            // ConPTY terminals (Alacritty, WezTerm) deliver Ctrl+/ as VK_OEM_MINUS
+            // with Ctrl+Shift, so the client forwards it as "C-S--".  That must
+            // reach the child as 0x1f (^_) — identical to Ctrl+_ and to tmux — so
+            // neovim's Ctrl+/ comment-toggle fires.  Before this branch, "C-S--"
+            // matched neither the alphabetic C-S- arm nor the len==3 C- arm and
+            // was silently dropped (issue #394).  No native KEY_EVENT injection:
+            // the raw byte is enough (ConPTY reconstructs the key) and injecting
+            // both would double-deliver (issue #363).
+            s if (s.starts_with("C-S-") || s.starts_with("c-s-"))
+                && s.chars().count() == 5
+                && s.chars().nth(4).map_or(false, |c| !c.is_ascii_alphabetic()) =>
+            {
+                let c = s.chars().nth(4).unwrap();
+                if let Some(byte) = ctrl_char_send_keys_byte(c) {
+                    let _ = p.writer.write_all(&[byte]);
+                    let _ = p.writer.flush();
+                }
+            }
             s if s.starts_with("C-") && s.len() == 3 => {
                 let c = s.chars().nth(2).unwrap_or('c');
-                let ctrl_char = (c.to_ascii_lowercase() as u8) & 0x1F;
+                // tmux-parity mapping so C-/ -> 0x1f (^_), not the naive '/' & 0x1f
+                // == 0x0f (^O) collision with C-o (issue #226/#394).  Letters keep
+                // their usual byte (a->0x01 …), so Ctrl+<letter> is unaffected.
+                let ctrl_char = ctrl_char_send_keys_byte(c)
+                    .unwrap_or((c.to_ascii_lowercase() as u8) & 0x1F);
                 // Always write the raw control byte so ConPTY can generate
                 // console control events (e.g. CTRL_C_EVENT for \x03).
                 // Raw bytes do NOT start with \x1b so they never corrupt
@@ -3456,6 +3484,10 @@ mod tests;
 #[cfg(test)]
 #[path = "../tests-rs/test_issue226_ctrl_slash.rs"]
 mod tests_issue226_ctrl_slash;
+
+#[cfg(test)]
+#[path = "../tests-rs/test_issue394_ctrl_slash_conpty.rs"]
+mod tests_issue394_ctrl_slash_conpty;
 
 #[cfg(test)]
 #[path = "../tests-rs/test_issue284_pageup_wsl.rs"]

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -2133,6 +2133,24 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                                         }
                                     }
                                 }
+                                // Ctrl+Shift+<punctuation/digit> that collapses to a single
+                                // C0 byte, e.g. Ctrl+/ delivered by ConPTY terminals
+                                // (Alacritty, WezTerm) as "C-S--" (VK_OEM_MINUS + Ctrl +
+                                // Shift).  It must reach the child as 0x1f (^_), matching
+                                // Ctrl+_ and tmux, so neovim's Ctrl+/ comment toggle fires
+                                // (issue #394).  This MUST precede the generic C- arm below,
+                                // whose nth(2) extraction would otherwise read the 'S' and
+                                // mis-send Ctrl+S.
+                                s if (s.starts_with("C-S-") || s.starts_with("C-s-"))
+                                    && s.chars().count() == 5
+                                    && s.chars().nth(4).map_or(false, |c| !c.is_ascii_alphabetic()) =>
+                                {
+                                    if let Some(c) = s.chars().nth(4) {
+                                        if let Some(ctrl) = crate::input::ctrl_char_send_keys_byte(c) {
+                                            send_text_to_active(&mut app, &String::from(ctrl as char))?;
+                                        }
+                                    }
+                                }
                                 s if s.starts_with("C-") => {
                                     if let Some(c) = s.chars().nth(2) {
                                         let Some(ctrl) = crate::input::ctrl_char_send_keys_byte(c) else { continue };

--- a/tests-rs/test_issue394_ctrl_slash_conpty.rs
+++ b/tests-rs/test_issue394_ctrl_slash_conpty.rs
@@ -1,0 +1,68 @@
+// Issue #394: Ctrl+/ under ConPTY terminals (Alacritty/WezTerm) on Windows.
+//
+// Those terminals route input through ConPTY, which synthesizes the 0x1f byte
+// (what Ctrl+/ produces) as VK_OEM_MINUS + Ctrl + Shift.  crossterm therefore
+// delivers Ctrl+/ as `Char('-')` with CONTROL|SHIFT, and the client forwards it
+// as the send-key name "C-S--".  Before the fix:
+//   * encode_key_event mapped it with the naive `'-' & 0x1f == 0x0d` (CR), and
+//   * the "C-S--" send-key name matched no arm in send_key_to_active and was
+//     silently dropped.
+// Either way neovim never received 0x1f, so its Ctrl+/ comment-toggle mapping
+// (which fires on 0x1f == C-_ == C-/) never ran.
+//
+// These tests pin the byte-level contract: Ctrl+/ and Ctrl+Shift+- must both
+// encode to 0x1f (^_), matching tmux and Ctrl+_.
+
+use super::*;
+use crossterm::event::{KeyCode, KeyEvent, KeyEventKind, KeyEventState, KeyModifiers};
+
+fn key(code: KeyCode, modifiers: KeyModifiers) -> KeyEvent {
+    KeyEvent { code, modifiers, kind: KeyEventKind::Press, state: KeyEventState::NONE }
+}
+
+// === encode_key_event: the direct byte path ===
+
+#[test]
+fn ctrl_slash_encodes_to_unit_separator() {
+    // Ctrl+/ (as delivered by native-path terminals) must be 0x1f, not 0x0f (^O).
+    let ev = key(KeyCode::Char('/'), KeyModifiers::CONTROL);
+    assert_eq!(encode_key_event(&ev).unwrap(), vec![0x1f]);
+}
+
+#[test]
+fn ctrl_shift_minus_encodes_to_unit_separator() {
+    // Ctrl+/ as ConPTY delivers it: Char('-') + CONTROL + SHIFT.  Must be 0x1f,
+    // NOT the naive '-' & 0x1f == 0x0d (CR) that the old code produced.
+    let ev = key(KeyCode::Char('-'), KeyModifiers::CONTROL | KeyModifiers::SHIFT);
+    let bytes = encode_key_event(&ev).unwrap();
+    assert_eq!(bytes, vec![0x1f], "Ctrl+Shift+- must be ^_ (0x1f), got {:02x?}", bytes);
+    assert_ne!(bytes, vec![0x0d], "regression: Ctrl+Shift+- collapsed to CR");
+}
+
+#[test]
+fn ctrl_underscore_encodes_to_unit_separator() {
+    // The canonical spelling of the same byte.
+    let ev = key(KeyCode::Char('_'), KeyModifiers::CONTROL);
+    assert_eq!(encode_key_event(&ev).unwrap(), vec![0x1f]);
+}
+
+#[test]
+fn ctrl_letters_are_unchanged_by_the_fix() {
+    // Guard: Ctrl+<letter> must keep its usual control byte (a->0x01 … w->0x17).
+    assert_eq!(encode_key_event(&key(KeyCode::Char('a'), KeyModifiers::CONTROL)).unwrap(), vec![0x01]);
+    assert_eq!(encode_key_event(&key(KeyCode::Char('c'), KeyModifiers::CONTROL)).unwrap(), vec![0x03]);
+    assert_eq!(encode_key_event(&key(KeyCode::Char('w'), KeyModifiers::CONTROL)).unwrap(), vec![0x17]);
+}
+
+// === ctrl_char_send_keys_byte parity used by the send-key dispatch arms ===
+
+#[test]
+fn dispatch_helper_maps_slash_and_minus_to_1f() {
+    // Both spellings the three dispatch paths (input.rs, server/mod.rs,
+    // commands.rs) rely on must yield 0x1f.
+    assert_eq!(ctrl_char_send_keys_byte('/'), Some(0x1f));
+    assert_eq!(ctrl_char_send_keys_byte('-'), Some(0x1f));
+    assert_eq!(ctrl_char_send_keys_byte('_'), Some(0x1f));
+    // And must NOT collide with C-o (^O 0x0f), the exact #226/#394 collision.
+    assert_ne!(ctrl_char_send_keys_byte('/'), ctrl_char_send_keys_byte('o'));
+}


### PR DESCRIPTION
Fixes #394.

## Problem

Under Alacritty/WezTerm on Windows, ConPTY synthesizes the `0x1f` byte that Ctrl+/ produces as `VK_OEM_MINUS` with Ctrl+Shift, so crossterm reports it as `Char('-') + CONTROL + SHIFT` and the client forwards the send-key name `C-S--`. The send-key decode paths then dropped or mis-mapped it, so the child (e.g. neovim) never received `0x1f` and its Ctrl+/ comment toggle never fired. Windows Terminal was unaffected because it uses native `INPUT_RECORD`s.

## Fix

Route all four send-key decode paths through the tmux-parity helper `ctrl_char_send_keys_byte` (which already maps `/`, `-`, `_` to `0x1f`, see #226) and add a `C-S-<punctuation>` arm so the shifted form is no longer dropped:

- `src/input.rs` `encode_key_event`: Ctrl branch uses `ctrl_char_send_keys_byte` instead of the naive `c & 0x1f` (which gave `/` -> 0x0f, `-` -> 0x0d).
- `src/input.rs` `send_key_to_active`: new `C-S-<non-alphabetic>` arm; the len==3 `C-` arm now uses `ctrl_char_send_keys_byte`.
- `src/server/mod.rs` SendKeys and `src/commands.rs` send-keys dispatch: new `C-S-<non-alphabetic>` arm before the generic `C-` arm, whose `nth(2)` char extraction otherwise read the `S` and mis-sent Ctrl+S.

Ctrl+<letter> and Ctrl+Shift+<letter> (#368) are untouched: the new arms match only non-alphabetic keys, and `ctrl_char_send_keys_byte` returns the same byte for letters.

## Verification

Adds `tests-rs/test_issue394_ctrl_slash_conpty.rs` (5 tests). Full suite passes.