### PR TITLE
Support mouse scrollback over Windows 10 SSH

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,3 +65,26 @@ jobs:
           $exe = (Resolve-Path "target\x86_64-pc-windows-msvc\release\psmux.exe").Path
           $env:PSMUX_EXE = $exe
           .\tests\run_smoke_integration.ps1
+
+      - name: Run raw SSH pipe mouse integration
+        shell: pwsh
+        run: |
+          $exe = (Resolve-Path "target\x86_64-pc-windows-msvc\release\psmux.exe").Path
+          .\tests\test_windows10_ssh_pipe_mouse.ps1 -Psmux $exe
+
+  posix-helper-tests:
+    name: POSIX helper tests (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Test SSH wrapper cleanup
+        run: sh tests/test_psmux_ssh_wrapper.sh
+
+      - name: Test helper installation
+        run: sh tests/test_install_psmux_win.sh

--- a/docs/mouse-ssh.md
+++ b/docs/mouse-ssh.md
@@ -1,32 +1,81 @@
 # Mouse Over SSH
 
-psmux has **first-class mouse support over SSH** when the server runs **Windows 11 build 22523+ (22H2+)**. Click panes, drag-resize borders, scroll, click tabs — everything works, from any SSH client on any OS.
+psmux has first-class mouse support over a normal SSH pseudo-terminal when the
+server runs Windows 11 build 22523 or newer. On Windows 10 and earlier Windows
+11 builds, use the included client wrapper to bypass ConPTY.
 
 ## Compatibility
 
-### Remote access (over SSH)
-
-| Client → Server | Keyboard | Mouse | Notes |
+| Client → Server | Keyboard | Mouse | Command |
 |---|:---:|:---:|---|
-| Linux → Windows 11 (22523+) | ✅ | ✅ | Full support |
-| macOS → Windows 11 (22523+) | ✅ | ✅ | Full support |
-| Windows 10 → Windows 11 (22523+) | ✅ | ✅ | Full support |
-| Windows 11 → Windows 11 (22523+) | ✅ | ✅ | Full support |
-| WSL → Windows 11 (22523+) | ✅ | ✅ | Full support |
-| Any OS → Windows 10 | ✅ | ❌ | ConPTY limitation (see below) |
-| Any OS → Windows 11 (pre-22523) | ✅ | ❌ | ConPTY limitation (see below) |
+| Any OS → Windows 11 build 22523+ | ✅ | ✅ | Normal `ssh` |
+| macOS/Linux → Windows 10 | ✅ | ✅ | `scripts/psmux-ssh.sh` |
+| Any OS → Windows 10 with a normal SSH PTY | ✅ | ❌ | ConPTY consumes mouse VT bytes |
+| Local Windows 10/11 | ✅ | ✅ | Run psmux normally |
 
-### Local use (no SSH)
+## Windows 10 client wrapper
 
-| Platform | Keyboard | Mouse |
-|---|:---:|:---:|
-| Windows 11 (local) | ✅ | ✅ |
-| Windows 10 (local) | ✅ | ✅ |
+Copy `scripts/psmux-ssh.sh` to the macOS or Linux client, then run:
 
-Mouse works perfectly when running psmux locally on both Windows 10 and 11.
+```sh
+sh psmux-ssh.sh --session work -- user@windows-host
 
-## Why No Mouse Over SSH on Windows 10?
+# A named psmux socket/namespace:
+sh psmux-ssh.sh --socket project --session work -- user@windows-host
 
-Windows 10's ConPTY consumes mouse-enable escape sequences internally and does not forward them to sshd. The SSH client never receives the signal to start sending mouse data. This is a Windows 10 ConPTY limitation that was fixed in Windows 11 (build 22523+). Keyboard input works fully on both versions — only mouse over SSH is affected.
+# SSH options are passed through after `--`:
+sh psmux-ssh.sh --session work -- -p 2222 user@windows-host
+```
 
-> **Recommendation:** Use Windows 11 build 22523+ (22H2 or later) as your psmux server for full SSH mouse support.
+For a persistent one-command client, copy both scripts to the client and run
+the installer once:
+
+```sh
+sh install-psmux-win.sh --host user@windows-host \
+  --psmux C:/Users/user/.cargo/bin/psmux.exe
+
+psmux-win -s work
+psmux-win -L project -s work
+```
+
+The installer writes only `~/.local/bin/psmux-win` and
+`${XDG_CONFIG_HOME:-~/.config}/psmux-win/config`. Existing copies are backed
+up with a timestamp before replacement. It does not edit SSH configuration.
+
+The remote `psmux` executable must be on `PATH`. The wrapper:
+
+1. saves the local terminal state and switches it to raw mode;
+2. enables xterm button/drag reporting and SGR coordinates locally;
+3. runs `ssh -T`, which gives psmux direct stdin/stdout pipes instead of a
+   Windows pseudoconsole;
+4. attaches to the requested session; and
+5. disables mouse reporting and restores the exact saved terminal state after
+   normal exit, failure, disconnect, `HUP`, `INT`, or `TERM`.
+
+Do not add `-t` or `-tt`. Allocating a remote PTY puts ConPTY back in the byte
+path and recreates the Windows 10 limitation.
+
+To test a not-yet-installed build, select its remote executable explicitly:
+
+```sh
+sh psmux-ssh.sh --session work \
+  --psmux C:/path/to/psmux.exe -- user@windows-host
+```
+
+## Byte-level cause
+
+With a normal interactive SSH session, Windows OpenSSH hosts the remote process
+inside ConPTY. On Windows 10, ConPTY consumes output DEC private-mode sequences
+such as `ESC[?1000h`, `ESC[?1002h`, and `ESC[?1006h`; the SSH client therefore
+never tells its terminal to report the wheel. Even if those modes are enabled
+separately on the client, Windows 10 ConPTY also consumes the inbound SGR wheel
+report (for example `ESC[<64;10;5M`) before psmux can parse it.
+
+There is no SSH terminal-mode negotiation flag for xterm mouse reporting, and a
+server process inside ConPTY cannot access sshd's pseudoconsole pipes. `ssh -T`
+is the supported OpenSSH mechanism that omits the remote PTY. In this mode the
+existing psmux VT pipe reader receives keyboard and SGR mouse bytes directly,
+and psmux queries terminal size with XTWINOPS (`ESC[18t`).
+
+The build gate for normal SSH PTYs remains in place: forcing mouse registration
+through old ConPTY versions is not a safe server-only workaround (issue #457).

--- a/scripts/install-psmux-win.sh
+++ b/scripts/install-psmux-win.sh
@@ -73,12 +73,23 @@ config_file=$config_dir/config
 target=$bin_dir/psmux-win
 stamp=$(date '+%Y%m%d-%H%M%S')
 
+backup_file() {
+    backup_source=$1
+    backup_target=$backup_source.backup-$stamp
+    suffix=0
+    while [ -e "$backup_target" ]; do
+        suffix=$((suffix + 1))
+        backup_target=$backup_source.backup-$stamp-$suffix
+    done
+    cp "$backup_source" "$backup_target"
+}
+
 mkdir -p "$bin_dir" "$config_dir"
 if [ -e "$target" ]; then
-    cp "$target" "$target.backup-$stamp"
+    backup_file "$target"
 fi
 if [ -e "$config_file" ]; then
-    cp "$config_file" "$config_file.backup-$stamp"
+    backup_file "$config_file"
 fi
 
 cp "$source_wrapper" "$target"

--- a/scripts/install-psmux-win.sh
+++ b/scripts/install-psmux-win.sh
@@ -1,0 +1,105 @@
+#!/bin/sh
+# Install the macOS/Linux client helper as ~/.local/bin/psmux-win.
+
+set -eu
+
+usage() {
+    cat <<'EOF'
+Usage: install-psmux-win.sh --host [user@]windows-host [--psmux REMOTE_PATH]
+                            [--bin-dir LOCAL_BIN_DIR]
+
+Example:
+  sh install-psmux-win.sh --host user@windows-host \
+    --psmux C:/Users/user/.cargo/bin/psmux.exe
+EOF
+}
+
+host=
+remote_psmux=psmux
+bin_dir=${HOME}/.local/bin
+while [ "$#" -gt 0 ]; do
+    case $1 in
+        --host)
+            [ "$#" -ge 2 ] || { echo "psmux-win install: --host requires a value" >&2; exit 2; }
+            host=$2
+            shift 2
+            ;;
+        --psmux)
+            [ "$#" -ge 2 ] || { echo "psmux-win install: --psmux requires a value" >&2; exit 2; }
+            remote_psmux=$2
+            shift 2
+            ;;
+        --bin-dir)
+            [ "$#" -ge 2 ] || { echo "psmux-win install: --bin-dir requires a value" >&2; exit 2; }
+            bin_dir=$2
+            shift 2
+            ;;
+        --help|-h)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "psmux-win install: unknown argument: $1" >&2
+            usage >&2
+            exit 2
+            ;;
+    esac
+done
+
+[ -n "$host" ] || { echo "psmux-win install: --host is required" >&2; exit 2; }
+case $host in
+    *[!A-Za-z0-9_.@%:-]*)
+        echo "psmux-win install: host contains unsupported characters" >&2
+        exit 2
+        ;;
+esac
+case $remote_psmux in
+    *[!A-Za-z0-9_./:\\-]*)
+        echo "psmux-win install: remote psmux must be a simple path without spaces" >&2
+        exit 2
+        ;;
+esac
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+source_wrapper=$script_dir/psmux-ssh.sh
+[ -r "$source_wrapper" ] || {
+    echo "psmux-win install: psmux-ssh.sh must be beside the installer" >&2
+    exit 1
+}
+
+config_home=${XDG_CONFIG_HOME:-"$HOME/.config"}
+config_dir=$config_home/psmux-win
+config_file=$config_dir/config
+target=$bin_dir/psmux-win
+stamp=$(date '+%Y%m%d-%H%M%S')
+
+mkdir -p "$bin_dir" "$config_dir"
+if [ -e "$target" ]; then
+    cp "$target" "$target.backup-$stamp"
+fi
+if [ -e "$config_file" ]; then
+    cp "$config_file" "$config_file.backup-$stamp"
+fi
+
+cp "$source_wrapper" "$target"
+chmod 755 "$target"
+
+tmp_config=$config_file.tmp.$$
+trap 'rm -f "$tmp_config"' EXIT HUP INT TERM
+{
+    printf 'host=%s\n' "$host"
+    printf 'remote_psmux=%s\n' "$remote_psmux"
+} >"$tmp_config"
+chmod 600 "$tmp_config"
+mv "$tmp_config" "$config_file"
+trap - EXIT HUP INT TERM
+
+printf 'Installed: %s\n' "$target"
+printf 'Config:    %s\n' "$config_file"
+printf '\nUsage:\n'
+printf '  psmux-win -s SESSION\n'
+printf '  psmux-win -L SOCKET -s SESSION\n'
+case :$PATH: in
+    *:"$bin_dir":*) ;;
+    *) printf '\nAdd %s to PATH, then open a new terminal.\n' "$bin_dir" ;;
+esac

--- a/scripts/psmux-ssh.sh
+++ b/scripts/psmux-ssh.sh
@@ -2,7 +2,7 @@
 # Run on the macOS/Linux client. Uses a plain SSH channel instead of a remote
 # ConPTY so Windows 10 cannot consume mouse registration or SGR input bytes.
 
-set -u
+set -eu
 
 program=${0##*/}
 
@@ -114,7 +114,7 @@ if [ ! -r "$tty_path" ] || [ ! -w "$tty_path" ]; then
     exit 1
 fi
 
-saved_stty=$($stty_bin -g <"$tty_path") || {
+saved_stty=$("$stty_bin" -g <"$tty_path") || {
     echo "psmux-ssh: could not read local terminal state" >&2
     exit 1
 }
@@ -136,7 +136,7 @@ cleanup() {
     if [ "$cleaned" -eq 0 ]; then
         cleaned=1
         printf '%b' "$mouse_off" >&3 2>/dev/null || true
-        $stty_bin "$saved_stty" <"$tty_path" 2>/dev/null || true
+        "$stty_bin" "$saved_stty" <"$tty_path" 2>/dev/null || true
     fi
     return "$rc"
 }
@@ -160,7 +160,7 @@ trap 'signal_exit TERM 143' TERM
 
 # Raw, no-echo, and no local signal translation are required so Ctrl+C and all
 # other control bytes reach the remote psmux pane exactly as typed.
-$stty_bin raw -echo -isig <"$tty_path" || {
+"$stty_bin" raw -echo -isig <"$tty_path" || {
     echo "psmux-ssh: could not put the local terminal in raw mode" >&2
     exit 1
 }
@@ -176,7 +176,7 @@ if [ -n "$session" ]; then
 fi
 
 # Do not exec: the wrapper must regain control to restore stty and mouse modes.
-$ssh_bin -T "$@" "$remote_command" <&4 &
+"$ssh_bin" -T "$@" "$remote_command" <&4 &
 child_pid=$!
 wait "$child_pid"
 rc=$?

--- a/scripts/psmux-ssh.sh
+++ b/scripts/psmux-ssh.sh
@@ -1,0 +1,184 @@
+#!/bin/sh
+# Run on the macOS/Linux client. Uses a plain SSH channel instead of a remote
+# ConPTY so Windows 10 cannot consume mouse registration or SGR input bytes.
+
+set -u
+
+program=${0##*/}
+
+config_home=${XDG_CONFIG_HOME:-"$HOME/.config"}
+config_file=${PSMUX_WIN_CONFIG:-"$config_home/psmux-win/config"}
+configured_host=
+configured_psmux=
+if [ -r "$config_file" ]; then
+    while IFS='=' read -r key value; do
+        case $key in
+            host) configured_host=$value ;;
+            remote_psmux) configured_psmux=$value ;;
+        esac
+    done <"$config_file"
+fi
+
+usage() {
+    cat <<EOF
+Usage: $program [--socket NAME] [--session NAME] [--psmux PATH] [--] [ssh-options] [user@]host
+
+Examples:
+  $program --session work -- user@windows-host
+  $program --socket project --session work -- user@windows-host
+  $program --session work -- -p 2222 user@windows-host
+
+The remote psmux executable must be on PATH. Do not pass ssh -t/-tt: this
+wrapper deliberately uses ssh -T to bypass Windows 10 ConPTY.
+
+When installed as psmux-win, host and remote executable defaults are read from:
+  $config_file
+EOF
+}
+
+session=
+socket=
+remote_psmux=${configured_psmux:-psmux}
+while [ "$#" -gt 0 ]; do
+    case $1 in
+        --socket|-L)
+            [ "$#" -ge 2 ] || { echo "psmux-ssh: --socket requires a value" >&2; exit 2; }
+            socket=$2
+            shift 2
+            ;;
+        --session|-s|-t)
+            [ "$#" -ge 2 ] || { echo "psmux-ssh: --session requires a value" >&2; exit 2; }
+            session=$2
+            shift 2
+            ;;
+        --psmux)
+            [ "$#" -ge 2 ] || { echo "psmux-ssh: --psmux requires a value" >&2; exit 2; }
+            remote_psmux=$2
+            shift 2
+            ;;
+        --help|-h)
+            usage
+            exit 0
+            ;;
+        --)
+            shift
+            break
+            ;;
+        *)
+            break
+            ;;
+    esac
+done
+
+if [ "$#" -eq 0 ] && [ -n "$configured_host" ]; then
+    set -- "$configured_host"
+fi
+[ "$#" -gt 0 ] || { usage >&2; exit 2; }
+
+case $session in
+    *[!A-Za-z0-9_.-]*)
+        echo "psmux-ssh: session names may contain only letters, digits, '.', '_', and '-'" >&2
+        exit 2
+        ;;
+esac
+
+case $socket in
+    *[!A-Za-z0-9_.-]*)
+        echo "psmux-ssh: socket names may contain only letters, digits, '.', '_', and '-'" >&2
+        exit 2
+        ;;
+esac
+
+case $remote_psmux in
+    *[!A-Za-z0-9_./:\\-]*)
+        echo "psmux-ssh: --psmux must be a simple executable name or path without spaces" >&2
+        exit 2
+        ;;
+esac
+
+for arg in "$@"; do
+    case $arg in
+        -t|-tt|-T)
+            echo "psmux-ssh: do not pass $arg; the wrapper requires ssh -T" >&2
+            exit 2
+            ;;
+    esac
+done
+
+tty_path=${PSMUX_SSH_TTY:-/dev/tty}
+stty_bin=${PSMUX_SSH_STTY:-stty}
+ssh_bin=${PSMUX_SSH_BIN:-ssh}
+
+if [ ! -r "$tty_path" ] || [ ! -w "$tty_path" ]; then
+    echo "psmux-ssh: $tty_path is not a usable terminal" >&2
+    exit 1
+fi
+
+saved_stty=$($stty_bin -g <"$tty_path") || {
+    echo "psmux-ssh: could not read local terminal state" >&2
+    exit 1
+}
+
+# Keep local terminal control bytes out of the SSH stream.  Give the
+# backgrounded ssh process an explicit /dev/tty input FD: POSIX shells may
+# otherwise replace an asynchronous command's stdin with /dev/null when job
+# control is unavailable, making the remote psmux client exit immediately.
+exec 3>"$tty_path"
+exec 4<"$tty_path"
+mouse_on='\033[?1000h\033[?1002h\033[?1006h'
+mouse_off='\033[?1006l\033[?1002l\033[?1000l'
+cleaned=0
+child_pid=
+
+cleanup() {
+    rc=$?
+    trap - EXIT HUP INT TERM
+    if [ "$cleaned" -eq 0 ]; then
+        cleaned=1
+        printf '%b' "$mouse_off" >&3 2>/dev/null || true
+        $stty_bin "$saved_stty" <"$tty_path" 2>/dev/null || true
+    fi
+    return "$rc"
+}
+
+signal_exit() {
+    sig=$1
+    code=$2
+    trap - "$sig"
+    if [ -n "$child_pid" ]; then
+        kill -"$sig" "$child_pid" 2>/dev/null || true
+        wait "$child_pid" 2>/dev/null || true
+        child_pid=
+    fi
+    exit "$code"
+}
+
+trap cleanup EXIT
+trap 'signal_exit HUP 129' HUP
+trap 'signal_exit INT 130' INT
+trap 'signal_exit TERM 143' TERM
+
+# Raw, no-echo, and no local signal translation are required so Ctrl+C and all
+# other control bytes reach the remote psmux pane exactly as typed.
+$stty_bin raw -echo -isig <"$tty_path" || {
+    echo "psmux-ssh: could not put the local terminal in raw mode" >&2
+    exit 1
+}
+printf '%b' "$mouse_on" >&3
+
+remote_command=$remote_psmux
+if [ -n "$socket" ]; then
+    remote_command="$remote_command -L $socket"
+fi
+remote_command="$remote_command attach"
+if [ -n "$session" ]; then
+    remote_command="$remote_command -t $session"
+fi
+
+# Do not exec: the wrapper must regain control to restore stty and mouse modes.
+$ssh_bin -T "$@" "$remote_command" <&4 &
+child_pid=$!
+wait "$child_pid"
+rc=$?
+child_pid=
+exit "$rc"

--- a/src/client.rs
+++ b/src/client.rs
@@ -1968,7 +1968,7 @@ pub fn run_remote(terminal: &mut Terminal<crate::platform::PsmuxBackend>, input:
     // Windows Terminal drops even a local client's mouse registration.
     let is_ssh_mode = crate::ssh_input::needs_vt_input();
     let mut last_mouse_enable = Instant::now();
-    // Cygwin pty (issue #474): cadence for the XTWINOPS size poll.
+    // Raw VT pipe: cadence for the XTWINOPS size poll.
     let mut last_pipe_size_query = Instant::now();
     // ── Cursor blink stabilisation ──────────────────────────────────
     // Cache the last-sent DECSCUSR code so we only write it when it
@@ -6203,7 +6203,7 @@ pub fn run_remote(terminal: &mut Terminal<crate::platform::PsmuxBackend>, input:
             last_mouse_enable = Instant::now();
         }
 
-        // ── Cygwin pty: periodic terminal-size poll (issue #474) ─────
+        // ── Raw VT pipe: periodic terminal-size poll ───────────────
         // A pipe carries no resize notifications, so ask the terminal for
         // its text-area size (XTWINOPS). The reply flows through the VT
         // reader, which updates the backend size override; an unchanged

--- a/src/main.rs
+++ b/src/main.rs
@@ -3957,17 +3957,17 @@ fn run_main() -> io::Result<()> {
         return run_control_mode(control_mode);
     }
 
-    // Cygwin/MSYS pty detection (issue #474): under mintty (Git Bash, MSYS2)
-    // stdin/stdout are pty pipes, not a console. The client then reads VT
-    // bytes from the pipe and writes UTF-8 frames back to it instead of
-    // using console APIs (which fail with ERROR_INVALID_FUNCTION there).
-    let pipe_vt = crate::ssh_input::stdin_is_cygwin_pty();
+    // Raw VT pipe detection: under mintty (Git Bash/MSYS2, issue #474) and
+    // under `ssh -T` (the Win10 SSH mouse workaround), stdin/stdout are pipes,
+    // not a console. Read and write VT bytes directly instead of using console
+    // APIs or routing them through ConPTY.
+    let pipe_vt = crate::ssh_input::stdin_is_vt_pipe();
 
     // If stdin is not a terminal (headless/non-interactive environment, e.g.
     // winget validation pipeline), print version and exit cleanly — starting
     // a TUI session would fail without an interactive console. A Cygwin pty
     // IS a terminal (a human sits on the mintty side) even though it is
-    // technically a pipe.
+    // technically a pipe. The same is true of an interactive `ssh -T` channel.
     if !std::io::stdin().is_terminal() && !pipe_vt {
         print_version();
         return Ok(());
@@ -3991,9 +3991,9 @@ fn run_main() -> io::Result<()> {
     let mut stdout = crate::platform::create_writer();
     enable_virtual_terminal_processing();
     if pipe_vt {
-        // A Cygwin pty is already raw from the native side (no console line
-        // discipline in the path); enable_raw_mode would call SetConsoleMode
-        // on the pipe handle and fail with ERROR_INVALID_FUNCTION.
+        // The local wrapper (or Cygwin pty) is already raw on the terminal
+        // side; enable_raw_mode would call SetConsoleMode on this pipe handle
+        // and fail with ERROR_INVALID_FUNCTION.
         // crossterm's ANSI detection needs TERM set to take the pure-ANSI
         // path on Windows — mintty always sets it, but make sure.
         if env::var("TERM").is_err() {
@@ -4035,10 +4035,10 @@ fn run_main() -> io::Result<()> {
     };
 
     if pipe_vt {
-        // Learn the real terminal size over the pty (XTWINOPS) before the
+        // Learn the real terminal size over the pipe (XTWINOPS) before the
         // first draw; the reader thread records the reply for the backend.
-        // Also enable SGR mouse / focus / bracketed paste directly — mintty
-        // handles these natively.
+        // Also enable SGR mouse / focus / bracketed paste directly. With
+        // `ssh -T`, these bytes reach the client terminal without ConPTY.
         crate::ssh_input::pipe_send_modes_enable();
         crate::ssh_input::request_pipe_terminal_size();
         for _ in 0..50 {

--- a/src/main.rs
+++ b/src/main.rs
@@ -4057,12 +4057,13 @@ fn run_main() -> io::Result<()> {
     let backend = crate::platform::PsmuxBackend::new(stdout);
     let mut terminal = Terminal::new(backend)?;
 
-    // For VT input mode (SSH / JetBrains), explicitly (re-)send mouse-enable
-    // escape sequences.  ConPTY may have consumed crossterm's
-    // EnableMouseCapture output without forwarding it.
-    if use_vt_input {
+    // For console-backed VT input (SSH / JetBrains), explicitly (re-)send
+    // mouse-enable escape sequences. ConPTY may have consumed crossterm's
+    // EnableMouseCapture output without forwarding it. Pipe mode already sent
+    // its safe mode set above and must not enter this ConPTY-specific path.
+    if use_vt_input && !pipe_vt {
         send_mouse_enable();
-    } else {
+    } else if !pipe_vt {
         // Local console: write the DECSET registration explicitly instead of
         // relying solely on ConPTY synthesizing it from ENABLE_MOUSE_INPUT.
         // Windows Terminal tracks this registration and can silently drop it

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -3981,7 +3981,7 @@ mod tests_ctrlc_shell_classify;
 /// to the console size APIs.
 static PIPE_TERM_SIZE: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(0);
 
-/// Record the real terminal size reported over the pty (issue #474).
+/// Record the real terminal size reported over a raw VT pipe.
 pub fn set_pipe_term_size(cols: u16, rows: u16) {
     if cols == 0 || rows == 0 {
         return;
@@ -4001,10 +4001,10 @@ pub fn pipe_term_size() -> Option<(u16, u16)> {
 
 /// TUI backend for the psmux client: [`ratatui::backend::CrosstermBackend`]
 /// over [`PsmuxWriter`], with one twist — `size()`/`window_size()` consult the
-/// pipe-mode override first so a client attached over a Cygwin pty (mintty,
-/// issue #474) renders at the real terminal size even though the console
-/// size APIs cannot see that terminal. Outside pipe mode the override is
-/// never set and every call delegates.
+/// pipe-mode override first so a client attached over a Cygwin pty or a
+/// no-ConPTY SSH channel renders at the real terminal size even though the
+/// console size APIs cannot see that terminal. Outside pipe mode the override
+/// is never set and every call delegates.
 pub struct PsmuxBackend {
     inner: ratatui::backend::CrosstermBackend<PsmuxWriter>,
 }

--- a/src/ssh_input.rs
+++ b/src/ssh_input.rs
@@ -1831,10 +1831,14 @@ mod tests;
 mod tests_issue457_ssh_mouse_build_gate;
 
 #[cfg(test)]
+#[path = "../tests-rs/test_windows10_ssh_mouse.rs"]
+mod tests_windows10_ssh_mouse;
+
+#[cfg(test)]
 #[path = "../tests-rs/test_pr468_wezterm_vt_input.rs"]
 mod tests_pr468_wezterm_vt_input;
 
-// ─── Cygwin/MSYS pty (pipe) client input — issue #474 ───────────────────────
+// ─── Raw VT pipe client input — issue #474 / Windows 10 SSH ────────────────
 //
 // Under mintty (Git Bash, MSYS2) the client's stdin is a Cygwin pty: a named
 // pipe carrying raw VT bytes, not a console. Console input APIs fail on it
@@ -1842,12 +1846,19 @@ mod tests_pr468_wezterm_vt_input;
 // to kill the client with "psmux: Incorrect function". This reader consumes
 // the pipe directly with `ReadFile` and feeds the same `VtParser` the SSH
 // path uses, so keys, mouse, paste, and focus events all decode identically.
+//
+// `ssh -T windows-host psmux attach` also gives psmux anonymous stdin/stdout
+// pipes instead of a ConPTY. This is the reliable Win10 mouse path: ConPTY is
+// absent, so DECSET mouse registration reaches the client terminal and its SGR
+// reports reach this parser byte-for-byte. The SSH environment distinguishes
+// that interactive pipe from an unrelated redirected local stdin.
 
-/// True when the client's stdin is a Cygwin/MSYS pty pipe. The NT pipe name
-/// carries a recognizable pattern: `msys-<hex>-pty<N>-{from,to}-master` (or
-/// `cygwin-…`). `PSMUX_PIPE_VT=1|0` forces the answer for tests.
+/// True when stdin is a raw VT pipe supplied by Cygwin/MSYS or by an SSH
+/// session with remote PTY allocation disabled (`ssh -T`). The NT pipe name
+/// identifies Cygwin/MSYS; anonymous SSH pipes are selected only when SSH
+/// environment variables are present. `PSMUX_PIPE_VT=1|0` forces the answer.
 #[cfg(windows)]
-pub fn stdin_is_cygwin_pty() -> bool {
+pub fn stdin_is_vt_pipe() -> bool {
     match std::env::var("PSMUX_PIPE_VT").ok().as_deref() {
         Some("1") => return true,
         Some("0") => return false,
@@ -1876,6 +1887,9 @@ pub fn stdin_is_cygwin_pty() -> bool {
         if GetFileType(h) != FILE_TYPE_PIPE {
             return false;
         }
+        if is_ssh_session() {
+            return true;
+        }
         // FILE_NAME_INFO: u32 byte length followed by the UTF-16 name.
         let mut buf = [0u8; 1024];
         if GetFileInformationByHandleEx(h, FILE_NAME_INFO, buf.as_mut_ptr() as *mut c_void, buf.len() as u32) == 0 {
@@ -1893,11 +1907,11 @@ pub fn stdin_is_cygwin_pty() -> bool {
 }
 
 #[cfg(not(windows))]
-pub fn stdin_is_cygwin_pty() -> bool {
+pub fn stdin_is_vt_pipe() -> bool {
     false
 }
 
-/// Marks the client as running in pipe (Cygwin pty) mode so other client
+/// Marks the client as running in raw VT pipe mode so other client
 /// code — the periodic size query in the render loop — can key off it.
 static PIPE_MODE: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
 
@@ -1939,9 +1953,9 @@ pub fn request_pipe_terminal_size() {
 }
 
 /// Enable the VT modes psmux needs from a pipe-mode terminal: SGR mouse
-/// reporting, focus events, and bracketed paste. mintty handles these
-/// natively (no ConPTY in the path), so the issue #457 build gating that
-/// applies to SSH-over-ConPTY does not apply here.
+/// reporting, focus events, and bracketed paste. The pipe connects directly
+/// to mintty or the SSH channel (no ConPTY in the path), so the issue #457
+/// build gating that applies to SSH-over-ConPTY does not apply here.
 pub fn pipe_send_modes_enable() {
     pipe_stdout_write(b"\x1b[?1000h\x1b[?1002h\x1b[?1006h\x1b[?1004h\x1b[?2004h");
 }
@@ -1977,7 +1991,7 @@ fn start_pipe_reader() -> io::Result<std::sync::mpsc::Receiver<Event>> {
 
     PIPE_MODE.store(true, std::sync::atomic::Ordering::SeqCst);
     let (tx, rx) = mpsc::sync_channel::<Event>(1024);
-    ssh_debug_log("pipe reader starting (cygwin pty mode)");
+    ssh_debug_log("pipe reader starting (raw VT pipe mode)");
 
     std::thread::spawn(move || {
         let handle = handle as *mut c_void;
@@ -2066,10 +2080,9 @@ fn start_pipe_reader() -> io::Result<std::sync::mpsc::Receiver<Event>> {
 }
 
 impl InputSource {
-    /// Input source for a client attached over a Cygwin/MSYS pty (issue
-    /// #474): VT byte stream from the stdin pipe. Falls back to crossterm if
-    /// the reader cannot start (the client then fails the same way it did
-    /// before pipe mode existed).
+    /// Input source for a client attached over a Cygwin/MSYS pty (issue #474)
+    /// or an SSH channel without a remote PTY: VT byte stream from stdin.
+    /// Falls back to crossterm if the reader cannot start.
     pub fn new_pipe() -> io::Result<Self> {
         #[cfg(windows)]
         {

--- a/src/ssh_input.rs
+++ b/src/ssh_input.rs
@@ -212,8 +212,8 @@ pub fn send_mouse_enable() {
 /// stayed mouse-dead until the client restarted (detach/reattach).
 ///
 /// Mode routing:
-///  * pipe mode (mintty / Cygwin pty) — re-send the curated pipe mode set
-///    (which deliberately excludes 1003 motion reporting).
+///  * pipe mode (mintty / Cygwin pty / no-PTY SSH) — re-send the curated pipe
+///    mode set (which deliberately excludes 1003 motion reporting).
 ///  * VT input mode (SSH / JediTerm / WezTerm) — full [`send_mouse_enable`],
 ///    including the stdin VTI restore and the DSR probe.
 ///  * local Windows console — write ONLY the DECSET bytes and re-assert
@@ -1929,7 +1929,13 @@ pub fn pipe_stdout_write(bytes: &[u8]) {
     #[link(name = "kernel32")]
     extern "system" {
         fn GetStdHandle(n: u32) -> *mut c_void;
-        fn WriteFile(h: *mut c_void, buf: *const u8, len: u32, written: *mut u32, ovl: *mut c_void) -> i32;
+        fn WriteFile(
+            h: *mut c_void,
+            buf: *const u8,
+            len: u32,
+            written: *mut u32,
+            ovl: *mut c_void,
+        ) -> i32;
     }
     const STD_OUTPUT_HANDLE: u32 = -11i32 as u32;
     unsafe {
@@ -1937,8 +1943,22 @@ pub fn pipe_stdout_write(bytes: &[u8]) {
         if h.is_null() || h == (-1isize) as *mut c_void {
             return;
         }
-        let mut written: u32 = 0;
-        let _ = WriteFile(h, bytes.as_ptr(), bytes.len() as u32, &mut written, std::ptr::null_mut());
+        let mut offset = 0;
+        while offset < bytes.len() {
+            let chunk_len = (bytes.len() - offset).min(u32::MAX as usize) as u32;
+            let mut written: u32 = 0;
+            let ok = WriteFile(
+                h,
+                bytes.as_ptr().add(offset),
+                chunk_len,
+                &mut written,
+                std::ptr::null_mut(),
+            );
+            if ok == 0 || written == 0 {
+                break;
+            }
+            offset += written as usize;
+        }
     }
 }
 

--- a/src/window_ops.rs
+++ b/src/window_ops.rs
@@ -1159,6 +1159,12 @@ pub fn handle_pane_mouse(app: &mut AppState, pane_id: usize, button: u8, col: i1
 
 /// Handle a semantic scroll event targeted at a specific pane.
 pub fn handle_pane_scroll(app: &mut AppState, pane_id: usize, up: bool) {
+    // Server request dispatch already applies this gate. Keep it here too so
+    // alternate/direct callers cannot scroll or enter copy mode with mouse off.
+    if !app.mouse_enabled {
+        return;
+    }
+
     // Ignore scroll in popup mode (#110)
     if matches!(app.mode, Mode::PopupMode { .. }) { return; }
 
@@ -1508,7 +1514,7 @@ mod position_token_tests {
 mod swap_mru_tests {
     use super::swap_pane_with_path;
     use crate::proxy_pane::create_proxy_pane;
-    use crate::types::{AppState, LayoutKind, Node, Window};
+    use crate::types::{AppState, LayoutKind, Mode, Node, Window};
     use ratatui::layout::Rect;
     use std::net::{TcpListener, TcpStream};
 
@@ -1565,6 +1571,43 @@ mod swap_mru_tests {
         }
     }
 
+    fn make_scrollback_app(mouse_enabled: bool) -> AppState {
+        let pane = proxy_pane(41, 8, 40);
+        let history = (0..80)
+            .map(|line| format!("history-{line}\r\n"))
+            .collect::<String>();
+        pane.term.lock().expect("term lock").process(history.as_bytes());
+
+        let mut app = AppState::new("mouse-scrollback".to_string());
+        app.mouse_enabled = mouse_enabled;
+        app.scroll_enter_copy_mode = true;
+        app.last_window_area = Rect {
+            x: 0,
+            y: 0,
+            width: 40,
+            height: 8,
+        };
+        app.windows.push(Window {
+            root: Node::Leaf(pane),
+            active_path: vec![],
+            name: "w0".to_string(),
+            id: 0,
+            activity_flag: false,
+            bell_flag: false,
+            silence_flag: false,
+            last_output_time: std::time::Instant::now(),
+            last_seen_version: 0,
+            manual_rename: false,
+            layout_index: 0,
+            pane_mru: vec![41],
+            zoom_saved: None,
+            linked_from: None,
+            floating: Vec::new(),
+            floating_focus: None,
+        });
+        app
+    }
+
     #[test]
     fn swap_with_path_updates_mru_for_focused_pane_after_swap() {
         let mut app = AppState::new("swap-mru".to_string());
@@ -1576,6 +1619,31 @@ mod swap_mru_tests {
         assert!(swapped, "swap should succeed");
         assert_eq!(app.windows[0].active_path, vec![1], "focus should follow moved active pane");
         assert_eq!(app.windows[0].pane_mru.first().copied(), Some(11), "MRU should be the focused pane id after swap");
+    }
+
+    #[test]
+    fn wheel_up_enters_copy_mode_and_repeated_wheel_scrolls_further() {
+        let mut app = make_scrollback_app(true);
+
+        super::handle_pane_scroll(&mut app, 41, true);
+        assert!(matches!(app.mode, Mode::CopyMode));
+        let first_offset = app.copy_scroll_offset;
+        assert!(first_offset > 0, "first wheel report must move into history");
+
+        super::handle_pane_scroll(&mut app, 41, true);
+        assert!(
+            app.copy_scroll_offset > first_offset,
+            "repeated wheel reports must continue scrolling"
+        );
+    }
+
+    #[test]
+    fn mouse_off_ignores_wheel_without_entering_copy_mode() {
+        let mut app = make_scrollback_app(false);
+
+        super::handle_pane_scroll(&mut app, 41, true);
+        assert!(matches!(app.mode, Mode::Passthrough));
+        assert_eq!(app.copy_scroll_offset, 0);
     }
 }
 

--- a/src/window_ops.rs
+++ b/src/window_ops.rs
@@ -1511,7 +1511,7 @@ mod position_token_tests {
 }
 
 #[cfg(test)]
-mod swap_mru_tests {
+mod window_ops_tests {
     use super::swap_pane_with_path;
     use crate::proxy_pane::create_proxy_pane;
     use crate::types::{AppState, LayoutKind, Mode, Node, Window};
@@ -1576,7 +1576,10 @@ mod swap_mru_tests {
         let history = (0..80)
             .map(|line| format!("history-{line}\r\n"))
             .collect::<String>();
-        pane.term.lock().expect("term lock").process(history.as_bytes());
+        pane.term
+            .lock()
+            .expect("term lock")
+            .process(history.as_bytes());
 
         let mut app = AppState::new("mouse-scrollback".to_string());
         app.mouse_enabled = mouse_enabled;
@@ -1628,7 +1631,10 @@ mod swap_mru_tests {
         super::handle_pane_scroll(&mut app, 41, true);
         assert!(matches!(app.mode, Mode::CopyMode));
         let first_offset = app.copy_scroll_offset;
-        assert!(first_offset > 0, "first wheel report must move into history");
+        assert!(
+            first_offset > 0,
+            "first wheel report must move into history"
+        );
 
         super::handle_pane_scroll(&mut app, 41, true);
         assert!(

--- a/tests-rs/test_windows10_ssh_mouse.rs
+++ b/tests-rs/test_windows10_ssh_mouse.rs
@@ -1,0 +1,89 @@
+use super::*;
+
+fn feed(parser: &mut VtParser, text: &str) -> Vec<Event> {
+    let mut events = Vec::new();
+    for ch in text.chars() {
+        parser.feed(ch, &mut |event| events.push(event));
+    }
+    events
+}
+
+fn mouse_kind(event: &Event) -> Option<MouseEventKind> {
+    match event {
+        Event::Mouse(mouse) => Some(mouse.kind),
+        _ => None,
+    }
+}
+
+#[test]
+fn sgr_wheel_up_and_down_parse_with_zero_based_coordinates() {
+    let mut parser = VtParser::new();
+    let events = feed(&mut parser, "\x1b[<64;10;5M\x1b[<65;12;7M");
+
+    assert_eq!(events.len(), 2);
+    assert_eq!(mouse_kind(&events[0]), Some(MouseEventKind::ScrollUp));
+    assert_eq!(mouse_kind(&events[1]), Some(MouseEventKind::ScrollDown));
+    match &events[0] {
+        Event::Mouse(mouse) => assert_eq!((mouse.column, mouse.row), (9, 4)),
+        other => panic!("expected mouse event, got {other:?}"),
+    }
+}
+
+#[test]
+fn repeated_sgr_wheel_reports_remain_distinct_events() {
+    let mut parser = VtParser::new();
+    let events = feed(
+        &mut parser,
+        "\x1b[<64;3;2M\x1b[<64;3;2M\x1b[<64;3;2M\x1b[<65;3;2M",
+    );
+    let kinds: Vec<_> = events.iter().filter_map(mouse_kind).collect();
+    assert_eq!(
+        kinds,
+        vec![
+            MouseEventKind::ScrollUp,
+            MouseEventKind::ScrollUp,
+            MouseEventKind::ScrollUp,
+            MouseEventKind::ScrollDown,
+        ]
+    );
+}
+
+#[test]
+fn partial_sgr_wheel_waits_for_the_final_byte() {
+    let mut parser = VtParser::new();
+    assert!(feed(&mut parser, "\x1b[<64;10;").is_empty());
+
+    let events = feed(&mut parser, "5M");
+    assert_eq!(events.len(), 1);
+    assert_eq!(mouse_kind(&events[0]), Some(MouseEventKind::ScrollUp));
+}
+
+#[test]
+fn malformed_sgr_mouse_is_dropped_and_parser_recovers() {
+    let mut parser = VtParser::new();
+    let malformed = feed(&mut parser, "\x1b[<64;10M");
+    assert!(malformed
+        .iter()
+        .all(|event| !matches!(event, Event::Mouse(_))));
+
+    let recovered = feed(&mut parser, "\x1b[<65;4;3M");
+    assert_eq!(recovered.len(), 1);
+    assert_eq!(mouse_kind(&recovered[0]), Some(MouseEventKind::ScrollDown));
+}
+
+#[cfg(windows)]
+#[test]
+fn pipe_mode_override_still_controls_detection() {
+    let _lock = crate::util::lock_test_env();
+    let previous = std::env::var("PSMUX_PIPE_VT").ok();
+
+    std::env::set_var("PSMUX_PIPE_VT", "1");
+    assert!(stdin_is_vt_pipe());
+    std::env::set_var("PSMUX_PIPE_VT", "0");
+    assert!(!stdin_is_vt_pipe());
+
+    match previous {
+        Some(value) => std::env::set_var("PSMUX_PIPE_VT", value),
+        None => std::env::remove_var("PSMUX_PIPE_VT"),
+    }
+}

--- a/tests/test_install_psmux_win.sh
+++ b/tests/test_install_psmux_win.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+set -eu
+
+repo=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+tmp=${TMPDIR:-/tmp}/install-psmux-win-$$
+trap 'rm -rf "$tmp"' EXIT HUP INT TERM
+mkdir -p "$tmp/home" "$tmp/config"
+
+HOME="$tmp/home" XDG_CONFIG_HOME="$tmp/config" \
+    sh "$repo/scripts/install-psmux-win.sh" \
+        --host user@windows-host \
+        --psmux C:/Users/user/.cargo/bin/psmux.exe \
+        --bin-dir "$tmp/bin" >/dev/null
+
+[ -x "$tmp/bin/psmux-win" ] || {
+    echo 'FAIL: psmux-win was not installed executable' >&2
+    exit 1
+}
+grep -Fx 'host=user@windows-host' "$tmp/config/psmux-win/config" >/dev/null
+grep -Fx 'remote_psmux=C:/Users/user/.cargo/bin/psmux.exe' "$tmp/config/psmux-win/config" >/dev/null
+
+HOME="$tmp/home" XDG_CONFIG_HOME="$tmp/config" \
+    sh "$repo/scripts/install-psmux-win.sh" \
+        --host user@windows-host \
+        --psmux psmux \
+        --bin-dir "$tmp/bin" >/dev/null
+
+find "$tmp/bin" -name 'psmux-win.backup-*' | grep . >/dev/null || {
+    echo 'FAIL: reinstall did not back up the launcher' >&2
+    exit 1
+}
+find "$tmp/config/psmux-win" -name 'config.backup-*' | grep . >/dev/null || {
+    echo 'FAIL: reinstall did not back up the config' >&2
+    exit 1
+}
+grep -Fx 'remote_psmux=psmux' "$tmp/config/psmux-win/config" >/dev/null
+
+echo 'PASS: installer creates executable and config, then backs both up on reinstall'

--- a/tests/test_install_psmux_win.sh
+++ b/tests/test_install_psmux_win.sh
@@ -4,9 +4,18 @@ set -eu
 repo=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
 tmp=${TMPDIR:-/tmp}/install-psmux-win-$$
 trap 'rm -rf "$tmp"' EXIT HUP INT TERM
-mkdir -p "$tmp/home" "$tmp/config"
+mkdir -p "$tmp/home" "$tmp/config" "$tmp/fake-bin"
 
-HOME="$tmp/home" XDG_CONFIG_HOME="$tmp/config" \
+# Force every installation to use the same timestamp. Reinstalls must create
+# distinct backups instead of overwriting the first one.
+cat >"$tmp/fake-bin/date" <<'EOF'
+#!/bin/sh
+printf '%s\n' '20260720-120000'
+EOF
+chmod +x "$tmp/fake-bin/date"
+test_path=$tmp/fake-bin:$PATH
+
+HOME="$tmp/home" XDG_CONFIG_HOME="$tmp/config" PATH="$test_path" \
     sh "$repo/scripts/install-psmux-win.sh" \
         --host user@windows-host \
         --psmux C:/Users/user/.cargo/bin/psmux.exe \
@@ -19,20 +28,50 @@ HOME="$tmp/home" XDG_CONFIG_HOME="$tmp/config" \
 grep -Fx 'host=user@windows-host' "$tmp/config/psmux-win/config" >/dev/null
 grep -Fx 'remote_psmux=C:/Users/user/.cargo/bin/psmux.exe' "$tmp/config/psmux-win/config" >/dev/null
 
-HOME="$tmp/home" XDG_CONFIG_HOME="$tmp/config" \
+HOME="$tmp/home" XDG_CONFIG_HOME="$tmp/config" PATH="$test_path" \
     sh "$repo/scripts/install-psmux-win.sh" \
         --host user@windows-host \
         --psmux psmux \
         --bin-dir "$tmp/bin" >/dev/null
 
-find "$tmp/bin" -name 'psmux-win.backup-*' | grep . >/dev/null || {
+[ -f "$tmp/bin/psmux-win.backup-20260720-120000" ] || {
     echo 'FAIL: reinstall did not back up the launcher' >&2
     exit 1
 }
-find "$tmp/config/psmux-win" -name 'config.backup-*' | grep . >/dev/null || {
+[ -f "$tmp/config/psmux-win/config.backup-20260720-120000" ] || {
     echo 'FAIL: reinstall did not back up the config' >&2
     exit 1
 }
 grep -Fx 'remote_psmux=psmux' "$tmp/config/psmux-win/config" >/dev/null
 
-echo 'PASS: installer creates executable and config, then backs both up on reinstall'
+HOME="$tmp/home" XDG_CONFIG_HOME="$tmp/config" PATH="$test_path" \
+    sh "$repo/scripts/install-psmux-win.sh" \
+        --host second@windows-host \
+        --psmux C:/psmux/psmux.exe \
+        --bin-dir "$tmp/bin" >/dev/null
+
+bin_backup_count=0
+for backup in "$tmp/bin"/psmux-win.backup-*; do
+    [ -e "$backup" ] || continue
+    bin_backup_count=$((bin_backup_count + 1))
+done
+config_backup_count=0
+for backup in "$tmp/config/psmux-win"/config.backup-*; do
+    [ -e "$backup" ] || continue
+    config_backup_count=$((config_backup_count + 1))
+done
+[ "$bin_backup_count" -eq 2 ] || {
+    echo "FAIL: expected 2 launcher backups, found $bin_backup_count" >&2
+    exit 1
+}
+[ "$config_backup_count" -eq 2 ] || {
+    echo "FAIL: expected 2 config backups, found $config_backup_count" >&2
+    exit 1
+}
+grep -Fx 'remote_psmux=C:/Users/user/.cargo/bin/psmux.exe' \
+    "$tmp/config/psmux-win/config.backup-20260720-120000" >/dev/null
+grep -Fx 'remote_psmux=psmux' \
+    "$tmp/config/psmux-win/config.backup-20260720-120000-1" >/dev/null
+grep -Fx 'host=second@windows-host' "$tmp/config/psmux-win/config" >/dev/null
+
+echo 'PASS: installer creates files and preserves every reinstall backup'

--- a/tests/test_macos_psmux_win_e2e.py
+++ b/tests/test_macos_psmux_win_e2e.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Real macOS PTY -> psmux-win -> OpenSSH -T -> Windows psmux E2E."""
+
+import fcntl
+import os
+import select
+import signal
+import struct
+import subprocess
+import sys
+import termios
+import time
+
+
+def required_env(name):
+    value = os.environ.get(name)
+    if not value:
+        raise RuntimeError(f"required environment variable is unset: {name}")
+    return value
+
+
+SESSION = required_env("PSMUX_E2E_SESSION")
+SOCKET = os.environ.get("PSMUX_E2E_SOCKET")
+WINDOWS = required_env("PSMUX_E2E_WINDOWS_HOST")
+REMOTE_PSMUX = required_env("PSMUX_E2E_REMOTE_EXE")
+
+
+def remote(*args):
+    command = ["ssh", "-T", "-o", "BatchMode=yes", WINDOWS, REMOTE_PSMUX]
+    if SOCKET:
+        command.extend(["-L", SOCKET])
+    command.extend(args)
+    return subprocess.check_output(command, text=True, timeout=15).strip()
+
+
+def state():
+    output = remote(
+        "list-panes",
+        "-t",
+        SESSION,
+        "-F",
+        "#{pane_in_mode}:#{scroll_position}:#{history_size}",
+    )
+    mode, offset, history = output.split(":")
+    return int(mode), int(offset), int(history)
+
+
+def drain(master, seconds, captured):
+    deadline = time.monotonic() + seconds
+    while time.monotonic() < deadline:
+        ready, _, _ = select.select([master], [], [], 0.1)
+        if not ready:
+            continue
+        try:
+            chunk = os.read(master, 65536)
+        except OSError:
+            return False
+        if not chunk:
+            return False
+        captured.extend(chunk)
+        # Answer psmux's XTWINOPS terminal-size query on the real Mac PTY.
+        if b"\x1b[18t" in chunk:
+            os.write(master, b"\x1b[8;30;100t")
+    return True
+
+
+def main():
+    # Make the starting state deterministic if a previous manual attach left
+    # the test pane in copy mode.
+    remote("send-keys", "-X", "cancel", "-t", SESSION)
+    before = state()
+    if before[2] <= 0:
+        raise AssertionError(f"test session has no scrollback: {before}")
+
+    pid, master = os.forkpty()
+    if pid == 0:
+        command = ["psmux-win"]
+        if SOCKET:
+            command.extend(["-L", SOCKET])
+        command.extend(["-t", SESSION])
+        os.execvp("psmux-win", command)
+
+    captured = bytearray()
+    stage = "startup"
+    try:
+        fcntl.ioctl(master, termios.TIOCSWINSZ, struct.pack("HHHH", 30, 100, 0, 0))
+        drain(master, 4.0, captured)
+        stage = "mouse-enable check"
+        required_on = (b"\x1b[?1000h", b"\x1b[?1002h", b"\x1b[?1006h")
+        if not all(sequence in captured for sequence in required_on):
+            raise AssertionError("Mac PTY did not receive all mouse-enable sequences")
+
+        stage = "first WheelUp"
+        os.write(master, b"\x1b[<64;10;5M")
+        drain(master, 1.5, captured)
+        first = state()
+        if first[0] != 1 or first[1] <= 0:
+            raise AssertionError(f"WheelUp did not enter/scroll copy mode: {before} -> {first}")
+
+        stage = "second WheelUp"
+        os.write(master, b"\x1b[<64;10;5M")
+        drain(master, 1.0, captured)
+        second = state()
+        if second[1] <= first[1]:
+            raise AssertionError(f"repeated WheelUp did not advance: {first} -> {second}")
+
+        # Default prefix Ctrl+B followed by d detaches, allowing the wrapper's
+        # EXIT trap to restore the Mac terminal state and disable mouse mode.
+        stage = "detach"
+        os.write(master, b"\x02d")
+        drain(master, 3.0, captured)
+        waited, status = os.waitpid(pid, os.WNOHANG)
+        if waited == 0:
+            os.kill(pid, signal.SIGTERM)
+            _, status = os.waitpid(pid, 0)
+        pid = 0
+
+        required_off = (b"\x1b[?1006l", b"\x1b[?1002l", b"\x1b[?1000l")
+        if not all(sequence in captured for sequence in required_off):
+            raise AssertionError("Mac PTY did not receive all mouse-disable cleanup sequences")
+
+        print("PASS: macOS PTY received DECSET 1000/1002/1006")
+        print(f"PASS: SGR WheelUp entered copy mode (offset={first[1]})")
+        print(f"PASS: repeated WheelUp advanced offset ({first[1]} -> {second[1]})")
+        print("PASS: detach emitted DEC reset cleanup for 1006/1002/1000")
+        return 0
+    except Exception:
+        print(f"PTY failure stage: {stage}", file=sys.stderr)
+        print(repr(bytes(captured[-4000:])), file=sys.stderr)
+        raise
+    finally:
+        if pid:
+            try:
+                os.kill(pid, signal.SIGTERM)
+            except ProcessLookupError:
+                pass
+            try:
+                os.waitpid(pid, 0)
+            except ChildProcessError:
+                pass
+        os.close(master)
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except Exception as error:
+        print(f"FAIL: {error}", file=sys.stderr)
+        sys.exit(1)

--- a/tests/test_macos_psmux_win_e2e.py
+++ b/tests/test_macos_psmux_win_e2e.py
@@ -10,6 +10,7 @@ import subprocess
 import sys
 import termios
 import time
+from pathlib import Path
 
 
 def required_env(name):
@@ -23,6 +24,10 @@ SESSION = required_env("PSMUX_E2E_SESSION")
 SOCKET = os.environ.get("PSMUX_E2E_SOCKET")
 WINDOWS = required_env("PSMUX_E2E_WINDOWS_HOST")
 REMOTE_PSMUX = required_env("PSMUX_E2E_REMOTE_EXE")
+WRAPPER = os.environ.get(
+    "PSMUX_E2E_WRAPPER",
+    str(Path(__file__).resolve().parent.parent / "scripts" / "psmux-ssh.sh"),
+)
 
 
 def remote(*args):
@@ -74,11 +79,13 @@ def main():
 
     pid, master = os.forkpty()
     if pid == 0:
-        command = ["psmux-win"]
+        command = ["sh", WRAPPER]
         if SOCKET:
-            command.extend(["-L", SOCKET])
-        command.extend(["-t", SESSION])
-        os.execvp("psmux-win", command)
+            command.extend(["--socket", SOCKET])
+        command.extend(
+            ["--session", SESSION, "--psmux", REMOTE_PSMUX, "--", WINDOWS]
+        )
+        os.execvp("sh", command)
 
     captured = bytearray()
     stage = "startup"
@@ -108,12 +115,14 @@ def main():
         # EXIT trap to restore the Mac terminal state and disable mouse mode.
         stage = "detach"
         os.write(master, b"\x02d")
-        drain(master, 3.0, captured)
+        drain(master, 5.0, captured)
         waited, status = os.waitpid(pid, os.WNOHANG)
         if waited == 0:
-            os.kill(pid, signal.SIGTERM)
-            _, status = os.waitpid(pid, 0)
+            raise AssertionError("wrapper did not exit after psmux detach")
         pid = 0
+        exit_code = os.waitstatus_to_exitcode(status)
+        if exit_code != 0:
+            raise AssertionError(f"wrapper exited with status {exit_code} after detach")
 
         required_off = (b"\x1b[?1006l", b"\x1b[?1002l", b"\x1b[?1000l")
         if not all(sequence in captured for sequence in required_off):

--- a/tests/test_psmux_ssh_wrapper.sh
+++ b/tests/test_psmux_ssh_wrapper.sh
@@ -1,0 +1,108 @@
+#!/bin/sh
+set -u
+
+repo=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+wrapper="$repo/scripts/psmux-ssh.sh"
+tmp=${TMPDIR:-/tmp}/psmux-ssh-wrapper-$$
+mkdir -p "$tmp/bin"
+trap 'rm -rf "$tmp"' EXIT HUP INT TERM
+
+cat >"$tmp/bin/stty" <<'EOF'
+#!/bin/sh
+if [ "${1-}" = "-g" ]; then
+    printf '%s\n' 'saved-terminal-state'
+else
+    printf '%s\n' "$*" >>"$MOCK_STTY_LOG"
+fi
+EOF
+
+cat >"$tmp/bin/ssh" <<'EOF'
+#!/bin/sh
+printf '%s\n' "$@" >"$MOCK_SSH_ARGS"
+if [ "${MOCK_SSH_SIGNAL-}" = "INT" ]; then
+    kill -INT "$PPID"
+    sleep 5
+fi
+exit "${MOCK_SSH_STATUS:-0}"
+EOF
+chmod +x "$tmp/bin/stty" "$tmp/bin/ssh"
+
+tty_file="$tmp/tty"
+stty_log="$tmp/stty.log"
+ssh_args="$tmp/ssh.args"
+expected_hex='1b5b3f31303030681b5b3f31303032681b5b3f31303036681b5b3f313030366c1b5b3f313030326c1b5b3f313030306c'
+
+run_wrapper() {
+    : >"$tty_file"
+    : >"$stty_log"
+    : >"$ssh_args"
+    MOCK_STTY_LOG="$stty_log" \
+    MOCK_SSH_ARGS="$ssh_args" \
+    MOCK_SSH_STATUS="${MOCK_SSH_STATUS:-0}" \
+    MOCK_SSH_SIGNAL="${MOCK_SSH_SIGNAL-}" \
+    PSMUX_SSH_TTY="$tty_file" \
+    PSMUX_SSH_STTY="$tmp/bin/stty" \
+    PSMUX_SSH_BIN="$tmp/bin/ssh" \
+        sh "$wrapper" --socket project --session work -- -p 2222 user@host
+}
+
+assert_cleanup() {
+    actual_hex=$(od -An -tx1 "$tty_file" | tr -d ' \n')
+    [ "$actual_hex" = "$expected_hex" ] || {
+        echo "FAIL: mouse cleanup bytes: $actual_hex" >&2
+        exit 1
+    }
+    grep -Fx 'raw -echo -isig' "$stty_log" >/dev/null || {
+        echo 'FAIL: raw terminal mode was not set' >&2
+        exit 1
+    }
+    grep -Fx 'saved-terminal-state' "$stty_log" >/dev/null || {
+        echo 'FAIL: saved terminal mode was not restored' >&2
+        exit 1
+    }
+}
+
+MOCK_SSH_STATUS=0
+unset MOCK_SSH_SIGNAL
+run_wrapper
+assert_cleanup
+grep -Fx -- '-T' "$ssh_args" >/dev/null
+grep -Fx -- 'psmux -L project attach -t work' "$ssh_args" >/dev/null
+echo 'PASS: normal exit restores terminal and uses the no-ConPTY SSH command'
+
+MOCK_SSH_STATUS=23
+set +e
+run_wrapper
+rc=$?
+set -e
+[ "$rc" -eq 23 ] || { echo "FAIL: SSH exit status was $rc, expected 23" >&2; exit 1; }
+assert_cleanup
+echo 'PASS: SSH failure preserves status and restores terminal'
+
+MOCK_SSH_STATUS=0
+MOCK_SSH_SIGNAL=INT
+set +e
+run_wrapper
+rc=$?
+set -e
+[ "$rc" -eq 130 ] || { echo "FAIL: INT exit status was $rc, expected 130" >&2; exit 1; }
+assert_cleanup
+echo 'PASS: INT restores terminal exactly once'
+
+config_file="$tmp/psmux-win.conf"
+printf '%s\n' 'host=configured@windows' 'remote_psmux=C:/psmux/psmux.exe' >"$config_file"
+: >"$tty_file"
+: >"$stty_log"
+: >"$ssh_args"
+MOCK_STTY_LOG="$stty_log" \
+MOCK_SSH_ARGS="$ssh_args" \
+MOCK_SSH_STATUS=0 \
+PSMUX_WIN_CONFIG="$config_file" \
+PSMUX_SSH_TTY="$tty_file" \
+PSMUX_SSH_STTY="$tmp/bin/stty" \
+PSMUX_SSH_BIN="$tmp/bin/ssh" \
+    sh "$wrapper" -L other -s session2
+assert_cleanup
+grep -Fx -- 'configured@windows' "$ssh_args" >/dev/null
+grep -Fx -- 'C:/psmux/psmux.exe -L other attach -t session2' "$ssh_args" >/dev/null
+echo 'PASS: installed-command config supplies host and remote executable defaults'

--- a/tests/test_psmux_ssh_wrapper.sh
+++ b/tests/test_psmux_ssh_wrapper.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-set -u
+set -eu
 
 repo=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
 wrapper="$repo/scripts/psmux-ssh.sh"
@@ -40,6 +40,7 @@ run_wrapper() {
     MOCK_SSH_ARGS="$ssh_args" \
     MOCK_SSH_STATUS="${MOCK_SSH_STATUS:-0}" \
     MOCK_SSH_SIGNAL="${MOCK_SSH_SIGNAL-}" \
+    PSMUX_WIN_CONFIG="$tmp/no-config" \
     PSMUX_SSH_TTY="$tty_file" \
     PSMUX_SSH_STTY="$tmp/bin/stty" \
     PSMUX_SSH_BIN="$tmp/bin/ssh" \

--- a/tests/test_windows10_ssh_pipe_mouse.ps1
+++ b/tests/test_windows10_ssh_pipe_mouse.ps1
@@ -1,0 +1,165 @@
+# Windows 10 SSH mouse E2E without a remote PTY. This models `ssh -T`: psmux
+# receives anonymous stdin/stdout pipes plus SSH_CONNECTION, so ConPTY is not
+# present. Raw SGR bytes must enter copy mode and keep scrolling.
+param(
+    [string]$Psmux = (Join-Path (Split-Path $PSScriptRoot -Parent) 'target\release\psmux.exe')
+)
+
+$ErrorActionPreference = 'Stop'
+$Namespace = 'e2e_win10_ssh_pipe'
+$Session = 'pipe_mouse'
+$script:Passed = 0
+$script:Failed = 0
+
+function Pass([string]$Message) {
+    Write-Host "  [PASS] $Message" -ForegroundColor Green
+    $script:Passed++
+}
+
+function Fail([string]$Message) {
+    Write-Host "  [FAIL] $Message" -ForegroundColor Red
+    $script:Failed++
+}
+
+function Send-Bytes($Process, [byte[]]$Bytes) {
+    $stream = $Process.StandardInput.BaseStream
+    $stream.Write($Bytes, 0, $Bytes.Length)
+    $stream.Flush()
+}
+
+function Vt-Bytes([string]$Tail) {
+    return [byte[]](@(0x1b) + [Text.Encoding]::ASCII.GetBytes($Tail))
+}
+
+function Wait-ForHistory([int]$Minimum = 50) {
+    for ($i = 0; $i -lt 50; $i++) {
+        $raw = & $Psmux -L $Namespace list-panes -t $Session -F '#{history_size}' 2>$null
+        $size = 0
+        if ($LASTEXITCODE -eq 0 -and
+            [int]::TryParse(($raw -join '').Trim(), [ref]$size) -and
+            $size -ge $Minimum) {
+            return $size
+        }
+        Start-Sleep -Milliseconds 200
+    }
+    throw "pane history did not reach $Minimum lines before the timeout"
+}
+
+function Get-State {
+    $base = "${Namespace}__${Session}"
+    $dataDir = Join-Path $env:USERPROFILE '.psmux'
+    $port = [int](Get-Content (Join-Path $dataDir "$base.port") -Raw).Trim()
+    $key = (Get-Content (Join-Path $dataDir "$base.key") -Raw).Trim()
+    $tcp = [Net.Sockets.TcpClient]::new('127.0.0.1', $port)
+    $tcp.ReceiveTimeout = 4000
+    try {
+        $stream = $tcp.GetStream()
+        $writer = [IO.StreamWriter]::new($stream)
+        $reader = [IO.StreamReader]::new($stream)
+        $writer.Write("AUTH $key`n")
+        $writer.Flush()
+        $null = $reader.ReadLine()
+        $writer.Write("dump-state`n")
+        $writer.Flush()
+        for ($i = 0; $i -lt 100; $i++) {
+            $line = $reader.ReadLine()
+            if ($line -and $line -ne 'NC' -and $line.Length -gt 100) {
+                return ($line | ConvertFrom-Json)
+            }
+        }
+        throw 'dump-state returned no JSON'
+    }
+    finally {
+        $tcp.Dispose()
+    }
+}
+
+if (-not (Test-Path $Psmux)) {
+    throw "psmux release binary not found: $Psmux"
+}
+
+Write-Host "`n=== Windows 10 SSH direct-pipe mouse E2E ===" -ForegroundColor Cyan
+& $Psmux -L $Namespace kill-server 2>$null | Out-Null
+& $Psmux -L $Namespace new-session -d -s $Session -- cmd.exe
+Start-Sleep -Seconds 2
+& $Psmux -L $Namespace set-option -g mouse on -t $Session | Out-Null
+& $Psmux -L $Namespace set-option -g scroll-enter-copy-mode on -t $Session | Out-Null
+& $Psmux -L $Namespace send-keys -t $Session 'for /L %i in (1,1,300) do @echo PIPE_HISTORY_%i' Enter | Out-Null
+$historySize = Wait-ForHistory
+Pass "pane history is ready (size=$historySize)"
+
+$psi = [Diagnostics.ProcessStartInfo]::new()
+$psi.FileName = (Resolve-Path $Psmux).Path
+$psi.Arguments = "-L $Namespace attach -t $Session"
+$psi.UseShellExecute = $false
+$psi.CreateNoWindow = $true
+$psi.RedirectStandardInput = $true
+$psi.RedirectStandardOutput = $true
+$psi.RedirectStandardError = $true
+$psi.EnvironmentVariables['SSH_CONNECTION'] = 'client 50000 server 22'
+$psi.EnvironmentVariables['PSMUX_SSH_DEBUG'] = '1'
+
+$process = [Diagnostics.Process]::Start($psi)
+$stdout = [IO.MemoryStream]::new()
+$stderr = [IO.MemoryStream]::new()
+$stdoutTask = $process.StandardOutput.BaseStream.CopyToAsync($stdout)
+$stderrTask = $process.StandardError.BaseStream.CopyToAsync($stderr)
+
+try {
+    Start-Sleep -Milliseconds 500
+    Send-Bytes $process (Vt-Bytes '[8;30;100t')
+    Start-Sleep -Seconds 3
+
+    $hex = (($stdout.ToArray() | ForEach-Object { $_.ToString('x2') }) -join '')
+    if ($hex.Contains('1b5b3f3130303068') -and
+        $hex.Contains('1b5b3f3130303268') -and
+        $hex.Contains('1b5b3f3130303668')) {
+        Pass 'mouse-enable DECSET 1000/1002/1006 reached the raw output pipe'
+    } else {
+        Fail 'raw output pipe is missing a mouse-enable DECSET sequence'
+    }
+    if ($hex.Contains('1b5b313874')) { Pass 'XTWINOPS size query reached the raw output pipe' }
+    else { Fail 'XTWINOPS size query missing from raw output pipe' }
+
+    $before = Get-State
+    Send-Bytes $process (Vt-Bytes '[<64;10;5M')
+    Start-Sleep -Seconds 2
+    $first = Get-State
+    if (-not $before.layout.copy_mode -and $first.layout.copy_mode -and $first.layout.scroll_offset -gt 0) {
+        Pass "SGR WheelUp entered copy mode (offset=$($first.layout.scroll_offset))"
+    } else {
+        Fail "WheelUp state before=$($before.layout.copy_mode) after=$($first.layout.copy_mode) offset=$($first.layout.scroll_offset)"
+    }
+
+    Send-Bytes $process (Vt-Bytes '[<64;10;5M')
+    Start-Sleep -Seconds 1
+    $second = Get-State
+    if ($second.layout.scroll_offset -gt $first.layout.scroll_offset) {
+        Pass "repeated WheelUp scrolled further ($($first.layout.scroll_offset) -> $($second.layout.scroll_offset))"
+    } else {
+        Fail "repeated WheelUp did not advance offset ($($first.layout.scroll_offset) -> $($second.layout.scroll_offset))"
+    }
+
+    & $Psmux -L $Namespace set-option -g mouse off -t $Session | Out-Null
+    Start-Sleep -Seconds 1
+    Send-Bytes $process (Vt-Bytes '[<64;10;5M')
+    Start-Sleep -Seconds 1
+    $disabled = Get-State
+    if ($disabled.layout.scroll_offset -eq $second.layout.scroll_offset) {
+        Pass 'mouse off ignored WheelUp without changing scroll position'
+    } else {
+        Fail "mouse off changed scroll offset ($($second.layout.scroll_offset) -> $($disabled.layout.scroll_offset))"
+    }
+}
+finally {
+    if (-not $process.HasExited) {
+        Send-Bytes $process ([byte[]](0x02, 0x64))
+        Start-Sleep -Milliseconds 700
+    }
+    if (-not $process.HasExited) { $process.Kill() }
+    $process.Dispose()
+    & $Psmux -L $Namespace kill-server 2>$null | Out-Null
+}
+
+Write-Host "`n=== Results: Passed=$script:Passed Failed=$script:Failed ===" -ForegroundColor Cyan
+exit $script:Failed

--- a/tests/test_windows10_ssh_pipe_mouse.ps1
+++ b/tests/test_windows10_ssh_pipe_mouse.ps1
@@ -80,7 +80,18 @@ if (-not (Test-Path $Psmux)) {
 
 Write-Host "`n=== Windows 10 SSH direct-pipe mouse E2E ===" -ForegroundColor Cyan
 & $Psmux -L $Namespace kill-server 2>$null | Out-Null
-& $Psmux -L $Namespace new-session -d -s $Session -- cmd.exe
+$hadNoWarm = Test-Path Env:PSMUX_NO_WARM
+$previousNoWarm = $env:PSMUX_NO_WARM
+try {
+    # Keep this isolated E2E from leaving an intentional warm standby process
+    # that would lock the release binary after the namespace is killed.
+    $env:PSMUX_NO_WARM = '1'
+    & $Psmux -L $Namespace new-session -d -s $Session -- cmd.exe
+}
+finally {
+    if ($hadNoWarm) { $env:PSMUX_NO_WARM = $previousNoWarm }
+    else { Remove-Item Env:PSMUX_NO_WARM -ErrorAction SilentlyContinue }
+}
 Start-Sleep -Seconds 2
 & $Psmux -L $Namespace set-option -g mouse on -t $Session | Out-Null
 & $Psmux -L $Namespace set-option -g scroll-enter-copy-mode on -t $Session | Out-Null


### PR DESCRIPTION
## Summary

- extend the existing raw VT pipe client path to support Windows OpenSSH sessions launched without a remote PTY
- add a portable `psmux-win` client helper for macOS and Linux that enables SGR mouse reporting locally, uses `ssh -T`, and always restores terminal state
- add parser, copy-mode, wrapper cleanup, installer, and Windows direct-pipe integration coverage
- document the Windows 10 byte-flow limitation and the supported workaround

## Problem

On Windows 10, a normal OpenSSH session places psmux behind ConPTY. That ConPTY version consumes outgoing DEC mouse-mode sequences such as `CSI ? 1000 h`, `CSI ? 1002 h`, and `CSI ? 1006 h`, so the client terminal never starts reporting the wheel. Even when mouse reporting is enabled separately on the client, inbound SGR reports such as `CSI < 64 ; 10 ; 5 M` do not reach psmux reliably through the old ConPTY input parser.

The existing Windows build gate must remain: forcing mouse reporting through affected ConPTY versions can crash the pane process (issue #457).

## Solution

The helper uses the supported OpenSSH no-PTY mode (`ssh -T`), removing ConPTY from the path. Windows OpenSSH then gives psmux anonymous stdin/stdout pipes. psmux detects that SSH pipe, reads VT bytes with its existing incremental parser, emits mouse/focus/paste modes directly, and obtains terminal dimensions through XTWINOPS.

The POSIX wrapper:

- saves the exact local terminal state
- enables xterm button/drag reporting and SGR coordinates
- forwards raw keyboard and mouse bytes over `ssh -T`
- restores stty and disables mouse reporting on normal exit, SSH failure, disconnect, `HUP`, `INT`, or `TERM`
- validates values interpolated into the Windows remote command

Normal SSH PTY behavior on supported Windows 11 builds is unchanged.

## Validation

- `cargo test --bin psmux` — 2443 passed
- focused SGR parser and scroll/copy-mode tests — 7 passed
- `cargo build --release` — passed
- Windows anonymous-pipe E2E — 6 passed, including repeated WheelUp and `mouse off`
- real macOS PTY -> OpenSSH `-T` -> Windows 10 psmux — DECSET 1000/1002/1006 observed, WheelUp entered copy mode at offset 3, the second report advanced to 6, and detach emitted mouse-disable cleanup
- POSIX wrapper and installer tests passed under Windows Git `sh` and macOS `/bin/sh`
- shell, Python, PowerShell, and workflow YAML syntax checks passed
- `git diff --check` — passed

## Notes

`cargo fmt --check` is already non-clean on `origin/master` because of repository-wide formatting drift. The new standalone Rust test file passes `rustfmt --check`.
