### PR TITLE
feat: status-line command prompt with Tab completion

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -796,6 +796,141 @@ pub fn render_clock_overlay(f: &mut Frame, area: Rect, colour: Color) {
 /// the modal popup overlay, so popups still stack on top. Reuses the popup
 /// run-rendering; borders come from `-B` (mapped to ratatui border types),
 /// `none` draws no border. The focused float gets a highlighted border.
+/// View state for the `:` command prompt, as handed to `render_command_prompt`.
+pub(crate) struct CommandPromptView<'a> {
+    /// Text the user has typed.
+    pub buf: &'a str,
+    /// Cursor as a BYTE offset into `buf`; always on a char boundary.
+    pub cursor: usize,
+    /// Label from `command-prompt -p`; `None` uses the default `:`.
+    pub label: Option<&'a str>,
+    /// Expanded `message-style`; empty falls back to tmux's `bg=yellow,fg=black`.
+    pub message_style: &'a str,
+    /// Expanded `mode-style`, used to highlight the completion list.
+    pub mode_style: &'a str,
+    /// Completion candidates. Empty means the list is closed.
+    pub completions: &'a [String],
+    /// Index of the selected candidate.
+    pub completion_sel: usize,
+}
+
+/// Draw the `:` command prompt on the status line, plus its completion list.
+///
+/// tmux draws this prompt in the status line rather than as a floating box, and
+/// on the LAST status line, so `set -g status 2` keeps the window list visible.
+/// When the status bar is hidden entirely we borrow one row of the content area
+/// rather than changing the layout constraints: `status_lines` feeds
+/// `last_status_lines`, so a layout change would force a client-size re-send and
+/// reflow every pane each time the prompt opens or closes.
+///
+/// `view_off` (horizontal scroll, in display columns) and `completion_scroll`
+/// are in/out state, clamped here against the geometry available this frame.
+///
+/// Returns the screen-absolute cursor position, or `None` if there was no room
+/// to draw. The caller must apply that via the post-draw atomic cursor write —
+/// NOT `Frame::set_cursor_position`, which the post-draw write would override
+/// with the active pane's cursor.
+pub(crate) fn render_command_prompt(
+    f: &mut Frame,
+    content_chunk: Rect,
+    status_chunk: Rect,
+    status_lines: usize,
+    status_at_top: bool,
+    view: &CommandPromptView,
+    view_off: &mut usize,
+    completion_scroll: &mut usize,
+) -> Option<(u16, u16)> {
+    use unicode_width::UnicodeWidthStr;
+    let screen = f.area();
+    let (prompt_row, prompt_x, prompt_w) = if status_lines > 0 && status_chunk.height > 0 {
+        (status_chunk.y + status_chunk.height - 1, status_chunk.x, status_chunk.width)
+    } else if content_chunk.height > 0 {
+        let y = if status_at_top { content_chunk.y } else { content_chunk.y + content_chunk.height - 1 };
+        (y, content_chunk.x, content_chunk.width)
+    } else {
+        return None;
+    };
+
+    let msg_style = crate::rendering::parse_tmux_style(
+        if view.message_style.is_empty() { "bg=yellow,fg=black" } else { view.message_style }
+    );
+    let prefix = view.label.unwrap_or(":");
+    let prefix_w = UnicodeWidthStr::width(prefix);
+    let total_w = prompt_w as usize;
+    let avail = total_w.saturating_sub(prefix_w).max(1);
+    // view.cursor is a BYTE offset and is always on a char boundary (the
+    // prompt's insert/backspace/left/right arms maintain that — issue #345).
+    // Convert it to a display column.
+    let cur_col = UnicodeWidthStr::width(&view.buf[..view.cursor.min(view.buf.len())]);
+    // Sticky horizontal scroll: shift only when the cursor would leave the
+    // window, so the text does not jitter on every keystroke.
+    if cur_col < *view_off {
+        *view_off = cur_col;
+    } else if cur_col >= *view_off + avail {
+        *view_off = cur_col + 1 - avail;
+    }
+    let visible = crate::style::skip_and_take_cols(view.buf, *view_off, avail);
+    let text = format!("{}{}", prefix, visible);
+    let used = UnicodeWidthStr::width(text.as_str());
+    let padded = format!("{}{}", text, " ".repeat(total_w.saturating_sub(used)));
+    let rect = Rect { x: prompt_x, y: prompt_row, width: prompt_w, height: 1 };
+    f.render_widget(Clear, rect);
+    f.render_widget(
+        Paragraph::new(Line::from(Span::styled(padded, msg_style))).style(msg_style),
+        rect,
+    );
+    let cx = (prompt_x as usize + prefix_w + cur_col.saturating_sub(*view_off))
+        .min(prompt_x as usize + total_w.saturating_sub(1)) as u16;
+
+    // Completion candidates, opening away from the prompt: below it when the
+    // status bar is at the top, above it otherwise.
+    if !view.completions.is_empty() {
+        let sel_style = crate::rendering::parse_tmux_style(view.mode_style);
+        let widest = view.completions.iter()
+            .map(|s| UnicodeWidthStr::width(s.as_str()))
+            .max().unwrap_or(0);
+        let box_w = ((widest + 4) as u16).clamp(6, screen.width.max(6)).min(screen.width);
+        let avail_h = if status_at_top {
+            (screen.y + screen.height).saturating_sub(prompt_row + 1)
+        } else {
+            prompt_row.saturating_sub(screen.y)
+        };
+        let rows = (view.completions.len() as u16)
+            .min(10)
+            .min(avail_h.saturating_sub(2));
+        if rows > 0 && box_w >= 6 {
+            let box_h = rows + 2;
+            let y = if status_at_top { prompt_row + 1 } else { prompt_row - box_h };
+            let x = prompt_x.min((screen.x + screen.width).saturating_sub(box_w));
+            let oa = Rect { x, y, width: box_w, height: box_h };
+            // Keep the selection inside the visible window.
+            if view.completion_sel < *completion_scroll {
+                *completion_scroll = view.completion_sel;
+            } else if view.completion_sel >= *completion_scroll + rows as usize {
+                *completion_scroll = view.completion_sel + 1 - rows as usize;
+            }
+            let block = Block::default().borders(Borders::ALL).border_style(sel_style);
+            let inner = block.inner(oa);
+            f.render_widget(Clear, oa);
+            f.render_widget(block, oa);
+            let lines: Vec<Line<'static>> = view.completions.iter().enumerate()
+                .skip(*completion_scroll)
+                .take(rows as usize)
+                .map(|(i, c)| {
+                    if i == view.completion_sel {
+                        Line::from(Span::styled(format!(" {} ", c), sel_style))
+                    } else {
+                        Line::from(format!(" {} ", c))
+                    }
+                })
+                .collect();
+            f.render_widget(Paragraph::new(Text::from(lines)), inner);
+        }
+    }
+
+    Some((cx, prompt_row))
+}
+
 pub(crate) fn render_float_overlays(f: &mut Frame, content_chunk: Rect, floats: &[FloatJson]) {
     for fl in floats {
         if fl.w < 2 || fl.h < 2 { continue; }
@@ -1434,6 +1569,16 @@ pub fn run_remote(terminal: &mut Terminal<crate::platform::PsmuxBackend>, input:
     let mut command_template: Option<String> = None;
     // Custom prompt label from command-prompt -p 'prompt:'
     let mut command_prompt_label: Option<String> = None;
+    // Tab-completion candidates for the command prompt. Non-empty IS the
+    // "list is open" flag — a separate bool could desync from the contents.
+    let mut command_completions: Vec<String> = Vec::new();
+    let mut command_completion_sel: usize = 0;
+    let mut command_completion_scroll: usize = 0;
+    // Byte range in command_buf that an accepted candidate replaces.
+    let mut command_completion_span: (usize, usize) = (0, 0);
+    // Horizontal scroll of the prompt, in display columns. Sticky: it shifts
+    // only when the cursor would leave the visible window.
+    let mut command_view_off: usize = 0;
     // Track active window name from last dump-state for #W expansion
     let mut active_window_name = String::new();
     let mut window_idx_input = false;
@@ -2626,9 +2771,21 @@ pub fn run_remote(terminal: &mut Terminal<crate::platform::PsmuxBackend>, input:
                                 }
                             }
                         }
+                        else if matches!(key.code, KeyCode::Esc) && command_input && !command_completions.is_empty() {
+                            // Esc dismisses the completion list only — the
+                            // prompt stays open. Must sit ahead of the general
+                            // Esc branch below, which closes the prompt.
+                            command_completions.clear();
+                            command_completion_sel = 0;
+                            command_completion_scroll = 0;
+                        }
                         else if matches!(key.code, KeyCode::Esc) && (command_input || renaming || pane_renaming || tree_chooser || buffer_chooser || session_chooser || confirm_cmd.is_some() || keys_viewer) {
                             command_input = false;
                             command_cursor = 0;
+                            command_completions.clear();
+                            command_completion_sel = 0;
+                            command_completion_scroll = 0;
+                            command_view_off = 0;
                             renaming = false;
                             pane_renaming = false;
                             tree_chooser = false;
@@ -2658,6 +2815,12 @@ pub fn run_remote(terminal: &mut Terminal<crate::platform::PsmuxBackend>, input:
                             #[cfg(windows)]
                             { ime_was_open = crate::platform::ime_disable(); }
                             prefix_armed = true; prefix_armed_at = Instant::now(); prefix_repeating = false; cmd_batch.push("prefix-begin\n".into());
+                            // This branch bypasses the key match below, where the
+                            // completion list is otherwise dismissed, so drop it
+                            // here too rather than leaving it rendered.
+                            command_completions.clear();
+                            command_completion_sel = 0;
+                            command_completion_scroll = 0;
                         }
                         // NOTE: when the prefix key is pressed while the prefix is
                         // ALREADY armed we deliberately do NOT re-arm here. Falling
@@ -2732,6 +2895,10 @@ pub fn run_remote(terminal: &mut Terminal<crate::platform::PsmuxBackend>, input:
                                 } else if cmd == "command-prompt" || cmd.starts_with("command-prompt ") {
                                     command_input = true;
                                     command_cursor = 0;
+                                    command_completions.clear();
+                                    command_completion_sel = 0;
+                                    command_completion_scroll = 0;
+                                    command_view_off = 0;
                                     command_history_idx = command_history.len();
                                     command_template = None;
                                     command_prompt_label = None;
@@ -2864,7 +3031,7 @@ pub fn run_remote(terminal: &mut Terminal<crate::platform::PsmuxBackend>, input:
                                 KeyCode::Char('t') => { cmd_batch.push("clock-mode\n".into()); }
                                 KeyCode::Char('=') => { do_choose_buffer = true; }
                                 KeyCode::Char('#') => { cmd_batch.push("list-buffers\n".into()); }
-                                KeyCode::Char(':') => { command_input = true; command_buf.clear(); command_cursor = 0; command_history_idx = command_history.len(); }
+                                KeyCode::Char(':') => { command_input = true; command_buf.clear(); command_cursor = 0; command_history_idx = command_history.len(); command_completions.clear(); command_completion_sel = 0; command_completion_scroll = 0; command_view_off = 0; }
                                 KeyCode::Char('\'') => { window_idx_input = true; window_idx_buf.clear(); }
                                 KeyCode::Char('w') => { do_choose_tree = true; }
                                 KeyCode::Char('s') => { do_choose_session = true; }
@@ -3187,6 +3354,12 @@ pub fn run_remote(terminal: &mut Terminal<crate::platform::PsmuxBackend>, input:
                                 paste_suppress_until.map_or(false, |t| Instant::now() < t);
                             #[cfg(not(windows))]
                             let paste_burst_active = false;
+                            // Any key that is not explicitly whitelisted below
+                            // closes the command-prompt completion list (tmux:
+                            // "any other key cancels completion"). A whitelist
+                            // at the match boundary beats sprinkling .clear()
+                            // through ~40 arms and missing one.
+                            let mut keep_completions = false;
                             match key.code {
                                 KeyCode::Up if session_chooser => { if session_selected > 0 { session_selected -= 1; } }
                                 KeyCode::Down if session_chooser => { if session_selected + 1 < session_entries.len() { session_selected += 1; } }
@@ -3489,6 +3662,67 @@ pub fn run_remote(terminal: &mut Terminal<crate::platform::PsmuxBackend>, input:
                                 KeyCode::Char(c) if pane_renaming && !key.modifiers.contains(KeyModifiers::CONTROL) && !paste_burst_active => { pane_title_buf.push(c); }
                                 KeyCode::Char(c) if window_idx_input && c.is_ascii_digit() && !paste_burst_active => { window_idx_buf.push(c); }
                                 KeyCode::Char(c) if command_input && !key.modifiers.contains(KeyModifiers::CONTROL) && !paste_burst_active => { command_buf.insert(command_cursor, c); command_cursor += c.len_utf8(); }
+
+                                // ── ':' prompt Tab-completion ───────────────
+                                // These arms MUST precede the unguarded
+                                // KeyCode::Tab / KeyCode::BackTab arms further
+                                // down, which push "send-key tab" and would
+                                // otherwise leak a literal tab into the pane
+                                // underneath the prompt.
+                                //
+                                // A tab arriving mid paste-burst is data, not a
+                                // completion request — same rationale as the
+                                // !paste_burst_active guard on Char above.
+                                KeyCode::Tab if command_input && paste_burst_active => {}
+
+                                // List open: navigate it.
+                                KeyCode::Tab | KeyCode::Down if command_input && !command_completions.is_empty() => {
+                                    command_completion_sel = (command_completion_sel + 1) % command_completions.len();
+                                    keep_completions = true;
+                                }
+                                KeyCode::BackTab | KeyCode::Up if command_input && !command_completions.is_empty() => {
+                                    command_completion_sel = command_completion_sel
+                                        .checked_sub(1)
+                                        .unwrap_or(command_completions.len() - 1);
+                                    keep_completions = true;
+                                }
+                                KeyCode::Enter if command_input && !command_completions.is_empty() => {
+                                    // Accept the selection into the buffer. This
+                                    // does not submit; a second Enter does.
+                                    let span = crate::completion::WordSpan {
+                                        start: command_completion_span.0,
+                                        end: command_completion_span.1,
+                                    };
+                                    let repl = format!("{} ", command_completions[command_completion_sel]);
+                                    let (nb, nc) = crate::completion::apply(&command_buf, &span, &repl);
+                                    command_buf = nb;
+                                    command_cursor = nc;
+                                    // keep_completions stays false → list closes.
+                                }
+
+                                // List closed: compute a completion.
+                                KeyCode::Tab if command_input => {
+                                    let (span, outcome) = crate::completion::complete(&command_buf, command_cursor);
+                                    match outcome {
+                                        crate::completion::CompletionOutcome::NoMatch => {}
+                                        crate::completion::CompletionOutcome::Unique { replacement }
+                                        | crate::completion::CompletionOutcome::Extended { replacement } => {
+                                            let (nb, nc) = crate::completion::apply(&command_buf, &span, &replacement);
+                                            command_buf = nb;
+                                            command_cursor = nc;
+                                        }
+                                        crate::completion::CompletionOutcome::Ambiguous { matches } => {
+                                            command_completions = matches;
+                                            command_completion_sel = 0;
+                                            command_completion_scroll = 0;
+                                            command_completion_span = (span.start, span.end);
+                                            keep_completions = true;
+                                        }
+                                    }
+                                }
+                                // Swallow BackTab in the prompt even with no
+                                // list open, so it never reaches the pane.
+                                KeyCode::BackTab if command_input => {}
                                 KeyCode::Backspace if renaming => { let _ = rename_buf.pop(); }
                                 KeyCode::Backspace if pane_renaming => { let _ = pane_title_buf.pop(); }
                                 KeyCode::Backspace if window_idx_input => { let _ = window_idx_buf.pop(); }
@@ -3609,6 +3843,11 @@ pub fn run_remote(terminal: &mut Terminal<crate::platform::PsmuxBackend>, input:
                                 KeyCode::Esc if renaming => { renaming = false; session_renaming = false; }
                                 KeyCode::Esc if pane_renaming => { pane_renaming = false; }
                                 KeyCode::Esc if window_idx_input => { window_idx_input = false; }
+                                // Unreachable: Esc is intercepted earlier by the
+                                // `matches!(key.code, KeyCode::Esc) && (command_input || ...)`
+                                // branch of the if/else chain that guards this
+                                // match, so it never reaches here. Kept as-is;
+                                // the live handler is up there.
                                 KeyCode::Esc if command_input => { command_input = false; command_cursor = 0; }
 
                                 // Command prompt: cursor movement, history, and editing keys
@@ -3899,6 +4138,14 @@ pub fn run_remote(terminal: &mut Terminal<crate::platform::PsmuxBackend>, input:
                                 KeyCode::F(n) => { cmd_batch.push(format!("send-key {}\n", modified_key_name(&format!("F{}", n), key.modifiers))); }
                                 _ => {}
                             }
+                            // Close the completion list unless the arm that just
+                            // ran explicitly asked to keep it (see the
+                            // keep_completions declaration above the match).
+                            if !keep_completions {
+                                command_completions.clear();
+                                command_completion_sel = 0;
+                                command_completion_scroll = 0;
+                            }
                         }
                     }
                     Event::Paste(data) => {
@@ -3912,7 +4159,13 @@ pub fn run_remote(terminal: &mut Terminal<crate::platform::PsmuxBackend>, input:
                             pane_renaming, &mut pane_title_buf,
                             window_idx_input, &mut window_idx_buf,
                         );
-                        if !consumed {
+                        if consumed {
+                            // Pasted text edits the prompt buffer, which
+                            // invalidates any open completion list.
+                            command_completions.clear();
+                            command_completion_sel = 0;
+                            command_completion_scroll = 0;
+                        } else {
                             let encoded = base64_encode(&data);
                             cmd_batch.push(format!("send-paste {}\n", encoded));
                         }
@@ -3981,8 +4234,10 @@ pub fn run_remote(terminal: &mut Terminal<crate::platform::PsmuxBackend>, input:
                         }
                         match me.kind {
                             MouseEventKind::Down(MouseButton::Left) => {
-                                // Status bar tab click
-                                if me.row == client_status_row {
+                                // Status bar tab click. Skipped while the command
+                                // prompt is open — it occupies the status row, so
+                                // a click there is not a window tab.
+                                if me.row == client_status_row && !command_input {
                                     let mut clicked_tab: Option<usize> = None;
                                     for &(win_idx, x_start, x_end) in &client_tab_positions {
                                         if me.column >= x_start && me.column < x_end {
@@ -4720,6 +4975,10 @@ pub fn run_remote(terminal: &mut Terminal<crate::platform::PsmuxBackend>, input:
         // which causes rapid cursor flicker during high-frequency
         // output (e.g. opencode streaming).
         let mut post_draw_cursor: Option<(u16, u16)> = None; // pane-local (col, row)
+        // Screen-absolute cursor for the ':' command prompt. Set inside the
+        // draw closure; takes priority over post_draw_cursor below, because the
+        // prompt owns the cursor while it is open.
+        let mut prompt_cursor: Option<(u16, u16)> = None;
         {
             fn active_cursor_info(node: &LayoutJson) -> Option<(bool, u16, u16, bool)> {
                 match node {
@@ -5819,19 +6078,9 @@ pub fn run_remote(terminal: &mut Terminal<crate::platform::PsmuxBackend>, input:
                 let para = Paragraph::new(format!("title: {}", pane_title_buf));
                 f.render_widget(para, overlay.inner(oa));
             }
-            if command_input {
-                let title = command_prompt_label.as_deref().unwrap_or("command");
-                let overlay = Block::default().borders(Borders::ALL).title(title);
-                let oa = centered_rect(60, 3, content_chunk);
-                f.render_widget(Clear, oa);
-                f.render_widget(&overlay, oa);
-                let inner = overlay.inner(oa);
-                let para = Paragraph::new(format!(": {}", command_buf));
-                f.render_widget(para, inner);
-                // Show cursor at the correct position within the prompt
-                let cx = inner.x + 2 + command_cursor as u16; // +2 for ": "
-                f.set_cursor_position((cx, inner.y));
-            }
+            // The ':' command prompt is drawn on the status line, at the very
+            // end of this closure — see the block after the display-panes
+            // overlay below.
             if window_idx_input {
                 let overlay = Block::default().borders(Borders::ALL).title("select window");
                 let oa = centered_rect(50, 3, content_chunk);
@@ -6109,6 +6358,32 @@ pub fn run_remote(terminal: &mut Terminal<crate::platform::PsmuxBackend>, input:
                 }
             }
 
+            // ── ':' command prompt, on the status line (tmux parity) ─────
+            // Drawn last so it paints over every other overlay, and so the
+            // status-hidden case can borrow a content row that the menu /
+            // customize / display-panes overlays above would otherwise repaint.
+            if command_input {
+                let view = CommandPromptView {
+                    buf: &command_buf,
+                    cursor: command_cursor,
+                    label: command_prompt_label.as_deref(),
+                    message_style: state.message_style.as_deref().unwrap_or(""),
+                    mode_style: &mode_style_str,
+                    completions: &command_completions,
+                    completion_sel: command_completion_sel,
+                };
+                prompt_cursor = render_command_prompt(
+                    f,
+                    content_chunk,
+                    status_chunk,
+                    status_lines,
+                    status_at_top,
+                    &view,
+                    &mut command_view_off,
+                    &mut command_completion_scroll,
+                );
+            }
+
         })?;
         if client_log_enabled() {
             client_log("draw", &format!("draw OK, render={}us overlays: popup={} confirm={} menu={} display_panes={}",
@@ -6248,7 +6523,11 @@ pub fn run_remote(terminal: &mut Terminal<crate::platform::PsmuxBackend>, input:
                 compute_active_rect_json_zoom_aware(&root, content_chunk, client_zoomed)
             };
             // Compute screen-global cursor position from pane-local coords.
-            let cursor_visible = if let (Some((cc, cr)), Some(inner)) = (post_draw_cursor, active_pane_area) {
+            // The ':' prompt wins when open — it already computed a
+            // screen-absolute position inside the draw closure.
+            let cursor_visible = if let Some(pc) = prompt_cursor {
+                Some(pc)
+            } else if let (Some((cc, cr)), Some(inner)) = (post_draw_cursor, active_pane_area) {
                 let cy = inner.y + cr.min(inner.height.saturating_sub(1));
                 let cx = inner.x + cc.min(inner.width.saturating_sub(1));
                 Some((cx, cy))

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -2583,6 +2583,10 @@ mod tests_copy_line_numbers_render;
 mod tests_floating_render;
 
 #[cfg(test)]
+#[path = "../tests-rs/test_command_prompt_render.rs"]
+mod tests_command_prompt_render;
+
+#[cfg(test)]
 #[path = "../tests-rs/test_pr207_compat_bugs.rs"]
 mod tests_pr207_compat_bugs;
 

--- a/src/completion.rs
+++ b/src/completion.rs
@@ -1,0 +1,162 @@
+//! Tab-completion for the `:` command prompt.
+//!
+//! The prompt itself lives in `client.rs` as flat key-handler arms inside the
+//! event loop, which is not reachable from a test.  Keeping the logic here
+//! means it can be unit-tested directly rather than mirrored — see the header
+//! of `tests-rs/test_issue345_command_prompt_utf8.rs` for what mirroring the
+//! prompt's editor cost us the last time.
+//!
+//! v1 completes the first token only.  [`CompletionContext`] is the seam for
+//! later work: completing option names after `set -g `, or targets after
+//! `-t `, means adding a variant plus an arm in [`candidates_for`].
+//! [`complete`], [`apply`] and the client's key handling stay unchanged.
+
+/// What the word under the cursor should be completed against.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CompletionContext {
+    /// The first token of the command line: complete against the command catalog.
+    CommandName,
+    /// Anything psmux cannot complete yet — arguments, flags, option names,
+    /// targets.  Yields no candidates, which makes Tab a swallowed no-op.
+    Unsupported,
+}
+
+/// Byte range of the word under the cursor.  Both ends are always on UTF-8
+/// char boundaries.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WordSpan {
+    pub start: usize,
+    pub end: usize,
+}
+
+/// The result of a completion attempt.  The `Extended`/`Ambiguous` split is
+/// what produces tmux's two-stage Tab: the first press extends as far as the
+/// input is unambiguous, and only a press that makes no progress opens the
+/// candidate list.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CompletionOutcome {
+    /// Nothing matches — swallow the key and change nothing.
+    NoMatch,
+    /// Exactly one match.  Insert it plus a trailing space; completion ends.
+    Unique { replacement: String },
+    /// The common prefix is strictly longer than what was typed.  Extend the
+    /// word, but do not open the list.
+    Extended { replacement: String },
+    /// The common prefix adds nothing and several candidates remain.  Open the
+    /// candidate list.
+    Ambiguous { matches: Vec<String> },
+}
+
+/// Byte range of the whitespace-delimited word containing `cursor`.
+///
+/// Returns an empty span when the cursor sits on whitespace.
+pub fn word_at_cursor(buf: &str, cursor: usize) -> WordSpan {
+    let bytes = buf.as_bytes();
+    let cursor = cursor.min(buf.len());
+    let is_sep = |b: u8| b == b' ' || b == b'\t';
+    // Scanning raw bytes for ASCII whitespace is char-boundary-safe: UTF-8
+    // continuation bytes are all >= 0x80, so they can never match.
+    let mut start = cursor;
+    while start > 0 && !is_sep(bytes[start - 1]) {
+        start -= 1;
+    }
+    let mut end = cursor;
+    while end < bytes.len() && !is_sep(bytes[end]) {
+        end += 1;
+    }
+    WordSpan { start, end }
+}
+
+/// Decide what `span` should be completed against.
+///
+/// A word is a command name when nothing but whitespace precedes it.  Note
+/// that `;`-chained command lines (`new-window ; spl`) currently classify the
+/// second command as [`CompletionContext::Unsupported`]; splitting on chains
+/// via `crate::config::split_chained_commands_pub` is deliberately left for
+/// the same follow-up that adds argument completion.
+pub fn classify(buf: &str, span: &WordSpan) -> CompletionContext {
+    if buf[..span.start].trim().is_empty() {
+        CompletionContext::CommandName
+    } else {
+        CompletionContext::Unsupported
+    }
+}
+
+/// All candidates available in a given context, unfiltered.
+pub fn candidates_for(ctx: &CompletionContext) -> Vec<String> {
+    match ctx {
+        CompletionContext::CommandName => crate::server::helpers::command_name_candidates()
+            .into_iter()
+            .map(String::from)
+            .collect(),
+        CompletionContext::Unsupported => Vec::new(),
+    }
+}
+
+/// Longest prefix shared by every item, truncated to a char boundary.
+pub fn longest_common_prefix(items: &[String]) -> String {
+    let mut iter = items.iter();
+    let first = match iter.next() {
+        Some(f) => f,
+        None => return String::new(),
+    };
+    let mut prefix_len = first.len();
+    for item in iter {
+        // Compare by char, not byte, so the result is always a valid boundary.
+        // Command names are ASCII today, but this will later be fed session and
+        // window names.
+        let common: usize = first
+            .chars()
+            .zip(item.chars())
+            .take_while(|(a, b)| a == b)
+            .map(|(a, _)| a.len_utf8())
+            .sum();
+        prefix_len = prefix_len.min(common);
+    }
+    first[..prefix_len].to_string()
+}
+
+/// Attempt to complete the word under the cursor.
+///
+/// Returns the span that any replacement applies to, alongside the outcome.
+pub fn complete(buf: &str, cursor: usize) -> (WordSpan, CompletionOutcome) {
+    let span = word_at_cursor(buf, cursor);
+    let ctx = classify(buf, &span);
+    let word = &buf[span.start..span.end];
+    // Case-sensitive prefix match, matching tmux.
+    let matches: Vec<String> = candidates_for(&ctx)
+        .into_iter()
+        .filter(|c| c.starts_with(word))
+        .collect();
+    let outcome = match matches.len() {
+        0 => CompletionOutcome::NoMatch,
+        1 => CompletionOutcome::Unique { replacement: format!("{} ", matches[0]) },
+        _ => {
+            let lcp = longest_common_prefix(&matches);
+            if lcp.len() > word.len() {
+                CompletionOutcome::Extended { replacement: lcp }
+            } else {
+                CompletionOutcome::Ambiguous { matches }
+            }
+        }
+    };
+    (span, outcome)
+}
+
+/// Splice `replacement` over `span`, returning the new buffer and the new byte
+/// cursor (immediately after the replacement).
+///
+/// The returned cursor is always on a char boundary, which the prompt's
+/// rendering and editing arms rely on (issue #345).
+pub fn apply(buf: &str, span: &WordSpan, replacement: &str) -> (String, usize) {
+    let mut out = String::with_capacity(buf.len() + replacement.len());
+    out.push_str(&buf[..span.start]);
+    out.push_str(replacement);
+    let cursor = out.len();
+    out.push_str(&buf[span.end..]);
+    (out, cursor)
+}
+
+#[cfg(test)]
+#[path = "../tests-rs/test_command_completion.rs"]
+mod tests_command_completion;

--- a/src/config.rs
+++ b/src/config.rs
@@ -590,11 +590,8 @@ pub(crate) fn is_known_command(app: &AppState, name: &str) -> bool {
         return true;
     }
     crate::server::helpers::TMUX_COMMANDS.iter().any(|entry| {
-        let (cmd, alias) = match entry.split_once(" (") {
-            Some((c, a)) => (c, a.trim_end_matches(')')),
-            None => (*entry, ""),
-        };
-        cmd == name || (!alias.is_empty() && alias == name)
+        let (cmd, alias) = crate::server::helpers::split_command_entry(entry);
+        cmd == name || alias == Some(name)
     })
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,6 +25,7 @@ mod window_ops;
 mod util;
 mod format;
 mod help;
+mod completion;
 mod server;
 mod preview;
 mod client;

--- a/src/server/helpers.rs
+++ b/src/server/helpers.rs
@@ -658,6 +658,39 @@ pub(crate) const TMUX_COMMANDS: &[&str] = &[
     "wait-for (wait)",
 ];
 
+/// Split a `TMUX_COMMANDS` entry into `(canonical_name, alias)`.
+///
+/// Entries are encoded either as `"command-prompt"` (no alias) or as
+/// `"split-window (splitw)"`.  The encoding is owned here, next to the data it
+/// describes, so consumers do not each re-implement the parse.
+pub(crate) fn split_command_entry(entry: &str) -> (&str, Option<&str>) {
+    match entry.split_once(" (") {
+        Some((cmd, alias)) => {
+            let alias = alias.trim_end_matches(')');
+            if alias.is_empty() { (cmd, None) } else { (cmd, Some(alias)) }
+        }
+        None => (entry, None),
+    }
+}
+
+/// Every token the `:` command prompt can complete: canonical command names
+/// plus their aliases, sorted and deduped.
+///
+/// Aliases are offered as first-class candidates because tmux completes both
+/// forms (`status_prompt_complete_list` matches name and alias) and users type
+/// `lsw`/`neww`/`splitw` as often as the long names.
+pub(crate) fn command_name_candidates() -> Vec<&'static str> {
+    let mut v: Vec<&'static str> = Vec::with_capacity(TMUX_COMMANDS.len() * 2);
+    for &entry in TMUX_COMMANDS {
+        let (cmd, alias) = split_command_entry(entry);
+        v.push(cmd);
+        if let Some(a) = alias { v.push(a); }
+    }
+    v.sort_unstable();
+    v.dedup();
+    v
+}
+
 #[cfg(test)]
 #[path = "../../tests-rs/test_issue451_status_styles.rs"]
 mod tests_issue451_status_styles;

--- a/src/style.rs
+++ b/src/style.rs
@@ -234,6 +234,58 @@ pub fn spans_visual_width(spans: &[Span]) -> usize {
     spans.iter().map(|s| UnicodeWidthStr::width(s.content.as_ref())).sum()
 }
 
+/// Take the substring of `s` occupying display columns
+/// `[skip_cols, skip_cols + take_cols)`.
+///
+/// Unlike `truncate_spans_to_width` this windows from both ends, which is what
+/// horizontally scrolling a long command-prompt line needs.  A double-width
+/// character straddling either edge becomes a space, so the result is exactly
+/// `take_cols` wide and no glyph is cut in half.
+pub fn skip_and_take_cols(s: &str, skip_cols: usize, take_cols: usize) -> String {
+    use unicode_width::UnicodeWidthChar;
+    let mut out = String::new();
+    let mut col = 0usize;
+    let mut taken = 0usize;
+    for ch in s.chars() {
+        if taken >= take_cols {
+            break;
+        }
+        let cw = UnicodeWidthChar::width(ch).unwrap_or(0);
+        if cw == 0 {
+            // Combining mark: attach it to whatever we last emitted.
+            if !out.is_empty() {
+                out.push(ch);
+            }
+            continue;
+        }
+        let start = col;
+        col += cw;
+        if col <= skip_cols {
+            continue; // entirely left of the window
+        }
+        if start < skip_cols {
+            // Straddles the left edge: emit blanks for the visible half.
+            let visible = (col - skip_cols).min(take_cols - taken);
+            for _ in 0..visible {
+                out.push(' ');
+            }
+            taken += visible;
+            continue;
+        }
+        if taken + cw > take_cols {
+            // Straddles the right edge: pad out and stop.
+            for _ in 0..(take_cols - taken) {
+                out.push(' ');
+            }
+            taken = take_cols;
+            break;
+        }
+        out.push(ch);
+        taken += cw;
+    }
+    out
+}
+
 /// Truncate a list of styled spans so their total visual width fits within
 /// `max_width` columns.  If the content exceeds `max_width`, spans are
 /// trimmed character by character and a trailing ellipsis is NOT added (to

--- a/tests-rs/test_command_completion.rs
+++ b/tests-rs/test_command_completion.rs
@@ -1,0 +1,249 @@
+// Tab-completion for the ':' command prompt.
+//
+// Unlike test_issue345_command_prompt_utf8.rs — which had to re-implement the
+// prompt's editor because it lives inline in client.rs's event loop — these
+// call the real functions in src/completion.rs.
+
+use crate::completion::{
+    apply, candidates_for, classify, complete, longest_common_prefix, word_at_cursor,
+    CompletionContext, CompletionOutcome, WordSpan,
+};
+
+// ── word_at_cursor ──────────────────────────────────────────────────────────
+
+#[test]
+fn word_span_at_start_of_buffer() {
+    assert_eq!(word_at_cursor("", 0), WordSpan { start: 0, end: 0 });
+}
+
+#[test]
+fn word_span_covers_whole_first_token() {
+    // Cursor mid-word still spans the entire word.
+    assert_eq!(word_at_cursor("new-window", 3), WordSpan { start: 0, end: 10 });
+    assert_eq!(word_at_cursor("new-window", 10), WordSpan { start: 0, end: 10 });
+}
+
+#[test]
+fn word_span_is_empty_on_trailing_space() {
+    let s = "new-window ";
+    assert_eq!(word_at_cursor(s, s.len()), WordSpan { start: 11, end: 11 });
+}
+
+#[test]
+fn word_span_finds_later_argument() {
+    let s = "new-window -n foo";
+    // Cursor inside "foo".
+    assert_eq!(word_at_cursor(s, 15), WordSpan { start: 14, end: 17 });
+}
+
+#[test]
+fn word_span_handles_multibyte_without_splitting() {
+    let s = "中文 ne";
+    let span = word_at_cursor(s, s.len());
+    // "中文" is 6 bytes + 1 space, so "ne" starts at 7.
+    assert_eq!(span, WordSpan { start: 7, end: 9 });
+    assert_eq!(&s[span.start..span.end], "ne");
+}
+
+// ── classify ────────────────────────────────────────────────────────────────
+
+#[test]
+fn first_token_is_a_command_name() {
+    let s = "new";
+    assert_eq!(classify(s, &word_at_cursor(s, 3)), CompletionContext::CommandName);
+}
+
+#[test]
+fn leading_whitespace_still_yields_command_name() {
+    let s = "   new";
+    assert_eq!(classify(s, &word_at_cursor(s, 6)), CompletionContext::CommandName);
+}
+
+#[test]
+fn later_token_is_unsupported_in_v1() {
+    let s = "set -g sta";
+    assert_eq!(classify(s, &word_at_cursor(s, s.len())), CompletionContext::Unsupported);
+}
+
+#[test]
+fn unsupported_context_yields_no_candidates() {
+    assert!(candidates_for(&CompletionContext::Unsupported).is_empty());
+}
+
+// ── longest_common_prefix ───────────────────────────────────────────────────
+
+#[test]
+fn lcp_of_empty_is_empty() {
+    assert_eq!(longest_common_prefix(&[]), "");
+}
+
+#[test]
+fn lcp_of_one_item_is_that_item() {
+    assert_eq!(longest_common_prefix(&["kill-server".to_string()]), "kill-server");
+}
+
+#[test]
+fn lcp_finds_shared_prefix() {
+    let items = vec!["ab".to_string(), "ac".to_string()];
+    assert_eq!(longest_common_prefix(&items), "a");
+}
+
+#[test]
+fn lcp_of_disjoint_items_is_empty() {
+    let items = vec!["kill-pane".to_string(), "new-window".to_string()];
+    assert_eq!(longest_common_prefix(&items), "");
+}
+
+#[test]
+fn lcp_lands_on_char_boundary() {
+    // Shared "中" then diverging — the result must not split the 3-byte char.
+    let items = vec!["中文".to_string(), "中间".to_string()];
+    let lcp = longest_common_prefix(&items);
+    assert_eq!(lcp, "中");
+    assert_eq!(lcp.len(), 3);
+}
+
+// ── complete ────────────────────────────────────────────────────────────────
+
+#[test]
+fn unique_match_completes_fully_with_trailing_space() {
+    let (_, outcome) = complete("kill-ser", 8);
+    assert_eq!(outcome, CompletionOutcome::Unique { replacement: "kill-server ".to_string() });
+}
+
+#[test]
+fn ambiguous_prefix_extends_to_common_prefix_first() {
+    // "disp" matches only the display-* family, so the first Tab can extend to
+    // "display" without picking for the user.
+    let (_, outcome) = complete("disp", 4);
+    match outcome {
+        CompletionOutcome::Extended { replacement } => {
+            assert_eq!(replacement, "display");
+        }
+        other => panic!("expected Extended, got {:?}", other),
+    }
+}
+
+#[test]
+fn prefix_shared_by_unrelated_families_opens_the_list_immediately() {
+    // "ne" spans both new-* and next-*, so there is nothing to extend and the
+    // first Tab must go straight to the list rather than guessing.
+    match complete("ne", 2).1 {
+        CompletionOutcome::Ambiguous { matches } => {
+            assert!(matches.iter().any(|m| m == "new-window"));
+            assert!(matches.iter().any(|m| m == "next-window"));
+        }
+        other => panic!("expected Ambiguous, got {:?}", other),
+    }
+}
+
+#[test]
+fn second_tab_on_common_prefix_opens_the_list() {
+    // "new" IS already the common prefix, so there is no progress to make.
+    let (_, outcome) = complete("new", 3);
+    match outcome {
+        CompletionOutcome::Ambiguous { matches } => {
+            for expected in ["new-session", "new-window", "new", "neww"] {
+                assert!(
+                    matches.iter().any(|m| m == expected),
+                    "expected {} among {:?}",
+                    expected,
+                    matches
+                );
+            }
+        }
+        other => panic!("expected Ambiguous, got {:?}", other),
+    }
+}
+
+#[test]
+fn aliases_are_completable() {
+    // "splitw" is only reachable as an alias of split-window.
+    let (_, outcome) = complete("splitw", 6);
+    assert_eq!(outcome, CompletionOutcome::Unique { replacement: "splitw ".to_string() });
+}
+
+#[test]
+fn no_match_yields_nomatch() {
+    assert_eq!(complete("zzz", 3).1, CompletionOutcome::NoMatch);
+}
+
+#[test]
+fn empty_buffer_offers_the_whole_catalog() {
+    match complete("", 0).1 {
+        CompletionOutcome::Ambiguous { matches } => {
+            assert_eq!(matches, crate::server::helpers::command_name_candidates());
+        }
+        other => panic!("expected Ambiguous, got {:?}", other),
+    }
+}
+
+#[test]
+fn arguments_are_not_completed_in_v1() {
+    // Guards the seam: when argument completion lands, this test changes
+    // deliberately rather than silently.
+    assert_eq!(complete("set -g sta", 10).1, CompletionOutcome::NoMatch);
+}
+
+// ── apply ───────────────────────────────────────────────────────────────────
+
+#[test]
+fn apply_splices_and_moves_cursor_past_replacement() {
+    let span = WordSpan { start: 0, end: 2 };
+    let (buf, cursor) = apply("ne", &span, "new-window ");
+    assert_eq!(buf, "new-window ");
+    assert_eq!(cursor, 11);
+}
+
+#[test]
+fn apply_preserves_text_after_the_span() {
+    let s = "ne -n foo";
+    let span = word_at_cursor(s, 2);
+    let (buf, cursor) = apply(s, &span, "new-window");
+    assert_eq!(buf, "new-window -n foo");
+    assert_eq!(cursor, 10);
+}
+
+#[test]
+fn apply_keeps_cursor_on_a_char_boundary_with_multibyte_prefix() {
+    let s = "中文 ne";
+    let span = word_at_cursor(s, s.len());
+    let (buf, cursor) = apply(s, &span, "new-window ");
+    assert_eq!(buf, "中文 new-window ");
+    // The panic in issue #345 came from a cursor inside a UTF-8 sequence.
+    assert!(buf.is_char_boundary(cursor));
+    // And the render path slices here every frame.
+    let _ = &buf[..cursor];
+}
+
+// ── catalog integrity ───────────────────────────────────────────────────────
+
+#[test]
+fn candidates_are_sorted_deduped_and_non_empty() {
+    let c = crate::server::helpers::command_name_candidates();
+    assert!(!c.is_empty());
+    let mut sorted = c.clone();
+    sorted.sort_unstable();
+    sorted.dedup();
+    assert_eq!(c, sorted, "command_name_candidates must be sorted and deduped");
+}
+
+#[test]
+fn every_candidate_is_a_command_the_parser_accepts() {
+    // Completion must never offer a token that config parsing would warn about.
+    let app = crate::types::AppState::new("completion_test".to_string());
+    for cand in crate::server::helpers::command_name_candidates() {
+        assert!(
+            crate::config::is_known_command(&app, cand),
+            "completion offers {:?} but is_known_command rejects it",
+            cand
+        );
+    }
+}
+
+#[test]
+fn split_command_entry_handles_both_encodings() {
+    use crate::server::helpers::split_command_entry;
+    assert_eq!(split_command_entry("command-prompt"), ("command-prompt", None));
+    assert_eq!(split_command_entry("split-window (splitw)"), ("split-window", Some("splitw")));
+}

--- a/tests-rs/test_command_prompt_render.rs
+++ b/tests-rs/test_command_prompt_render.rs
@@ -1,0 +1,298 @@
+// The ':' command prompt renders on the STATUS LINE (tmux parity), not as a
+// centered box — deterministic render proof.
+//
+// Drives the real client `render_command_prompt` through a headless TestBackend
+// and asserts on cells. Ground truth for a client-rendered overlay: capture-pane
+// cannot see it, and dump-state carries no prompt state at all.
+
+use crate::client::{render_command_prompt, CommandPromptView};
+use ratatui::layout::Rect;
+
+const W: u16 = 80;
+const H: u16 = 24;
+
+struct Rendered {
+    buf: ratatui::buffer::Buffer,
+    cursor: Option<(u16, u16)>,
+    view_off: usize,
+    completion_scroll: usize,
+}
+
+/// Render with a status bar of `status_lines` rows at top or bottom, laid out
+/// exactly as `run_remote` does.
+fn render(
+    buf_text: &str,
+    cursor: usize,
+    label: Option<&str>,
+    completions: &[String],
+    completion_sel: usize,
+    status_lines: usize,
+    status_at_top: bool,
+    mut view_off: usize,
+    mut completion_scroll: usize,
+) -> Rendered {
+    use ratatui::backend::TestBackend;
+    use ratatui::Terminal;
+    let sl = status_lines as u16;
+    let (content_chunk, status_chunk) = if status_at_top {
+        (Rect::new(0, sl, W, H - sl), Rect::new(0, 0, W, sl))
+    } else {
+        (Rect::new(0, 0, W, H - sl), Rect::new(0, H - sl, W, sl))
+    };
+    let backend = TestBackend::new(W, H);
+    let mut term = Terminal::new(backend).unwrap();
+    let mut cursor_out = None;
+    term.draw(|f| {
+        let view = CommandPromptView {
+            buf: buf_text,
+            cursor,
+            label,
+            message_style: "",
+            mode_style: "",
+            completions,
+            completion_sel,
+        };
+        cursor_out = render_command_prompt(
+            f,
+            content_chunk,
+            status_chunk,
+            status_lines,
+            status_at_top,
+            &view,
+            &mut view_off,
+            &mut completion_scroll,
+        );
+    })
+    .unwrap();
+    Rendered {
+        buf: term.backend().buffer().clone(),
+        cursor: cursor_out,
+        view_off,
+        completion_scroll,
+    }
+}
+
+/// Simple bottom-status render: 1 status line, no completions.
+fn render_simple(buf_text: &str, cursor: usize) -> Rendered {
+    render(buf_text, cursor, None, &[], 0, 1, false, 0, 0)
+}
+
+fn row_text(buf: &ratatui::buffer::Buffer, y: u16) -> String {
+    let w = buf.area.width as usize;
+    (0..w)
+        .map(|x| buf.content[(y as usize) * w + x].symbol())
+        .collect::<String>()
+        .trim_end()
+        .to_string()
+}
+
+// ── position ────────────────────────────────────────────────────────────────
+
+#[test]
+fn prompt_renders_on_the_bottom_status_row() {
+    let r = render_simple("split-window -h", 15);
+    // Bottom row of an 80x24 screen, NOT a centered box.
+    assert_eq!(row_text(&r.buf, H - 1), ":split-window -h");
+    // And the middle of the screen is untouched — no floating overlay.
+    assert_eq!(row_text(&r.buf, H / 2), "");
+}
+
+#[test]
+fn prompt_renders_on_the_top_row_when_status_is_at_top() {
+    let r = render("neww", 4, None, &[], 0, 1, true, 0, 0);
+    assert_eq!(row_text(&r.buf, 0), ":neww");
+    assert_eq!(row_text(&r.buf, H - 1), "");
+}
+
+#[test]
+fn prompt_uses_the_last_status_line_when_status_is_two_rows() {
+    // `set -g status 2`: line 0 keeps the window list, the prompt takes line 1.
+    let r = render("neww", 4, None, &[], 0, 2, false, 0, 0);
+    assert_eq!(row_text(&r.buf, H - 1), ":neww");
+    assert_eq!(row_text(&r.buf, H - 2), "", "first status line is left alone");
+}
+
+#[test]
+fn prompt_borrows_a_content_row_when_the_status_bar_is_hidden() {
+    // `set -g status off` → status_lines == 0, so there is no status row.
+    let r = render("neww", 4, None, &[], 0, 0, false, 0, 0);
+    assert_eq!(row_text(&r.buf, H - 1), ":neww");
+}
+
+#[test]
+fn custom_label_replaces_the_colon_prefix() {
+    // command-prompt -p "name:" -I "dev"
+    let r = render("dev", 3, Some("name:"), &[], 0, 1, false, 0, 0);
+    assert_eq!(row_text(&r.buf, H - 1), "name:dev");
+}
+
+// ── cursor ──────────────────────────────────────────────────────────────────
+
+#[test]
+fn cursor_sits_after_the_typed_text() {
+    let r = render_simple("neww", 4);
+    // 1 col for ':' + 4 typed chars.
+    assert_eq!(r.cursor, Some((5, H - 1)));
+}
+
+#[test]
+fn cursor_tracks_a_mid_buffer_position() {
+    let r = render_simple("neww", 2);
+    assert_eq!(r.cursor, Some((3, H - 1)));
+}
+
+#[test]
+fn cursor_is_a_display_column_not_a_byte_offset() {
+    // Two double-width chars: 6 bytes, but 4 display columns (issue #345 —
+    // command_cursor is a byte offset and must be converted for rendering).
+    let s = "中文";
+    let r = render_simple(s, s.len());
+    assert_eq!(s.len(), 6, "precondition: 6 bytes");
+    assert_eq!(r.cursor, Some((1 + 4, H - 1)), "cursor at 4 columns, not 6");
+}
+
+// ── horizontal scrolling ────────────────────────────────────────────────────
+
+#[test]
+fn long_input_scrolls_to_keep_the_cursor_visible() {
+    // 100 chars into an 80-col row: the view must shift and the cursor must
+    // stay on screen rather than running off the right edge.
+    let long = "a".repeat(100);
+    let r = render_simple(&long, long.len());
+    assert!(r.view_off > 0, "view should have scrolled, got {}", r.view_off);
+    let (cx, _) = r.cursor.unwrap();
+    assert!(cx < W, "cursor must stay on screen, got {}", cx);
+    // The tail of the buffer is what is visible.
+    assert_eq!(row_text(&r.buf, H - 1).len(), W as usize - 1);
+}
+
+#[test]
+fn short_input_does_not_scroll() {
+    let r = render_simple("neww", 4);
+    assert_eq!(r.view_off, 0);
+}
+
+// ── completion list ─────────────────────────────────────────────────────────
+
+fn cands() -> Vec<String> {
+    ["new-session", "new-window", "new", "neww"]
+        .iter()
+        .map(|s| s.to_string())
+        .collect()
+}
+
+#[test]
+fn completion_list_opens_above_a_bottom_prompt() {
+    let c = cands();
+    let r = render("new", 3, None, &c, 0, 1, false, 0, 0);
+    // Prompt still on the bottom row.
+    assert_eq!(row_text(&r.buf, H - 1), ":new");
+    // 4 candidates + 2 border rows = 6, sitting directly above the prompt.
+    let top = H - 1 - 6;
+    assert!(row_text(&r.buf, top).starts_with('┌'), "list top border above prompt");
+    assert!(row_text(&r.buf, H - 2).starts_with('└'), "list bottom border abuts prompt");
+    // Candidates in between.
+    let body: String = (top + 1..H - 2).map(|y| row_text(&r.buf, y)).collect();
+    for expected in ["new-session", "new-window", "neww"] {
+        assert!(body.contains(expected), "expected {} in list, got {:?}", expected, body);
+    }
+}
+
+#[test]
+fn completion_list_opens_below_a_top_prompt() {
+    let c = cands();
+    let r = render("new", 3, None, &c, 0, 1, true, 0, 0);
+    assert_eq!(row_text(&r.buf, 0), ":new");
+    assert!(row_text(&r.buf, 1).starts_with('┌'), "list opens below a top prompt");
+}
+
+#[test]
+fn completion_list_is_absent_when_there_are_no_candidates() {
+    let r = render_simple("new", 3);
+    assert_eq!(row_text(&r.buf, H - 2), "", "no list box when completions are empty");
+}
+
+#[test]
+fn long_candidate_list_is_capped_and_scrolls_to_the_selection() {
+    let many: Vec<String> = (0..40).map(|i| format!("cmd-{:02}", i)).collect();
+    // Select an entry far down the list.
+    let r = render("cmd", 3, None, &many, 25, 1, false, 0, 0);
+    assert!(
+        r.completion_scroll > 0,
+        "scroll should follow the selection, got {}",
+        r.completion_scroll
+    );
+    // Capped at 10 rows + 2 borders.
+    let top = H - 1 - 12;
+    assert!(row_text(&r.buf, top).starts_with('┌'), "list capped at 10 rows");
+    let body: String = (top + 1..H - 2).map(|y| row_text(&r.buf, y)).collect();
+    assert!(body.contains("cmd-25"), "selected entry must be visible, got {:?}", body);
+}
+
+// ── degenerate geometry ─────────────────────────────────────────────────────
+
+#[test]
+fn zero_height_content_and_no_status_renders_nothing() {
+    use ratatui::backend::TestBackend;
+    use ratatui::Terminal;
+    let backend = TestBackend::new(W, H);
+    let mut term = Terminal::new(backend).unwrap();
+    let mut out = Some((0, 0));
+    let (mut vo, mut cs) = (0, 0);
+    term.draw(|f| {
+        let view = CommandPromptView {
+            buf: "neww",
+            cursor: 4,
+            label: None,
+            message_style: "",
+            mode_style: "",
+            completions: &[],
+            completion_sel: 0,
+        };
+        out = render_command_prompt(
+            f,
+            Rect::new(0, 0, W, 0),
+            Rect::new(0, 0, W, 0),
+            0,
+            false,
+            &view,
+            &mut vo,
+            &mut cs,
+        );
+    })
+    .unwrap();
+    assert_eq!(out, None, "no room to draw → no cursor");
+}
+
+#[test]
+fn very_narrow_terminal_does_not_panic() {
+    use ratatui::backend::TestBackend;
+    use ratatui::Terminal;
+    // Narrower than the label, with a completion list open.
+    let backend = TestBackend::new(4, 6);
+    let mut term = Terminal::new(backend).unwrap();
+    let c = cands();
+    let (mut vo, mut cs) = (0, 0);
+    term.draw(|f| {
+        let view = CommandPromptView {
+            buf: "new-window",
+            cursor: 10,
+            label: Some("a-very-long-label:"),
+            message_style: "",
+            mode_style: "",
+            completions: &c,
+            completion_sel: 3,
+        };
+        let _ = render_command_prompt(
+            f,
+            Rect::new(0, 0, 4, 5),
+            Rect::new(0, 5, 4, 1),
+            1,
+            false,
+            &view,
+            &mut vo,
+            &mut cs,
+        );
+    })
+    .unwrap();
+}


### PR DESCRIPTION
Move the `:` command prompt from a centered bordered box to the bottom status line (matching tmux), and add tmux 3.x-style Tab completion for command names.

- New src/completion.rs: pure, testable completion engine (word-at-cursor, context classification, longest-common-prefix, two-stage Tab behavior). Structured as the extension seam for later option/target completion.
- server/helpers.rs: split_command_entry + command_name_candidates derive the completion catalog from TMUX_COMMANDS (canonical names + aliases).
- config.rs: is_known_command reuses split_command_entry.
- client.rs: render the prompt on the status line with sticky horizontal scroll and a navigable candidate list; fix pre-existing tab-leak and invisible-cursor bugs; UTF-8 column-aware cursor.
- style.rs: skip_and_take_cols helper for display-column windowing.
- Tests: 28 completion unit tests + 16 TestBackend render tests.

Only the `:` prompt moves; rename/pane-title/confirm keep their boxes.


Claude-Session: https://claude.ai/code/session_01TYCsveWuTo69mZj5hCiuK9