### PR TITLE
perf(platform): cache the process-table walk on the format render path

### DIFF
--- a/src/debug_log.rs
+++ b/src/debug_log.rs
@@ -13,6 +13,7 @@
 //! | `PSMUX_SSH_DEBUG=1`    | `~/.psmux/ssh_input.log`          | SSH input handling (existing)        |
 //! | `PSMUX_LATENCY_LOG=1`  | `~/.psmux/latency.log`            | Keypress-to-render latency (existing)|
 //! | `PSMUX_SESSION_DEBUG=1`| `~/.psmux/session_debug.log`      | Session-registry stale-port cleanup  |
+//! | `PSMUX_AUTORENAME_DEBUG=1` | `~/.psmux/autorename.log`     | Process-tree walk for automatic-rename |
 //!
 //! All loggers are:
 //! - **Off by default** — zero overhead when disabled (one atomic load per call)

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -2890,11 +2890,32 @@ pub mod process_info {
     }
 
     /// Append a line to ~/.psmux/autorename.log (first 100 entries only).
+    ///
+    /// Gated on `PSMUX_AUTORENAME_DEBUG=1`, like every other logger in
+    /// `src/debug_log.rs`. It was previously UNGATED — the only logger in the
+    /// tree that was — so every psmux server ever run wrote up to 100 lines of
+    /// process-tree tracing from this hot path, with an open+append syscall per
+    /// line. On this developer's machine it had accumulated a 703KB file. The
+    /// 100-entry cap is per-process, so the file grows without bound across
+    /// server restarts and the cap gives no protection against that.
     fn autorename_log(msg: &str) {
         use std::sync::atomic::{AtomicU32, Ordering};
+        use std::sync::OnceLock;
+        static ENABLED: OnceLock<bool> = OnceLock::new();
+        if !*ENABLED.get_or_init(|| {
+            // Accept "1" or "true", matching debug_log.rs's env_enabled so every
+            // debug gate in the tree behaves the same way.
+            std::env::var("PSMUX_AUTORENAME_DEBUG")
+                .map_or(false, |v| v == "1" || v.eq_ignore_ascii_case("true"))
+        }) {
+            return;
+        }
         static COUNT: AtomicU32 = AtomicU32::new(0);
         let n = COUNT.fetch_add(1, Ordering::Relaxed);
-        if n > 100 { return; }
+        // fetch_add returns the PREVIOUS value, so `>= 100` caps at exactly 100
+        // writes (n = 0..=99); `> 100` allowed 101. This cap predates the branch;
+        // aligned with the "first 100 entries" doc while touching the function.
+        if n >= 100 { return; }
         let home = std::env::var("USERPROFILE").or_else(|_| std::env::var("HOME")).unwrap_or_default();
         let path = format!("{}/.psmux/autorename.log", home);
         if let Ok(mut f) = std::fs::OpenOptions::new().create(true).append(true).open(&path) {
@@ -2977,77 +2998,168 @@ pub mod process_info {
     /// look one level deeper so the meaningful program is returned instead
     /// of the wrapper.
     fn find_foreground_child_pid(root_pid: u32) -> Option<u32> {
-        unsafe {
-            let snap = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
-            if snap == INVALID_HANDLE || snap == 0 {
+        // Render-path caller: reuse a recent snapshot rather than walking every
+        // process on the machine per repaint. See `process_table`.
+        let entries = match process_table(RENDER_PATH_TTL) {
+            Some(t) => t,
+            None => {
                 autorename_log(&format!("root={} SNAPSHOT FAILED", root_pid));
                 return None;
             }
+        };
 
-            // Collect (pid, ppid, exe_name_lower) for every process.
-            let mut entries: Vec<(u32, u32, String)> = Vec::with_capacity(512);
-            let mut pe: PROCESSENTRY32W = std::mem::zeroed();
-            pe.dw_size = std::mem::size_of::<PROCESSENTRY32W>() as u32;
+        autorename_log(&format!("root={} snapshot_entries={}", root_pid, entries.len()));
 
-            if Process32FirstW(snap, &mut pe) != 0 {
-                let name = exe_name_from_entry(&pe);
-                entries.push((pe.th32_process_id, pe.th32_parent_process_id, name));
-                while Process32NextW(snap, &mut pe) != 0 {
-                    let name = exe_name_from_entry(&pe);
-                    entries.push((pe.th32_process_id, pe.th32_parent_process_id, name));
-                }
-            }
-            CloseHandle(snap);
+        // Immediate children of root_pid, skipping system processes.
+        let direct: Vec<(u32, String)> = entries.iter()
+            .filter(|(_, ppid, name)| *ppid == root_pid && !is_system_exe(name))
+            .map(|(pid, _, name)| (*pid, name.clone()))
+            .collect();
 
-            autorename_log(&format!("root={} snapshot_entries={}", root_pid, entries.len()));
+        for (pid, name) in &direct {
+            autorename_log(&format!("  direct_child: pid={} name={}", pid, name));
+        }
 
-            // Immediate children of root_pid, skipping system processes.
-            let direct: Vec<(u32, String)> = entries.iter()
-                .filter(|(_, ppid, name)| *ppid == root_pid && !is_system_exe(name))
+        if direct.is_empty() {
+            autorename_log(&format!("root={} no_direct_children", root_pid));
+            return None;
+        }
+
+        // Pick the immediate child.  When multiple exist, prefer the
+        // largest PID (most recently created).
+        let (mut chosen_pid, chosen_name) = direct.iter()
+            .max_by_key(|(pid, _)| *pid)
+            .map(|(pid, name)| (*pid, name.clone()))
+            .unwrap();
+
+        autorename_log(&format!("root={} immediate_child={} name={}", root_pid, chosen_pid, chosen_name));
+
+        // If the immediate child is a known wrapper (cmd, bash, npx, ...),
+        // look one level deeper for the real program.
+        if is_wrapper_exe(&chosen_name) {
+            let grandchildren: Vec<(u32, String)> = entries.iter()
+                .filter(|(_, ppid, name)| *ppid == chosen_pid && !is_system_exe(name))
                 .map(|(pid, _, name)| (*pid, name.clone()))
                 .collect();
 
-            for (pid, name) in &direct {
-                autorename_log(&format!("  direct_child: pid={} name={}", pid, name));
-            }
-
-            if direct.is_empty() {
-                autorename_log(&format!("root={} no_direct_children", root_pid));
-                return None;
-            }
-
-            // Pick the immediate child.  When multiple exist, prefer the
-            // largest PID (most recently created).
-            let (mut chosen_pid, chosen_name) = direct.iter()
+            if let Some((gc_pid, gc_name)) = grandchildren.iter()
                 .max_by_key(|(pid, _)| *pid)
-                .map(|(pid, name)| (*pid, name.clone()))
-                .unwrap();
+            {
+                autorename_log(&format!(
+                    "root={} wrapper={} skip_to_grandchild={} name={}",
+                    root_pid, chosen_name, gc_pid, gc_name
+                ));
+                chosen_pid = *gc_pid;
+            }
+        }
 
-            autorename_log(&format!("root={} immediate_child={} name={}", root_pid, chosen_pid, chosen_name));
+        autorename_log(&format!("root={} selected={}", root_pid, chosen_pid));
+        Some(chosen_pid)
+    }
 
-            // If the immediate child is a known wrapper (cmd, bash, npx, ...),
-            // look one level deeper for the real program.
-            if is_wrapper_exe(&chosen_name) {
-                let grandchildren: Vec<(u32, String)> = entries.iter()
-                    .filter(|(_, ppid, name)| *ppid == chosen_pid && !is_system_exe(name))
-                    .map(|(pid, _, name)| (*pid, name.clone()))
-                    .collect();
+    /// One `(pid, ppid, lowercased_exe_name)` row per process on the machine.
+    type ProcTable = std::sync::Arc<Vec<(u32, u32, String)>>;
 
-                if let Some((gc_pid, gc_name)) = grandchildren.iter()
-                    .max_by_key(|(pid, _)| *pid)
-                {
-                    autorename_log(&format!(
-                        "root={} wrapper={} skip_to_grandchild={} name={}",
-                        root_pid, chosen_name, gc_pid, gc_name
-                    ));
-                    chosen_pid = *gc_pid;
+    static PROC_TABLE_CACHE: std::sync::LazyLock<
+        std::sync::Mutex<Option<(std::time::Instant, ProcTable)>>,
+    > = std::sync::LazyLock::new(|| std::sync::Mutex::new(None));
+
+    thread_local! {
+        /// Count of REAL `CreateToolhelp32Snapshot` walks performed by THIS
+        /// thread, as opposed to cache hits. The whole point of this module's
+        /// caching is a number that does not scale with the frame rate, so the
+        /// number is made observable rather than inferred from a timing
+        /// measurement, which would be flaky on a loaded machine.
+        ///
+        /// Per-thread rather than global specifically so the tests are not at
+        /// the mercy of the parallel test suite: several other test modules
+        /// reach this code through `#{pane_current_command}` and friends, and a
+        /// global counter would let their walks inflate another test's delta.
+        pub(crate) static PROC_TABLE_WALKS: std::cell::Cell<u64> =
+            const { std::cell::Cell::new(0) };
+    }
+
+    /// Enumerate every process on the machine, with an optional freshness bound.
+    ///
+    /// `CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS)` walks the whole system —
+    /// ~340 processes on a normal desktop — and three separate functions here
+    /// used to do it independently, with their own identical copy of the
+    /// enumeration loop and no caching between them.
+    ///
+    /// That was fine when the callers were rare (a Ctrl+C, a mouse click) and
+    /// catastrophic once `#{pane_current_command}` and `#{pane_current_path}`
+    /// reached it: both are expanded on the server's per-output render path, so
+    /// a status bar or window title referencing them took TWO full snapshots per
+    /// repaint — i.e. per keystroke, on the same thread that delivers keystrokes
+    /// to ConPTY. `window_ops::scroll_foreground_classify` had already hit this
+    /// and worked around it with its own 2s per-pane cache; the format path had
+    /// no such guard.
+    ///
+    /// `max_age` is per-caller on purpose rather than a single global TTL:
+    /// reusing a snapshot changes what a caller can observe, and the paths that
+    /// route Ctrl+C and mouse events are not places to introduce staleness for a
+    /// performance win they do not need. They pass `Duration::ZERO` and always
+    /// enumerate fresh; only the render-path callers opt into reuse.
+    ///
+    /// Returns `None` only when the snapshot itself fails. Failures are never
+    /// cached.
+    fn process_table(max_age: std::time::Duration) -> Option<ProcTable> {
+        if !max_age.is_zero() {
+            // Recover a poisoned lock rather than skipping the cache. The inner
+            // value is only ever a fully-published entry or None (the critical
+            // sections are a single assignment / a clone), so `into_inner` is
+            // safe, and silently disabling the cache for the rest of the process
+            // after some unrelated panic is the outcome worth avoiding. Matches
+            // the recovery the tests use.
+            let guard = PROC_TABLE_CACHE.lock().unwrap_or_else(|e| e.into_inner());
+            if let Some((at, table)) = guard.as_ref() {
+                if at.elapsed() < max_age {
+                    return Some(std::sync::Arc::clone(table));
                 }
             }
-
-            autorename_log(&format!("root={} selected={}", root_pid, chosen_pid));
-            Some(chosen_pid)
         }
+
+        PROC_TABLE_WALKS.with(|c| c.set(c.get() + 1));
+        let entries = unsafe {
+            let snap = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
+            if snap == INVALID_HANDLE || snap == 0 {
+                return None;
+            }
+            let mut entries: Vec<(u32, u32, String)> = Vec::with_capacity(512);
+            let mut pe: PROCESSENTRY32W = std::mem::zeroed();
+            pe.dw_size = std::mem::size_of::<PROCESSENTRY32W>() as u32;
+            if Process32FirstW(snap, &mut pe) != 0 {
+                entries.push((pe.th32_process_id, pe.th32_parent_process_id, exe_name_from_entry(&pe)));
+                while Process32NextW(snap, &mut pe) != 0 {
+                    entries.push((pe.th32_process_id, pe.th32_parent_process_id, exe_name_from_entry(&pe)));
+                }
+            }
+            CloseHandle(snap);
+            entries
+        };
+
+        let table: ProcTable = std::sync::Arc::new(entries);
+        // Publish even for a ZERO-max_age caller: it paid for the walk, so a
+        // later render-path caller may as well reuse it. Recover a poisoned lock
+        // here too (see the read site above) so a panic elsewhere cannot leave
+        // the cache permanently unpopulated.
+        {
+            let mut guard = PROC_TABLE_CACHE.lock().unwrap_or_else(|e| e.into_inner());
+            *guard = Some((std::time::Instant::now(), std::sync::Arc::clone(&table)));
+        }
+        Some(table)
     }
+
+    /// Freshness bound for the render path (`#{pane_current_command}`,
+    /// `#{pane_current_path}`, automatic-rename).
+    ///
+    /// These feed a status bar and a window title, where a fraction of a second
+    /// of lag is invisible, and they are re-expanded on every frame. 250ms caps
+    /// the cost at 4 snapshots/second no matter how fast a pane is drawing,
+    /// while still updating a window title fast enough to look instant.
+    /// automatic-rename separately throttles itself to 1/s per pane, so it is
+    /// unaffected by this bound in practice.
+    const RENDER_PATH_TTL: std::time::Duration = std::time::Duration::from_millis(250);
 
     /// Extract the lowercased executable name from a PROCESSENTRY32W.
     fn exe_name_from_entry(pe: &PROCESSENTRY32W) -> String {
@@ -3120,54 +3232,44 @@ pub mod process_info {
     /// Snapshot the process table and resolve the deepest foreground leaf
     /// under `root_pid`.  Outer `None` = snapshot failed; inner `None` =
     /// root absent from the snapshot (rare race).
+    ///
+    /// Routes through the shared `process_table()` cache like the other walkers
+    /// in this module. Both callers (`foreground_is_shell`,
+    /// `foreground_is_vt_bridge`) run on the Ctrl+C path — real user input, not
+    /// per frame — so this passes `Duration::ZERO` and always enumerates fresh:
+    /// misrouting an interrupt off a stale process tree would be a real bug.
     fn foreground_leaf_name(root_pid: u32) -> Option<Option<String>> {
-        unsafe {
-            let snap = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
-            if snap == INVALID_HANDLE || snap == 0 {
-                return None;
-            }
+        let entries = process_table(std::time::Duration::ZERO)?;
 
-            let mut entries: Vec<(u32, u32, String)> = Vec::with_capacity(512);
-            let mut pe: PROCESSENTRY32W = std::mem::zeroed();
-            pe.dw_size = std::mem::size_of::<PROCESSENTRY32W>() as u32;
-            if Process32FirstW(snap, &mut pe) != 0 {
-                entries.push((pe.th32_process_id, pe.th32_parent_process_id, exe_name_from_entry(&pe)));
-                while Process32NextW(snap, &mut pe) != 0 {
-                    entries.push((pe.th32_process_id, pe.th32_parent_process_id, exe_name_from_entry(&pe)));
+        // Descend to the deepest foreground leaf, skipping system
+        // processes, by following the highest-PID child at each level
+        // (a most-recently-created heuristic).  The iteration guard
+        // prevents pathological loops from PID-reuse cycles in the snapshot.
+        let mut cur = root_pid;
+        let mut leaf_name: Option<String> = None;
+        for _ in 0..64 {
+            let next = entries.iter()
+                .filter(|(pid, ppid, name)| *ppid == cur && *pid != cur && !is_system_exe(name))
+                .max_by_key(|(pid, _, _)| *pid);
+            match next {
+                Some((pid, _, name)) => {
+                    cur = *pid;
+                    leaf_name = Some(name.clone());
                 }
+                None => break,
             }
-            CloseHandle(snap);
-
-            // Descend to the deepest foreground leaf, skipping system
-            // processes, by following the highest-PID child at each level
-            // (a most-recently-created heuristic).  The iteration guard
-            // prevents pathological loops from PID-reuse cycles in the snapshot.
-            let mut cur = root_pid;
-            let mut leaf_name: Option<String> = None;
-            for _ in 0..64 {
-                let next = entries.iter()
-                    .filter(|(pid, ppid, name)| *ppid == cur && *pid != cur && !is_system_exe(name))
-                    .max_by_key(|(pid, _, _)| *pid);
-                match next {
-                    Some((pid, _, name)) => {
-                        cur = *pid;
-                        leaf_name = Some(name.clone());
-                    }
-                    None => break,
-                }
-            }
-
-            // The process whose Ctrl+C behavior matters is the deepest
-            // foreground leaf.  If the root has no children, classify the root
-            // itself — a bare shell prompt resolves to pwsh/cmd (shell), while a
-            // directly-exec'd pane (create_window_raw) resolves to the program
-            // it ran, which may be a live TUI that must NOT be force-signalled.
-            Some(leaf_name.or_else(|| {
-                entries.iter()
-                    .find(|(pid, _, _)| *pid == root_pid)
-                    .map(|(_, _, name)| name.clone())
-            }))
         }
+
+        // The process whose Ctrl+C behavior matters is the deepest
+        // foreground leaf.  If the root has no children, classify the root
+        // itself — a bare shell prompt resolves to pwsh/cmd (shell), while a
+        // directly-exec'd pane (create_window_raw) resolves to the program
+        // it ran, which may be a live TUI that must NOT be force-signalled.
+        Some(leaf_name.or_else(|| {
+            entries.iter()
+                .find(|(pid, _, _)| *pid == root_pid)
+                .map(|(_, _, name)| name.clone())
+        }))
     }
 
     /// Walk the process tree from `root_pid` and check if any descendant
@@ -3175,44 +3277,40 @@ pub mod process_info {
     /// This is used for mouse injection: VT bridge processes need VT mouse
     /// sequences written to the PTY master, not Win32 MOUSE_EVENT records.
     pub fn has_vt_bridge_descendant(root_pid: u32) -> bool {
-        unsafe {
-            let snap = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
-            if snap == INVALID_HANDLE || snap == 0 { return false; }
+        // ZERO max_age, same reasoning as foreground_is_shell: this picks the
+        // mouse-injection transport for a real click, and its callers in
+        // window_ops already keep their own 2s per-pane cache in front of it.
+        let entries = match process_table(std::time::Duration::ZERO) {
+            Some(t) => t,
+            None => return false,
+        };
 
-            let mut entries: Vec<(u32, u32, String)> = Vec::with_capacity(256);
-            let mut pe: PROCESSENTRY32W = std::mem::zeroed();
-            pe.dw_size = std::mem::size_of::<PROCESSENTRY32W>() as u32;
-
-            if Process32FirstW(snap, &mut pe) != 0 {
-                let name = exe_name_from_entry(&pe);
-                entries.push((pe.th32_process_id, pe.th32_parent_process_id, name));
-                while Process32NextW(snap, &mut pe) != 0 {
-                    let name = exe_name_from_entry(&pe);
-                    entries.push((pe.th32_process_id, pe.th32_parent_process_id, name));
-                }
-            }
-            CloseHandle(snap);
-
-            // BFS from root_pid to check all descendants
-            let mut queue: Vec<u32> = vec![root_pid];
-            let mut head = 0;
-            while head < queue.len() {
-                let parent = queue[head];
-                head += 1;
-                for (pid, ppid, name) in &entries {
-                    if *ppid == parent && *pid != root_pid
-                        && !queue.contains(pid)
-                    {
-                        if is_vt_bridge_exe(name) {
-                            return true;
-                        }
-                        queue.push(*pid);
+        // BFS from root_pid to check all descendants
+        let mut queue: Vec<u32> = vec![root_pid];
+        let mut head = 0;
+        while head < queue.len() {
+            let parent = queue[head];
+            head += 1;
+            for (pid, ppid, name) in entries.iter() {
+                if *ppid == parent && *pid != root_pid
+                    && !queue.contains(pid)
+                {
+                    if is_vt_bridge_exe(name) {
+                        return true;
                     }
+                    queue.push(*pid);
                 }
             }
-            false
         }
+        false
     }
+
+    // Path is relative to src/platform/process_info/ — an inline module inside a
+    // file-based module adds a directory level, so this needs one more `..` than
+    // the equivalent declaration in src/server/helpers.rs.
+    #[cfg(test)]
+    #[path = "../../../tests-rs/test_proc_table_cache.rs"]
+    mod tests_proc_table_cache;
 }
 
 #[cfg(not(windows))]

--- a/tests-rs/test_proc_table_cache.rs
+++ b/tests-rs/test_proc_table_cache.rs
@@ -1,0 +1,188 @@
+//! The render path must not walk the whole process table per frame.
+//!
+//! `#{pane_current_command}` and `#{pane_current_path}` resolve a pane's
+//! foreground process, and on Windows that means
+//! `CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS)` — an enumeration of every
+//! process on the machine (~340 on a normal desktop). Both variables are
+//! expanded on the server's per-output render path, so a status bar or window
+//! title referencing them took two full system walks per repaint, on the same
+//! thread that delivers keystrokes to ConPTY.
+//!
+//! These tests assert the property that matters: the number of real walks is
+//! bounded by time, not by how many times the render path asks. They count
+//! actual enumerations via the thread-local `PROC_TABLE_WALKS` rather than
+//! timing anything, so they do not get flaky on a loaded machine.
+//!
+//! Concurrency note: the *cache* is process-wide, and several other test
+//! modules reach it through `#{pane_current_command}`. So a foreign thread can
+//! populate the cache and turn one of our expected walks into a hit — it can
+//! never cause an extra walk on our thread, because the counter is
+//! thread-local. Assertions are written as upper bounds wherever a foreign
+//! cache fill is possible, and as exact counts only where it is not.
+//!
+//! The freshness split is deliberate and is also pinned here: render-path
+//! callers reuse a recent table, while the Ctrl+C and mouse-injection routers
+//! always enumerate fresh, because serving them a stale process tree would
+//! misroute a real keypress or click.
+
+use super::*;
+use std::time::Duration;
+
+/// Serialise this module's own tests: they share the process-wide cache slot
+/// and each starts by invalidating it.
+static CACHE_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+fn lock() -> std::sync::MutexGuard<'static, ()> {
+    CACHE_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner())
+}
+
+fn walks() -> u64 {
+    PROC_TABLE_WALKS.with(|c| c.get())
+}
+
+/// Force the next render-path call to miss the cache, so a test starts from a
+/// known state regardless of what ran before it. Recovers a poisoned lock (same
+/// as `lock()` below) so an earlier panicking test cannot leave a populated
+/// cache behind and make these order-dependent.
+fn invalidate() {
+    let mut g = PROC_TABLE_CACHE.lock().unwrap_or_else(|e| e.into_inner());
+    *g = None;
+}
+
+#[test]
+fn render_path_calls_share_one_walk_within_the_ttl() {
+    let _g = lock();
+    invalidate();
+    let before = walks();
+
+    // 200 expansions, as a fast-drawing pane would produce.
+    for _ in 0..200 {
+        let _ = process_table(RENDER_PATH_TTL);
+    }
+
+    let taken = walks() - before;
+    assert!(
+        taken <= 1,
+        "200 render-path lookups inside one TTL took {} process walks; they \
+         must share at most one — the snapshot cache is not being consulted",
+        taken
+    );
+}
+
+#[test]
+fn pane_current_command_and_path_share_a_walk() {
+    // The concrete pairing from the reported bug: a status-right with
+    // #{pane_current_path} plus a set-titles-string with
+    // #{pane_current_command}, expanded in the same frame, used to cost two
+    // full walks. They must now cost at most one.
+    let _g = lock();
+    invalidate();
+    let before = walks();
+
+    let _ = get_foreground_process_name(std::process::id());
+    let _ = get_foreground_cwd(std::process::id());
+
+    let taken = walks() - before;
+    assert!(
+        taken <= 1,
+        "pane_current_command + pane_current_path in one frame took {} process \
+         walks; they must share one",
+        taken
+    );
+}
+
+#[test]
+fn an_expired_entry_is_re_walked() {
+    // A cache that never expires would pass every other test here and silently
+    // freeze the window title on whatever was running when the pane opened.
+    // A 1ms bound makes a foreign refresh landing inside the window negligible,
+    // so this can assert an exact count.
+    let _g = lock();
+    let short = Duration::from_millis(1);
+    let _ = process_table(Duration::ZERO); // seed a known-fresh entry
+    std::thread::sleep(Duration::from_millis(30));
+
+    let before = walks();
+    let _ = process_table(short);
+    let taken = walks() - before;
+
+    assert_eq!(
+        taken, 1,
+        "an entry older than the freshness bound must be re-walked; took {}",
+        taken
+    );
+}
+
+#[test]
+fn the_render_path_ttl_is_bounded_and_non_zero() {
+    // Zero would silently disable the cache and restore the per-frame walk;
+    // an over-long bound would freeze the window title. Neither is a change
+    // anyone should make without noticing.
+    assert!(
+        !RENDER_PATH_TTL.is_zero(),
+        "RENDER_PATH_TTL of zero disables the cache — that is the bug, restored"
+    );
+    assert!(
+        RENDER_PATH_TTL <= Duration::from_millis(500),
+        "RENDER_PATH_TTL of {:?} is long enough to make the window title look \
+         stuck",
+        RENDER_PATH_TTL
+    );
+}
+
+#[test]
+fn zero_max_age_always_walks() {
+    // Ctrl+C routing (foreground_is_shell) and mouse-transport selection
+    // (has_vt_bridge_descendant) pass Duration::ZERO. They fire on deliberate
+    // user input, not per frame, and must never act on a stale process tree.
+    // A foreign thread cannot suppress these, so the count is exact.
+    let _g = lock();
+    let before = walks();
+
+    for _ in 0..5 {
+        let _ = process_table(Duration::ZERO);
+    }
+
+    let taken = walks() - before;
+    assert_eq!(
+        taken, 5,
+        "Duration::ZERO must bypass the cache every time; got {} walks for 5 \
+         calls — an interrupt or click could be routed off a stale tree",
+        taken
+    );
+}
+
+#[test]
+fn a_fresh_walk_refreshes_the_shared_cache() {
+    // A ZERO-max_age caller still paid for the walk, so a render-path caller
+    // immediately after should reuse it rather than walking again.
+    let _g = lock();
+    let _ = process_table(Duration::ZERO);
+    let before = walks();
+    let _ = process_table(RENDER_PATH_TTL);
+
+    assert_eq!(
+        walks() - before,
+        0,
+        "a render-path lookup right after a fresh walk should reuse it"
+    );
+}
+
+#[test]
+fn the_table_is_plausibly_populated() {
+    // Guard against the caching layer succeeding at returning nothing: every
+    // assertion above would still pass on a permanently empty table.
+    let _g = lock();
+    let table = process_table(Duration::ZERO).expect("process snapshot should succeed");
+    assert!(
+        table.len() > 10,
+        "process table has only {} entries — enumeration is broken, and the \
+         cache tests above would pass anyway",
+        table.len()
+    );
+    let me = std::process::id();
+    assert!(
+        table.iter().any(|(pid, _, _)| *pid == me),
+        "the test process itself should appear in its own process table"
+    );
+}


### PR DESCRIPTION
`#{pane_current_command}` and `#{pane_current_path}` resolve a pane's foreground process, which on Windows means a full
CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS) over every process on the machine (~340 on a normal desktop). Both variables are expanded on the server's per-output render path, so a status bar with `#{pane_current_path}` plus a `set-titles-string` with `#{pane_current_command}` took two full system walks per repaint, on the thread that also delivers keystrokes.

This is a pattern the codebase already agrees with: window_ops's scroll path guards the same calls with a 2s per-pane cache, noting the walk is too expensive to redo per wheel tick. The format path had no equivalent. And the number of independent walkers keeps growing. #491 just added foreground_leaf_name and foreground_is_vt_bridge, so a single Ctrl+C now snapshots the table twice.

Introduce a shared, time-bounded snapshot (`process_table`) and route every walker through it:

- Render-path callers (find_foreground_child_pid) reuse a snapshot up to 250ms old, so a fast-drawing pane pays at most four walks a second instead of one per frame, while a window title still updates fast enough to look instant.
- Input-routing callers: foreground_is_shell / foreground_is_vt_bridge (Ctrl+C) and has_vt_bridge_descendant (mouse transport) pass Duration::ZERO and always enumerate fresh, because acting on a stale process tree would misroute an interrupt or a click. #491's foreground_leaf_name now goes through this too.
- A fresh walk publishes into the shared slot, so a ZERO-age caller warms the cache for a following render-path caller.

Also gate autorename_log behind PSMUX_AUTORENAME_DEBUG. It was the only logger in the tree that was unconditional, doing a file open plus append on this hot path for the first 100 calls of every server; it had left a 700KB file behind.

tests-rs/test_proc_table_cache.rs asserts the property that matters: the number of real walks is bounded by time, not by how many times the render path asks, and that ZERO-age callers always walk. Verified the tests fail when the render TTL is set to zero.