### PR TITLE
Fix duplicate client attachment registration

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1782,33 +1782,23 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                     let _ = resp.send(format!("{}\n", line));
                 }
                 CtrlReq::ClientAttach(cid) => {
-                    app.attached_clients = app.attached_clients.saturating_add(1);
-                    app.latest_client_id = Some(cid);
-                    // Register in client registry if not already present
-                    app.client_registry.entry(cid).or_insert_with(|| {
-                        let tty = format!("/dev/pts/{}", cid);
-                        crate::types::ClientInfo {
-                            id: cid,
-                            width: app.last_window_area.width,
-                            height: app.last_window_area.height,
-                            connected_at: std::time::Instant::now(),
-                            last_activity: std::time::Instant::now(),
-                            tty_name: tty,
-                            is_control: false,
-                        }
-                    });
-                    hook_event = Some("client-attached");
-                    // update-environment: refresh env vars from the attaching client's environment
-                    let update_vars = app.update_environment.clone();
-                    for var_spec in &update_vars {
-                        let remove = var_spec.starts_with('-');
-                        let name = if remove { &var_spec[1..] } else { var_spec.as_str() };
-                        if remove {
-                            app.environment.remove(name);
-                        } else if let Ok(val) = std::env::var(name) {
-                            app.environment.insert(name.to_string(), val);
-                        } else {
-                            app.environment.remove(name);
+                    // Registration and the attached counter are one idempotent
+                    // operation. A duplicate attach for the same connection
+                    // must not leave the session permanently ghost-attached.
+                    if app.register_client(cid, false) {
+                        hook_event = Some("client-attached");
+                        // update-environment: refresh env vars from the attaching client's environment
+                        let update_vars = app.update_environment.clone();
+                        for var_spec in &update_vars {
+                            let remove = var_spec.starts_with('-');
+                            let name = if remove { &var_spec[1..] } else { var_spec.as_str() };
+                            if remove {
+                                app.environment.remove(name);
+                            } else if let Ok(val) = std::env::var(name) {
+                                app.environment.insert(name.to_string(), val);
+                            } else {
+                                app.environment.remove(name);
+                            }
                         }
                     }
                 }
@@ -5028,18 +5018,9 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                         output_paused_panes: std::collections::HashSet::new(),
                         pane_last_output: std::collections::HashMap::new(),
                     });
-                    // Register control client in the client registry
-                    let tty = format!("/dev/pts/{}", client_id);
-                    app.client_registry.insert(client_id, crate::types::ClientInfo {
-                        id: client_id,
-                        width: app.last_window_area.width,
-                        height: app.last_window_area.height,
-                        connected_at: std::time::Instant::now(),
-                        last_activity: std::time::Instant::now(),
-                        tty_name: tty,
-                        is_control: true,
-                    });
-                    app.attached_clients = app.attached_clients.saturating_add(1);
+                    // Register control clients with the same idempotent
+                    // counter/registry invariant as normal TUI clients.
+                    app.register_client(client_id, true);
                     // Real tmux fires server hooks (session-changed, window-add,
                     // etc.) as side effects of the initial attach-session command.
                     // iTerm2 depends on %session-changed to enable writes

--- a/src/types.rs
+++ b/src/types.rs
@@ -835,6 +835,38 @@ impl AppState {
         }
     }
 
+    /// Register a newly attached client exactly once.
+    ///
+    /// A persistent connection can deliver more than one attach command for
+    /// the same server-assigned client id.  Treating each command as a new
+    /// client desynchronizes `attached_clients` from `client_registry`, because
+    /// the registry entry is naturally unique while the counter is not.
+    /// Returns `true` only when a new registry entry was inserted.
+    pub fn register_client(&mut self, cid: u64, is_control: bool) -> bool {
+        if self.client_registry.contains_key(&cid) {
+            return false;
+        }
+
+        let tty = format!("/dev/pts/{}", cid);
+        self.client_registry.insert(cid, ClientInfo {
+            id: cid,
+            width: self.last_window_area.width,
+            height: self.last_window_area.height,
+            connected_at: std::time::Instant::now(),
+            last_activity: std::time::Instant::now(),
+            tty_name: tty,
+            is_control,
+        });
+        self.attached_clients = self.attached_clients.saturating_add(1);
+        // Preserve the existing distinction between an interactive TUI client
+        // and a control-mode client: only the former becomes the latest client
+        // used for terminal sizing/input routing.
+        if !is_control {
+            self.latest_client_id = Some(cid);
+        }
+        true
+    }
+
     /// Reap a dead client's `client_registry` entry exactly once, keeping the
     /// `attached_clients` counter in lock-step with the registry.
     ///

--- a/tests-rs/test_issue434_reap_client.rs
+++ b/tests-rs/test_issue434_reap_client.rs
@@ -141,3 +141,34 @@ fn reap_last_client_reaches_zero_once() {
     assert!(!app.reap_client(1));
     assert_eq!(app.attached_clients, 0, "stays zero, no spurious re-trigger");
 }
+
+// A persistent connection may send both its implicit `client-attach` and an
+// explicit `attach-session`. Both map to ClientAttach for the same server-side
+// id. Before register_client(), the counter incremented twice while the registry
+// contained one row; the single disconnect then left attached_clients == 1
+// forever even though list-clients was empty.
+#[test]
+fn duplicate_attach_then_single_detach_does_not_leave_ghost_attached() {
+    let mut app = AppState::new("test434_duplicate_attach".to_string());
+
+    assert!(app.register_client(42, false), "first attach registers the client");
+    assert!(!app.register_client(42, false), "duplicate attach is a no-op");
+    assert_eq!(app.attached_clients, 1);
+    assert_eq!(app.client_registry.len(), 1);
+
+    assert!(app.reap_client(42), "one detach reaps the one client");
+    assert_eq!(app.attached_clients, 0, "session is no longer ghost-attached");
+    assert!(app.client_registry.is_empty(), "list-clients has no ghost row");
+}
+
+#[test]
+fn duplicate_control_register_preserves_counter_registry_invariant() {
+    let mut app = AppState::new("test434_duplicate_control".to_string());
+    app.latest_client_id = Some(12);
+
+    assert!(app.register_client(77, true));
+    assert!(!app.register_client(77, true));
+    assert_eq!(app.attached_clients, app.client_registry.len());
+    assert!(app.client_registry.get(&77).unwrap().is_control);
+    assert_eq!(app.latest_client_id, Some(12), "control clients do not replace the latest interactive client");
+}


### PR DESCRIPTION
## Summary

- make client attachment registration idempotent by server-assigned client ID
- use the same registration path for interactive and control-mode clients
- add regressions for duplicate interactive and control-mode attach events

## Problem

A connection can emit `ClientAttach` more than once for the same client ID. The client registry already deduplicates those events with `entry(...).or_insert(...)`, but `attached_clients` was incremented before the registry insertion.

After two attach events and one matching detach, the registry was empty while `attached_clients` remained `1`. That inconsistent state kept the server logically attached even though no client remained, which could surface as ghost-client or detach-policy behavior.

## Root cause and fix

Registration accounting and registry insertion were separate operations. This change centralizes them in `AppState::register_client` and reports whether the ID was newly registered.

The interactive and control-mode paths now:

- increment `attached_clients` only when a new client ID is inserted
- run attach hooks and refresh environment state only on first registration
- preserve the existing behavior where only interactive clients replace `latest_client_id`

There are no wire-protocol, command-line, or output-format changes.

## Validation

- `cargo test --bin psmux reap_client` — 8 passed, 0 failed
- `cargo build --release` — passed
- `git diff origin/master...HEAD --check` — passed
- Windows persistent-connection E2E: duplicate attach for one client ID followed by one detach returns the session to detached state
- Windows attach/detach E2E: `list-windows`, `list-panes`, and `capture-pane` remain available before, during, and after a client attach

This is a follow-up hardening for the client reaping and attachment-state work around #434.
