### PR TITLE
fix(server): prevent duplicate same-name servers via an atomic session-creation guard

### DIFF
--- a/src/platform.rs
+++ b/src/platform.rs
@@ -290,6 +290,65 @@ pub fn process_is_alive(_pid: u32) -> bool {
     true
 }
 
+/// Single-server-per-session-name lock (RAII). Holding the guard means this
+/// process owns the right to be THE server for a given session name. Dropping it
+/// (or the process exiting) releases the underlying Windows named mutex, which
+/// the OS also auto-releases on a crash — so there is no stale-lock to reap.
+#[cfg(windows)]
+pub struct SessionMutex { handle: *mut std::ffi::c_void }
+#[cfg(windows)]
+unsafe impl Send for SessionMutex {}
+#[cfg(windows)]
+impl Drop for SessionMutex {
+    fn drop(&mut self) {
+        #[link(name = "kernel32")]
+        extern "system" { fn CloseHandle(h: isize) -> i32; }
+        if !self.handle.is_null() { unsafe { CloseHandle(self.handle as isize); } }
+    }
+}
+
+/// Acquire the single-server lock for session `name` (P0: kill the duplicate-
+/// same-name-server race). Returns `Some(guard)` when this process MAY run as
+/// the server — because it now owns the mutex, or a previous owner died and left
+/// it abandoned, or the FFI was unavailable (**fail-open**, so a legitimate start
+/// is never blocked). Returns `None` ONLY when another LIVE process already owns
+/// the name, i.e. this is a duplicate cold-spawn that must exit.
+#[cfg(windows)]
+pub fn acquire_session_mutex(name: &str) -> Option<SessionMutex> {
+    #[link(name = "kernel32")]
+    extern "system" {
+        fn CreateMutexW(attrs: *const std::ffi::c_void, initial_owner: i32, name: *const u16) -> *mut std::ffi::c_void;
+        fn WaitForSingleObject(h: *mut std::ffi::c_void, ms: u32) -> u32;
+        fn CloseHandle(h: isize) -> i32;
+    }
+    const WAIT_OBJECT_0: u32 = 0x0000_0000;
+    const WAIT_ABANDONED: u32 = 0x0000_0080; // prior owner died holding it -> ours now
+    const WAIT_TIMEOUT: u32 = 0x0000_0102;   // another live process owns it
+    // Backslash is the kernel-object namespace separator and must not appear in
+    // the leaf name; map path chars out. `Local\` scopes it to this session.
+    let sanitized: String = name.chars().map(|c| if c == '\\' || c == '/' { '_' } else { c }).collect();
+    let obj = format!("Local\\psmux-session-{sanitized}");
+    let wide: Vec<u16> = obj.encode_utf16().chain(std::iter::once(0)).collect();
+    unsafe {
+        let h = CreateMutexW(std::ptr::null(), 0, wide.as_ptr());
+        if h.is_null() {
+            return Some(SessionMutex { handle: std::ptr::null_mut() }); // fail-open
+        }
+        match WaitForSingleObject(h, 0) {
+            WAIT_OBJECT_0 | WAIT_ABANDONED => Some(SessionMutex { handle: h }),
+            WAIT_TIMEOUT => { CloseHandle(h as isize); None }
+            _ => Some(SessionMutex { handle: h }), // unknown -> fail-open
+        }
+    }
+}
+
+#[cfg(not(windows))]
+pub struct SessionMutex;
+/// Non-Windows: no cross-process named mutex plumbed; fail-open (never block a
+/// legitimate start). psmux's duplicate-server race is a Windows-only concern.
+#[cfg(not(windows))]
+pub fn acquire_session_mutex(_name: &str) -> Option<SessionMutex> { Some(SessionMutex) }
+
 /// Enable virtual terminal processing on Windows Console Host.
 /// This is required for ANSI color codes to work in conhost.exe (legacy console).
 #[cfg(windows)]

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -754,6 +754,30 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
     // Server starts detached with a reasonable default window size
     app.attached_clients = 0;
 
+    // ── P0: single-server-per-name guard (issue #2) ─────────────────────────
+    // Hold a named mutex keyed on this session's base name for the server's whole
+    // life. If another LIVE server already owns the name, we are a duplicate from
+    // a cold-spawn race (has-session false-negatived under load, or two
+    // `new-session -s X` raced) — exit cleanly so the winner stays the single
+    // source of truth. Two servers on one name desync the .port/.key files and
+    // wedge the session ("appears lost"). Warm (standby) servers are exempt (the
+    // warm pool intentionally runs several). Fail-open: any FFI hiccup yields a
+    // live guard, never a blocked legitimate start.
+    let _session_guard = {
+        let base = app.port_file_base();
+        if crate::session::is_warm_session(&base) {
+            None
+        } else {
+            match crate::platform::acquire_session_mutex(&base) {
+                Some(g) => Some(g),
+                None => {
+                    warm_debug(&format!("server STARTUP: session '{}' already owned by a live server — exiting duplicate", base));
+                    return Ok(()); // do NOT touch the winner's .port/.key/.sid
+                }
+            }
+        }
+    };
+
     // Bind the control listener BEFORE loading config so that run-shell
     // commands spawned by load_config can connect back to the server.
     let (tx, rx) = mpsc::channel::<CtrlReq>();

--- a/tests/test_no_duplicate_server.ps1
+++ b/tests/test_no_duplicate_server.ps1
@@ -1,0 +1,56 @@
+# Regression: two servers must never run for the same session name (P0, issue #2).
+#
+# ROOT CAUSE (pre-fix): `new-session -s X` cold-spawns a server after a
+# non-atomic "does X already exist?" check. Under load `has-session` false-
+# negatives (or two creators race), so two `server -s X` bind different ephemeral
+# ports, desync the `X.port`/`.key` files, and the session wedges / "appears
+# lost" (blank attach, `os error 10060`, kill-session can't reach it).
+#
+# FIX: run_server acquires a Windows named mutex keyed on the session base name
+# and exits immediately if another live server already owns it (fail-open on any
+# FFI hiccup; warm/standby servers exempt).
+#
+# This test spawns a second `server -s <name>` while the first is alive and
+# asserts the second EXITS and only one server survives. Isolated USERPROFILE.
+
+$ErrorActionPreference = "Continue"
+$PSMUX = $env:PSMUX_EXE
+if (-not $PSMUX -or -not (Test-Path $PSMUX)) { $PSMUX = "$PSScriptRoot\..\target\release\tmux.exe" }
+if (-not (Test-Path $PSMUX)) { $PSMUX = "$PSScriptRoot\..\target\debug\tmux.exe" }
+if (-not (Test-Path $PSMUX)) { Write-Host "FATAL: no psmux exe ($PSMUX)" -ForegroundColor Red; exit 2 }
+
+$tmpHome = Join-Path $env:TEMP ("psmux_dup_" + [guid]::NewGuid().ToString("N").Substring(0,8))
+New-Item -ItemType Directory (Join-Path $tmpHome ".psmux") -Force | Out-Null
+$env:USERPROFILE = $tmpHome; $env:HOME = $tmpHome
+$env:PSMUX_ALLOW_NESTING = "1"
+$name = "dupguard"
+$pass = 0; $fail = 0
+function Result($n,$ok,$m){ if($ok){$script:pass++;Write-Host "  PASS  $n" -ForegroundColor Green}else{$script:fail++;Write-Host "  FAIL  $n ($m)" -ForegroundColor Red} }
+
+$spawned = @()
+try {
+    $a = Start-Process -FilePath $PSMUX -ArgumentList 'server','-s',$name -WindowStyle Hidden -PassThru
+    $spawned += $a
+    Start-Sleep -Seconds 2
+    $b = Start-Process -FilePath $PSMUX -ArgumentList 'server','-s',$name -WindowStyle Hidden -PassThru
+    $spawned += $b
+    Start-Sleep -Seconds 2
+
+    $aAlive  = $null -ne (Get-Process -Id $a.Id -EA SilentlyContinue) -and -not (Get-Process -Id $a.Id -EA SilentlyContinue).HasExited
+    $bProc   = Get-Process -Id $b.Id -EA SilentlyContinue
+    $bExited = ($null -eq $bProc) -or $bProc.HasExited
+    Result "first server stays alive"            $aAlive  "A exited unexpectedly"
+    Result "duplicate second server exits"        $bExited "B (duplicate) is still running"
+
+    $live = @(Get-CimInstance Win32_Process | Where-Object { $_.CommandLine -match "server -s $name" })
+    Result "exactly one server survives"          ($live.Count -eq 1) "found $($live.Count)"
+}
+finally {
+    foreach ($p in $spawned) { Stop-Process -Id $p.Id -Force -EA SilentlyContinue }
+    Get-CimInstance Win32_Process | Where-Object { $_.CommandLine -match "server -s $name" } | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -EA SilentlyContinue }
+    Start-Sleep -Milliseconds 300
+    Remove-Item -Recurse -Force $tmpHome -EA SilentlyContinue
+}
+Write-Host ""
+Write-Host "no-duplicate-server: $pass passed, $fail failed" -ForegroundColor Cyan
+if ($fail -gt 0) { exit 1 } else { exit 0 }


### PR DESCRIPTION
## Problem

Two servers can end up running for the **same session name**. `new-session -s X`
cold-spawns a server after a non-atomic "does `X` already exist?" check, so if two
creators race — or `has-session` false-negatives under load — both spawn a
`server -s X`. They bind different ephemeral ports and race to write `X.port` /
`X.key`; the loser is a live orphan. The result is a desynced session that
"appears lost": blank `attach`, one-shot commands time out, and `kill-session`
can't reach the winner. It reproduces readily when several sessions/agents are
created concurrently.

The warm-claim path already guards against this (its code comment notes "a
slow/missing response must NOT trigger a cold spawn: doing so would create a
SECOND server with the same name"). The **cold-spawn** path had no equivalent
atomic guard.

## Fix

`run_server` acquires a Windows **named mutex** keyed on the session base name and
exits immediately if another live server already owns it.

- Named mutexes are auto-released by the OS on process death, so there is **no
  stale lock to reap** (unlike a lockfile), and an *abandoned* mutex — a prior
  owner that crashed — is correctly taken over (`WAIT_ABANDONED`).
- **Fail-open**: any FFI hiccup (null handle, unexpected wait result) yields a
  live guard, so a legitimate start is never blocked.
- **Warm/standby servers are exempt** (the warm pool intentionally runs several).

Adds `platform::acquire_session_mutex` + a `SessionMutex` RAII guard (no-op
fail-open stub on non-Windows).

## Test

`tests/test_no_duplicate_server.ps1` spawns a duplicate `server -s X` while the
first is alive and asserts the duplicate exits with exactly one survivor (red
before, green after). The existing session lifecycle behaviour is unaffected.

## Known limitation

A claimed-warm server later renamed to `X` does not hold `X`'s mutex, so a
warm-vs-cold race is still covered only by the existing warm-claim guard, not
this one. The common cold-vs-cold race is fixed.
