### PR TITLE
Fix two Windows process-teardown leaks (inverted TerminateProcess, prune_exited orphan)

### DIFF
--- a/crates/portable-pty-psmux/src/win/mod.rs
+++ b/crates/portable-pty-psmux/src/win/mod.rs
@@ -42,7 +42,8 @@ impl WinChild {
         let proc = self.proc.lock().unwrap().try_clone().unwrap();
         let res = unsafe { TerminateProcess(proc.as_raw_handle() as _, 1) };
         let err = IoError::last_os_error();
-        if res != 0 {
+        // TerminateProcess returns nonzero on SUCCESS, zero on failure.
+        if res == 0 {
             Err(err)
         } else {
             Ok(())
@@ -71,7 +72,8 @@ impl ChildKiller for WinChildKiller {
     fn kill(&mut self) -> IoResult<()> {
         let res = unsafe { TerminateProcess(self.proc.as_raw_handle() as _, 1) };
         let err = IoError::last_os_error();
-        if res != 0 {
+        // TerminateProcess returns nonzero on SUCCESS, zero on failure.
+        if res == 0 {
             Err(err)
         } else {
             Ok(())

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -423,6 +423,12 @@ pub fn prune_exited(n: Node, remain_on_exit: bool) -> (Option<Node>, usize) {
                         p.dead = true;
                         (Some(Node::Leaf(p)), 1)
                     } else {
+                        // Shell exited on its own: sweep any orphaned descendants
+                        // (backgrounded child processes) before dropping the pane.
+                        // Closing the ConPTY alone does NOT terminate grandchildren,
+                        // so without this they leak. Mirrors the explicit kill-pane
+                        // path and the reaper case kill_process_tree documents.
+                        crate::platform::process_kill::kill_process_tree(&mut p.child);
                         (None, 0)
                     }
                 }


### PR DESCRIPTION
Two small Windows process-teardown fixes found while auditing a real process leak.

**1. Inverted `TerminateProcess` return** — `crates/portable-pty-psmux/src/win/mod.rs`
Win32 `TerminateProcess` returns **nonzero on success**, zero on failure, but `do_kill` and `WinChildKiller::kill` returned `Err` on success / `Ok` on failure. `WinChild::kill` hides it with `.ok()`, but `WinChildKiller::kill` (from `clone_killer`) hands callers the inverted result. Fixed to `if res == 0 { Err } else { Ok }`.

**2. `prune_exited` orphans a self-exited shell's process tree** — `src/tree.rs`
When a pane's shell exits on its own (`try_wait()==Some`, `remain_on_exit=false`), the pane is dropped — only the ConPTY closes. Backgrounded grandchildren of that shell then leak, because `kill_process_tree` (which the explicit kill-pane/window/session paths already call) is never run on this path. Added the sweep.

## Validation
`tests/test_kill_tree.ps1` passes (4/4) against a full release build.

---
*Authored by Claude (Anthropic) at @andrew-tawfeek's direction, after debugging a Windows process-leak he hit in production.*
