### PR TITLE
fix(rendering): stop rewriting box-drawing characters inside pane content at border junctions

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -575,6 +575,87 @@ fn collect_layout_borders(
     }
 }
 
+pub fn border_mask_from_layout(
+    node: &LayoutJson,
+    area: Rect,
+    buf_area: Rect,
+    zoomed: bool,
+) -> Vec<usize> {
+    let mut cells = Vec::new();
+    mark_layout_borders(node, area, buf_area, zoomed, &mut cells);
+    cells.sort_unstable();
+    cells.dedup();
+    cells
+}
+
+fn mark_layout_borders(
+    node: &LayoutJson,
+    area: Rect,
+    buf_area: Rect,
+    zoomed: bool,
+    cells: &mut Vec<usize>,
+) {
+    let LayoutJson::Split {
+        kind,
+        sizes,
+        children,
+    } = node
+    else {
+        return;
+    };
+    let effective_sizes: Vec<u16> = if sizes.len() == children.len() {
+        sizes.clone()
+    } else {
+        vec![(100 / children.len().max(1)) as u16; children.len()]
+    };
+    let is_horizontal = kind == "Horizontal";
+
+    if zoomed {
+        // Match render_layout_json's zoom early-return exactly: no separator
+        // drawn for this split, recurse into the chosen child at the SAME area.
+        if let Some(i) = effective_sizes.iter().position(|&s| s != 0) {
+            if let Some(child) = children.get(i) {
+                mark_layout_borders(child, area, buf_area, zoomed, cells);
+            }
+        }
+        return;
+    }
+
+    let rects = split_with_gaps(is_horizontal, &effective_sizes, area);
+    let w = buf_area.width as usize;
+    for i in 0..children.len().saturating_sub(1) {
+        if i >= rects.len() {
+            break;
+        }
+        if is_horizontal {
+            // Vertical separator line at column `pos`, spanning this split's own area height.
+            let pos = rects[i].x + rects[i].width;
+            if pos >= buf_area.x && pos < buf_area.x + buf_area.width {
+                for y in area.y..area.y + area.height {
+                    if y >= buf_area.y && y < buf_area.y + buf_area.height {
+                        cells.push((y - buf_area.y) as usize * w + (pos - buf_area.x) as usize);
+                    }
+                }
+            }
+        } else {
+            // Horizontal separator line at row `pos`, spanning this split's own area width.
+            let pos = rects[i].y + rects[i].height;
+            if pos >= buf_area.y && pos < buf_area.y + buf_area.height {
+                for x in area.x..area.x + area.width {
+                    if x >= buf_area.x && x < buf_area.x + buf_area.width {
+                        cells.push((pos - buf_area.y) as usize * w + (x - buf_area.x) as usize);
+                    }
+                }
+            }
+        }
+    }
+    for (i, child) in children.iter().enumerate() {
+        if i < rects.len() {
+            mark_layout_borders(child, rects[i], buf_area, zoomed, cells);
+        }
+    }
+}
+
 /// Check if any leaf in a LayoutJson subtree is the active pane.
 /// Compute the rectangle of the active pane by searching the LayoutJson tree.
 pub fn compute_active_rect_json(node: &LayoutJson, area: Rect) -> Option<Rect> {
@@ -4768,34 +4849,31 @@ pub fn run_remote(terminal: &mut Terminal<CrosstermBackend<crate::platform::Psmu
                 } else { None }
             };
             render_layout_json(f, &root, content_chunk, dim_preds, pane_border_fg, pane_active_border_fg, clock_active, clock_col, active_rect, &mode_style_str, state.zoomed, border_status, border_format, total_panes, bchars, copy_ln);
-            fix_border_intersections(f.buffer_mut(), bchars);
+            let border_mask = border_mask_from_layout(&root, content_chunk, f.buffer_mut().area, state.zoomed);
+            fix_border_intersections(f.buffer_mut(), bchars, &border_mask);
             // render_json and fix_border_intersections can leave inconsistent styles
             // at intersections and along edges shared by nested splits.
             if let Some(ar) = active_rect {
                 let buf = f.buffer_mut();
                 let w = buf.area.width as usize;
-                let h = buf.area.height as usize;
                 let border_style = Style::default().fg(pane_border_fg);
                 let active_style = Style::default().fg(pane_active_border_fg);
-                for row in 0..h {
-                    for col in 0..w {
-                        let idx = row * w + col;
-                        if idx >= buf.content.len() { continue; }
-                        let ch = buf.content[idx].symbol().chars().next().unwrap_or(' ');
-                        // Only re-color junction characters. The straight │ and ─ separators
-                        // are now already colored correctly per-cell by render_layout_json based
-                        // on adjacency, so re-coloring them here would clobber that work for
-                        // 3+ pane layouts where a separator borders both active and inactive panes.
-                        if !matches!(ch, '┼' | '├' | '┤' | '┬' | '┴') { continue; }
-                        let x = buf.area.x + col as u16;
-                        let y = buf.area.y + row as u16;
-                        let adj = (x + 1 == ar.x && y >= ar.y && y < ar.y + ar.height)
-                            || (x == ar.x + ar.width && y >= ar.y && y < ar.y + ar.height)
-                            || (y + 1 == ar.y && x >= ar.x && x < ar.x + ar.width)
-                            || (y == ar.y + ar.height && x >= ar.x && x < ar.x + ar.width)
-                            || ((x + 1 == ar.x || x == ar.x + ar.width) && (y + 1 == ar.y || y == ar.y + ar.height));
-                        buf.content[idx].set_style(if adj { active_style } else { border_style });
-                    }
+                for &idx in &border_mask {
+                    if idx >= buf.content.len() { continue; }
+                    let ch = buf.content[idx].symbol().chars().next().unwrap_or(' ');
+                    // Only re-color junction characters. The straight │ and ─ separators
+                    // are now already colored correctly per-cell by render_layout_json based
+                    // on adjacency, so re-coloring them here would clobber that work for
+                    // 3+ pane layouts where a separator borders both active and inactive panes.
+                    if !matches!(ch, '┼' | '├' | '┤' | '┬' | '┴') { continue; }
+                    let x = buf.area.x + (idx % w) as u16;
+                    let y = buf.area.y + (idx / w) as u16;
+                    let adj = (x + 1 == ar.x && y >= ar.y && y < ar.y + ar.height)
+                        || (x == ar.x + ar.width && y >= ar.y && y < ar.y + ar.height)
+                        || (y + 1 == ar.y && x >= ar.x && x < ar.x + ar.width)
+                        || (y == ar.y + ar.height && x >= ar.x && x < ar.x + ar.width)
+                        || ((x + 1 == ar.x || x == ar.x + ar.width) && (y + 1 == ar.y || y == ar.y + ar.height));
+                    buf.content[idx].set_style(if adj { active_style } else { border_style });
                 }
             }
 

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -2555,6 +2555,10 @@ mod tests_pr255_active_border;
 mod tests_pane_border_lines_render;
 
 #[cfg(test)]
+#[path = "../tests-rs/test_pane_content_box_drawing.rs"]
+mod tests_pane_content_box_drawing;
+
+#[cfg(test)]
 #[path = "../tests-rs/test_copy_line_numbers_render.rs"]
 mod tests_copy_line_numbers_render;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -420,7 +420,8 @@ fn run_main() -> io::Result<()> {
                     crate::border_lines::border_chars(crate::border_lines::DEFAULT),
                     None,
                 );
-                crate::rendering::fix_border_intersections(f.buffer_mut(), crate::border_lines::border_chars(crate::border_lines::DEFAULT));
+                let border_mask = crate::client::border_mask_from_layout(&layout, area, f.buffer_mut().area, false);
+                crate::rendering::fix_border_intersections(f.buffer_mut(), crate::border_lines::border_chars(crate::border_lines::DEFAULT), &border_mask);
             }).unwrap();
             // Dump the buffer as ANSI escape sequences so colors are visible.
             let buf = term.backend().buffer().clone();

--- a/src/preview.rs
+++ b/src/preview.rs
@@ -712,7 +712,8 @@ pub fn render_dump_tree(
         crate::border_lines::border_chars(crate::border_lines::DEFAULT),
         None,
     );
-    crate::rendering::fix_border_intersections(f.buffer_mut(), crate::border_lines::border_chars(crate::border_lines::DEFAULT));
+    let border_mask = crate::client::border_mask_from_layout(layout, area, f.buffer_mut().area, false);
+    crate::rendering::fix_border_intersections(f.buffer_mut(), crate::border_lines::border_chars(crate::border_lines::DEFAULT), &border_mask);
 }
 
 #[cfg(test)]

--- a/src/rendering.rs
+++ b/src/rendering.rs
@@ -140,13 +140,22 @@ pub fn render_window(f: &mut Frame, app: &mut AppState, area: Rect) {
     let win = &mut app.windows[app.active_idx];
     let active_rect = compute_active_rect(&win.root, &win.active_path, area);
     render_node(f, &mut win.root, &win.active_path, &mut Vec::new(), area, dim_preds, border_style, active_border_style, copy_cursor, active_rect, window_style, window_active_style, &border_status, &border_format, &mut 0, bchars);
-    fix_border_intersections(f.buffer_mut(), bchars);
+    let buf_area = f.buffer_mut().area;
+    let mask = border_mask_from_node(&win.root, area, buf_area);
+    fix_border_intersections(f.buffer_mut(), bchars, &mask);
 }
 
 /// Post-pass: fix border intersection characters where horizontal and vertical
 /// separator lines meet. Converts plain '│' and '─' to proper junction
 /// characters ('┼', '├', '┤', '┬', '┴') at intersection points.
-pub fn fix_border_intersections(buf: &mut Buffer, bchars: Option<crate::border_lines::BorderChars>) {
+///
+/// `sep_cells` is the sorted, deduplicated list of cell indices psmux actually
+/// drew separators on (indexed like `buf.content`, i.e. `row * buf.area.width +
+/// col` relative to `buf.area`). Both the candidate cell and the crossing
+/// neighbour must be in `sep_cells` before a junction glyph is pushed, so
+/// box-drawing characters printed by child programs inside pane content (which
+/// are never in the list) are left untouched.
+pub fn fix_border_intersections(buf: &mut Buffer, bchars: Option<crate::border_lines::BorderChars>, sep_cells: &[usize]) {
     // `none` (bchars == None) draws no separators, and `spaces` has no distinct
     // junction glyphs, so intersection-fixing is a no-op for both.
     let Some(bc) = bchars else { return; };
@@ -158,53 +167,115 @@ pub fn fix_border_intersections(buf: &mut Buffer, bchars: Option<crate::border_l
     let h = buf.area.height as usize;
     if w == 0 || h == 0 { return; }
 
+    let is_sep = |i: usize| sep_cells.binary_search(&i).is_ok();
+
     // Collect fixes first so detection sees only original characters.
     let mut fixes: Vec<(usize, char)> = Vec::new();
 
-    for row in 0..h {
-        for col in 0..w {
-            let idx = row * w + col;
-            if idx >= buf.content.len() { continue; }
-            let ch = buf.content[idx].symbol().chars().next().unwrap_or(' ');
+    // Walk only the drawn separator cells rather than scanning the whole buffer.
+    for &idx in sep_cells {
+        if idx >= buf.content.len() { continue; }
+        let row = idx / w;
+        let col = idx % w;
+        let ch = buf.content[idx].symbol().chars().next().unwrap_or(' ');
 
-            if ch == vert {
-                // Cell already has vertical (up+down). Check for horizontal neighbours.
-                let has_left = col > 0 && {
-                    let li = row * w + (col - 1);
-                    li < buf.content.len() && buf.content[li].symbol().chars().next() == Some(horiz)
-                };
-                let has_right = col + 1 < w && {
-                    let ri = row * w + (col + 1);
-                    ri < buf.content.len() && buf.content[ri].symbol().chars().next() == Some(horiz)
-                };
-                match (has_left, has_right) {
-                    (true, true)  => fixes.push((idx, bc.cross)),
-                    (true, false) => fixes.push((idx, bc.right_tee)),
-                    (false, true) => fixes.push((idx, bc.left_tee)),
-                    _ => {}
-                }
-            } else if ch == horiz {
-                // Cell already has horizontal (left+right). Check for vertical neighbours.
-                let has_up = row > 0 && {
-                    let ui = (row - 1) * w + col;
-                    ui < buf.content.len() && buf.content[ui].symbol().chars().next() == Some(vert)
-                };
-                let has_down = row + 1 < h && {
-                    let di = (row + 1) * w + col;
-                    di < buf.content.len() && buf.content[di].symbol().chars().next() == Some(vert)
-                };
-                match (has_up, has_down) {
-                    (true, true)  => fixes.push((idx, bc.cross)),
-                    (true, false) => fixes.push((idx, bc.bottom_tee)),
-                    (false, true) => fixes.push((idx, bc.top_tee)),
-                    _ => {}
-                }
+        if ch == vert {
+            // Cell already has vertical (up+down). Check for horizontal neighbours.
+            let has_left = col > 0 && {
+                let li = row * w + (col - 1);
+                li < buf.content.len() && is_sep(li)
+                    && buf.content[li].symbol().starts_with(horiz)
+            };
+            let has_right = col + 1 < w && {
+                let ri = row * w + (col + 1);
+                ri < buf.content.len() && is_sep(ri)
+                    && buf.content[ri].symbol().starts_with(horiz)
+            };
+            match (has_left, has_right) {
+                (true, true)  => fixes.push((idx, bc.cross)),
+                (true, false) => fixes.push((idx, bc.right_tee)),
+                (false, true) => fixes.push((idx, bc.left_tee)),
+                _ => {}
+            }
+        } else if ch == horiz {
+            // Cell already has horizontal (left+right). Check for vertical neighbours.
+            let has_up = row > 0 && {
+                let ui = (row - 1) * w + col;
+                ui < buf.content.len() && is_sep(ui)
+                    && buf.content[ui].symbol().starts_with(vert)
+            };
+            let has_down = row + 1 < h && {
+                let di = (row + 1) * w + col;
+                di < buf.content.len() && is_sep(di)
+                    && buf.content[di].symbol().starts_with(vert)
+            };
+            match (has_up, has_down) {
+                (true, true)  => fixes.push((idx, bc.cross)),
+                (true, false) => fixes.push((idx, bc.bottom_tee)),
+                (false, true) => fixes.push((idx, bc.top_tee)),
+                _ => {}
             }
         }
     }
 
     for (idx, ch) in fixes {
         buf.content[idx].set_char(ch);
+    }
+}
+
+/// Collect the buffer-cell indices where psmux draws a pane separator,
+/// mirroring the separator geometry in [`render_node`]'s `Node::Split` arm
+/// (`split_with_gaps` → `rects[i].x + width` / `rects[i].y + height`, spanning
+/// the split's own `area`).
+///
+/// Indices match `Buffer::content` (`(y - buf_area.y) * buf_area.width +
+/// (x - buf_area.x)`). The result is sorted and deduplicated so callers can
+/// iterate the drawn cells directly and test membership with `binary_search`
+/// (see [`fix_border_intersections`]) — no whole-buffer array needed.
+pub fn border_mask_from_node(root: &Node, area: Rect, buf_area: Rect) -> Vec<usize> {
+    let mut cells = Vec::new();
+    mark_node_borders(root, area, buf_area, &mut cells);
+    cells.sort_unstable();
+    cells.dedup();
+    cells
+}
+
+fn mark_node_borders(node: &Node, area: Rect, buf_area: Rect, cells: &mut Vec<usize>) {
+    let Node::Split { kind, sizes, children } = node else { return; };
+    let effective_sizes: Vec<u16> = if sizes.len() == children.len() {
+        sizes.clone()
+    } else { vec![100 / children.len().max(1) as u16; children.len()] };
+    let is_horizontal = *kind == LayoutKind::Horizontal;
+    let rects = split_with_gaps(is_horizontal, &effective_sizes, area);
+    for (i, child) in children.iter().enumerate() {
+        if i < rects.len() {
+            mark_node_borders(child, rects[i], buf_area, cells);
+        }
+    }
+
+    let w = buf_area.width as usize;
+    for i in 0..children.len().saturating_sub(1) {
+        if i >= rects.len() { break; }
+        if is_horizontal {
+            let sep_x = rects[i].x + rects[i].width;
+            if sep_x < buf_area.x + buf_area.width && sep_x >= buf_area.x {
+                for y in area.y..area.y + area.height {
+                    if y >= buf_area.y && y < buf_area.y + buf_area.height {
+                        // Guards above bound y/x to buf_area, so idx < w*h.
+                        cells.push((y - buf_area.y) as usize * w + (sep_x - buf_area.x) as usize);
+                    }
+                }
+            }
+        } else {
+            let sep_y = rects[i].y + rects[i].height;
+            if sep_y < buf_area.y + buf_area.height && sep_y >= buf_area.y {
+                for x in area.x..area.x + area.width {
+                    if x >= buf_area.x && x < buf_area.x + buf_area.width {
+                        cells.push((sep_y - buf_area.y) as usize * w + (x - buf_area.x) as usize);
+                    }
+                }
+            }
+        }
     }
 }
 

--- a/tests-rs/test_pane_border_lines_render.rs
+++ b/tests-rs/test_pane_border_lines_render.rs
@@ -69,7 +69,8 @@ fn render_counts(kind: &str, style: &str, w: u16, h: u16) -> std::collections::H
             bchars,
             None,
         );
-        crate::rendering::fix_border_intersections(f.buffer_mut(), bchars);
+        let border_mask = crate::client::border_mask_from_layout(&layout, area, f.buffer_mut().area, false);
+        crate::rendering::fix_border_intersections(f.buffer_mut(), bchars, &border_mask);
     }).unwrap();
 
     let buf = term.backend().buffer().clone();
@@ -157,7 +158,8 @@ fn nested_split_produces_double_junction() {
             false, Color::Reset, active_rect, "", false, "off", "", total, bchars,
             None,
         );
-        crate::rendering::fix_border_intersections(f.buffer_mut(), bchars);
+        let border_mask = crate::client::border_mask_from_layout(&layout, area, f.buffer_mut().area, false);
+        crate::rendering::fix_border_intersections(f.buffer_mut(), bchars, &border_mask);
     }).unwrap();
     let buf = term.backend().buffer().clone();
     let mut junctions = 0;

--- a/tests-rs/test_pane_content_box_drawing.rs
+++ b/tests-rs/test_pane_content_box_drawing.rs
@@ -1,0 +1,263 @@
+// Regression test for #452: a Markdown table (box-drawing │ ─ ┼) printed by a
+// program *inside* pane content must never be mistaken for a psmux-drawn pane
+// border. Before the geometry-mask fix, the whole-buffer recolor pass in
+// `run_remote` restyled every junction glyph ('┼', '├', '┤', '┬', '┴') with
+// the pane-border color, dimming a table's joints while its '│'/'─' lines
+// kept the content's own colors — mismatched joints. `fix_border_intersections`
+// had the same character-sniffing problem and could also rewrite content
+// '│'/'─' adjacent to a perpendicular '─'/'│' into junction glyphs.
+//
+// This test builds a real split layout (so a genuine separator exists
+// elsewhere in the buffer), injects a small box-drawing table into one pane's
+// content region, builds the geometry mask via `border_mask_from_layout`, and
+// asserts `fix_border_intersections` leaves every content cell's glyph AND
+// style untouched.
+
+use crate::layout::LayoutJson;
+
+fn leaf(id: usize, active: bool) -> LayoutJson {
+    LayoutJson::Leaf {
+        id,
+        rows: 10,
+        cols: 20,
+        cursor_row: 0,
+        cursor_col: 0,
+        alternate_screen: false,
+        hide_cursor: false,
+        cursor_shape: 0,
+        active,
+        copy_mode: false,
+        scroll_offset: 0,
+        sel_start_row: None,
+        sel_start_col: None,
+        sel_end_row: None,
+        sel_end_col: None,
+        sel_mode: None,
+        copy_cursor_row: None,
+        copy_cursor_col: None,
+        content: Vec::new(),
+        rows_v2: Vec::new(),
+        title: None,
+    }
+}
+
+fn split(kind: &str, children: Vec<LayoutJson>) -> LayoutJson {
+    LayoutJson::Split {
+        kind: kind.to_string(),
+        sizes: vec![50; children.len()],
+        children,
+    }
+}
+
+#[cfg(windows)]
+#[test]
+fn fix_border_intersections_leaves_pane_content_table_untouched() {
+    use ratatui::backend::TestBackend;
+    use ratatui::layout::Rect;
+    use ratatui::style::{Color, Style};
+    use ratatui::Terminal;
+
+    // 2-pane horizontal split: a real separator column exists somewhere near
+    // the middle of the 40-wide buffer. We inject the markdown table into the
+    // left pane, well clear of that separator column.
+    let layout = split("Horizontal", vec![leaf(0, true), leaf(1, false)]);
+    let backend = TestBackend::new(40, 12);
+    let mut term = Terminal::new(backend).unwrap();
+    let total = layout.count_leaves();
+    let border_fg = Color::DarkGray;
+    let active_border_fg = Color::Green;
+    let content_fg = Color::Yellow;
+    let bchars = crate::border_lines::border_chars("single");
+
+    // Markdown-table-like block: header separator row uses '┼', straight
+    // lines use '│' and '─'. Written into rows 2..5, cols 2..9 — inside the
+    // left pane (cols 0..~19), far from the separator column (~19-20).
+    let table_rows: [&str; 3] = [
+        "a│b─┼c─",
+        "──┼────",
+        "d│e─┼f─",
+    ];
+
+    let mut snapshot: Vec<(usize, char, Style)> = Vec::new();
+
+    term.draw(|f| {
+        let area = Rect::new(0, 0, 40, 12);
+        let active_rect = crate::client::compute_active_rect_json(&layout, area);
+        crate::client::render_layout_json(
+            f, &layout, area,
+            false,
+            border_fg, active_border_fg,
+            false, Color::Reset,
+            active_rect,
+            "", false, "off", "",
+            total,
+            bchars,
+            None,
+        );
+
+        // Inject the fake table into the buffer as pane content would appear.
+        let buf = f.buffer_mut();
+        let w = buf.area.width as usize;
+        let content_style = Style::default().fg(content_fg);
+        for (r, row_str) in table_rows.iter().enumerate() {
+            let y = 2 + r;
+            for (c, ch) in row_str.chars().enumerate() {
+                let x = 2 + c;
+                let idx = y * w + x;
+                if idx < buf.content.len() {
+                    buf.content[idx].set_char(ch);
+                    buf.content[idx].set_style(content_style);
+                }
+            }
+        }
+
+        // Snapshot the injected cells before running the post-pass.
+        for (r, row_str) in table_rows.iter().enumerate() {
+            let y = 2 + r;
+            for (c, _) in row_str.chars().enumerate() {
+                let x = 2 + c;
+                let idx = y * w + x;
+                if idx < buf.content.len() {
+                    let cell = &buf.content[idx];
+                    snapshot.push((idx, cell.symbol().chars().next().unwrap_or(' '), cell.style()));
+                }
+            }
+        }
+
+        let border_mask = crate::client::border_mask_from_layout(&layout, area, buf.area, false);
+
+        // Sanity: the mask must be false for every injected content cell,
+        // otherwise this test isn't exercising the guard.
+        for &(idx, _, _) in &snapshot {
+            assert!(border_mask.binary_search(&idx).is_err(), "content cell idx {} unexpectedly marked as a separator", idx);
+        }
+
+        crate::rendering::fix_border_intersections(f.buffer_mut(), bchars, &border_mask);
+    }).unwrap();
+
+    let buf = term.backend().buffer().clone();
+    for (idx, expected_ch, expected_style) in snapshot {
+        let cell = &buf.content[idx];
+        let actual_ch = cell.symbol().chars().next().unwrap_or(' ');
+        assert_eq!(actual_ch, expected_ch, "content cell idx {} glyph changed", idx);
+        assert_eq!(cell.style(), expected_style, "content cell idx {} style changed", idx);
+        assert_ne!(cell.style().fg, Some(border_fg), "content cell idx {} recolored to border fg", idx);
+        assert_ne!(cell.style().fg, Some(active_border_fg), "content cell idx {} recolored to active border fg", idx);
+    }
+}
+
+// Regression test for the zoom-unaware follow-up bug: `border_mask_from_layout`
+// must mirror `render_layout_json`'s zoom early-return exactly. When zoomed,
+// `window_ops::toggle_zoom` encodes the layout with sizes like `[100, 0]`.
+// `split_with_gaps`'s min-1-cell-stealing turns `[100, 0]` into e.g. `[78, 1]`
+// for width 80, which (if the mask were computed as though unzoomed) would
+// mark a phantom separator column at `area.x + 78` — squarely inside content
+// that `render_layout_json` actually rendered edge-to-edge across the full
+// area for the zoomed pane. A junction char sitting on that column must never
+// be treated as a real separator.
+#[cfg(windows)]
+#[test]
+fn fix_border_intersections_leaves_zoomed_pane_content_untouched() {
+    use ratatui::backend::TestBackend;
+    use ratatui::layout::Rect;
+    use ratatui::style::{Color, Style};
+    use ratatui::Terminal;
+
+    // Zoomed 2-pane horizontal split, sizes [100, 0] — exactly how
+    // window_ops::toggle_zoom encodes "pane 0 is zoomed".
+    let layout = LayoutJson::Split {
+        kind: "Horizontal".to_string(),
+        sizes: vec![100, 0],
+        children: vec![leaf(0, true), leaf(1, false)],
+    };
+    let backend = TestBackend::new(80, 12);
+    let mut term = Terminal::new(backend).unwrap();
+    let border_fg = Color::DarkGray;
+    let active_border_fg = Color::Green;
+    let content_fg = Color::Yellow;
+    let bchars = crate::border_lines::border_chars("single");
+
+    // Box-drawing content straddling column 78 (the phantom separator column
+    // for the equivalent UNZOOMED [78, 1] split geometry), including a
+    // junction glyph '┼' at that exact column.
+    let table_rows: [&str; 3] = [
+        "a─┼b",
+        "──┼─",
+        "c─┼d",
+    ];
+    let start_x: usize = 76; // columns 76..79; column 78 is the 3rd char (index 2)
+
+    let mut snapshot: Vec<(usize, char, Style)> = Vec::new();
+    let mut phantom_col_idx: usize = 0;
+
+    term.draw(|f| {
+        let area = Rect::new(0, 0, 80, 12);
+        let active_rect = crate::client::compute_active_rect_json_zoom_aware(&layout, area, true);
+        // Production sets total_panes = 1 when zoomed (client.rs: `if state.zoomed { 1 } else { root.count_leaves() }`).
+        let total_panes = 1;
+        crate::client::render_layout_json(
+            f, &layout, area,
+            false,
+            border_fg, active_border_fg,
+            false, Color::Reset,
+            active_rect,
+            "", true, "off", "",
+            total_panes,
+            bchars,
+            None,
+        );
+
+        let buf = f.buffer_mut();
+        let w = buf.area.width as usize;
+        phantom_col_idx = 3 * w + 78;
+        let content_style = Style::default().fg(content_fg);
+        for (r, row_str) in table_rows.iter().enumerate() {
+            let y = 3 + r;
+            for (c, ch) in row_str.chars().enumerate() {
+                let x = start_x + c;
+                let idx = y * w + x;
+                if idx < buf.content.len() {
+                    buf.content[idx].set_char(ch);
+                    buf.content[idx].set_style(content_style);
+                }
+            }
+        }
+
+        for (r, row_str) in table_rows.iter().enumerate() {
+            let y = 3 + r;
+            for (c, _) in row_str.chars().enumerate() {
+                let x = start_x + c;
+                let idx = y * w + x;
+                if idx < buf.content.len() {
+                    let cell = &buf.content[idx];
+                    snapshot.push((idx, cell.symbol().chars().next().unwrap_or(' '), cell.style()));
+                }
+            }
+        }
+
+        let border_mask = crate::client::border_mask_from_layout(&layout, area, buf.area, true);
+
+        // The phantom-separator column (78) for the equivalent unzoomed
+        // [78, 1] split geometry must NOT be marked as a separator when zoomed.
+        assert!(
+            border_mask.binary_search(&phantom_col_idx).is_err(),
+            "zoomed mask incorrectly marked phantom separator column 78 (idx {}) as a real border",
+            phantom_col_idx
+        );
+        for &(idx, _, _) in &snapshot {
+            assert!(border_mask.binary_search(&idx).is_err(), "content cell idx {} unexpectedly marked as a separator under zoom", idx);
+        }
+
+        crate::rendering::fix_border_intersections(f.buffer_mut(), bchars, &border_mask);
+    }).unwrap();
+
+    let buf = term.backend().buffer().clone();
+    for (idx, expected_ch, expected_style) in snapshot {
+        let cell = &buf.content[idx];
+        let actual_ch = cell.symbol().chars().next().unwrap_or(' ');
+        assert_eq!(actual_ch, expected_ch, "zoomed content cell idx {} glyph changed", idx);
+        assert_eq!(cell.style(), expected_style, "zoomed content cell idx {} style changed", idx);
+        assert_ne!(cell.style().fg, Some(border_fg), "zoomed content cell idx {} recolored to border fg", idx);
+        assert_ne!(cell.style().fg, Some(active_border_fg), "zoomed content cell idx {} recolored to active border fg", idx);
+    }
+}

--- a/tests-rs/test_pr255_active_border.rs
+++ b/tests-rs/test_pr255_active_border.rs
@@ -137,7 +137,8 @@ fn render_three_panes_does_not_color_unrelated_separator_active() {
             crate::border_lines::border_chars("single"),
             None,
         );
-        crate::rendering::fix_border_intersections(f.buffer_mut(), crate::border_lines::border_chars("single"));
+        let border_mask = crate::client::border_mask_from_layout(&layout, area, f.buffer_mut().area, false);
+        crate::rendering::fix_border_intersections(f.buffer_mut(), crate::border_lines::border_chars("single"), &border_mask);
     }).unwrap();
 
     // Inspect every horizontal separator cell '─' on the right side of the
@@ -204,7 +205,8 @@ fn render_two_panes_keeps_half_highlight_path() {
             crate::border_lines::border_chars("single"),
             None,
         );
-        crate::rendering::fix_border_intersections(f.buffer_mut(), crate::border_lines::border_chars("single"));
+        let border_mask = crate::client::border_mask_from_layout(&layout, area, f.buffer_mut().area, false);
+        crate::rendering::fix_border_intersections(f.buffer_mut(), crate::border_lines::border_chars("single"), &border_mask);
     }).unwrap();
 
     // The vertical separator '│' should have at least some cells colored as


### PR DESCRIPTION
Closes #452

## Problem

Box-drawing lines drawn *by programs running inside a pane* — a rendered
markdown table, midnight commander, anything that prints `│ ─ ┼` — came out
with inconsistent joints: the junction glyphs (`┼ ├ ┤ ┬ ┴`) were repainted
with the dim pane-border color while the `│`/`─` lines connecting them kept
the content's own colors.

## Root cause

After rendering, `run_remote` runs a recolor pass meant to fix inconsistent
styles at psmux's own separator intersections: it scanned the **entire
buffer** and restyled *every* junction glyph (`┼ ├ ┤ ┬ ┴`) with the
border/active-border style. It had no way to tell psmux-drawn junctions apart
from identical glyphs a child program printed as pane content, so a table's
joints got dimmed to the border color while its straight lines were left
alone.

`fix_border_intersections` — the pass that upgrades plain `│`/`─` separators
into junction glyphs where pane borders cross — had the same whole-buffer
character-sniffing problem: any content `│`/`─` with a perpendicular
neighbour could be rewritten into a junction glyph.

## Fix

Both passes are now restricted to a **geometry-derived border mask**: the
exact set of buffer cells where psmux itself drew a separator, computed from
the layout tree rather than by inspecting characters.

- `border_mask_from_layout` (`src/client.rs`) walks the `LayoutJson` tree and
  collects separator cell indices, mirroring `render_layout_json`'s geometry
  (`split_with_gaps`), including the zoomed-pane early-return so the mask
  matches what was actually drawn.
- `border_mask_from_node` (`src/rendering.rs`) does the same for the local
  `Node` tree, mirroring `render_node`'s `Node::Split` arm.
- `fix_border_intersections` now takes the mask and only walks masked cells;
  a junction glyph is emitted only when **both** the candidate cell and the
  crossing neighbour are in the mask. Content cells are never in the mask, so
  child-program box drawing is left byte-for-byte untouched.
- The active-border junction recolor pass in `run_remote` iterates the mask
  instead of the whole buffer, so it can no longer restyle content cells.

## Changes

| File | Change |
|------|--------|
| `src/rendering.rs` | `fix_border_intersections` takes a `sep_cells` mask; added `border_mask_from_node` |
| `src/client.rs` | Added `border_mask_from_layout`; `run_remote` builds the mask and passes it to both post-passes |
| `src/main.rs`, `src/preview.rs` | Build the mask at the remaining `fix_border_intersections` call sites |
| `src/commands.rs` | Register new test module |
| `tests-rs/test_pane_content_box_drawing.rs` | **New** regression test: renders a real split (genuine separator present), injects a box-drawing table into pane content, asserts glyphs *and* styles are untouched |
| `tests-rs/test_pane_border_lines_render.rs`, `tests-rs/test_pr255_active_border.rs` | Updated call sites for the new signature; existing junction/active-border expectations unchanged |

## Testing

- New regression test `fix_border_intersections_leaves_pane_content_table_untouched`.
- Existing border-line and active-border-color tests still pass with the mask
  in place, confirming real pane-border junctions are still upgraded and
  colored as before.