### PR TITLE
fix(config): strip #branch suffix before deriving @plugin path

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1164,18 +1164,23 @@ pub fn parse_option_value(app: &mut AppState, rest: &str, _is_global: bool) {
             // Tries:  ~/.psmux/plugins/<full-value>/plugin.conf
             //   then: ~/.psmux/plugins/<last-component>/plugin.conf
             if key == "@plugin" && !value.is_empty() {
-                let plugin_name = value.rsplit('/').next().unwrap_or(value);
+                // Strip an optional '#branch' suffix before deriving the plugin
+                // path. Branch names may contain '/' (e.g. 'temp/integration'),
+                // so splitting the raw value on '/' would treat the branch tail
+                // as the plugin name and never find the installed directory.
+                let base = value.split('#').next().unwrap_or(value);
+                let plugin_name = base.rsplit('/').next().unwrap_or(base);
                 if plugin_name != "ppm" {
                     let home = env::var("USERPROFILE").or_else(|_| env::var("HOME")).unwrap_or_default();
                     let xdg_config = env::var("XDG_CONFIG_HOME")
                         .unwrap_or_else(|_| format!("{}\\.config", home));
                     let candidates = [
                         // Classic paths: ~/.psmux/plugins/
-                        format!("{}\\.psmux\\plugins\\{}\\plugin.conf", home, value.replace('/', "\\")),
+                        format!("{}\\.psmux\\plugins\\{}\\plugin.conf", home, base.replace('/', "\\")),
                         format!("{}\\.psmux\\plugins\\{}\\plugin.conf", home, plugin_name),
                         format!("{}\\.psmux\\plugins\\psmux-plugins\\{}\\plugin.conf", home, plugin_name),
                         // XDG paths: ~/.config/psmux/plugins/
-                        format!("{}\\psmux\\plugins\\{}\\plugin.conf", xdg_config, value.replace('/', "\\")),
+                        format!("{}\\psmux\\plugins\\{}\\plugin.conf", xdg_config, base.replace('/', "\\")),
                         format!("{}\\psmux\\plugins\\{}\\plugin.conf", xdg_config, plugin_name),
                         format!("{}\\psmux\\plugins\\psmux-plugins\\{}\\plugin.conf", xdg_config, plugin_name),
                     ];
@@ -1196,11 +1201,11 @@ pub fn parse_option_value(app: &mut AppState, rest: &str, _is_global: bool) {
                     if !found {
                         let ps1_candidates = [
                             // Classic paths
-                            format!("{}\\.psmux\\plugins\\{}\\{}.ps1", home, value.replace('/', "\\"), plugin_name),
+                            format!("{}\\.psmux\\plugins\\{}\\{}.ps1", home, base.replace('/', "\\"), plugin_name),
                             format!("{}\\.psmux\\plugins\\{}\\{}.ps1", home, plugin_name, plugin_name),
                             format!("{}\\.psmux\\plugins\\psmux-plugins\\{}\\{}.ps1", home, plugin_name, plugin_name),
                             // XDG paths
-                            format!("{}\\psmux\\plugins\\{}\\{}.ps1", xdg_config, value.replace('/', "\\"), plugin_name),
+                            format!("{}\\psmux\\plugins\\{}\\{}.ps1", xdg_config, base.replace('/', "\\"), plugin_name),
                             format!("{}\\psmux\\plugins\\{}\\{}.ps1", xdg_config, plugin_name, plugin_name),
                             format!("{}\\psmux\\plugins\\psmux-plugins\\{}\\{}.ps1", xdg_config, plugin_name, plugin_name),
                         ];

--- a/tests-rs/test_config_plugin_paths.rs
+++ b/tests-rs/test_config_plugin_paths.rs
@@ -178,3 +178,39 @@ fn plugin_discovery_xdg_ps1_entry() {
 
     let _ = fs::remove_dir_all(&tmp);
 }
+
+/// A '#branch' suffix on the spec must not shadow the plugin name. Branch names
+/// may contain '/' (e.g. 'temp/integration'), so deriving the name from the last
+/// '/' segment of 'MattKotsenas/psmux-plugins/psmux-test-branch#temp/integration'
+/// would pick 'integration' and miss the plugin; the '#branch' suffix is stripped
+/// first. Regression guard.
+#[test]
+fn plugin_discovery_strips_branch_suffix() {
+    let _lock = crate::util::lock_test_env();
+    let tmp = std::env::temp_dir().join("psmux_test_branch_suffix");
+    let _ = fs::remove_dir_all(&tmp);
+
+    let plugin_dir = tmp.join(".psmux").join("plugins").join("psmux-test-branch");
+    fs::create_dir_all(&plugin_dir).unwrap();
+    fs::write(
+        plugin_dir.join("plugin.conf"),
+        "set -g @test-branch-option 'branch-found'\n",
+    ).unwrap();
+
+    let _env = EnvGuard::new(tmp.to_str().unwrap());
+
+    let mut app = mock_app();
+    parse_config_content(
+        &mut app,
+        "set -g @plugin 'MattKotsenas/psmux-plugins/psmux-test-branch#temp/integration'\n",
+    );
+
+    let val = app.user_options.get("@test-branch-option");
+    assert_eq!(
+        val.map(|s| s.as_str()),
+        Some("branch-found"),
+        "A '#temp/integration' branch suffix must not shadow the plugin name"
+    );
+
+    let _ = fs::remove_dir_all(&tmp);
+}


### PR DESCRIPTION
The native `@plugin` auto-source derives the plugin directory from the spec with `value.rsplit('/').next()`. Branch names can contain `/` (e.g. `temp/integration`), so a spec like `owner/psmux-plugins/psmux-continuum#temp/integration` resolves the plugin name to `integration`, and no `plugin.conf` is ever sourced — silently breaking themes, settings, and continuum's auto-restore hooks after a reboot.

This strips an optional `#branch` suffix into a base value before deriving both the plugin name and the candidate paths, so a `#branch` pin (used to dogfood a fork branch) no longer defeats plugin discovery.

Regression test: `plugin_discovery_strips_branch_suffix`.
