### PR TITLE
fix: detect WezTerm for VT mouse input so SGR sequences don't leak into panes

### DIFF
--- a/src/ssh_input.rs
+++ b/src/ssh_input.rs
@@ -223,6 +223,14 @@ pub fn needs_vt_input() -> bool {
     is_ssh_session()
         || std::env::var("TERMINAL_EMULATOR")
             .map_or(false, |v| v.contains("JetBrains"))
+        // WezTerm on Windows is a ConPTY-based VT terminal that writes VT mouse
+        // escape sequences to the ConPTY input pipe, exactly like JediTerm.
+        // ConPTY does not translate these into MOUSE_EVENT records, so without
+        // the VT input parser the raw SGR bytes (e.g. "\x1b[<35;..M") leak
+        // through as KEY_EVENT text into the active pane. Detect WezTerm via the
+        // env vars it always sets and route it through the VT input path.
+        || std::env::var("TERM_PROGRAM").map_or(false, |v| v == "WezTerm")
+        || std::env::var_os("WEZTERM_PANE").is_some()
 }
 
 /// Returns the Windows build number (e.g. 19045 for Win10 22H2, 22631 for


### PR DESCRIPTION
## Problem
Under WezTerm on Windows, moving or clicking the mouse prints raw SGR mouse sequences (e.g. `␛[<35;79;36M`) as literal text into the active pane instead of being handled as mouse input. `set -g mouse off` does **not** suppress it, because this is an input-decoding path, not the mouse option.

## Root cause
`needs_vt_input()` only routes input through the VT mouse parser for SSH sessions or JediTerm (`TERMINAL_EMULATOR` contains `"JetBrains"`). WezTerm is a ConPTY-based VT terminal that — exactly like JediTerm — writes VT mouse escape sequences to the ConPTY input pipe. ConPTY does not translate these into `MOUSE_EVENT` records, so the Win32 `ReadConsoleInputW` reader never sees them as mouse events and the raw bytes leak through as `KEY_EVENT` text into the pane. This is the same failure mode the JediTerm branch already exists to handle — WezTerm was simply never added.

## Fix
Detect WezTerm via the environment variables it always sets (`WEZTERM_PANE`, and `TERM_PROGRAM=WezTerm`) and route it through the same VT input path. `TERMINAL_EMULATOR` is referenced only in `needs_vt_input()`, so the change is self-contained.

## Testing
Built from `master` and run under WezTerm on Windows 11 (pwsh). Before: mouse motion/clicks flood the active pane with `␛[<..M` text. After: no leakage, and mouse (wheel-scroll, click-to-focus) works correctly.
