### PR TITLE
feat: async #(command) status expansion (non-blocking format jobs)

### DIFF
--- a/src/format.rs
+++ b/src/format.rs
@@ -246,53 +246,63 @@ pub fn expand_format_for_window(fmt: &str, app: &AppState, win_idx: usize) -> St
     result
 }
 
-/// Execute a shell command and return its stdout (trimmed).
-/// Used for `#(command)` expansion (tmux compatibility).
+/// Expand `#(command)` (tmux compatibility): return the last cached stdout and,
+/// when it is missing or older than the TTL, spawn a background worker to
+/// refresh it. The call never blocks the server loop; the worker's result is
+/// delivered over `format_job_tx` and applied by the drain in the server loop,
+/// which then repaints. Before the first result the expansion is empty.
 ///
-/// Results are cached in `app.format_shell_cache` keyed by the command
-/// string, with TTL = `status-interval` seconds (matching tmux's refresh
-/// semantics for `#(...)`). When `status-interval` is 0, a 1s floor is
-/// used so typing latency is bounded — tmux never repaints fast enough
-/// for the spawn cost to dominate, but our server-push path can fire
-/// ~30 times per second during active TUI redraws.
-///
-/// Cache miss / expiry path spawns a fresh subprocess synchronously.
-/// First call after expiry pays the spawn cost; subsequent calls within
-/// the TTL window return instantly. See issue #272.
+/// Cached in `app.format_shell_cache`, keyed by command string, TTL =
+/// `status-interval` seconds (1s floor). A command already in flight is not
+/// re-spawned, so a burst of pushes runs it at most once per TTL. See issue #272.
 fn run_shell_command(cmd: &str, app: &AppState) -> String {
     let ttl = std::time::Duration::from_secs(app.status_interval.max(1));
 
-    // Fast path: return cached value if still fresh.
-    if let Ok(guard) = app.format_shell_cache.lock() {
-        if let Some((stored_at, value)) = guard.get(cmd) {
-            if stored_at.elapsed() < ttl {
-                return value.clone();
+    let mut guard = match app.format_shell_cache.lock() {
+        Ok(g) => g,
+        Err(_) => return String::new(),
+    };
+
+    // Fast path: a fresh value, returned without spawning. Otherwise capture the
+    // last output + freshness base and decide whether to spawn a refresh worker.
+    let (last_value, base_at, should_spawn) = match guard.get(cmd) {
+        Some(e) => {
+            if e.at.elapsed() < ttl {
+                return e.value.clone();
             }
+            (e.value.clone(), e.at, !e.running)
+        }
+        None => (String::new(), std::time::Instant::now(), true),
+    };
+
+    if should_spawn {
+        if let Some(tx) = app.format_job_tx.as_ref() {
+            let tx = tx.clone();
+            let cmd_owned = cmd.to_string();
+            // Mark in-flight (keeping the old freshness base) before spawning so
+            // other #() expansions in the same push don't double-spawn.
+            guard.insert(cmd.to_string(), crate::types::ShellEntry { at: base_at, value: last_value.clone(), running: true });
+            drop(guard);
+            std::thread::spawn(move || {
+                use std::process::Command;
+                use crate::platform::HideWindowCommandExt;
+                let output = if cfg!(windows) {
+                    Command::new("cmd").args(["/C", &cmd_owned]).hide_window().output()
+                } else {
+                    Command::new("sh").args(["-c", &cmd_owned]).output()
+                };
+                let value = match output {
+                    Ok(o) if o.status.success() => {
+                        String::from_utf8_lossy(&o.stdout).trim().to_string()
+                    }
+                    _ => String::new(),
+                };
+                let _ = tx.send((cmd_owned, value));
+            });
         }
     }
 
-    // Cache miss or expired: spawn the subprocess.
-    use std::process::Command;
-    use crate::platform::HideWindowCommandExt;
-    let output = if cfg!(windows) {
-        Command::new("cmd").args(["/C", cmd]).hide_window().output()
-    } else {
-        Command::new("sh").args(["-c", cmd]).output()
-    };
-    let value = match output {
-        Ok(o) if o.status.success() => {
-            String::from_utf8_lossy(&o.stdout).trim().to_string()
-        }
-        _ => String::new(),
-    };
-
-    // Insert/refresh the cache entry. Lock failures (poisoned) are
-    // ignored — the subprocess already ran, the user still gets output.
-    if let Ok(mut guard) = app.format_shell_cache.lock() {
-        guard.insert(cmd.to_string(), (std::time::Instant::now(), value.clone()));
-    }
-
-    value
+    last_value
 }
 
 /// Escape '%' to '%%' in expanded variable content so chrono's strftime

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -739,6 +739,13 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
     let pty_system = native_pty_system();
 
     let mut app = AppState::new(session_name);
+    // Preinitialize the async #(command) format-job channel (see the
+    // format_job_rx doc in types.rs).
+    {
+        let (fjtx, fjrx) = std::sync::mpsc::channel();
+        app.format_job_tx = Some(fjtx);
+        app.format_job_rx = Some(fjrx);
+    }
     app.socket_name = socket_name;
     app.session_group = group_target;
     // Server starts detached with a reasonable default window size
@@ -5307,6 +5314,17 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                     };
                     state_dirty = true;
                 }
+            }
+        }
+        // Drain async #(command) format-job results (non-blocking): refresh the
+        // cache entry and repaint so the fresh output replaces the stale one.
+        if let Some(rx) = app.format_job_rx.as_ref() {
+            while let Ok((cmd, output)) = rx.try_recv() {
+                if let Ok(mut guard) = app.format_shell_cache.lock() {
+                    let now = std::time::Instant::now();
+                    guard.insert(cmd, crate::types::ShellEntry { at: now, value: output, running: false });
+                }
+                state_dirty = true;
             }
         }
         // ── Server-push: proactively send frames to attached clients ──

--- a/src/types.rs
+++ b/src/types.rs
@@ -406,6 +406,18 @@ pub struct CopyModeState {
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum FocusDir { Left, Right, Up, Down }
 
+/// One cached `#(command)` expansion: the last output plus the state of any
+/// in-flight background worker refreshing it.
+#[derive(Clone)]
+pub struct ShellEntry {
+    /// When `value` was last refreshed; the TTL base for re-running the command.
+    pub at: std::time::Instant,
+    /// Last run's stdout (trimmed); empty on failure or before the first result.
+    pub value: String,
+    /// A background worker for this command is currently in flight.
+    pub running: bool,
+}
+
 pub struct AppState {
     pub windows: Vec<Window>,
     pub active_idx: usize,
@@ -515,6 +527,12 @@ pub struct AppState {
     pub run_shell_rx: Option<mpsc::Receiver<(String, String)>>,
     /// Sender cloned into each run-shell background thread.
     pub run_shell_tx: Option<mpsc::Sender<(String, String)>>,
+    /// Receiver for async #(command) format-job results (cmd, output).
+    /// Preinitialized in the server loop (unlike run_shell_*) because
+    /// run_shell_command sees only &AppState and can't create it lazily.
+    pub format_job_rx: Option<mpsc::Receiver<(String, String)>>,
+    /// Sender cloned into each #() background worker.
+    pub format_job_tx: Option<mpsc::Sender<(String, String)>>,
     pub session_name: String,
     /// Numeric session ID (tmux-compatible: $0, $1, $2...).
     pub session_id: usize,
@@ -667,7 +685,7 @@ pub struct AppState {
     /// during active typing), which serializes a slow helper (e.g. pwsh
     /// at ~280 ms cold-start) onto the server main loop and lags echo.
     /// Keyed by command string; entries expire after `status_interval`.
-    pub format_shell_cache: std::sync::Mutex<std::collections::HashMap<String, (std::time::Instant, String)>>,
+    pub format_shell_cache: std::sync::Mutex<std::collections::HashMap<String, ShellEntry>>,
     /// status-justify: left, centre, right, absolute-centre
     pub status_justify: String,
     /// main-pane-width: percentage for main pane in main-vertical layout (0 = use 60% heuristic)
@@ -1020,6 +1038,8 @@ impl AppState {
             session_key: String::new(),
             run_shell_rx: None,
             run_shell_tx: None,
+            format_job_rx: None,
+            format_job_tx: None,
             session_name,
             session_id: crate::session::allocate_session_id(),
             socket_name: None,

--- a/tests-rs/test_issue272_format_shell_cache.rs
+++ b/tests-rs/test_issue272_format_shell_cache.rs
@@ -1,54 +1,58 @@
-// Issue #272: TTL cache for `#(cmd)` shell expansions in status-format.
+// Issue #272 + async #() format jobs.
 //
-// These tests prove the cache layer added in src/format.rs:
-//   1. First call spawns the subprocess (cache miss).
-//   2. Subsequent calls within TTL return the cached value WITHOUT spawning.
-//   3. Calls after TTL expiry re-spawn.
-//   4. Different commands have separate cache entries (no key collisions).
-//   5. status_interval=0 still caches with a 1s floor (so typing never
-//      pays the spawn cost on every state_dirty push).
+// run_shell_command is non-blocking: it spawns the subprocess on a background
+// thread, returns the last cached value (empty on the first call), and the
+// server loop drains completed results to refresh the cache. These tests prove
+// the async contract: the call never blocks, one worker runs per command per
+// TTL / in-flight window (dup guard + cache), TTL expiry re-spawns, distinct
+// commands are independent, the value reaches the caller after a drain, and the
+// cached value is the stdout (not the command text).
 //
-// Spawn detection strategy: the helper command appends a line to a unique
-// counter file each time it runs. We count file lines to prove how many
-// real subprocess spawns happened, regardless of what `expand_format`
-// returns. This is the irrefutable measurement.
+// Spawn detection: the helper appends a line to a unique counter file each time
+// it actually runs, so line count == real subprocess spawns, independent of
+// what expand_format returns. `mock_app` preinitializes the format-job channel
+// (as the server loop does) and `drain`/`wait_for_drain` replicate the loop's
+// non-blocking result drain.
 
 use super::*;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 fn mock_app(interval_secs: u64) -> AppState {
     let mut app = AppState::new("issue272".to_string());
     app.window_base_index = 0;
     app.status_interval = interval_secs;
+    // Preinitialize the format-job channel exactly as the server loop does, so
+    // the async path can spawn workers and deliver results.
+    let (tx, rx) = std::sync::mpsc::channel();
+    app.format_job_tx = Some(tx);
+    app.format_job_rx = Some(rx);
     app
 }
 
-/// Build a counter file path unique to this test (avoids cross-test races).
 fn counter_path(test_name: &str) -> std::path::PathBuf {
-    // Include a per-process random suffix so parallel runs don't collide.
     let pid = std::process::id();
     let nanos = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap()
         .as_nanos();
-    std::env::temp_dir().join(format!(
-        "psmux_issue272_{}_{}_{}.count",
-        test_name, pid, nanos
-    ))
+    std::env::temp_dir().join(format!("psmux_issue272_{}_{}_{}.count", test_name, pid, nanos))
 }
 
-/// Build a `#(...)` command that appends to `counter_path` each time the
-/// subprocess runs. The command's stdout is empty; we measure spawn count
-/// purely by counting lines in the counter file.
+/// A `#(...)` inner command that appends one line to `counter` when it runs.
+/// Its stdout is empty, so `#()` expands to "".
 fn tracer_cmd(counter: &std::path::Path) -> String {
-    // On Windows the format engine uses `cmd /C`; on Unix it uses `sh -c`.
-    // Either way, redirecting an `echo` to a file is portable enough for
-    // our needs here. Use forward slashes so cmd /C accepts the path.
+    let p = counter.display().to_string().replace('\\', "/");
+    format!("echo x>>{}", p)
+}
+
+/// Like `tracer_cmd` but waits ~1s first, so a synchronous spawn would visibly
+/// block. `ping -n 2` is the classic cmd sleep and reads no stdin.
+fn slow_tracer_cmd(counter: &std::path::Path) -> String {
     let p = counter.display().to_string().replace('\\', "/");
     if cfg!(windows) {
-        format!("echo x>>{}", p)
+        format!("ping -n 2 127.0.0.1 >nul & echo x>>{}", p)
     } else {
-        format!("echo x>>{}", p)
+        format!("sleep 1; echo x>>{}", p)
     }
 }
 
@@ -63,128 +67,76 @@ fn cleanup(p: &std::path::Path) {
     let _ = std::fs::remove_file(p);
 }
 
+/// Replicate the server loop's drain: pull completed `#()` results and refresh
+/// the cache so the next `expand_format` returns the fresh value.
+fn drain(app: &AppState) -> usize {
+    let mut n = 0;
+    if let Some(rx) = app.format_job_rx.as_ref() {
+        while let Ok((cmd, output)) = rx.try_recv() {
+            if let Ok(mut g) = app.format_shell_cache.lock() {
+                let now = Instant::now();
+                g.insert(cmd, crate::types::ShellEntry { at: now, value: output, running: false });
+            }
+            n += 1;
+        }
+    }
+    n
+}
+
+fn wait_for_drain(app: &AppState, timeout: Duration) -> usize {
+    let deadline = Instant::now() + timeout;
+    loop {
+        let n = drain(app);
+        if n > 0 || Instant::now() >= deadline {
+            return n;
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+}
+
+fn wait_for_spawns(counter: &std::path::Path, expected: usize, timeout: Duration) -> usize {
+    let deadline = Instant::now() + timeout;
+    loop {
+        let c = line_count(counter);
+        if c >= expected || Instant::now() >= deadline {
+            return c;
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+}
+
 // ───────────────────────── tests ─────────────────────────
 
 #[test]
-fn cache_miss_spawns_once_then_cache_hits_skip_spawn() {
-    let counter = counter_path("hit_skip");
+fn expand_does_not_block_on_the_subprocess() {
+    let counter = counter_path("nonblock");
     cleanup(&counter);
     let app = mock_app(15);
-    let fmt = format!("X#({})Y", tracer_cmd(&counter));
+    let fmt = format!("#({})", slow_tracer_cmd(&counter));
 
-    // Call expand_format 50 times in tight succession (simulates the
-    // server-push path firing during active typing).
-    for _ in 0..50 {
-        let _ = expand_format(&fmt, &app);
-    }
+    let t0 = Instant::now();
+    let out = expand_format(&fmt, &app);
+    let elapsed = t0.elapsed();
 
-    let spawns = line_count(&counter);
-    cleanup(&counter);
-
-    assert_eq!(
-        spawns, 1,
-        "Cache MISS-then-HIT: 50 expand_format calls within TTL should \
-         spawn the subprocess exactly once. Observed: {} spawns. \
-         (If this fails, the TTL cache regressed and issue #272 is back.)",
-        spawns
+    // The helper waits ~1s; a synchronous spawn would block here. The async
+    // path must return immediately with empty output.
+    assert!(
+        elapsed < Duration::from_millis(300),
+        "expand_format blocked {:?} on a ~1s helper (issue #272 residual is back)",
+        elapsed
     );
+    assert_eq!(out, "", "first render shows empty #() before the worker completes; got {:?}", out);
+
+    // Let the worker finish so it doesn't outlive the test.
+    wait_for_spawns(&counter, 1, Duration::from_secs(5));
+    cleanup(&counter);
 }
 
 #[test]
-fn cache_expires_and_respawns_after_ttl() {
-    let counter = counter_path("expiry");
+fn one_spawn_per_window_and_value_after_drain() {
+    let counter = counter_path("value");
     cleanup(&counter);
-    // status_interval=1 -> TTL = 1s.
-    let app = mock_app(1);
-    let fmt = format!("#({})", tracer_cmd(&counter));
-
-    let _ = expand_format(&fmt, &app);
-    assert_eq!(line_count(&counter), 1, "First call should spawn");
-
-    // Burst of calls within TTL — should not respawn.
-    for _ in 0..10 { let _ = expand_format(&fmt, &app); }
-    assert_eq!(
-        line_count(&counter),
-        1,
-        "Calls within 1s TTL window should hit cache (no respawn)"
-    );
-
-    // Wait past TTL.
-    std::thread::sleep(Duration::from_millis(1100));
-
-    // Next call should respawn.
-    let _ = expand_format(&fmt, &app);
-    let spawns = line_count(&counter);
-    cleanup(&counter);
-
-    assert_eq!(
-        spawns, 2,
-        "After TTL expiry the next call must respawn. Observed total spawns: {}",
-        spawns
-    );
-}
-
-#[test]
-fn different_commands_have_independent_cache_entries() {
-    let counter_a = counter_path("indep_a");
-    let counter_b = counter_path("indep_b");
-    cleanup(&counter_a);
-    cleanup(&counter_b);
-
-    let app = mock_app(15);
-    let fmt_a = format!("#({})", tracer_cmd(&counter_a));
-    let fmt_b = format!("#({})", tracer_cmd(&counter_b));
-
-    for _ in 0..20 {
-        let _ = expand_format(&fmt_a, &app);
-        let _ = expand_format(&fmt_b, &app);
-    }
-
-    let a = line_count(&counter_a);
-    let b = line_count(&counter_b);
-    cleanup(&counter_a);
-    cleanup(&counter_b);
-
-    assert_eq!(a, 1, "Command A should spawn exactly once across 20 calls; got {}", a);
-    assert_eq!(b, 1, "Command B should spawn exactly once across 20 calls; got {}", b);
-}
-
-#[test]
-fn status_interval_zero_still_caches_with_one_second_floor() {
-    let counter = counter_path("zero_interval");
-    cleanup(&counter);
-    // The fix uses .max(1) so status-interval=0 doesn't disable caching.
-    // Without that floor a user with `set -g status-interval 0` would
-    // still hit the per-frame spawn pathology described in issue #272.
-    let app = mock_app(0);
-    let fmt = format!("#({})", tracer_cmd(&counter));
-
-    for _ in 0..50 {
-        let _ = expand_format(&fmt, &app);
-    }
-
-    let spawns = line_count(&counter);
-    cleanup(&counter);
-
-    assert_eq!(
-        spawns, 1,
-        "status_interval=0 must still cache (1s floor) to keep typing snappy. \
-         Got {} spawns from 50 rapid calls.",
-        spawns
-    );
-}
-
-#[test]
-fn cached_value_is_returned_to_callers_not_just_silently_dropped() {
-    // This test guards against a subtle bug: if the cache stores values
-    // but expand_format ignores them and re-runs anyway, spawn count is
-    // still right but output could be stale/empty/wrong. Verify the
-    // caller sees the cached output.
-    let counter = counter_path("retval");
-    cleanup(&counter);
-
     let app = mock_app(60);
-    // Helper that prints a stable token AND increments the counter.
     let p = counter.display().to_string().replace('\\', "/");
     let cmd = if cfg!(windows) {
         format!("echo TOKEN-272 & echo x>>{}", p)
@@ -193,41 +145,123 @@ fn cached_value_is_returned_to_callers_not_just_silently_dropped() {
     };
     let fmt = format!("[#({})]", cmd);
 
-    let first = expand_format(&fmt, &app);
+    // First render: worker spawned, value not ready yet -> empty.
+    assert_eq!(expand_format(&fmt, &app), "[]", "empty before the worker completes");
+    // 50 rapid calls in the same window must not double-spawn (cache is fresh).
+    for _ in 0..50 {
+        let _ = expand_format(&fmt, &app);
+    }
+
+    let drained = wait_for_drain(&app, Duration::from_secs(5));
+    assert_eq!(drained, 1, "exactly one result should drain");
+
     let second = expand_format(&fmt, &app);
     let third = expand_format(&fmt, &app);
-
     let spawns = line_count(&counter);
     cleanup(&counter);
 
-    assert!(
-        first.contains("TOKEN-272"),
-        "First call output must contain helper stdout, got: {:?}",
-        first
-    );
-    assert_eq!(
-        first, second,
-        "Cached call must return same value as first call"
-    );
-    assert_eq!(
-        second, third,
-        "Cached call must keep returning same value"
-    );
-    assert_eq!(
-        spawns, 1,
-        "Only one spawn should have occurred across 3 calls within TTL; got {}",
-        spawns
-    );
+    assert!(second.contains("TOKEN-272"), "value must reach the caller after drain; got {:?}", second);
+    assert_eq!(second, third, "cached value stays stable within TTL");
+    assert_eq!(spawns, 1, "one spawn total within the TTL window; got {}", spawns);
 }
 
 #[test]
-fn cache_does_not_leak_command_text_into_output() {
-    // Sanity check: the cache key is the command, but the cached *value*
-    // is the stdout. A bug where we cache the command text instead would
-    // make the status line display the helper command verbatim.
-    let counter = counter_path("no_leak");
+fn respawns_after_ttl_expiry() {
+    let counter = counter_path("ttl");
     cleanup(&counter);
+    let app = mock_app(1); // TTL = 1s
+    let fmt = format!("#({})", tracer_cmd(&counter));
 
+    let _ = expand_format(&fmt, &app);
+    wait_for_drain(&app, Duration::from_secs(5));
+    assert_eq!(line_count(&counter), 1, "first call spawns");
+
+    for _ in 0..10 {
+        let _ = expand_format(&fmt, &app);
+    }
+    assert_eq!(line_count(&counter), 1, "within TTL: no respawn");
+
+    std::thread::sleep(Duration::from_millis(1100));
+    let _ = expand_format(&fmt, &app);
+    let spawns = wait_for_spawns(&counter, 2, Duration::from_secs(5));
+    cleanup(&counter);
+    assert_eq!(spawns, 2, "respawn after TTL expiry; got {}", spawns);
+}
+
+#[test]
+fn in_flight_worker_blocks_a_second_spawn_after_ttl() {
+    // Dup guard: if the entry is TTL-expired but a worker is still running, do
+    // NOT spawn a second one. A ~1s helper with a 1s TTL exercises the window
+    // where `at` is expired but `running` is still true.
+    let counter = counter_path("dupguard");
+    cleanup(&counter);
+    let app = mock_app(1); // TTL = 1s
+    let fmt = format!("#({})", slow_tracer_cmd(&counter));
+
+    let _ = expand_format(&fmt, &app); // spawn worker (waits ~1s)
+    // Hammer just past the 1s TTL while the worker is still in flight (and we
+    // never drain, so `running` stays true).
+    std::thread::sleep(Duration::from_millis(1050));
+    for _ in 0..10 {
+        let _ = expand_format(&fmt, &app);
+    }
+
+    let spawns = wait_for_spawns(&counter, 1, Duration::from_secs(5));
+    std::thread::sleep(Duration::from_millis(200));
+    let after = line_count(&counter);
+    cleanup(&counter);
+    assert_eq!(spawns, 1, "in-flight worker present; got {} spawns", spawns);
+    assert_eq!(after, 1, "no second worker while one was in flight; got {}", after);
+}
+
+#[test]
+fn distinct_commands_are_independent() {
+    let ca = counter_path("indep_a");
+    let cb = counter_path("indep_b");
+    cleanup(&ca);
+    cleanup(&cb);
+    let app = mock_app(15);
+    let fa = format!("#({})", tracer_cmd(&ca));
+    let fb = format!("#({})", tracer_cmd(&cb));
+
+    for _ in 0..20 {
+        let _ = expand_format(&fa, &app);
+        let _ = expand_format(&fb, &app);
+    }
+
+    wait_for_spawns(&ca, 1, Duration::from_secs(5));
+    wait_for_spawns(&cb, 1, Duration::from_secs(5));
+    std::thread::sleep(Duration::from_millis(150));
+    let a = line_count(&ca);
+    let b = line_count(&cb);
+    cleanup(&ca);
+    cleanup(&cb);
+    assert_eq!(a, 1, "command A spawns exactly once; got {}", a);
+    assert_eq!(b, 1, "command B spawns exactly once; got {}", b);
+}
+
+#[test]
+fn status_interval_zero_uses_one_second_floor() {
+    let counter = counter_path("zero");
+    cleanup(&counter);
+    // The .max(1) floor keeps status-interval=0 from re-spawning on every push.
+    let app = mock_app(0);
+    let fmt = format!("#({})", tracer_cmd(&counter));
+
+    for _ in 0..50 {
+        let _ = expand_format(&fmt, &app);
+    }
+    wait_for_spawns(&counter, 1, Duration::from_secs(5));
+    std::thread::sleep(Duration::from_millis(150));
+    let spawns = line_count(&counter);
+    cleanup(&counter);
+    assert_eq!(spawns, 1, "interval=0 floor keeps 50 rapid calls to one spawn; got {}", spawns);
+}
+
+#[test]
+fn value_is_stdout_not_command_text() {
+    let counter = counter_path("noleak");
+    cleanup(&counter);
     let app = mock_app(15);
     let p = counter.display().to_string().replace('\\', "/");
     let cmd = if cfg!(windows) {
@@ -237,13 +271,15 @@ fn cache_does_not_leak_command_text_into_output() {
     };
     let fmt = format!("#({})", cmd);
 
-    let out = expand_format(&fmt, &app);
+    let _ = expand_format(&fmt, &app); // spawn
+    wait_for_drain(&app, Duration::from_secs(5));
+    let out = expand_format(&fmt, &app); // cached value
     cleanup(&counter);
 
-    assert!(out.contains("SAFE_OUT"), "Output should contain helper stdout");
+    assert!(out.contains("SAFE_OUT"), "value should be the helper stdout; got {:?}", out);
     assert!(
         !out.contains("echo SAFE_OUT"),
-        "Output must NOT contain the raw command text (cache key vs value mixup): {:?}",
+        "value must be stdout, not the raw command text; got {:?}",
         out
     );
 }


### PR DESCRIPTION
## What

Make `#(command)` status expansion asynchronous. `run_shell_command` no longer runs the subprocess with a blocking `Command::output()` on the server main loop. It returns the last cached output immediately (empty before the first result), spawns the command on a background thread, and the server loop drains the result to refresh the cache and repaint.

## Why

A `#(cmd)` in a status format was expanded synchronously on the server main loop, so a slow helper stalled the whole server push. #272 mitigated the frequency with a TTL cache, and its discussion suggested a better fix:

> First call after expiry still blocks ~280 ms once ... running #(...) on a
> worker pool would eliminate even that, but it's a bigger change than the bug
> warrants.

This is that worker model. tmux runs `#()` the same way (an async job that paints the previous result and updates on completion).

## How

Mirrors the existing async `run-shell` path (background thread + a result channel drained each loop iteration):

- `types.rs`: the cache value becomes `ShellEntry { at, value, running }`; add a
  `format_job_rx/tx` channel, preinitialized in `run_server`.
- `format.rs`: `run_shell_command` returns the cached value and, when it is
  missing or older than the TTL and not already in flight, spawns a background
  worker. A command already running is not re-spawned, so a burst of pushes runs
  it at most once per TTL.
- `server/mod.rs`: drain completed results each loop iteration, refresh the cache,
  and mark the frame dirty so the fresh output is painted.

Otherwise unchanged: same TTL (`status-interval`, 1s floor) and `cfg!(windows)` shell; workers inherit the server's `PSMUX_TARGET_SESSION`.

## Testing

`tests-rs/test_issue272_format_shell_cache.rs` is rewritten for the async contract (7 tests)

Follow-up to #272 (retires the residual per-interval block its cache left).
