### PR TITLE
fix(session): honor -L namespace over $TMUX (tmux socket precedence)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -281,46 +281,18 @@ fn run_main() -> io::Result<()> {
         }
     }
     if env::var("PSMUX_TARGET_SESSION").is_err() {
-        // No explicit session from -t: try to resolve from TMUX env var (set inside psmux panes)
-        // TMUX format: /tmp/psmux-<pid>/<socket_name>,<port>,<session_idx>
-        if let Ok(tmux_val) = env::var("TMUX") {
-            // Extract the port from the TMUX value
-            let parts: Vec<&str> = tmux_val.split(',').collect();
-            if parts.len() >= 2 {
-                if let Ok(port) = parts[1].trim().parse::<u16>() {
-                    // Look up which session owns this port (port file base
-                    // already includes -L namespace prefix if applicable)
-                    let home = env::var("USERPROFILE").or_else(|_| env::var("HOME")).unwrap_or_default();
-                    let psmux_dir = format!("{}\\.psmux", home);
-                    if let Ok(entries) = std::fs::read_dir(&psmux_dir) {
-                        for entry in entries.flatten() {
-                            let path = entry.path();
-                            if path.extension().map(|e| e == "port").unwrap_or(false) {
-                                if let Ok(port_str) = std::fs::read_to_string(&path) {
-                                    if let Ok(file_port) = port_str.trim().parse::<u16>() {
-                                        if file_port == port {
-                                            if let Some(port_file_base) = path.file_stem().and_then(|s| s.to_str()) {
-                                                // Skip warm (standby) sessions — they are internal-only
-                                                if !crate::session::is_warm_session(port_file_base) {
-                                                    env::set_var("PSMUX_TARGET_SESSION", port_file_base);
-                                                }
-                                            }
-                                            break;
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
-    // Fallback: if no -t flag and session still not resolved (e.g. TMUX pointed
-    // to a warm session, or no TMUX at all), pick the most recent real session.
-    // When -L namespace is active, only resolve within that namespace.
-    if env::var("PSMUX_TARGET_SESSION").is_err() {
-        if let Some(name) = crate::session::resolve_last_session_name_ns(l_socket_name.as_deref()) {
+        // No explicit `-t session`: resolve which server to route to. `$TMUX`
+        // (set inside every psmux pane) names the current server; the `-L`
+        // namespace and the most-recent-session fallback are applied inside
+        // resolve_routing_target.
+        let home = env::var("USERPROFILE").or_else(|_| env::var("HOME")).unwrap_or_default();
+        let psmux_dir = std::path::PathBuf::from(format!("{}\\.psmux", home));
+        let tmux_env = env::var("TMUX").ok();
+        if let Some(name) = crate::session::resolve_routing_target(
+            l_socket_name.as_deref(),
+            tmux_env.as_deref(),
+            &psmux_dir,
+        ) {
             env::set_var("PSMUX_TARGET_SESSION", &name);
         }
     }

--- a/src/session.rs
+++ b/src/session.rs
@@ -1098,8 +1098,14 @@ pub fn resolve_last_session_name() -> Option<String> {
 /// When `ns` is None, only non-namespaced sessions (no "__" in name) are considered.
 pub fn resolve_last_session_name_ns(ns: Option<&str>) -> Option<String> {
     let home = env::var("USERPROFILE").or_else(|_| env::var("HOME")).ok()?;
-    let dir = format!("{}\\.psmux", home);
-    let last = std::fs::read_to_string(format!("{}\\last_session", dir)).ok();
+    resolve_last_session_name_ns_in(std::path::Path::new(&format!("{}\\.psmux", home)), ns)
+}
+
+/// Registry-directory-parameterized variant of [`resolve_last_session_name_ns`]:
+/// the most recent real (non-warm) session base in namespace `ns`. Taking the
+/// dir explicitly lets routing be unit-tested without mutating `USERPROFILE`/`HOME`.
+pub fn resolve_last_session_name_ns_in(dir: &std::path::Path, ns: Option<&str>) -> Option<String> {
+    let last = std::fs::read_to_string(dir.join("last_session")).ok();
     if let Some(name) = last {
         let name = name.trim().to_string();
         // Only accept the cached last_session if it matches the namespace filter
@@ -1107,13 +1113,12 @@ pub fn resolve_last_session_name_ns(ns: Option<&str>) -> Option<String> {
             Some(n) => name.starts_with(&format!("{}__", n)),
             None => !name.contains("__"),
         };
-        if ns_ok {
-            let p = format!("{}\\{}.port", dir, name);
-            if std::path::Path::new(&p).exists() { return Some(name); }
+        if ns_ok && dir.join(format!("{}.port", name)).exists() {
+            return Some(name);
         }
     }
     let mut picks: Vec<(String, std::time::SystemTime)> = Vec::new();
-    if let Ok(rd) = std::fs::read_dir(&dir) {
+    if let Ok(rd) = std::fs::read_dir(dir) {
         for e in rd.flatten() {
             if let Some(fname) = e.file_name().to_str() {
                 if let Some((base, ext)) = fname.rsplit_once('.') {
@@ -1131,6 +1136,45 @@ pub fn resolve_last_session_name_ns(ns: Option<&str>) -> Option<String> {
     });
     picks.sort_by_key(|(_, t)| *t);
     picks.last().map(|(n, _)| n.clone())
+}
+
+/// Resolve the routing target session (the port-file base name) for a CLI
+/// command that did not name an explicit `-t session`.
+///
+/// `$TMUX` (set inside every psmux pane, formatted `<socketpath>,<port>,<idx>`)
+/// identifies the current server via its control `<port>`; `psmux_dir` is the
+/// `.psmux` registry directory of `<base>.port` files; `l_socket_name` is the
+/// `-L` namespace, if any. Returns the base to route to, or `None`.
+pub fn resolve_routing_target(
+    l_socket_name: Option<&str>,
+    tmux_env: Option<&str>,
+    psmux_dir: &std::path::Path,
+) -> Option<String> {
+    if let Some(tmux_val) = tmux_env {
+        if let Some(base) = session_base_owning_tmux_port(tmux_val, psmux_dir) {
+            return Some(base);
+        }
+    }
+    resolve_last_session_name_ns_in(psmux_dir, l_socket_name)
+}
+
+/// Find the session port-file base whose control port matches the one encoded
+/// in a `$TMUX` value (`<socketpath>,<port>,<idx>`). Warm (standby) sessions are
+/// internal-only and never adopted.
+fn session_base_owning_tmux_port(tmux_val: &str, psmux_dir: &std::path::Path) -> Option<String> {
+    let port: u16 = tmux_val.split(',').nth(1)?.trim().parse().ok()?;
+    for entry in std::fs::read_dir(psmux_dir).ok()?.flatten() {
+        let path = entry.path();
+        if path.extension().map(|e| e == "port").unwrap_or(false) {
+            if let Ok(port_str) = std::fs::read_to_string(&path) {
+                if port_str.trim().parse::<u16>().ok() == Some(port) {
+                    let base = path.file_stem().and_then(|s| s.to_str())?;
+                    return if is_warm_session(base) { None } else { Some(base.to_string()) };
+                }
+            }
+        }
+    }
+    None
 }
 
 pub fn resolve_default_session_name() -> Option<String> {

--- a/src/session.rs
+++ b/src/session.rs
@@ -1141,6 +1141,13 @@ pub fn resolve_last_session_name_ns_in(dir: &std::path::Path, ns: Option<&str>) 
 /// Resolve the routing target session (the port-file base name) for a CLI
 /// command that did not name an explicit `-t session`.
 ///
+/// Socket-selection precedence follows tmux: `-L`/`-S` take precedence over
+/// `$TMUX`, which tmux consults only when neither is given (tmux.c `main()`:
+/// `if (path == NULL && label == NULL)`). psmux has no single socket, so this
+/// maps to: adopt the current server named by `$TMUX` only when its session is
+/// in the requested `-L` namespace; otherwise resolve within the namespace (the
+/// most-recent session, else the namespaced `X__default`).
+///
 /// `$TMUX` (set inside every psmux pane, formatted `<socketpath>,<port>,<idx>`)
 /// identifies the current server via its control `<port>`; `psmux_dir` is the
 /// `.psmux` registry directory of `<base>.port` files; `l_socket_name` is the
@@ -1150,12 +1157,25 @@ pub fn resolve_routing_target(
     tmux_env: Option<&str>,
     psmux_dir: &std::path::Path,
 ) -> Option<String> {
+    // Adopt the current server (named by `$TMUX`) only when it is in-namespace.
     if let Some(tmux_val) = tmux_env {
         if let Some(base) = session_base_owning_tmux_port(tmux_val, psmux_dir) {
-            return Some(base);
+            let in_namespace = match l_socket_name {
+                Some(ns) => base.starts_with(&format!("{}__", ns)),
+                None => true,
+            };
+            if in_namespace {
+                return Some(base);
+            }
         }
     }
-    resolve_last_session_name_ns_in(psmux_dir, l_socket_name)
+    // Otherwise the most recent real session in the namespace,
+    if let Some(name) = resolve_last_session_name_ns_in(psmux_dir, l_socket_name) {
+        return Some(name);
+    }
+    // else a namespaced `X__default` so `-L X` never leaks to the un-namespaced
+    // `default` server. With no `-L`, stay unresolved (the caller keeps "default").
+    l_socket_name.map(|ns| format!("{}__default", ns))
 }
 
 /// Find the session port-file base whose control port matches the one encoded
@@ -1446,3 +1466,7 @@ mod tests_session_id_alloc_race;
 #[cfg(test)]
 #[path = "../tests-rs/test_issue448_orphan_reaper.rs"]
 mod tests_issue448_orphan_reaper;
+
+#[cfg(test)]
+#[path = "../tests-rs/test_l_socket_tmux_precedence.rs"]
+mod tests_l_socket_tmux_precedence;

--- a/tests-rs/test_l_socket_tmux_precedence.rs
+++ b/tests-rs/test_l_socket_tmux_precedence.rs
@@ -1,0 +1,168 @@
+// -L / $TMUX socket-selection precedence (tmux parity).
+//
+// The rule and its tmux rationale live on `session::resolve_routing_target`.
+// These pin the observable invariant — an out-of-namespace `$TMUX` never wins
+// under `-L X`, and `-L X` with nothing to resolve targets `X__default`, never
+// the un-namespaced `default` — against a throwaway registry directory: no
+// server, no env mutation, so they run in-process under `cargo test` and never
+// touch the live ~/.psmux.
+
+use super::*;
+
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+static TMP_COUNTER: AtomicUsize = AtomicUsize::new(0);
+
+/// A throwaway registry directory holding `<base>.port` files, removed on drop.
+struct TempRegistry {
+    dir: PathBuf,
+}
+
+impl TempRegistry {
+    fn new() -> Self {
+        let mut dir = std::env::temp_dir();
+        let n = TMP_COUNTER.fetch_add(1, Ordering::SeqCst);
+        dir.push(format!("psmux_lprec_{}_{}", std::process::id(), n));
+        std::fs::create_dir_all(&dir).expect("create temp registry dir");
+        TempRegistry { dir }
+    }
+
+    /// Write `<base>.port` containing `port` (as a live session would).
+    fn with_session(&self, base: &str, port: u16) -> &Self {
+        std::fs::write(self.dir.join(format!("{}.port", base)), port.to_string())
+            .expect("write .port file");
+        self
+    }
+
+    fn path(&self) -> &Path {
+        &self.dir
+    }
+}
+
+impl Drop for TempRegistry {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.dir);
+    }
+}
+
+/// A `$TMUX` value whose control `<port>` is `port`. Mirrors set_tmux_env's
+/// `<socketpath>,<port>,<idx>` — only the middle field drives resolution.
+fn tmux_for(port: u16) -> String {
+    format!("/tmp/psmux-1/default,{},0", port)
+}
+
+// ── Scenario A: `-L X` must take precedence over `$TMUX` when nested elsewhere ──
+
+#[test]
+fn dash_l_overrides_tmux_when_nested_outside_namespace() {
+    // The current server is `main` (port 6001); an isolated `X__work` session
+    // (port 7001) also exists.
+    let reg = TempRegistry::new();
+    reg.with_session("main", 6001).with_session("X__work", 7001);
+    // Precondition: prove the setup so a drift can't make this pass vacuously.
+    assert!(reg.path().join("main.port").exists(), "precondition: main.port present");
+    assert!(reg.path().join("X__work.port").exists(), "precondition: X__work.port present");
+
+    // Attached inside `main` (its port is in $TMUX), running `psmux -L X <cmd>`.
+    // tmux parity: `-L X` overrides `$TMUX`, so the command targets the X
+    // namespace (X__work), NOT the current `main` server.
+    let tmux = tmux_for(6001);
+    let got = resolve_routing_target(Some("X"), Some(&tmux), reg.path());
+    assert_eq!(
+        got.as_deref(),
+        Some("X__work"),
+        "`-L X` from inside `main` must route to the X namespace, not the current server"
+    );
+}
+
+// ── Scenario B: `-L X` with no in-namespace session must not leak to `default` ──
+
+#[test]
+fn dash_l_with_no_session_targets_namespaced_default_not_real_default() {
+    // A real `default` server (5000) and the current `main` (6001) exist, but
+    // NO session in the X namespace.
+    let reg = TempRegistry::new();
+    reg.with_session("default", 5000).with_session("main", 6001);
+    assert!(
+        !reg.path().join("X__default.port").exists(),
+        "precondition: no X-namespace session exists"
+    );
+
+    // Nested inside `main`, `-L X` must resolve within X. With nothing to
+    // resolve it targets the namespaced `X__default` (which does not exist ->
+    // "no server running on X__default"), never the real `default` server.
+    let tmux = tmux_for(6001);
+    let got = resolve_routing_target(Some("X"), Some(&tmux), reg.path());
+    assert_eq!(
+        got.as_deref(),
+        Some("X__default"),
+        "`-L X` with no session must target the namespaced default, never `default` or the current `main`"
+    );
+}
+
+#[test]
+fn dash_l_with_no_session_and_no_tmux_targets_namespaced_default() {
+    // Clean shell (no $TMUX), a real `default` server exists, no X session.
+    let reg = TempRegistry::new();
+    reg.with_session("default", 5000);
+    assert!(
+        !reg.path().join("X__default.port").exists(),
+        "precondition: no X-namespace session exists"
+    );
+
+    let got = resolve_routing_target(Some("X"), None, reg.path());
+    assert_eq!(
+        got.as_deref(),
+        Some("X__default"),
+        "clean-shell `-L X` with no X session must target X__default, not `default`"
+    );
+}
+
+// ── No-regression guards ──────────────────────────────────────────────────
+
+#[test]
+fn dash_l_adopts_current_session_when_nested_inside_same_namespace() {
+    // Attached inside `X__work` (7001); another X session `X__other` (7002) is
+    // newer. The command must act on the CURRENT session (X__work), so the fix
+    // must not naively ignore $TMUX whenever `-L` is present.
+    let reg = TempRegistry::new();
+    reg.with_session("X__work", 7001).with_session("X__other", 7002);
+    let tmux = tmux_for(7001);
+    let got = resolve_routing_target(Some("X"), Some(&tmux), reg.path());
+    assert_eq!(
+        got.as_deref(),
+        Some("X__work"),
+        "`-L X` nested inside an X session must act on that current session"
+    );
+}
+
+#[test]
+fn no_dash_l_adopts_current_server_from_tmux() {
+    // With no `-L`, `$TMUX` selects the current server (tmux: `$TMUX` socket wins).
+    let reg = TempRegistry::new();
+    reg.with_session("main", 6001);
+    let tmux = tmux_for(6001);
+    let got = resolve_routing_target(None, Some(&tmux), reg.path());
+    assert_eq!(
+        got.as_deref(),
+        Some("main"),
+        "with no `-L`, `$TMUX` selects the current server"
+    );
+}
+
+#[test]
+fn warm_session_is_never_adopted_from_tmux() {
+    // $TMUX points at the internal warm (standby) server; a real `main` exists.
+    let reg = TempRegistry::new();
+    reg.with_session("__warm__", 9001).with_session("main", 6001);
+    assert!(is_warm_session("__warm__"), "precondition: __warm__ is a warm base");
+
+    let tmux = tmux_for(9001);
+    let got = resolve_routing_target(None, Some(&tmux), reg.path());
+    assert_eq!(
+        got.as_deref(),
+        Some("main"),
+        "a warm server must never be adopted; fall through to the real session"
+    );
+}


### PR DESCRIPTION
## Problem

When run from inside another session, `psmux -L X <cmd>` resolved its target session from `$TMUX` and routed to the current / `default` server, ignoring `-L X`. Confirmed with `psmux -L X list-windows` reading the default server, while `list-windows -a`, `list-panes -a`, and `kill-server` were correctly namespace-isolated.

Because the leak was in the central single-target resolver, it also affected `send-keys` and every other command that routes without an explicit `-t.

## tmux behavior

tmux's socket-selection precedence is `-S` > `-L` > `$TMUX` > `"default"`; it reads `$TMUX` only when neither `-L` nor `-S` is given (`tmux.c` `main()`: `if (path == NULL && label == NULL)`). In psmux the per-session port file is the "socket", optionally namespaced `X__session.port`, so honoring `-L X` means the current server named by `$TMUX` is adopted only when its session lives in the `X` namespace.

## Fix

Extract the inline `PSMUX_TARGET_SESSION` resolution out of `main()` into a pure `session::resolve_routing_target`, and make it:

- adopt the `$TMUX` session only when it matches the requested `-L` namespace (otherwise ignore `$TMUX` and resolve within the namespace);
- fall back to a namespaced `X__default` when nothing resolves under `-L X`, so a command never silently leaks to the un-namespaced `default` server (tmux would report "no server running on X").

Split into two commits: a behavior-preserving refactor (extract the pure fn) then the fix, so the "no behavior change" step is separable from the parity fix.
