### PR TITLE
fix(server): expand status-bar #() asynchronously on the push path

### DIFF
--- a/src/format.rs
+++ b/src/format.rs
@@ -246,23 +246,21 @@ pub fn expand_format_for_window(fmt: &str, app: &AppState, win_idx: usize) -> St
     result
 }
 
-/// Expand `#(command)` (tmux compatibility): return the last cached stdout and,
-/// when it is missing or older than the TTL, spawn a background worker to
-/// refresh it. The call never blocks the server loop; the worker's result is
-/// delivered over `format_job_tx` and applied by the drain in the server loop,
-/// which then repaints. Before the first result the expansion is empty.
-///
-/// Cached in `app.format_shell_cache`, keyed by command string, TTL =
-/// `status-interval` seconds (1s floor). A command already in flight is not
-/// re-spawned, so a burst of pushes runs it at most once per TTL. See issue #272.
+// NOTE: this doc block used to sit here, detached, describing `run_shell_command`
+// as if it were unconditionally async — which it is not, and has not been since
+// d981d94. `cargo` flagged it as an unused doc comment and it was left in place;
+// meanwhile it was the only documentation anyone reading this file would find,
+// and it described the wrong half of the function. It now lives on
+// `run_shell_command` itself, covering BOTH branches.
 thread_local! {
     // When true, `#()` expansion is ASYNC (spawn a background worker, return the
     // cached value, apply the result on a later repaint). Default false = SYNC.
     static FORMAT_ASYNC: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
 }
 
-/// RAII guard that puts `#()` expansion in ASYNC mode for its lifetime. ONLY the
-/// periodic status-bar / dump-state render path should use this: that path runs
+/// RAII guard that puts `#()` expansion in ASYNC mode for its lifetime.
+///
+/// ONLY the periodic status-bar / render path should use this: that path runs
 /// every server-loop tick, so a slow `#(command)` there must never block the
 /// loop (issue #272 / PR #477). Every other caller — one-shot `display-message
 /// -p '#(cmd)'`, hooks, etc. — expands `#()` synchronously so a single expansion
@@ -270,19 +268,58 @@ thread_local! {
 /// async, which silently broke one-shot `#()` (it returned the empty pre-first-
 /// result value and never repainted). This restores tmux-parity: async only for
 /// the status bar, synchronous everywhere else.
-pub struct AsyncFormatGuard(());
+///
+/// DO NOT construct this at a render call site. It is created inside the three
+/// functions that make up the render path —
+/// `server::helpers::expand_status_formats`, `list_windows_json_with_tabs`, and
+/// `append_extra_style_json`. It was previously created at the call sites, and
+/// the server auto-push block was written without it, so `#()` in the status bar
+/// spawned a process synchronously on the event loop that also delivers
+/// keystrokes — on every pane output burst. Keeping construction inside the
+/// functions means a new render path cannot reintroduce that.
+pub struct AsyncFormatGuard(bool);
 impl AsyncFormatGuard {
     pub fn new() -> Self {
-        FORMAT_ASYNC.with(|c| c.set(true));
-        AsyncFormatGuard(())
+        // Save and restore the PREVIOUS value rather than unconditionally
+        // clearing on drop. If two guarded helpers ever nest, a blind
+        // `set(false)` in the inner Drop would silently drop the outer region
+        // back to synchronous — re-creating the exact bug this guard exists to
+        // prevent, but only in the nested case and therefore much harder to
+        // spot. Restoring makes nesting a non-event.
+        let prev = FORMAT_ASYNC.with(|c| c.replace(true));
+        AsyncFormatGuard(prev)
     }
 }
 impl Drop for AsyncFormatGuard {
     fn drop(&mut self) {
-        FORMAT_ASYNC.with(|c| c.set(false));
+        let prev = self.0;
+        FORMAT_ASYNC.with(|c| c.set(prev));
     }
 }
 
+/// Expand `#(command)` (tmux compatibility). Has two modes, selected by the
+/// thread-local [`FORMAT_ASYNC`] flag that [`AsyncFormatGuard`] sets:
+///
+/// - **Sync (the default, no guard active):** run the command inline with
+///   `Command::output()` and return its real stdout. Correct — and required —
+///   for one-shot callers like `display-message -p '#(cmd)'`, which have no
+///   later repaint to pick up an async result. It BLOCKS the calling thread for
+///   as long as the child runs.
+/// - **Async (under an [`AsyncFormatGuard`]):** return the last cached stdout
+///   and, when it is missing or older than the TTL, spawn a background worker to
+///   refresh it. Never blocks; the worker's result is delivered over
+///   `format_job_tx` and applied by the drain in the server loop, which then
+///   repaints. Before the first result the expansion is empty.
+///
+/// The async cache is `app.format_shell_cache`, keyed by command string, TTL =
+/// `status-interval` seconds (1s floor). A command already in flight is not
+/// re-spawned, so a burst of pushes runs it at most once per TTL (issue #272).
+///
+/// The sync branch writes that cache but deliberately does not read it: a
+/// one-shot caller asked for the command's output *now*, and serving it a value
+/// from up to `status-interval` ago would make `#(date)` and friends silently
+/// stale. That asymmetry is why the guard has to be right — anything on the
+/// render path that misses it does not merely lose caching, it blocks the loop.
 fn run_shell_command(cmd: &str, app: &AppState) -> String {
     // Synchronous one-shot expansion (the default): run the command inline and
     // return its real output. A one-shot `display-message -p '#(cmd)'` has no

--- a/src/server/helpers.rs
+++ b/src/server/helpers.rs
@@ -110,6 +110,87 @@ pub(crate) fn json_escape_string(s: &str) -> String {
     out
 }
 
+/// Every status/style format that has to be expanded to build one render frame.
+///
+/// This exists because the DumpState handler and the server auto-push block in
+/// `server/mod.rs` need the identical set of expansions, and for a while they
+/// each had their own copy of the list. One copy was wrapped in an
+/// [`crate::format::AsyncFormatGuard`] and the other was not, so `#()` in the
+/// status bar spawned a process synchronously on the server event loop — the
+/// same thread that delivers keystrokes to ConPTY — on every pane output burst.
+/// With a `cmd /c` helper measured at 88ms and a loop that targets 1ms
+/// iterations while PTY data flows, that alone was seconds of input lag per
+/// second of typing.
+///
+/// The fix is structural: one list, one guard, owned by the function. Adding a
+/// new render path can no longer reintroduce the bug, because there is nothing
+/// left to remember to do.
+pub(crate) struct StatusFormats {
+    pub status_style: String,
+    pub status_left: String,
+    pub status_right: String,
+    pub pane_border_style: String,
+    pub pane_active_border_style: String,
+    pub pane_border_hover_style: String,
+    pub window_status_separator: String,
+    pub window_status_style: String,
+    pub window_status_current_style: String,
+    pub mode_style: String,
+    pub message_style: String,
+    /// Pre-built JSON array for the multi-line status bar.
+    pub status_format_json: String,
+    /// Expanded `set-titles-string`, or `None` when `set-titles` is off. The
+    /// client turns this into an OSC 0 for its host terminal.
+    pub host_title: Option<String>,
+}
+
+/// Expand every per-frame status/style format in one guarded pass.
+///
+/// `status_style` is passed in rather than read from `app` because both callers
+/// hold it in a metadata cache that is only rebuilt on structural change.
+pub(crate) fn expand_status_formats(app: &AppState, status_style: &str) -> StatusFormats {
+    use crate::format::expand_format;
+    // The one guard. Everything below expands #() asynchronously against the
+    // TTL cache instead of blocking the event loop.
+    let _async_fmt = crate::format::AsyncFormatGuard::new();
+    StatusFormats {
+        status_style: expand_format(status_style, app),
+        status_left: expand_format(&app.status_left, app),
+        status_right: expand_format(&app.status_right, app),
+        pane_border_style: expand_format(&app.pane_border_style, app),
+        pane_active_border_style: expand_format(&app.pane_active_border_style, app),
+        pane_border_hover_style: expand_format(&app.pane_border_hover_style, app),
+        window_status_separator: expand_format(&app.window_status_separator, app),
+        window_status_style: expand_format(&app.window_status_style, app),
+        window_status_current_style: expand_format(&app.window_status_current_style, app),
+        mode_style: expand_format(&app.mode_style, app),
+        message_style: expand_format(&app.message_style, app),
+        status_format_json: {
+            let mut sf = String::from("[");
+            for (i, fmt_str) in app.status_format.iter().enumerate() {
+                if i > 0 { sf.push(','); }
+                sf.push('"');
+                sf.push_str(&json_escape_string(&expand_format(fmt_str, app)));
+                sf.push('"');
+            }
+            sf.push(']');
+            sf
+        },
+        // set-titles-string was expanded outside the guard on BOTH paths, so it
+        // blocked even where the rest of the bar did not. It belongs here.
+        host_title: if app.set_titles {
+            let fmt = if app.set_titles_string.is_empty() {
+                "#S:#I:#W"
+            } else {
+                app.set_titles_string.as_str()
+            };
+            Some(expand_format(fmt, app))
+        } else {
+            None
+        },
+    }
+}
+
 /// Inject the status-bar style options that were dropped when the monolithic
 /// `app.rs` renderer was split into the modular client (regression from the
 /// modularization refactor, issue #451). The client only ever received
@@ -120,6 +201,13 @@ pub(crate) fn json_escape_string(s: &str) -> String {
 /// `}`, add fields, re-close), so the giant format-string arg list is untouched.
 pub(crate) fn append_extra_style_json(buf: &mut String, app: &AppState) {
     if !buf.ends_with('}') { return; }
+    // Guard lives HERE, not at the call site. This runs on the per-repaint
+    // render path (both the DumpState handler and the server auto-push block),
+    // so any #() in these style options must expand async or it blocks the one
+    // event loop that also delivers keystrokes. Keeping the guard inside the
+    // function makes that impossible to forget when a new call site appears —
+    // which is exactly how the auto-push path lost it.
+    let _async_fmt = crate::format::AsyncFormatGuard::new();
     buf.pop();
     for (key, raw) in [
         ("status_left_style", &app.status_left_style),
@@ -140,6 +228,10 @@ pub(crate) fn append_extra_style_json(buf: &mut String, app: &AppState) {
 /// Build windows JSON with pre-expanded tab_text for each window.
 /// The tab_text is the fully expanded window-status-format / window-status-current-format.
 pub(crate) fn list_windows_json_with_tabs(app: &AppState) -> io::Result<String> {
+    // Async #() for the same reason as append_extra_style_json above — and this
+    // one expands window-status-format once PER WINDOW, so a synchronous #()
+    // here multiplies by the window count.
+    let _async_fmt = crate::format::AsyncFormatGuard::new();
     let mut v: Vec<WinInfo> = Vec::new();
     for (i, w) in app.windows.iter().enumerate() {
         let is_active = i == app.active_idx;
@@ -661,3 +753,7 @@ pub(crate) const TMUX_COMMANDS: &[&str] = &[
 #[cfg(test)]
 #[path = "../../tests-rs/test_issue451_status_styles.rs"]
 mod tests_issue451_status_styles;
+
+#[cfg(test)]
+#[path = "../../tests-rs/test_render_path_async_format.rs"]
+mod tests_render_path_async_format;

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1976,40 +1976,30 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                     // to bright green). wsf/wscf stay raw: they are per-window
                     // formats the client expands with each window's own context.
                     // #() in these periodic status/style formats expands ASYNC so
-                    // a slow shell helper never blocks the server loop; the guard
-                    // is dropped right after this block so one-shot expansions
-                    // elsewhere (display-message -p) stay synchronous (see format.rs).
-                    let _async_fmt = crate::format::AsyncFormatGuard::new();
-                    let ss_escaped = json_escape_string(&expand_format(&cached_status_style, &app));
-                    let sl_expanded = json_escape_string(&expand_format(&app.status_left, &app));
-                    let sr_expanded = json_escape_string(&expand_format(&app.status_right, &app));
-                    let pbs_escaped = json_escape_string(&expand_format(&app.pane_border_style, &app));
-                    let pabs_escaped = json_escape_string(&expand_format(&app.pane_active_border_style, &app));
-                    let pbhs_escaped = json_escape_string(&expand_format(&app.pane_border_hover_style, &app));
+                    // a slow shell helper never blocks the server loop. The guard
+                    // now lives inside expand_status_formats, so one-shot
+                    // expansions elsewhere (display-message -p) still run
+                    // synchronously (see format.rs) without anything to remember
+                    // here.
+                    let sf = helpers::expand_status_formats(&app, &cached_status_style);
+                    let ss_escaped = json_escape_string(&sf.status_style);
+                    let sl_expanded = json_escape_string(&sf.status_left);
+                    let sr_expanded = json_escape_string(&sf.status_right);
+                    let pbs_escaped = json_escape_string(&sf.pane_border_style);
+                    let pabs_escaped = json_escape_string(&sf.pane_active_border_style);
+                    let pbhs_escaped = json_escape_string(&sf.pane_border_hover_style);
                     let wsf_escaped = json_escape_string(&app.window_status_format);
                     let wscf_escaped = json_escape_string(&app.window_status_current_format);
-                    let wss_escaped = json_escape_string(&expand_format(&app.window_status_separator, &app));
-                    let ws_style_escaped = json_escape_string(&expand_format(&app.window_status_style, &app));
-                    let wsc_style_escaped = json_escape_string(&expand_format(&app.window_status_current_style, &app));
-                    let mode_style_escaped = json_escape_string(&expand_format(&app.mode_style, &app));
+                    let wss_escaped = json_escape_string(&sf.window_status_separator);
+                    let ws_style_escaped = json_escape_string(&sf.window_status_style);
+                    let wsc_style_escaped = json_escape_string(&sf.window_status_current_style);
+                    let mode_style_escaped = json_escape_string(&sf.mode_style);
                     // #372: message-style was never sent to the client (it
                     // hard-coded bg=yellow,fg=black). Send it, format-expanded.
-                    let message_style_escaped = json_escape_string(&expand_format(&app.message_style, &app));
+                    let message_style_escaped = json_escape_string(&sf.message_style);
                     let status_position_escaped = json_escape_string(&app.status_position);
                     let status_justify_escaped = json_escape_string(&app.status_justify);
-                    // Build status_format JSON array for multi-line status bar
-                    let status_format_json = {
-                        let mut sf = String::from("[");
-                        for (i, fmt_str) in app.status_format.iter().enumerate() {
-                            if i > 0 { sf.push(','); }
-                            sf.push('"');
-                            sf.push_str(&json_escape_string(&expand_format(fmt_str, &app)));
-                            sf.push('"');
-                        }
-                        sf.push(']');
-                        sf
-                    };
-                    drop(_async_fmt); // end async-#() region; later expansions run synchronously
+                    let status_format_json = &sf.status_format_json;
                     let cursor_style_code = crate::rendering::configured_cursor_code();
                     let _ = std::fmt::Write::write_fmt(&mut combined_buf, format_args!(
                         "{{\"layout\":{},\"windows\":{},\"prefix\":\"{}\",\"prefix2\":\"{}\",\"tree\":{},\"base_index\":{},\"pane_base_index\":{},\"prediction_dimming\":{},\"status_style\":\"{}\",\"status_left\":\"{}\",\"status_right\":\"{}\",\"pane_border_style\":\"{}\",\"pane_active_border_style\":\"{}\",\"pane_border_hover_style\":\"{}\",\"wsf\":\"{}\",\"wscf\":\"{}\",\"wss\":\"{}\",\"ws_style\":\"{}\",\"wsc_style\":\"{}\",\"clock_mode\":{},\"bindings\":{},\"status_left_length\":{},\"status_right_length\":{},\"status_lines\":{},\"status_format\":{},\"mode_style\":\"{}\",\"message_style\":\"{}\",\"status_position\":\"{}\",\"status_justify\":\"{}\",\"cursor_style_code\":{},\"status_visible\":{},\"repeat_time\":{},\"zoomed\":{},\"defaults_suppressed\":{},\"pwsh_mouse_selection\":{},\"mouse_selection\":{},\"paste_detection\":{},\"choose_tree_preview\":{},\"scroll_enter_copy_mode\":{},\"bold_is_bright\":{}}}",
@@ -2080,19 +2070,18 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                         }
                         helpers::append_copy_ln_json(&app, &mut combined_buf);
                         helpers::append_floats_json(&app, &mut combined_buf);
-                        // set-titles: when on, expand set-titles-string and ship
-                        // it so the client emits OSC 0 to its host terminal.
-                        if app.set_titles && combined_buf.ends_with('}') {
-                            let fmt = if app.set_titles_string.is_empty() {
-                                "#S:#I:#W"
-                            } else {
-                                app.set_titles_string.as_str()
-                            };
-                            let expanded = expand_format(fmt, &app);
-                            combined_buf.pop();
-                            combined_buf.push_str(",\"host_title\":\"");
-                            combined_buf.push_str(&json_escape_string(&expanded));
-                            combined_buf.push_str("\"}");
+                        // set-titles: when on, ship the expanded set-titles-string
+                        // so the client emits OSC 0 to its host terminal.
+                        // Expanded under the async guard in
+                        // expand_status_formats; it used to be expanded here,
+                        // outside it.
+                        if let Some(title) = sf.host_title.as_deref() {
+                            if combined_buf.ends_with('}') {
+                                combined_buf.pop();
+                                combined_buf.push_str(",\"host_title\":\"");
+                                combined_buf.push_str(&json_escape_string(title));
+                                combined_buf.push_str("\"}");
+                            }
                         }
                         // Issue #269: forward OSC 9;4 progress from the active
                         // pane so the client emits the same sequence to the
@@ -5539,34 +5528,28 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
             // #372: style options must be format-expanded too (see persistent
             // path above). wsf/wscf stay raw: per-window formats the client
             // expands with each window's own context.
-            let ss_escaped = json_escape_string(&expand_format(&cached_status_style, &app));
-            let sl_expanded = json_escape_string(&expand_format(&app.status_left, &app));
-            let sr_expanded = json_escape_string(&expand_format(&app.status_right, &app));
-            let pbs_escaped = json_escape_string(&expand_format(&app.pane_border_style, &app));
-            let pabs_escaped = json_escape_string(&expand_format(&app.pane_active_border_style, &app));
-            let pbhs_escaped = json_escape_string(&expand_format(&app.pane_border_hover_style, &app));
+            // All of it goes through the one guarded helper — this block used to
+            // carry its own copy of the list WITHOUT the async guard, which is
+            // what made every keystroke wait on a status-bar #() spawn.
+            let sf = helpers::expand_status_formats(&app, &cached_status_style);
+            let ss_escaped = json_escape_string(&sf.status_style);
+            let sl_expanded = json_escape_string(&sf.status_left);
+            let sr_expanded = json_escape_string(&sf.status_right);
+            let pbs_escaped = json_escape_string(&sf.pane_border_style);
+            let pabs_escaped = json_escape_string(&sf.pane_active_border_style);
+            let pbhs_escaped = json_escape_string(&sf.pane_border_hover_style);
             let wsf_escaped = json_escape_string(&app.window_status_format);
             let wscf_escaped = json_escape_string(&app.window_status_current_format);
-            let wss_escaped = json_escape_string(&expand_format(&app.window_status_separator, &app));
-            let ws_style_escaped = json_escape_string(&expand_format(&app.window_status_style, &app));
-            let wsc_style_escaped = json_escape_string(&expand_format(&app.window_status_current_style, &app));
-            let mode_style_escaped = json_escape_string(&expand_format(&app.mode_style, &app));
+            let wss_escaped = json_escape_string(&sf.window_status_separator);
+            let ws_style_escaped = json_escape_string(&sf.window_status_style);
+            let wsc_style_escaped = json_escape_string(&sf.window_status_current_style);
+            let mode_style_escaped = json_escape_string(&sf.mode_style);
             // #372: message-style was never sent to the client (it hard-coded
             // bg=yellow,fg=black). Send it, format-expanded.
-            let message_style_escaped = json_escape_string(&expand_format(&app.message_style, &app));
+            let message_style_escaped = json_escape_string(&sf.message_style);
             let status_position_escaped = json_escape_string(&app.status_position);
             let status_justify_escaped = json_escape_string(&app.status_justify);
-            let status_format_json = {
-                let mut sf = String::from("[");
-                for (i, fmt_str) in app.status_format.iter().enumerate() {
-                    if i > 0 { sf.push(','); }
-                    sf.push('"');
-                    sf.push_str(&json_escape_string(&expand_format(fmt_str, &app)));
-                    sf.push('"');
-                }
-                sf.push(']');
-                sf
-            };
+            let status_format_json = &sf.status_format_json;
             let cursor_style_code = crate::rendering::configured_cursor_code();
             let _ = std::fmt::Write::write_fmt(&mut combined_buf, format_args!(
                 "{{\"layout\":{},\"windows\":{},\"prefix\":\"{}\",\"prefix2\":\"{}\",\"tree\":{},\"base_index\":{},\"pane_base_index\":{},\"prediction_dimming\":{},\"status_style\":\"{}\",\"status_left\":\"{}\",\"status_right\":\"{}\",\"pane_border_style\":\"{}\",\"pane_active_border_style\":\"{}\",\"pane_border_hover_style\":\"{}\",\"wsf\":\"{}\",\"wscf\":\"{}\",\"wss\":\"{}\",\"ws_style\":\"{}\",\"wsc_style\":\"{}\",\"clock_mode\":{},\"bindings\":{},\"status_left_length\":{},\"status_right_length\":{},\"status_lines\":{},\"status_format\":{},\"mode_style\":\"{}\",\"message_style\":\"{}\",\"status_position\":\"{}\",\"status_justify\":\"{}\",\"cursor_style_code\":{},\"status_visible\":{},\"repeat_time\":{},\"zoomed\":{},\"pwsh_mouse_selection\":{},\"mouse_selection\":{},\"paste_detection\":{},\"choose_tree_preview\":{},\"scroll_enter_copy_mode\":{},\"bold_is_bright\":{}}}",
@@ -5625,19 +5608,17 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                 }
                 helpers::append_copy_ln_json(&app, &mut combined_buf);
                 helpers::append_floats_json(&app, &mut combined_buf);
-                // set-titles: when on, expand set-titles-string and ship
-                // it so the client emits OSC 0 to its host terminal.
-                if app.set_titles && combined_buf.ends_with('}') {
-                    let fmt = if app.set_titles_string.is_empty() {
-                        "#S:#I:#W"
-                    } else {
-                        app.set_titles_string.as_str()
-                    };
-                    let expanded = expand_format(fmt, &app);
-                    combined_buf.pop();
-                    combined_buf.push_str(",\"host_title\":\"");
-                    combined_buf.push_str(&json_escape_string(&expanded));
-                    combined_buf.push_str("\"}");
+                // set-titles: when on, ship the expanded set-titles-string so the
+                // client emits OSC 0 to its host terminal. Expanded up in
+                // expand_status_formats, under the async guard — it used to be
+                // expanded right here, outside it.
+                if let Some(title) = sf.host_title.as_deref() {
+                    if combined_buf.ends_with('}') {
+                        combined_buf.pop();
+                        combined_buf.push_str(",\"host_title\":\"");
+                        combined_buf.push_str(&json_escape_string(title));
+                        combined_buf.push_str("\"}");
+                    }
                 }
                 // Issue #269: forward OSC 9;4 progress from the active pane.
                 if combined_buf.ends_with('}') {

--- a/tests-rs/test_render_path_async_format.rs
+++ b/tests-rs/test_render_path_async_format.rs
@@ -1,0 +1,299 @@
+//! The render path must expand `#()` asynchronously.
+//!
+//! tests-rs/test_issue272_format_shell_cache.rs already proves the async
+//! contract of `run_shell_command` itself — but every one of those tests opts
+//! in by constructing an `AsyncFormatGuard` by hand. That is precisely the
+//! thing that broke: the guard was correct, the contract was correct, and the
+//! server's auto-push block simply did not use it. A `#(cmd /c ...)` in
+//! status-right therefore ran `Command::output()` synchronously on the single
+//! server event loop — the same thread that delivers keystrokes to ConPTY — on
+//! every pane output burst, which is up to ~1000/s while a shell is drawing.
+//! Measured cost of the real-world offender: 88ms per call. The result was
+//! severe, permanent keyboard lag that only appeared inside psmux.
+//!
+//! So these tests deliberately do NOT construct a guard. They call the render
+//! helpers exactly as the server loop calls them and assert the observable
+//! consequence: the call returns promptly, and N calls inside one TTL produce
+//! one subprocess spawn rather than N.
+//!
+//! Spawn accounting is the same trick as the #272 suite: the inner command
+//! appends a line to a unique file each time it really runs, so line count is
+//! ground truth independent of what the expansion returns.
+
+use super::*;
+use std::time::{Duration, Instant};
+
+fn counter_path(tag: &str) -> std::path::PathBuf {
+    let pid = std::process::id();
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    std::env::temp_dir().join(format!("psmux_renderpath_{}_{}_{}.count", tag, pid, nanos))
+}
+
+/// `#()` inner command that takes ~1s and then records that it ran. Slow on
+/// purpose: a synchronous spawn is then unmistakable in the wall clock instead
+/// of being lost in noise.
+fn slow_tracer(counter: &std::path::Path) -> String {
+    let p = counter.display().to_string().replace('\\', "/");
+    if cfg!(windows) {
+        format!("ping -n 2 127.0.0.1 >nul & echo x>>{}", p)
+    } else {
+        format!("sleep 1; echo x>>{}", p)
+    }
+}
+
+fn fast_tracer(counter: &std::path::Path) -> String {
+    let p = counter.display().to_string().replace('\\', "/");
+    format!("echo x>>{}", p)
+}
+
+fn line_count(p: &std::path::Path) -> usize {
+    std::fs::read_to_string(p).map(|s| s.lines().count()).unwrap_or(0)
+}
+
+fn cleanup(p: &std::path::Path) {
+    let _ = std::fs::remove_file(p);
+}
+
+fn wait_for_spawns(counter: &std::path::Path, expected: usize, timeout: Duration) -> usize {
+    let deadline = Instant::now() + timeout;
+    loop {
+        let c = line_count(counter);
+        if c >= expected || Instant::now() >= deadline {
+            return c;
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+}
+
+fn mock_app(interval_secs: u64) -> AppState {
+    let mut app = AppState::new("renderpath".to_string());
+    app.window_base_index = 0;
+    app.status_interval = interval_secs;
+    let (tx, rx) = std::sync::mpsc::channel();
+    app.format_job_tx = Some(tx);
+    app.format_job_rx = Some(rx);
+    app
+}
+
+/// A synchronous spawn of the ~1s helper would park the event loop for ~1s.
+/// Anything under this is comfortably "did not block".
+const NONBLOCKING: Duration = Duration::from_millis(300);
+
+// ───────────────── expand_status_formats: the main render call ─────────────────
+
+#[test]
+fn status_right_hash_paren_does_not_block_the_render_path() {
+    let counter = counter_path("sr_block");
+    cleanup(&counter);
+    let mut app = mock_app(15);
+    app.status_right = format!("#({})", slow_tracer(&counter));
+
+    // No AsyncFormatGuard here on purpose — expand_status_formats owns it.
+    let t0 = Instant::now();
+    let out = expand_status_formats(&app, "");
+    let elapsed = t0.elapsed();
+
+    assert!(
+        elapsed < NONBLOCKING,
+        "expand_status_formats blocked {:?} on a ~1s status-right helper — the \
+         render path is spawning synchronously on the server event loop again, \
+         which is the keyboard-lag bug",
+        elapsed
+    );
+    assert_eq!(
+        out.status_right, "",
+        "first render shows empty #() until the worker completes; got {:?}",
+        out.status_right
+    );
+
+    wait_for_spawns(&counter, 1, Duration::from_secs(5));
+    cleanup(&counter);
+}
+
+#[test]
+fn repeated_renders_spawn_once_per_ttl() {
+    let counter = counter_path("sr_once");
+    cleanup(&counter);
+    let mut app = mock_app(60);
+    app.status_right = format!("#({})", fast_tracer(&counter));
+
+    // 50 pushes inside one TTL. Synchronously that is 50 processes.
+    for _ in 0..50 {
+        let _ = expand_status_formats(&app, "");
+    }
+
+    wait_for_spawns(&counter, 1, Duration::from_secs(5));
+    std::thread::sleep(Duration::from_millis(200));
+    let spawns = line_count(&counter);
+    cleanup(&counter);
+
+    assert_eq!(
+        spawns, 1,
+        "50 renders inside one TTL must share one spawn; got {} — the TTL cache \
+         is being bypassed, which means the render path lost its async guard",
+        spawns
+    );
+}
+
+#[test]
+fn status_left_is_guarded_too() {
+    let counter = counter_path("sl_block");
+    cleanup(&counter);
+    let mut app = mock_app(15);
+    app.status_left = format!("#({})", slow_tracer(&counter));
+
+    let t0 = Instant::now();
+    let _ = expand_status_formats(&app, "");
+    assert!(t0.elapsed() < NONBLOCKING, "status-left blocked the render path");
+
+    wait_for_spawns(&counter, 1, Duration::from_secs(5));
+    cleanup(&counter);
+}
+
+/// `set-titles-string` was expanded OUTSIDE the guard on both render paths, so
+/// it blocked even where the rest of the bar did not. It is now part of
+/// `expand_status_formats`.
+#[test]
+fn set_titles_string_is_guarded() {
+    let counter = counter_path("title_block");
+    cleanup(&counter);
+    let mut app = mock_app(15);
+    app.set_titles = true;
+    app.set_titles_string = format!("#({})", slow_tracer(&counter));
+
+    let t0 = Instant::now();
+    let out = expand_status_formats(&app, "");
+    let elapsed = t0.elapsed();
+
+    assert!(
+        elapsed < NONBLOCKING,
+        "set-titles-string blocked the render path for {:?}",
+        elapsed
+    );
+    assert!(out.host_title.is_some(), "set-titles on should produce a host_title");
+
+    wait_for_spawns(&counter, 1, Duration::from_secs(5));
+    cleanup(&counter);
+}
+
+#[test]
+fn host_title_is_none_when_set_titles_is_off() {
+    let app = mock_app(15);
+    assert!(
+        expand_status_formats(&app, "").host_title.is_none(),
+        "set-titles off must not emit a host_title"
+    );
+}
+
+// ───────────────── the other two guarded render helpers ─────────────────
+
+#[test]
+fn extra_style_json_does_not_block_the_render_path() {
+    let counter = counter_path("extra_block");
+    cleanup(&counter);
+    let mut app = mock_app(15);
+    app.status_left_style = format!("#({})", slow_tracer(&counter));
+
+    let mut buf = String::from("{}");
+    let t0 = Instant::now();
+    append_extra_style_json(&mut buf, &app);
+    let elapsed = t0.elapsed();
+
+    assert!(
+        elapsed < NONBLOCKING,
+        "append_extra_style_json blocked {:?} — it runs on every frame too",
+        elapsed
+    );
+
+    wait_for_spawns(&counter, 1, Duration::from_secs(5));
+    cleanup(&counter);
+}
+
+#[test]
+fn window_status_format_does_not_block_the_render_path() {
+    let counter = counter_path("wsf_block");
+    cleanup(&counter);
+    let mut app = mock_app(15);
+    app.window_status_format = format!("#({})", slow_tracer(&counter));
+    app.window_status_current_format = app.window_status_format.clone();
+
+    let t0 = Instant::now();
+    let _ = list_windows_json_with_tabs(&app);
+    let elapsed = t0.elapsed();
+
+    assert!(
+        elapsed < NONBLOCKING,
+        "list_windows_json_with_tabs blocked {:?} — and it expands once PER \
+         WINDOW, so a synchronous #() here multiplies by the window count",
+        elapsed
+    );
+
+    wait_for_spawns(&counter, 1, Duration::from_secs(5));
+    cleanup(&counter);
+}
+
+// ───────────────── the other half of the contract ─────────────────
+
+/// The guard must not leak out of the render helpers. One-shot callers
+/// (`display-message -p '#(cmd)'`) have no later repaint to pick up an async
+/// result, so they must still block and return real output. This is the
+/// invariant that d981d94 restored, and it is what makes the guard's placement
+/// load-bearing rather than cosmetic.
+#[test]
+fn expansion_outside_the_render_helpers_is_still_synchronous() {
+    let counter = counter_path("sync_after");
+    cleanup(&counter);
+    let app = mock_app(15);
+
+    // Run a render first, so any leaked thread-local state would be active.
+    let _ = expand_status_formats(&app, "");
+
+    let p = counter.display().to_string().replace('\\', "/");
+    let cmd = if cfg!(windows) {
+        format!("echo ONESHOT & echo x>>{}", p)
+    } else {
+        format!("echo ONESHOT; echo x>>{}", p)
+    };
+    let out = crate::format::expand_format(&format!("#({})", cmd), &app);
+    cleanup(&counter);
+
+    assert!(
+        out.contains("ONESHOT"),
+        "a one-shot #() must expand synchronously and return real stdout on the \
+         FIRST call; got {:?} (async mode leaked out of the render helpers)",
+        out
+    );
+}
+
+/// Nested guards must not drop the outer region back to synchronous. The guard
+/// saves and restores the previous flag value rather than clearing it, so this
+/// stays true even if the render helpers are ever composed.
+#[test]
+fn nested_guards_keep_the_outer_region_async() {
+    let counter = counter_path("nested");
+    cleanup(&counter);
+    let app = mock_app(15);
+
+    let outer = crate::format::AsyncFormatGuard::new();
+    {
+        // Inner guarded helper; its Drop must not clear the outer guard.
+        let _ = expand_status_formats(&app, "");
+    }
+    let t0 = Instant::now();
+    let _ = crate::format::expand_format(&format!("#({})", slow_tracer(&counter)), &app);
+    let elapsed = t0.elapsed();
+    drop(outer);
+
+    assert!(
+        elapsed < NONBLOCKING,
+        "after an inner guard was dropped the outer region went synchronous \
+         ({:?}) — AsyncFormatGuard::drop is clearing instead of restoring",
+        elapsed
+    );
+
+    wait_for_spawns(&counter, 1, Duration::from_secs(5));
+    cleanup(&counter);
+}

--- a/tests-rs/test_render_path_async_format.rs
+++ b/tests-rs/test_render_path_async_format.rs
@@ -38,9 +38,15 @@ fn counter_path(tag: &str) -> std::path::PathBuf {
 fn slow_tracer(counter: &std::path::Path) -> String {
     let p = counter.display().to_string().replace('\\', "/");
     if cfg!(windows) {
-        format!("ping -n 2 127.0.0.1 >nul & echo x>>\"{}\"", p)
+        // NOTE: the redirect target is intentionally unquoted. `#()` runs via
+        // `Command::new("cmd").args(["/C", ...])`, and quoting the target makes
+        // cmd.exe mangle the redirect (Rust's arg escaping collides with cmd's
+        // quote parsing) so the append silently fails — even on a space-free
+        // path. The filename here is fixed, so the only way a space enters is
+        // the temp directory itself; not worth fighting cmd for in a helper.
+        format!("ping -n 2 127.0.0.1 >nul & echo x>>{}", p)
     } else {
-        format!("sleep 1; echo x>>\"{}\"", p)
+        format!("sleep 1; echo x>>{}", p)
     }
 }
 

--- a/tests-rs/test_render_path_async_format.rs
+++ b/tests-rs/test_render_path_async_format.rs
@@ -38,9 +38,9 @@ fn counter_path(tag: &str) -> std::path::PathBuf {
 fn slow_tracer(counter: &std::path::Path) -> String {
     let p = counter.display().to_string().replace('\\', "/");
     if cfg!(windows) {
-        format!("ping -n 2 127.0.0.1 >nul & echo x>>{}", p)
+        format!("ping -n 2 127.0.0.1 >nul & echo x>>\"{}\"", p)
     } else {
-        format!("sleep 1; echo x>>{}", p)
+        format!("sleep 1; echo x>>\"{}\"", p)
     }
 }
 


### PR DESCRIPTION
The server auto-push block re-expands the whole status bar every time a pane produces output, and while on the single event loop it also delivers keystrokes to ConPTY. That expansion was running #() synchronously. 

d981d94 made sync the default for one-shot callers and re-added AsyncFormatGuard to only one of the two identical render sites. That site is the DumpState handler. This left the push block spawning a process per #() per push.

With a cmd/pwsh status helper that is tens to ~hundreds of ms. A loop that targets 1ms iterations while PTY data flows is large and persistent input lag that only appears inside psmux. A repainting prompt (Starship) turns "per frame" into "per keystroke".

Fix it structurally rather than by adding the guard back a third time:

- Collect every per-frame status/style expansion into one helper: helpers::expand_status_formats, which owns the AsyncFormatGuard. Both the DumpState handler and the push block now call it, so a future render path cannot reintroduce the bug by forgetting the guard.
- Move the guard into list_windows_json_with_tabs and append_extra_style_json too. Both run on the render path and both expanded #() unguarded (the former once per window).
- set-titles-string was expanded outside the guard on BOTH paths. It is now part of expand_status_formats.
- Make AsyncFormatGuard save/restore the previous flag instead of clearing on drop so nesting the guarded helpers can't drop an outer region back to sync.
- Relocate the stale detached doc block onto run_shell_command, documenting both modes. Cargo flagged it unused. It described run_shell_command as unconditionally async. It is not.

Adds tests-rs/test_render_path_async_format.rs, which calls the render helpers exactly as the loop does and asserts they neither block on a slow #() nor spawn more than once per TTL. The existing #272 suite only ever exercised the guard via manual construction, which is why this regressed unnoticed.