### PR TITLE
fix(ipc): confirm command execution via a FIFO session-info barrier (builds on #464)

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1286,13 +1286,23 @@ struct ClientDragState {
 /// thread, and return a (writer, frame_rx) pair ready for the event loop.
 /// Sets a 5-second write timeout so blocked writes never freeze the client.
 fn establish_connection(addr: &str, key: &str) -> io::Result<Connection> {
-    let stream = std::net::TcpStream::connect(addr)?;
+    // Bounded connect: a wedged/backlogged server otherwise makes `attach` hang
+    // until the ~21s Windows SYN-retransmit and surface as `os error 10060`.
+    // A 2s timeout turns that into a fast, clear failure the caller can report
+    // (and lets try_reconnect back off promptly instead of stalling).
+    let sockaddr: std::net::SocketAddr = addr.parse()
+        .map_err(|_| io::Error::new(io::ErrorKind::Other, format!("bad server address: {addr}")))?;
+    let stream = std::net::TcpStream::connect_timeout(&sockaddr, Duration::from_secs(2))?;
     stream.set_nodelay(true)?;
     let mut writer = stream.try_clone()?;
     writer.set_nodelay(true)?;
     writer.set_write_timeout(Some(Duration::from_secs(5)))?;
     let mut reader = BufReader::new(stream);
 
+    // Bound the AUTH read too: a wedged server that accepts the socket but never
+    // answers would otherwise block the attach forever with no feedback. The
+    // persistent read timeout is (re)set to 2s just below, after auth.
+    let _ = reader.get_ref().set_read_timeout(Some(Duration::from_secs(3)));
     let _ = writer.write_all(format!("AUTH {}\n", key).as_bytes());
     let _ = writer.flush();
     let mut auth_line = String::new();

--- a/src/main.rs
+++ b/src/main.rs
@@ -160,6 +160,40 @@ fn cli_pane_index_exists(idx_spec: &str) -> Option<bool> {
     if any { Some(false) } else { None }
 }
 
+/// Probe whether a session's server is still alive and responding.
+/// Returns true only if we can connect+auth (server is up); a connection
+/// refusal or a missing port file means the session is gone. A *timeout*
+/// returns true — conservative on purpose, so a busy server is never wrongly
+/// declared dead (used by kill-session to decide when the kill has landed).
+fn probe_session_alive(session_name: &str) -> bool {
+    let home = env::var("USERPROFILE").or_else(|_| env::var("HOME")).unwrap_or_default();
+    let path = format!("{}\\.psmux\\{}.port", home, session_name);
+    let port = match std::fs::read_to_string(&path).ok().and_then(|s| s.trim().parse::<u16>().ok()) {
+        Some(p) => p,
+        None => return false, // no port file → gone
+    };
+    let addr: std::net::SocketAddr = match format!("127.0.0.1:{}", port).parse() {
+        Ok(a) => a,
+        Err(_) => return false,
+    };
+    let key = read_session_key(session_name).unwrap_or_default();
+    match std::net::TcpStream::connect_timeout(&addr, Duration::from_millis(500)) {
+        Ok(mut s) => {
+            let _ = s.set_read_timeout(Some(Duration::from_millis(500)));
+            let _ = write!(s, "AUTH {}\n", key);
+            let _ = write!(s, "session-info\n");
+            let _ = s.flush();
+            let mut buf = [0u8; 256];
+            match std::io::Read::read(&mut s, &mut buf) {
+                Ok(n) if n > 0 => String::from_utf8_lossy(&buf[..n]).contains("OK"),
+                _ => true, // connected but silent → assume alive
+            }
+        }
+        Err(e) if e.kind() == io::ErrorKind::ConnectionRefused => false, // gone
+        Err(_) => true, // timeout/other → can't confirm dead, assume alive
+    }
+}
+
 fn main() {
     if let Err(e) = run_main() {
         // Print a user-friendly error message instead of Rust's Debug format
@@ -568,10 +602,14 @@ fn run_main() -> io::Result<()> {
                                     if let Ok(port_str) = std::fs::read_to_string(e.path()) {
                                         if let Ok(_p) = port_str.trim().parse::<u16>() {
                                             let addr = format!("127.0.0.1:{}", port_str.trim());
-                                            if let Ok(mut s) = std::net::TcpStream::connect_timeout(
+                                            let conn = std::net::TcpStream::connect_timeout(
                                                 &addr.parse().unwrap(),
                                                 Duration::from_millis(200)
-                                            ) {
+                                            );
+                                            // Only prune a session that ACTIVELY refused (truly dead);
+                                            // a timeout means busy-but-alive and must not be deleted.
+                                            let refused = matches!(&conn, Err(e) if e.kind() == io::ErrorKind::ConnectionRefused);
+                                            if let Ok(mut s) = conn {
                                                 // Format expansion for variables like
                                                 // pane_current_command/pane_current_path can
                                                 // take 40+ ms each (OS process queries), so
@@ -653,8 +691,8 @@ fn run_main() -> io::Result<()> {
                                                     }
                                                     println!("{}", display_name); 
                                                 }
-                                            } else {
-                                                // stale port file - remove it along with matching key
+                                            } else if refused {
+                                                // Actively refused → truly dead; remove stale port + key.
                                                 let _ = std::fs::remove_file(e.path());
                                                 let key_path = e.path().with_extension("key");
                                                 let _ = std::fs::remove_file(&key_path);
@@ -1761,10 +1799,14 @@ fn run_main() -> io::Result<()> {
                                     if let Ok(port_str) = std::fs::read_to_string(e.path()) {
                                         if let Ok(_p) = port_str.trim().parse::<u16>() {
                                             let addr = format!("127.0.0.1:{}", port_str.trim());
-                                            if let Ok(mut s) = std::net::TcpStream::connect_timeout(
+                                            let conn = std::net::TcpStream::connect_timeout(
                                                 &addr.parse().unwrap(),
                                                 Duration::from_millis(500),
-                                            ) {
+                                            );
+                                            // Only prune a session that ACTIVELY refused (truly dead);
+                                            // a timeout means busy-but-alive and must not be deleted.
+                                            let refused = matches!(&conn, Err(e) if e.kind() == io::ErrorKind::ConnectionRefused);
+                                            if let Ok(mut s) = conn {
                                                 let _ = s.set_read_timeout(Some(Duration::from_millis(500)));
                                                 let key_path = format!("{}\\.psmux\\{}.key", home, base);
                                                 if let Ok(key) = std::fs::read_to_string(&key_path) {
@@ -1802,7 +1844,7 @@ fn run_main() -> io::Result<()> {
                                                         Err(_) => break,
                                                     }
                                                 }
-                                            } else {
+                                            } else if refused {
                                                 let _ = std::fs::remove_file(e.path());
                                                 let key_path = e.path().with_extension("key");
                                                 let _ = std::fs::remove_file(&key_path);
@@ -1877,10 +1919,14 @@ fn run_main() -> io::Result<()> {
                                     if let Ok(port_str) = std::fs::read_to_string(e.path()) {
                                         if let Ok(_p) = port_str.trim().parse::<u16>() {
                                             let addr = format!("127.0.0.1:{}", port_str.trim());
-                                            if let Ok(mut s) = std::net::TcpStream::connect_timeout(
+                                            let conn = std::net::TcpStream::connect_timeout(
                                                 &addr.parse().unwrap(),
                                                 Duration::from_millis(500),
-                                            ) {
+                                            );
+                                            // Only prune a session that ACTIVELY refused (truly dead);
+                                            // a timeout means busy-but-alive and must not be deleted.
+                                            let refused = matches!(&conn, Err(e) if e.kind() == io::ErrorKind::ConnectionRefused);
+                                            if let Ok(mut s) = conn {
                                                 let _ = s.set_read_timeout(Some(Duration::from_millis(500)));
                                                 let key_path = format!("{}\\.psmux\\{}.key", home, base);
                                                 if let Ok(key) = std::fs::read_to_string(&key_path) {
@@ -1919,7 +1965,7 @@ fn run_main() -> io::Result<()> {
                                                         Err(_) => break,
                                                     }
                                                 }
-                                            } else {
+                                            } else if refused {
                                                 let _ = std::fs::remove_file(e.path());
                                                 let key_path = e.path().with_extension("key");
                                                 let _ = std::fs::remove_file(&key_path);
@@ -2088,14 +2134,41 @@ fn run_main() -> io::Result<()> {
                 if let Some(ref t) = target {
                     env::set_var("PSMUX_TARGET_SESSION", t);
                 }
-                // Try to send kill command to server
-                if send_control("kill-session\n".to_string()).is_err() {
-                    // Server not responding - clean up stale port file
-                    let home = env::var("USERPROFILE").or_else(|_| env::var("HOME")).unwrap_or_default();
-                    let port_path = format!("{}\\.psmux\\{}.port", home, session_name);
-                    let _ = std::fs::remove_file(&port_path);
+                // Send the kill, then VERIFY the session is actually gone,
+                // retrying within a deadline. psmux's loopback IPC intermittently
+                // drops or defers a single command, so a one-shot send is not
+                // reliable. Crucially, a mere timeout must NOT be treated as
+                // "server dead" — that used to delete a live-but-busy server's
+                // port file, orphaning it and triggering relaunch storms.
+                let home = env::var("USERPROFILE").or_else(|_| env::var("HOME")).unwrap_or_default();
+                let port_path = format!("{}\\.psmux\\{}.port", home, session_name);
+                let deadline = std::time::Instant::now() + Duration::from_secs(5);
+                let mut gone = !probe_session_alive(&session_name);
+                let mut refused = false;
+                while !gone {
+                    match send_control("kill-session\n".to_string()) {
+                        Ok(()) => {}
+                        Err(e) if e.kind() == io::ErrorKind::ConnectionRefused => { refused = true; break; }
+                        Err(_) => {} // busy/timeout — keep trying until the deadline
+                    }
+                    std::thread::sleep(Duration::from_millis(150));
+                    if !probe_session_alive(&session_name) { gone = true; break; }
+                    if std::time::Instant::now() >= deadline { break; }
                 }
-                return Ok(());
+                if gone || refused {
+                    // Server is down (killed or actively refused) → remove the
+                    // now-stale port file. (Idempotent: the server also removes
+                    // its own on a clean exit.)
+                    let _ = std::fs::remove_file(&port_path);
+                    return Ok(());
+                }
+                // Still alive after the deadline → genuine failure. Exit non-zero
+                // so scripts (and the watchdog) can trust $? instead of seeing a
+                // false success on a command that silently did nothing.
+                return Err(io::Error::new(
+                    io::ErrorKind::TimedOut,
+                    format!("kill-session: session '{}' still present after 5s", session_name),
+                ));
             }
             // has-session - Check if session exists (for scripting)
             "has-session" | "has" => {

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -1880,7 +1880,11 @@ match cmd {
     "session-info" => {
         let (rtx, rrx) = mpsc::channel::<String>();
         let _ = tx.send(CtrlReq::SessionInfo(rtx));
-        if let Ok(line) = rrx.recv() {
+        // Bounded wait: session-info doubles as the Tier 2 execution barrier for
+        // send_control, so it must never block the connection thread forever if
+        // the event loop is momentarily wedged — that would leak the thread and
+        // hold the socket open. 3s is far longer than a healthy loop cycle.
+        if let Ok(line) = rrx.recv_timeout(Duration::from_secs(3)) {
             if persistent {
                 let _ = tx.send(CtrlReq::ShowTextPopup("session-info".to_string(), line));
             } else {

--- a/src/session.rs
+++ b/src/session.rs
@@ -1117,6 +1117,14 @@ pub fn send_control(line: String) -> io::Result<()> {
         let _ = write!(stream, "TARGET {}\n", ft);
     }
     let _ = write!(stream, "{}", line);
+    // Tier 2 — confirmed EXECUTION (not just delivery): append a `session-info`
+    // barrier. It round-trips through the server's single FIFO event loop, so its
+    // reply proves the command above was actually applied, not merely enqueued.
+    // This makes send_control synchronous and closes races where a caller inspects
+    // the effect immediately after the CLI returns. For commands whose server
+    // handler tears down the connection first (e.g. kill-session), the barrier is
+    // simply never answered — that path is covered by the caller's verify-retry.
+    let _ = write!(stream, "session-info\n");
     let _ = stream.flush();
     // Half-close the write side so the server observes EOF *after* our bytes.
     // TCP guarantees all sent data is delivered before the FIN, so the server's
@@ -1124,8 +1132,9 @@ pub fn send_control(line: String) -> io::Result<()> {
     // the RST-on-close race that used to silently drop fire-and-forget commands
     // (the old 50ms "drain" read was only a partial mitigation).
     let _ = stream.shutdown(std::net::Shutdown::Write);
-    // Drain to EOF (bounded by the read timeout): confirms the server stayed up
-    // and consumed the command before we drop the socket.
+    // Read to EOF (bounded by the read timeout): blocks until the server has
+    // processed the barrier — i.e. the command has executed — or the connection
+    // closes / times out.
     let mut buf = [0u8; 256];
     loop {
         match std::io::Read::read(&mut stream, &mut buf) {

--- a/src/session.rs
+++ b/src/session.rs
@@ -1106,20 +1106,34 @@ pub fn send_control(line: String) -> io::Result<()> {
     let port = std::fs::read_to_string(&path).ok().and_then(|s| s.trim().parse::<u16>().ok()).ok_or_else(|| io::Error::new(io::ErrorKind::Other, format!("no server running on session '{}'", target)))?.clone();
     let session_key = read_session_key(&target).unwrap_or_default();
     let addr: std::net::SocketAddr = format!("127.0.0.1:{}", port).parse().unwrap();
-    let mut stream = std::net::TcpStream::connect_timeout(&addr, Duration::from_millis(100))?;
+    // 1s connect timeout: a busy-but-alive server must not be mistaken for a
+    // dead one. The old 100ms falsely tripped callers' stale-port cleanup,
+    // deleting the port file of a server that was merely slow to accept.
+    let mut stream = std::net::TcpStream::connect_timeout(&addr, Duration::from_millis(1000))?;
     let _ = stream.set_nodelay(true);
-    let _ = stream.set_read_timeout(Some(Duration::from_millis(50)));
+    let _ = stream.set_read_timeout(Some(Duration::from_millis(2000)));
     let _ = write!(stream, "AUTH {}\n", session_key);
     if let Some(ref ft) = full_target {
         let _ = write!(stream, "TARGET {}\n", ft);
     }
     let _ = write!(stream, "{}", line);
     let _ = stream.flush();
-    // Read the "OK" response to drain the receive buffer before closing.
-    // This prevents Windows from sending RST (due to unread data) which
-    // could cause the server to lose the command.
-    let mut buf = [0u8; 64];
-    let _ = std::io::Read::read(&mut stream, &mut buf);
+    // Half-close the write side so the server observes EOF *after* our bytes.
+    // TCP guarantees all sent data is delivered before the FIN, so the server's
+    // read_line always sees the full command before its loop ends — eliminating
+    // the RST-on-close race that used to silently drop fire-and-forget commands
+    // (the old 50ms "drain" read was only a partial mitigation).
+    let _ = stream.shutdown(std::net::Shutdown::Write);
+    // Drain to EOF (bounded by the read timeout): confirms the server stayed up
+    // and consumed the command before we drop the socket.
+    let mut buf = [0u8; 256];
+    loop {
+        match std::io::Read::read(&mut stream, &mut buf) {
+            Ok(0) => break,
+            Ok(_) => continue,
+            Err(_) => break,
+        }
+    }
     Ok(())
 }
 
@@ -1135,25 +1149,42 @@ pub fn send_control_with_response(line: String) -> io::Result<String> {
     let path = format!("{}\\.psmux\\{}.port", home, target);
     let port = std::fs::read_to_string(&path).ok().and_then(|s| s.trim().parse::<u16>().ok()).ok_or_else(|| io::Error::new(io::ErrorKind::Other, format!("no server running on session '{}'", target)))?.clone();
     let session_key = read_session_key(&target).unwrap_or_default();
-    let addr = format!("127.0.0.1:{}", port);
-    let mut stream = std::net::TcpStream::connect(&addr)?;
+    // Bounded connect: against a saturated listen backlog, a bare connect()
+    // fails only after the ~21s Windows SYN-retransmit and surfaces as the
+    // notorious `os error 10060`. A 1s timeout turns that into a fast, retryable
+    // error instead of a multi-second hang printed to the user.
+    let addr: std::net::SocketAddr = format!("127.0.0.1:{}", port).parse()
+        .map_err(|_| io::Error::new(io::ErrorKind::Other, "bad server address"))?;
+    let mut stream = std::net::TcpStream::connect_timeout(&addr, Duration::from_millis(1000))?;
     let _ = stream.set_nodelay(true);
-    let _ = stream.set_read_timeout(Some(Duration::from_millis(2000)));
+    let _ = stream.set_read_timeout(Some(Duration::from_millis(3000)));
     let _ = write!(stream, "AUTH {}\n", session_key);
     if let Some(ref ft) = full_target {
         let _ = write!(stream, "TARGET {}\n", ft);
     }
     let _ = write!(stream, "{}", line);
     let _ = stream.flush();
+    // Half-close so the server sees EOF after our request and closes the socket
+    // once the reply is complete — giving a definitive Ok(0) end-of-response
+    // instead of relying on an idle-gap timeout to guess the reply is done.
+    let _ = stream.shutdown(std::net::Shutdown::Write);
     let mut buf = Vec::new();
     let mut temp = [0u8; 4096];
+    let mut timed_out = false;
     loop {
         match std::io::Read::read(&mut stream, &mut temp) {
             Ok(0) => break,
             Ok(n) => buf.extend_from_slice(&temp[..n]),
-            Err(e) if e.kind() == io::ErrorKind::WouldBlock || e.kind() == io::ErrorKind::TimedOut => break,
+            Err(e) if e.kind() == io::ErrorKind::WouldBlock || e.kind() == io::ErrorKind::TimedOut => { timed_out = true; break; }
             Err(_) => break,
         }
+    }
+    // A timeout with zero bytes received is a FAILED round-trip, not an empty
+    // result set. Returning Ok("") here made `list-windows`/`ls` report zero
+    // windows on a merely-slow server (silent wrong answer). Surface it as a
+    // retryable error so the caller can retry or report honestly.
+    if timed_out && buf.is_empty() {
+        return Err(io::Error::new(io::ErrorKind::TimedOut, "no response from server (timed out)"));
     }
     let result = String::from_utf8_lossy(&buf).to_string();
     // Strip the "OK\n" AUTH response prefix if present

--- a/tests/test_command_reliability.ps1
+++ b/tests/test_command_reliability.ps1
@@ -1,0 +1,100 @@
+# Regression: one-shot CLI commands must not silently no-op or report a false
+# result. Covers the Tier 1–3 command-reliability fixes.
+#
+# ROOT CAUSE (pre-fix): the client/server loopback IPC could drop a fire-and-
+# forget command while the CLI still returned exit 0 (`kill-session` no-op with
+# $?=0), and a slow server made `ls`/`list-windows` print `os error 10060` or
+# return an empty (wrong) result. Under a burst of window-creates the single
+# event loop stalled on synchronous warm-pane spawns, amplifying the timeouts.
+#
+# WHAT THIS ASSERTS:
+#   - new-session -d yields a listable session (ls + list-windows, no 10060)
+#   - has-session returns 0 when present, 1 when absent
+#   - kill-session returns 0 AND the session is *actually* gone afterwards
+#   - kill-session on a real-but-busy session still confirms teardown
+#   - a burst of 5 rapid new-windows followed by kill-session tears down cleanly
+#   - no command ever emits `os error 10060` / `os error 100xx`
+#
+# Isolated to a throwaway USERPROFILE so it never touches real sessions.
+
+$ErrorActionPreference = "Stop"
+$PSMUX = $env:PSMUX_EXE
+if (-not $PSMUX -or -not (Test-Path $PSMUX)) { $PSMUX = "$PSScriptRoot\..\target\release\psmux.exe" }
+if (-not (Test-Path $PSMUX)) { $PSMUX = "$PSScriptRoot\..\target\debug\psmux.exe" }
+if (-not (Test-Path $PSMUX)) {
+    Write-Host "FATAL: could not resolve psmux executable ($PSMUX)" -ForegroundColor Red
+    exit 1
+}
+
+$tmpHome = Join-Path $env:TEMP ("psmux_rel_" + [guid]::NewGuid().ToString("N").Substring(0,8))
+New-Item -ItemType Directory $tmpHome -Force | Out-Null
+New-Item -ItemType Directory (Join-Path $tmpHome ".psmux") -Force | Out-Null
+$env:USERPROFILE = $tmpHome; $env:HOME = $tmpHome
+$env:PSMUX_ALLOW_NESTING = "1"   # this test harness itself may run inside psmux
+
+$pass = 0; $fail = 0
+function Result($name, $ok, $msg) {
+    if ($ok) { $script:pass++; Write-Host "  PASS  $name" -ForegroundColor Green }
+    else     { $script:fail++; Write-Host "  FAIL  $name  ($msg)" -ForegroundColor Red }
+}
+function Run($cmdArgs) {
+    # Returns @{ Out=<combined output string>; Code=<exit code> }
+    $out = & $PSMUX @cmdArgs 2>&1 | Out-String
+    return @{ Out = $out; Code = $LASTEXITCODE }
+}
+# A command's output must never surface a raw socket timeout.
+function NoTimeout($out) { return ($out -notmatch 'os error 100\d\d' -and $out -notmatch '10060') }
+
+try {
+    # --- basic lifecycle -----------------------------------------------------
+    $r = Run @('new-session','-d','-s','rel1')
+    Result 'new-session -d exits 0' ($r.Code -eq 0) "code=$($r.Code) out=$($r.Out)"
+    Start-Sleep -Milliseconds 800
+
+    $r = Run @('ls')
+    Result 'ls lists the session'   ($r.Out -match 'rel1:') "out=$($r.Out)"
+    Result 'ls has no 10060'        (NoTimeout $r.Out)      "out=$($r.Out)"
+
+    $r = Run @('list-windows','-t','rel1')
+    Result 'list-windows returns a window' ($r.Out -match '^\s*0:') "out=$($r.Out)"
+    Result 'list-windows has no 10060'     (NoTimeout $r.Out)       "out=$($r.Out)"
+
+    $r = Run @('has-session','-t','rel1')
+    Result 'has-session present -> 0' ($r.Code -eq 0) "code=$($r.Code)"
+    $r = Run @('has-session','-t','does-not-exist')
+    Result 'has-session absent -> 1'  ($r.Code -eq 1) "code=$($r.Code)"
+
+    # --- the core fix: kill actually kills, and reports honestly -------------
+    $r = Run @('kill-session','-t','rel1')
+    Result 'kill-session exits 0' ($r.Code -eq 0) "code=$($r.Code) out=$($r.Out)"
+    Start-Sleep -Milliseconds 500
+    $r = Run @('has-session','-t','rel1')
+    Result 'session is actually gone after kill' ($r.Code -eq 1) "code=$($r.Code)"
+
+    # --- Tier 3: window-create burst then teardown --------------------------
+    $r = Run @('new-session','-d','-s','burst')
+    Result 'burst new-session exits 0' ($r.Code -eq 0) "code=$($r.Code)"
+    Start-Sleep -Milliseconds 500
+    for ($i = 0; $i -lt 5; $i++) { Run @('new-window','-t','burst') | Out-Null }
+    Start-Sleep -Milliseconds 800
+    $r = Run @('list-windows','-t','burst')
+    $winCount = ([regex]::Matches($r.Out, '(?m)^\s*\d+:')).Count
+    Result 'burst created ~6 windows' ($winCount -ge 5) "count=$winCount out=$($r.Out)"
+    Result 'burst list has no 10060'  (NoTimeout $r.Out) "out=$($r.Out)"
+
+    $r = Run @('kill-session','-t','burst')
+    Result 'burst kill-session exits 0' ($r.Code -eq 0) "code=$($r.Code)"
+    Start-Sleep -Milliseconds 500
+    $r = Run @('has-session','-t','burst')
+    Result 'burst session gone after kill' ($r.Code -eq 1) "code=$($r.Code)"
+}
+finally {
+    # Best-effort cleanup: kill any servers this test spawned, then the temp home.
+    foreach ($s in @('rel1','burst')) { & $PSMUX kill-session -t $s 2>$null | Out-Null }
+    Start-Sleep -Milliseconds 300
+    Remove-Item -Recurse -Force $tmpHome -ErrorAction SilentlyContinue
+}
+
+Write-Host ""
+Write-Host "command-reliability: $pass passed, $fail failed" -ForegroundColor Cyan
+if ($fail -gt 0) { exit 1 } else { exit 0 }


### PR DESCRIPTION
> **Note:** builds on #464 (Tier 1). The net-new change here is the final commit,
> "Tier 2 — confirm command EXECUTION via a FIFO barrier". Review after #464.

## Idea

Tier 1 (#464) guarantees a fire-and-forget command is *delivered* to the server;
it does not guarantee the command has *finished executing* before the CLI exits,
so a script that inspects the effect immediately after can still race.

`send_control` now appends a `session-info` request after its command.
`session-info` round-trips through the server's single FIFO event loop
(`CtrlReq::SessionInfo` → blocking reply), so receiving its answer proves every
command dispatched earlier on the connection has actually been applied.
`send_control` thus becomes synchronous — it returns only once the command has
executed. Commands whose handler tears down the connection first (e.g.
`kill-session`) simply leave the barrier unanswered; that path is covered by the
caller's verify-retry from #464.

Also hardens the server: the `session-info` handler waited on an unbounded
`rrx.recv()`; since it now doubles as the execution barrier, it uses
`recv_timeout(3s)` so a momentarily-wedged event loop can't leak the connection
thread.

## Tradeoff (please weigh)

This adds one event-loop round-trip to **every** mutating one-shot command. That
makes scripting race-free, but under a heavy command stream it is extra
event-loop traffic. If that default is undesirable upstream, an alternative is to
gate the barrier behind a flag (opt-in for callers that need
inspect-after-mutate ordering) — happy to adjust.
