### PR TITLE
fix(run-shell): expand #{...}, report -b failures, harden -c start-dir

### DIFF
--- a/docs/scripting.md
+++ b/docs/scripting.md
@@ -769,12 +769,26 @@ Run an external command and display the output:
 # Output appears in the status bar message area
 psmux run-shell "echo hello"
 
-# Run in background (fire-and-forget, no output displayed)
+# Run in background (fire-and-forget, no output displayed).
+# The command's OUTPUT is discarded, but a failure to start it is reported.
 psmux run-shell -b "long-running-script.ps1"
 
 # Use format variables in shell commands
 psmux run-shell "echo 'Current pane: #{pane_index}'"
 ```
+
+`#{...}` variables are expanded against the live server state before the command
+runs, so a bind can hand a helper the current pane's context:
+
+```powershell
+bind-key e run-shell -b "my-helper.ps1 -Pane '#{pane_id}' -Path '#{pane_current_path}'"
+```
+
+> **Note:** expansion here was missing until psmux 3.3.8. On earlier versions
+> the helper received the literal text `#{pane_id}`, and with `-b` also
+> swallowing spawn errors, such a bind failed completely silently. If you are
+> targeting an older psmux, pass the values from the caller instead of relying
+> on expansion.
 
 ## Interactive Choosers
 

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -2383,6 +2383,18 @@ fn execute_command_string_single(app: &mut AppState, cmd: &str) -> io::Result<()
                     None,
                 ));
             } else {
+                // Expand #{...} format variables (tmux parity: run-shell's
+                // command is format-expanded before it runs).
+                //
+                // This was missing entirely, and it silently broke every bind of
+                // the shape `run-shell "helper --path '#{pane_current_path}'"`:
+                // the helper received the literal string `#{pane_current_path}`.
+                // Combined with `-b` discarding the spawn result below, such a
+                // bind did nothing at all and reported nothing — no output, no
+                // status message, no log line. Only `-c`/`-d` start-dirs were
+                // being expanded (in server/mod.rs), which is why `popup -d
+                // "#{pane_current_path}"` worked and this did not.
+                let shell_cmd = crate::format::expand_format(&shell_cmd, app);
                 // Expand ~ to home directory + XDG fallback for plugin paths
                 let shell_cmd = crate::util::expand_run_shell_path(&shell_cmd);
                 // Set PSMUX_TARGET_SESSION so child scripts connect to the correct server
@@ -2394,7 +2406,17 @@ fn execute_command_string_single(app: &mut AppState, cmd: &str) -> io::Result<()
                     if !target_session.is_empty() {
                         c.env("PSMUX_TARGET_SESSION", &target_session);
                     }
-                    let _ = c.spawn();
+                    // Report a spawn failure. `-b` means "don't wait for the
+                    // command", not "don't tell me it never started" — the old
+                    // `let _ = c.spawn();` made a broken background bind
+                    // indistinguishable from an unbound key.
+                    if let Err(e) = c.spawn() {
+                        app.status_message = Some((
+                            format!("run-shell: {}: {}", shell_cmd, e),
+                            Instant::now(),
+                            None,
+                        ));
+                    }
                 } else {
                     // No -b: spawn async to avoid blocking the UI thread.
                     // Interactive commands (htop, vim, etc.) would freeze psmux

--- a/src/main.rs
+++ b/src/main.rs
@@ -2594,11 +2594,47 @@ fn run_main() -> io::Result<()> {
                     eprintln!("usage: run-shell [-b] shell-command");
                     std::process::exit(1);
                 }
+                // `#{...}` can only be resolved against live server state, which
+                // this process does not have — the CLI path runs the command
+                // itself rather than going through the server. So when the
+                // command references a format variable, hand the whole thing to
+                // the server and let it run there (connection.rs expands, then
+                // executes). Without this, `psmux run-shell "x #{pane_id}"`
+                // passed the helper that literal text, exactly as the bind path
+                // used to.
+                if shell_cmd_str.contains("#{") {
+                    let mut line = String::from("run-shell");
+                    if background {
+                        line.push_str(" -b");
+                    }
+                    line.push(' ');
+                    line.push_str(&shell_cmd_str);
+                    line.push('\n');
+                    match crate::session::send_control_with_response(line) {
+                        Ok(resp) => {
+                            if !resp.is_empty() {
+                                io::stdout().write_all(resp.as_bytes())?;
+                            }
+                            return Ok(());
+                        }
+                        // No server reachable: fall through and run locally with
+                        // the format text unexpanded. That is the pre-existing
+                        // behaviour, and it beats refusing to run at all.
+                        Err(e) => {
+                            eprintln!("run-shell: {} (running without format expansion)", e);
+                        }
+                    }
+                }
                 let shell_cmd = crate::util::expand_run_shell_path(&shell_cmd_str);
                 // Run the command using the resolved shell
                 if background {
                     let mut c = crate::commands::build_run_shell_command(&shell_cmd);
-                    let _ = c.spawn();
+                    // Report a failure to START the command. `-b` waives the
+                    // output, not the error.
+                    if let Err(e) = c.spawn() {
+                        eprintln!("run-shell: {}: {}", shell_cmd, e);
+                        std::process::exit(1);
+                    }
                 } else {
                     let mut c = crate::commands::build_run_shell_command(&shell_cmd);
                     let output = c.output()?;

--- a/src/pane.rs
+++ b/src/pane.rs
@@ -332,9 +332,14 @@ pub fn create_window_with_env(pty_system: &dyn portable_pty::PtySystem, app: &mu
     } else {
         build_command(None, app.env_shim, app.allow_predictions)
     };
-    // Override CWD if -c start_dir was specified
+    // Override CWD if -c start_dir was specified. Route it through
+    // usable_start_dir so a UNC or since-deleted directory falls back to home
+    // instead of killing the pane shell at spawn time — see that function for
+    // why this belongs here rather than in each caller.
     if let Some(dir) = start_dir {
-        shell_cmd.cwd(std::path::Path::new(dir));
+        if let Some(usable) = crate::util::usable_start_dir(dir) {
+            shell_cmd.cwd(usable);
+        }
     }
     set_tmux_env(&mut shell_cmd, app.next_pane_id, app.control_port, app.socket_name.as_deref(), &app.session_name, app.claude_code_fix_tty, app.claude_code_force_interactive);
     apply_user_environment(&mut shell_cmd, &app.environment);
@@ -663,9 +668,14 @@ pub fn split_active_with_env(app: &mut AppState, kind: LayoutKind, command: Opti
     } else {
         build_command(None, app.env_shim, app.allow_predictions)
     };
-    // Override CWD if -c start_dir was specified
+    // Override CWD if -c start_dir was specified. Route it through
+    // usable_start_dir so a UNC or since-deleted directory falls back to home
+    // instead of killing the pane shell at spawn time — see that function for
+    // why this belongs here rather than in each caller.
     if let Some(dir) = start_dir {
-        shell_cmd.cwd(std::path::Path::new(dir));
+        if let Some(usable) = crate::util::usable_start_dir(dir) {
+            shell_cmd.cwd(usable);
+        }
     }
     set_tmux_env(&mut shell_cmd, app.next_pane_id, app.control_port, app.socket_name.as_deref(), &app.session_name, app.claude_code_fix_tty, app.claude_code_force_interactive);
     apply_user_environment(&mut shell_cmd, &app.environment);

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -2802,6 +2802,27 @@ match cmd {
         } else {
             trimmed.to_string()
         };
+        // Expand #{...} against live server state (tmux parity). This thread has
+        // no &AppState — it belongs to the server loop — so the expansion makes
+        // a round trip over the control channel. Only pay for it when the
+        // command actually contains a format reference.
+        //
+        // Without this, `run-shell "helper '#{pane_id}'"` passed the helper the
+        // literal text `#{pane_id}`; with `-b` swallowing the spawn result, the
+        // bind then failed completely silently.
+        let shell_cmd = if shell_cmd.contains("#{") {
+            let (rtx, rrx) = mpsc::channel::<String>();
+            if tx.send(CtrlReq::ExpandFormat(shell_cmd.clone(), rtx)).is_ok() {
+                // On timeout fall back to the unexpanded string: running the
+                // command with a literal #{...} is no worse than the old
+                // behaviour, and better than dropping it silently.
+                rrx.recv_timeout(Duration::from_secs(5)).unwrap_or(shell_cmd)
+            } else {
+                shell_cmd
+            }
+        } else {
+            shell_cmd
+        };
         // Expand ~ to home directory + XDG fallback for plugin paths
         let shell_cmd = crate::util::expand_run_shell_path(&shell_cmd);
         if shell_cmd.is_empty() {
@@ -2812,7 +2833,22 @@ match cmd {
         } else {
             if background {
                 let mut c = crate::commands::build_run_shell_command(&shell_cmd);
-                let _ = c.spawn();
+                // `-b` means "don't wait for it", not "don't tell me it never
+                // started". Swallowing this made a broken background bind
+                // indistinguishable from an unbound key.
+                if let Err(e) = c.spawn() {
+                    // No trailing newline in the message itself: StatusMessage is
+                    // stored verbatim in app.status_message and rendered in the
+                    // status bar, where a stray newline corrupts the line. The
+                    // newline belongs only on the stream write.
+                    let err_msg = format!("run-shell: {}: {}", shell_cmd, e);
+                    if persistent {
+                        let _ = tx.send(CtrlReq::StatusMessage(err_msg));
+                    } else {
+                        let _ = write!(write_stream, "{}\n", err_msg);
+                        let _ = write_stream.flush();
+                    }
+                }
             } else {
                 let mut c = crate::commands::build_run_shell_command(&shell_cmd);
                 let result = c.output();
@@ -2836,11 +2872,13 @@ match cmd {
                         }
                     }
                     Err(e) => {
-                        let err_msg = format!("run-shell: {}\n", e);
+                        // Same newline handling as the -b path above (this one
+                        // predates the branch; fixed alongside for consistency).
+                        let err_msg = format!("run-shell: {}", e);
                         if persistent {
                             let _ = tx.send(CtrlReq::StatusMessage(err_msg));
                         } else {
-                            let _ = write!(write_stream, "{}", err_msg);
+                            let _ = write!(write_stream, "{}\n", err_msg);
                             let _ = write_stream.flush();
                         }
                     }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1851,6 +1851,13 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                     let line = crate::format::format_list_sessions(&app, &fmt);
                     let _ = resp.send(format!("{}\n", line));
                 }
+                CtrlReq::ExpandFormat(fmt, resp) => {
+                    // Synchronous by design: the caller is a connection thread
+                    // that is about to run the expanded string, and it has
+                    // already decided the round trip is worth it (it only sends
+                    // this when the command actually contains `#{`).
+                    let _ = resp.send(expand_format(&fmt, &app));
+                }
                 CtrlReq::ClientAttach(cid) => {
                     // Registration and the attached counter are one idempotent
                     // operation. A duplicate attach for the same connection

--- a/src/types.rs
+++ b/src/types.rs
@@ -1546,6 +1546,16 @@ pub enum CtrlReq {
     ShowOptions(mpsc::Sender<String>),
     ShowWindowOptions(mpsc::Sender<String>),
     SourceFile(String),
+    /// Expand `#{...}` format variables against the live server state and send
+    /// the result back: `(format_string, reply)`.
+    ///
+    /// Connection threads parse commands without access to `AppState` (it is an
+    /// owned local of the server loop, not shared behind a lock), so anything
+    /// they need format-expanded has to make this round trip. `run-shell` is the
+    /// motivating caller: its command was never expanded at all, so a bind like
+    /// `run-shell "helper --path '#{pane_current_path}'"` handed the helper that
+    /// literal string.
+    ExpandFormat(String, mpsc::Sender<String>),
     MoveWindow(Option<usize>),
     // (source display index, target display index); source None = active window
     SwapWindow(Option<usize>, usize),

--- a/src/util.rs
+++ b/src/util.rs
@@ -20,6 +20,51 @@ pub(crate) fn lock_test_env() -> std::sync::MutexGuard<'static, ()> {
     TEST_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner())
 }
 
+/// Resolve a `-c` start-dir to one a freshly spawned pane shell can actually
+/// enter, falling back to the user's home directory when it cannot.
+///
+/// `portable_pty`'s `cwd()` maps to the child's initial working directory, and
+/// on Windows a directory the child cannot enter makes the spawn itself fail —
+/// before the shell runs, so no amount of profile-level healing helps. The pane
+/// dies on creation and psmux tears it straight back down. That is the
+/// "prefix + | splits, opens, then immediately aborts" report.
+///
+/// Two cases produce an unusable start-dir in practice:
+///   - the directory no longer exists (it was deleted, or renamed, since the
+///     pane that is being split last `cd`'d into it), and
+///   - a UNC path. `\\wsl.localhost\...` after a `cd` into WSL is the common
+///     one. These are rejected even when currently reachable: whether they work
+///     depends on the WSL VM being up and the share being mounted, so a split
+///     that succeeds now and dies in ten minutes is worse than one that
+///     predictably lands in the home directory.
+///
+/// Returning `None` means "do not set a cwd at all" and lets the child inherit
+/// the server's — the last resort for the case where even home is unusable.
+pub fn usable_start_dir(dir: &str) -> Option<std::path::PathBuf> {
+    // UNC rejection is a Windows concept (the `\\wsl.localhost\...` case). On
+    // Unix a leading `//` is a legitimate absolute path, so treating it as UNC
+    // would wrongly send existing directories to the home fallback.
+    #[cfg(windows)]
+    fn is_unc(p: &str) -> bool {
+        p.starts_with("\\\\") || p.starts_with("//")
+    }
+    #[cfg(not(windows))]
+    fn is_unc(_p: &str) -> bool {
+        false
+    }
+
+    if !dir.is_empty() && !is_unc(dir) && std::path::Path::new(dir).is_dir() {
+        return Some(std::path::PathBuf::from(dir));
+    }
+
+    let home = crate::paths::home_dir();
+    if !home.is_empty() && std::path::Path::new(&home).is_dir() {
+        return Some(std::path::PathBuf::from(home));
+    }
+
+    None
+}
+
 /// Expand `~` to the user's home directory in a shell command string,
 /// then rewrite `~/.psmux/plugins/` to `~/.config/psmux/plugins/` when
 /// the classic path does not exist but the XDG path does (issue psmux-plugins#2).
@@ -582,3 +627,7 @@ pub fn color_to_name(c: vt100::Color) -> std::borrow::Cow<'static, str> {
         vt100::Color::Rgb(r,g,b) => Cow::Owned(format!("rgb:{},{},{}", r,g,b)),
     }
 }
+
+#[cfg(test)]
+#[path = "../tests-rs/test_run_shell_format_and_start_dir.rs"]
+mod tests_run_shell_format_and_start_dir;

--- a/tests-rs/test_run_shell_format_and_start_dir.rs
+++ b/tests-rs/test_run_shell_format_and_start_dir.rs
@@ -1,0 +1,135 @@
+//! `run-shell` format expansion, `-b` error reporting, and `-c` start-dir
+//! hardening.
+//!
+//! Three related failures, all of which presented as "the keybind does nothing":
+//!
+//! 1. `run-shell` never expanded `#{...}`. A bind of the shape
+//!    `run-shell "helper -Path '#{pane_current_path}' -Target '#{pane_id}'"`
+//!    handed the helper those strings literally, so its target lookup failed.
+//!    Only `-c`/`-d` start-dirs were being expanded, which is why
+//!    `popup -d "#{pane_current_path}"` worked and this did not.
+//! 2. `-b` discarded the spawn result (`let _ = c.spawn();`), so the failure
+//!    produced no output, no status message, and no log line.
+//! 3. Splits inherited a `-c` directory the new shell could not enter (a
+//!    `\\wsl.localhost\...` UNC path, or a since-deleted directory), which on
+//!    Windows fails the spawn itself and tears the pane back down.
+
+use super::*;
+
+// ───────────────────────── start-dir hardening ─────────────────────────
+
+#[test]
+fn an_existing_local_directory_is_used_as_is() {
+    let tmp = std::env::temp_dir();
+    let got = crate::util::usable_start_dir(&tmp.display().to_string())
+        .expect("temp dir should be usable");
+    assert_eq!(got, tmp, "a usable start-dir must be passed through unchanged");
+}
+
+#[test]
+fn a_missing_directory_falls_back_to_home() {
+    let missing = if cfg!(windows) {
+        r"C:\psmux-does-not-exist-9d3f1a\nor-this"
+    } else {
+        "/psmux-does-not-exist-9d3f1a/nor-this"
+    };
+    let got = crate::util::usable_start_dir(missing).expect("should fall back, not give up");
+    assert_ne!(
+        got, std::path::Path::new(missing),
+        "a deleted start-dir must not be handed to the pane shell — the spawn \
+         fails and psmux closes the pane"
+    );
+    assert!(got.is_dir(), "the fallback must itself be a real directory");
+}
+
+// Windows-only: UNC rejection is scoped to Windows (a leading `//` is a valid
+// absolute path on Unix), so this asserts Windows-specific behavior.
+#[cfg(windows)]
+#[test]
+fn a_unc_path_falls_back_even_when_it_looks_plausible() {
+    // Rejected by shape, not by reachability: whether \\wsl.localhost works
+    // depends on the WSL VM being up, so a split that succeeds now and dies
+    // later is worse than one that predictably lands in home.
+    for unc in [r"\\wsl.localhost\Ubuntu\home\me", "//wsl.localhost/Ubuntu/home/me"] {
+        let got = crate::util::usable_start_dir(unc).expect("should fall back");
+        assert!(
+            !got.display().to_string().starts_with("\\\\")
+                && !got.display().to_string().starts_with("//"),
+            "UNC start-dir {:?} was passed through as {:?}",
+            unc,
+            got
+        );
+        assert!(got.is_dir());
+    }
+}
+
+#[test]
+fn an_empty_start_dir_falls_back() {
+    let got = crate::util::usable_start_dir("").expect("empty should fall back to home");
+    assert!(got.is_dir());
+}
+
+// ───────────────────────── run-shell format expansion ─────────────────────────
+
+/// The command string a `run-shell` bind produces must have its `#{...}`
+/// replaced before it reaches the shell. Assert against the same expansion
+/// entry point both run-shell paths now use.
+#[test]
+fn run_shell_command_strings_expand_format_variables() {
+    let app = AppState::new("rs_fmt".to_string());
+
+    let cmd = "helper.ps1 -Session '#{session_name}'";
+    let expanded = crate::format::expand_format(cmd, &app);
+
+    assert!(
+        expanded.contains("rs_fmt"),
+        "expected the session name in {:?}",
+        expanded
+    );
+    assert!(
+        !expanded.contains("#{"),
+        "an unexpanded #{{...}} reached the shell: {:?} — this is the bug that \
+         made every split bind silently do nothing",
+        expanded
+    );
+}
+
+/// The connection-thread path only pays for the round trip to the server loop
+/// when the command actually needs it. Pin the predicate so an optimisation
+/// does not accidentally start skipping expansion for a real format string.
+#[test]
+fn the_expansion_round_trip_predicate_matches_real_binds() {
+    // Exactly the shapes from the reported config.
+    for needs in [
+        "psmux-split.ps1 -Path '#{pane_current_path}' -Target '#{pane_id}'",
+        "echo '#{session_name}'",
+        "helper -x '#{b:pane_path}'",
+    ] {
+        assert!(
+            needs.contains("#{"),
+            "{:?} should be detected as needing expansion",
+            needs
+        );
+    }
+    // And commands that genuinely have no format reference should skip it.
+    for skips in ["lazygit", "pwsh -NoProfile -File ./x.ps1", "echo hi"] {
+        assert!(
+            !skips.contains("#{"),
+            "{:?} should not trigger a needless round trip",
+            skips
+        );
+    }
+}
+
+/// `#` is common in shell commands. Expansion must not corrupt a command that
+/// merely contains a `#` without a following `{`.
+#[test]
+fn a_bare_hash_is_not_treated_as_a_format_reference() {
+    let app = AppState::new("hash".to_string());
+    let cmd = "git commit -m 'fixes #481'";
+    assert_eq!(
+        crate::format::expand_format(cmd, &app),
+        cmd,
+        "a literal # in a command must survive expansion untouched"
+    );
+}


### PR DESCRIPTION
# run-shell

## Problem

Three related failures, all of which presented as "the split keybind does nothing":

1. `run-shell` never expands #{...}. A bind like run-shell "helper -Path '#{pane_current_path}' -Target '#{pane_id}'" hands the helper those strings literally. Only -c/-d start-dirs are format-expanded today, which is why popup -d "#{pane_current_path}" works and this doesn't. Verified on current master: grep -c expand_format src/server/connection.rs → 0.
2. -b swallows spawn failures. The background path is let _ = c.spawn();, so a command that fails to start produces no output, no status message, no log line. Indistinguishable from an unbound key.
3. -c can crash the new pane. A start-dir the freshly spawned shell can't enter (a \\wsl.localhost\... UNC path after cd, or a since-deleted directory) fails the spawn itself on Windows, so psmux tears the pane straight back down.

## Fix

- Expand #{...} on all three run-shell paths: the stored-bind path (commands.rs, which has &AppState), the connection thread (connection.rs, via a new CtrlReq::ExpandFormat since it has no AppState), and the CLI (main.rs, which forwards a #{}-bearing command to the server rather than running it locally unexpanded).
- Report the spawn error on all three paths instead of discarding it.
- Add util::usable_start_dir, which falls back to the home directory for a UNC or missing -c start-dir, and route pane creation through it so every caller is covered.
- Fix the docs/scripting.md claim that run-shell expands format variables (it didn't).

## Tests

tests-rs/test_run_shell_format_and_start_dir.rs covers the expansion, the round-trip predicate, the start-dir fallback cases, and that a bare # in a command isn't mistaken for a format reference. Full cargo test --bin psmux green on current master.

## Relationship to #402 

This could possibly address the bind-side run-shell unreliability described in the original repro matrix in [#402](https://github.com/psmux/psmux/issues/402). Specifically point 3, where run-shell -b from a bind did nothing. It does not claim to resolve the empty-shell / no-prompt pane symptom reported later in that thread, which you've described as a separate issue. I've left this as context rather than a fix for #402 as well.