### PR TITLE
fix(warm): skip client-facing hooks on the __warm__ server

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -962,11 +962,15 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
             Err(e) => { eprintln!("psmux: warm pane pre-spawn failed: {e}"); }
         }
     }
-    // Fire client-attached hooks once at startup so plugins populate initial
-    // data (e.g. CPU/battery) even for detached sessions (tppanel previews).
-    crate::commands::fire_hooks(&mut app, "client-attached");
-    // Fire session-created hook at startup
-    crate::commands::fire_hooks(&mut app, "session-created");
+    // Fire client-attached and session-created hooks once at startup so plugins
+    // populate initial data (e.g. CPU/battery) even for detached sessions
+    // (tppanel previews). Skip the warm server: firing here would double-fire
+    // every client/session hook (e.g. a duplicate continuum auto-save loop). A
+    // claimed warm server gets them once it becomes real (see CtrlReq::ClaimSession).
+    if !app.is_warm_server() {
+        crate::commands::fire_hooks(&mut app, "client-attached");
+        crate::commands::fire_hooks(&mut app, "session-created");
+    }
     // Spawn a warm server for the NEXT new-session when the current session
     // is allowed to keep background state alive.
     if should_spawn_warm_server(&app) {
@@ -2999,7 +3003,11 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                     // its own startup, but the user may have changed their
                     // config since then (or the warm server was spawned by a
                     // different session with a different PSMUX_CONFIG_FILE).
+                    // Clear config-derived state first so the reload is authoritative:
+                    // hooks removed from the config drop out, and `set-hook -a`
+                    // append hooks don't stack a second copy onto the warm server's.
                     app.key_tables.clear();
+                    app.hooks.clear();
                     app.defaults_suppressed = false;
                     crate::config::populate_default_bindings(&mut app);
                     load_config(&mut app);
@@ -3011,6 +3019,12 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                     if let Ok(mut w) = shared_aliases_main.write() {
                         *w = app.command_aliases.clone();
                     }
+                    // Fire client-attached/session-created for the now-real session:
+                    // the startup path skips these while warm, so this is where a
+                    // claimed session gets them - exactly once - starting plugins
+                    // like continuum's auto-save and auto-restore.
+                    crate::commands::fire_hooks(&mut app, "client-attached");
+                    crate::commands::fire_hooks(&mut app, "session-created");
                     // Fire client-session-changed hook (warm server claimed by new session)
                     if let Some(cmds) = app.hooks.get("client-session-changed") { let cmds = cmds.clone(); for cmd in &cmds { let _ = execute_command_string(&mut app, cmd); } }
                     meta_dirty = true;

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -2940,6 +2940,11 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                     // user's session-creation time — reset on claim or list-sessions /
                     // session_created / uptime would report the warm pool's age.
                     app.created_at = chrono::Local::now();
+                    // Same reason for the status-interval phase: the warm server skips
+                    // the timer (see should_run_status_interval_timer), so its last-fire
+                    // stamp is the warm start time — reset it so a claimed session fires
+                    // one interval after creation, not immediately.
+                    app.last_status_interval_fire = std::time::Instant::now();
                     // Update env so run-shell/hooks from this server target the new name
                     env::set_var("PSMUX_TARGET_SESSION", app.port_file_base());
                     // Honour the client's working directory: the warm server
@@ -5413,7 +5418,7 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
             crate::types::push_frame(&combined_buf);
         }
         // ── Status-interval timer: fire hooks periodically ──
-        if app.status_interval > 0 {
+        if app.should_run_status_interval_timer() {
             let elapsed = app.last_status_interval_fire.elapsed().as_secs();
             if elapsed >= app.status_interval {
                 app.last_status_interval_fire = std::time::Instant::now();

--- a/src/types.rs
+++ b/src/types.rs
@@ -749,6 +749,19 @@ pub struct AppState {
 }
 
 impl AppState {
+    /// Whether this server should run the periodic `status-interval` timer,
+    /// which fires user `status-interval` hooks and re-renders the status line
+    /// so time formats (`%H:%M:%S`, `%r`, ...) stay current.
+    ///
+    /// The hidden `__warm__` pre-spawn server has no clients and no visible
+    /// status bar, so it must not run this timer: otherwise a global
+    /// `status-interval` hook fires twice — once on the real server and once
+    /// on the warm one. Once claimed and renamed, its `session_name` is no
+    /// longer `__warm__`, so it runs the timer normally.
+    pub fn should_run_status_interval_timer(&self) -> bool {
+        self.status_interval > 0 && self.session_name != "__warm__"
+    }
+
     /// Reap a dead client's `client_registry` entry exactly once, keeping the
     /// `attached_clients` counter in lock-step with the registry.
     ///

--- a/src/types.rs
+++ b/src/types.rs
@@ -749,17 +749,26 @@ pub struct AppState {
 }
 
 impl AppState {
+    /// Whether this is the hidden `__warm__` pre-spawn server: a server started
+    /// ahead of time so the next `new-session` can claim it instead of paying a
+    /// cold-start. It has no client and no visible session until it is claimed
+    /// and renamed to a real session, so it must sit out anything that assumes a
+    /// real, client-facing session - status-interval timers, startup
+    /// client-attached/session-created hooks, and the like.
+    pub fn is_warm_server(&self) -> bool {
+        self.session_name == "__warm__"
+    }
+
     /// Whether this server should run the periodic `status-interval` timer,
     /// which fires user `status-interval` hooks and re-renders the status line
     /// so time formats (`%H:%M:%S`, `%r`, ...) stay current.
     ///
-    /// The hidden `__warm__` pre-spawn server has no clients and no visible
-    /// status bar, so it must not run this timer: otherwise a global
-    /// `status-interval` hook fires twice — once on the real server and once
-    /// on the warm one. Once claimed and renamed, its `session_name` is no
-    /// longer `__warm__`, so it runs the timer normally.
+    /// The `__warm__` server has no clients and no visible status bar, so it must
+    /// not run this timer: otherwise a global `status-interval` hook fires twice -
+    /// once on the real server and once on the warm one. Once claimed and renamed,
+    /// it is no longer warm and runs the timer normally.
     pub fn should_run_status_interval_timer(&self) -> bool {
-        self.status_interval > 0 && self.session_name != "__warm__"
+        self.status_interval > 0 && !self.is_warm_server()
     }
 
     /// Reap a dead client's `client_registry` entry exactly once, keeping the

--- a/tests-rs/test_server.rs
+++ b/tests-rs/test_server.rs
@@ -166,6 +166,17 @@ fn warm_server_does_not_run_status_interval_timer() {
 }
 
 #[test]
+fn is_warm_server_tracks_the_reserved_name() {
+    // Guards the double-fire fix; see AppState::is_warm_server.
+    let mut app = AppState::new("__warm__".to_string());
+    assert!(app.is_warm_server(), "the __warm__ pre-spawn server is warm");
+
+    // Claiming a warm server renames it to the real session; it is no longer warm.
+    app.session_name = "main".to_string();
+    assert!(!app.is_warm_server(), "a claimed/real session is not warm");
+}
+
+#[test]
 fn get_option_bell_action() {
     let app = AppState::new("test".to_string());
     let val = super::options::get_option_value(&app, "bell-action");

--- a/tests-rs/test_server.rs
+++ b/tests-rs/test_server.rs
@@ -143,6 +143,29 @@ fn get_option_allow_rename() {
 }
 
 #[test]
+fn warm_server_does_not_run_status_interval_timer() {
+    // Guards the double-fire fix; see AppState::should_run_status_interval_timer.
+    let mut app = AppState::new("__warm__".to_string());
+    app.status_interval = 5;
+    assert!(
+        !app.should_run_status_interval_timer(),
+        "warm server must not run the status-interval timer"
+    );
+
+    app.session_name = "main".to_string();
+    assert!(
+        app.should_run_status_interval_timer(),
+        "a real session must run the status-interval timer"
+    );
+
+    app.status_interval = 0;
+    assert!(
+        !app.should_run_status_interval_timer(),
+        "status-interval=0 disables the timer"
+    );
+}
+
+#[test]
 fn get_option_bell_action() {
     let app = AppState::new("test".to_string());
     let val = super::options::get_option_value(&app, "bell-action");


### PR DESCRIPTION
## Problem

The hidden `__warm__` pre-spawn server has no client and no visible session, but it runs the same `run_server` event loop as a real server, so it fires client-facing hooks. Two symptoms:

1. `status-interval` fires twice: a global `status-interval` hook runs once on the real server and once on the warm one.
2. Startup `client-attached`/`session-created` fire twice: `run_server` fires these once at startup "so plugins populate initial data", on the warm server too. A plugin whose `client-attached` hook spawns a process (e.g. psmux-continuum's auto-save loop) gets two loops, one per server, and double-saves.

## Fix

Gate the warm server out of client-facing hook work behind one predicate:

```rust
pub fn is_warm_server(&self) -> bool {
    self.session_name == "__warm__"
}
```

- **`status-interval` timer:** `should_run_status_interval_timer()` is `status_interval > 0 && !is_warm_server()`.
- **Startup hooks:** the startup `client-attached`/`session-created` fire is skipped when `is_warm_server()`.
- **Claim path:** because the warm server skips the startup fire, the claim path fires `client-attached`/`session-created` after promotion, so a claimed session gets them exactly once. It also clears `app.hooks` before reloading config, so the reload is authoritative: hooks removed from the config drop out, and `set-hook -a` append hooks don't stack a second copy.

When a warm server is claimed and renamed, `is_warm_server()` flips false and it behaves like any real server. `last_status_interval_fire` is reset on claim so the claimed session's first status fire lands one interval after creation, not immediately.