### PR TITLE
fix(#443): route every capture and copy path through the blank-cell backfill

### DIFF
--- a/src/copy_mode.rs
+++ b/src/copy_mode.rs
@@ -461,34 +461,23 @@ pub fn yank_selection(app: &mut AppState) -> io::Result<()> {
             match sel_mode {
                 crate::types::SelectionMode::Rect => {
                     let c0 = anchor.1.min(pos.1); let c1 = anchor.1.max(pos.1);
-                    let mut line = String::new();
-                    for c in c0..=c1 {
-                        if let Some(cell) = parser.screen().cell(r, c) { line.push_str(&cell.contents().to_string()); } else { line.push(' '); }
-                    }
+                    let line = capture_row_text(parser.screen(), r, c0..c1.saturating_add(1));
                     text.push_str(line.trim_end());
                     if !is_last { text.push('\n'); }
                 }
                 crate::types::SelectionMode::Line => {
-                    let mut line = String::new();
-                    for c in 0..cols {
-                        if let Some(cell) = parser.screen().cell(r, c) { line.push_str(&cell.contents().to_string()); } else { line.push(' '); }
-                    }
+                    let line = capture_row_text(parser.screen(), r, 0..cols);
                     text.push_str(line.trim_end());
                     text.push('\n');
                 }
                 crate::types::SelectionMode::Char => {
                     if total_lines == 1 {
                         let c0 = anchor.1.min(pos.1); let c1 = anchor.1.max(pos.1);
-                        for c in c0..=c1 {
-                            if let Some(cell) = parser.screen().cell(r, c) { text.push_str(&cell.contents().to_string()); } else { text.push(' '); }
-                        }
+                        text.push_str(&capture_row_text(parser.screen(), r, c0..c1.saturating_add(1)));
                     } else {
                         let line_start = if is_first { top_col } else { 0 };
                         let line_end   = if is_last  { bot_col } else { cols.saturating_sub(1) };
-                        let mut line = String::new();
-                        for c in line_start..=line_end {
-                            if let Some(cell) = parser.screen().cell(r, c) { line.push_str(&cell.contents().to_string()); } else { line.push(' '); }
-                        }
+                        let line = capture_row_text(parser.screen(), r, line_start..line_end.saturating_add(1));
                         text.push_str(line.trim_end());
                         if !is_last { text.push('\n'); }
                     }
@@ -575,9 +564,7 @@ pub fn capture_active_pane(app: &mut AppState) -> io::Result<()> {
     let screen = parser.screen();
     let mut text = String::new();
     for r in 0..p.last_rows {
-        let mut row = String::new();
-        for c in 0..p.last_cols { if let Some(cell) = screen.cell(r, c) { row.push_str(&cell.contents().to_string()); } else { row.push(' '); } }
-        text.push_str(row.trim_end());
+        text.push_str(capture_row_text(screen, r, 0..p.last_cols).trim_end());
         text.push('\n');
     }
     app.paste_buffers.insert(0, text);
@@ -603,6 +590,21 @@ fn push_capture_cell(row: &mut String, cell: Option<&vt100::Cell>) {
     }
 }
 
+/// Serialize grid columns `cols` of `row` with `push_capture_cell` semantics.
+///
+/// Every path that turns grid cells back into user-visible text routes through
+/// here so the blank-cell backfill and wide-glyph handling of issue #443 stay
+/// consistent across `capture-pane` and the copy-mode yanks. Callers that only
+/// need a trimmed line should `trim_end()` the result themselves, since the
+/// range variants of `capture-pane` deliberately keep their padding.
+fn capture_row_text(screen: &vt100::Screen, row: u16, cols: std::ops::Range<u16>) -> String {
+    let mut out = String::with_capacity(cols.len());
+    for c in cols {
+        push_capture_cell(&mut out, screen.cell(row, c));
+    }
+    out
+}
+
 pub fn capture_active_pane_text(app: &mut AppState) -> io::Result<Option<String>> {
     let win = &mut app.windows[app.active_idx];
     let p = match active_pane_mut(&mut win.root, &win.active_path) { Some(p) => p, None => return Ok(None) };
@@ -610,9 +612,7 @@ pub fn capture_active_pane_text(app: &mut AppState) -> io::Result<Option<String>
     let screen = parser.screen();
     let mut text = String::new();
     for r in 0..p.last_rows {
-        let mut row = String::new();
-        for c in 0..p.last_cols { push_capture_cell(&mut row, screen.cell(r, c)); }
-        text.push_str(row.trim_end());
+        text.push_str(capture_row_text(screen, r, 0..p.last_cols).trim_end());
         text.push('\n');
     }
     // Trim trailing all-empty lines so iTerm2 doesn't advance its cursor
@@ -925,11 +925,7 @@ pub fn copy_end_of_line(app: &mut AppState) -> io::Result<()> {
     let parser = match p.term.lock() { Ok(g) => g, Err(_) => return Ok(()) };
     let screen = parser.screen();
     let cols = p.last_cols;
-    let mut text = String::new();
-    for col in c..cols {
-        if let Some(cell) = screen.cell(r, col) { text.push_str(&cell.contents().to_string()); } else { text.push(' '); }
-    }
-    let text = text.trim_end().to_string();
+    let text = capture_row_text(screen, r, c..cols).trim_end().to_string();
     app.paste_buffers.insert(0, text.clone());
     if app.paste_buffers.len() > 10 { app.paste_buffers.pop(); }
     copy_to_system_clipboard(&text);
@@ -987,9 +983,7 @@ pub fn capture_active_pane_range(app: &mut AppState, s: Option<i32>, e: Option<i
         let screen = parser.screen();
         let mut text = String::new();
         for r in start..=end {
-            let mut row = String::new();
-            for c in 0..cols { push_capture_cell(&mut row, screen.cell(r, c)); }
-            text.push_str(row.trim_end());
+            text.push_str(capture_row_text(screen, r, 0..cols).trim_end());
             text.push('\n');
         }
         // An explicit range (-S/-E) is honored line for line, matching tmux:
@@ -1044,11 +1038,7 @@ pub fn capture_active_pane_range(app: &mut AppState, s: Option<i32>, e: Option<i
 
         for aline in read_start..=read_end {
             let r = (aline + actual_sb) as u16;
-            let mut row = String::new();
-            for c in 0..cols {
-                push_capture_cell(&mut row, parser.screen().cell(r, c));
-            }
-            text.push_str(row.trim_end());
+            text.push_str(capture_row_text(parser.screen(), r, 0..cols).trim_end());
             text.push('\n');
         }
         next_abs = read_end + 1;
@@ -1640,3 +1630,7 @@ pub fn select_a_word_big(app: &mut AppState) {
     }
     app.copy_selection_mode = crate::types::SelectionMode::Char;
 }
+
+#[cfg(test)]
+#[path = "../tests-rs/test_issue443_blank_cell_capture.rs"]
+mod tests_issue443_blank_cell_capture;

--- a/tests-rs/test_issue443_blank_cell_capture.rs
+++ b/tests-rs/test_issue443_blank_cell_capture.rs
@@ -1,0 +1,349 @@
+// Issue #443 (follow-up): a never-written grid cell must serialize as a space
+// on EVERY capture/copy path, not just the three `capture-pane` paths fixed in
+// de119a0.
+//
+// Root cause recap: `vt100::Cell::contents()` returns "" for a cell the cursor
+// merely skipped over (CUF `ESC[nC`, CHA `ESC[nG`, HPA, tabs, ...). A serializer
+// that pushes `contents()` verbatim therefore contributes nothing for that cell
+// and the on-screen gap closes up, fusing adjacent words. `push_capture_cell`
+// backfills a space for those cells and skips the trailing half of a wide glyph
+// so no phantom column appears after CJK.
+//
+// de119a0 routed only `capture_active_pane_text` (`-p`), `capture_active_pane_range`
+// and `capture_active_pane_styled` (`-e`) through that helper. These paths were
+// left on the old inline `push_str(cell.contents())` and still collapse:
+//
+//   * `capture_active_pane`    — `capture-pane` / `capturep` with no `-p`,
+//                                i.e. capture into a paste buffer. Same command
+//                                as the issue title, just the buffer variant.
+//   * `yank_selection`         — copy-mode yank (`y`, `M-w`, mouse drag release)
+//                                in all three selection modes.
+//   * `copy_end_of_line`       — copy-mode `D`.
+//
+// These tests drive the REAL functions over a real PTY-backed pane tree (no
+// psmux server and no session is created), feeding VT bytes straight into the
+// pane parser. Registered from src/copy_mode.rs.
+
+use super::*;
+
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicU8};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use crate::types::{Node, SelectionMode};
+
+const ROWS: u16 = 6;
+const COLS: u16 = 40;
+
+// "CUFA" then a 4-column cursor-forward, then "CUFB" — the issue's payload.
+const CUF_PAYLOAD: &[u8] = b"CUFA\x1b[4CCUFB\x1b[4CCUFC";
+const CUF_EXPECTED: &str = "CUFA    CUFB    CUFC";
+
+fn make_pane(id: usize, rows: u16, cols: u16) -> crate::types::Pane {
+    let pty = portable_pty::native_pty_system();
+    let pair = pty
+        .openpty(portable_pty::PtySize { rows, cols, pixel_width: 0, pixel_height: 0 })
+        .expect("openpty");
+    let mut cmd = portable_pty::CommandBuilder::new("cmd.exe");
+    cmd.arg("/c");
+    cmd.arg("exit");
+    let child = pair.slave.spawn_command(cmd).expect("spawn dummy");
+    let writer = pair.master.take_writer().expect("writer");
+    let term = Arc::new(Mutex::new(vt100::Parser::new(rows, cols, 0)));
+    let epoch = Instant::now() - Duration::from_secs(2);
+    crate::types::Pane {
+        master: pair.master,
+        writer,
+        child,
+        term,
+        last_rows: rows,
+        last_cols: cols,
+        id,
+        title: format!("pane{id}"),
+        title_locked: false,
+        child_pid: None,
+        data_version: Arc::new(AtomicU64::new(0)),
+        last_title_check: epoch,
+        last_infer_title: epoch,
+        dead: false,
+        last_text_input: None,
+        last_special_key: None,
+        vt_bridge_cache: None,
+        vti_mode_cache: None,
+        mouse_input_cache: None,
+        scroll_fg_cache: None,
+        cursor_shape: Arc::new(AtomicU8::new(0)),
+        bell_pending: Arc::new(AtomicBool::new(false)),
+        cpr_pending: Arc::new(AtomicBool::new(false)),
+        color_query_pending: Arc::new(std::sync::atomic::AtomicU32::new(0)),
+        copy_state: None,
+        pane_style: None,
+        squelch_until: None,
+        output_ring: Arc::new(Mutex::new(std::collections::VecDeque::new())),
+        spawned_at: None,
+    }
+}
+
+fn make_window(id: usize) -> crate::types::Window {
+    crate::types::Window {
+        root: Node::Split { kind: crate::types::LayoutKind::Horizontal, sizes: vec![], children: vec![] },
+        active_path: vec![],
+        name: "w".to_string(),
+        id,
+        activity_flag: false,
+        bell_flag: false,
+        silence_flag: false,
+        last_output_time: Instant::now(),
+        last_seen_version: 0,
+        manual_rename: false,
+        layout_index: 0,
+        pane_mru: vec![],
+        zoom_saved: None,
+        linked_from: None,
+        floating: Vec::new(),
+        floating_focus: None,
+    }
+}
+
+/// One window, one pane (root is the leaf so `active_path` stays empty), with
+/// `bytes` already fed through the pane's vt100 parser.
+fn app_showing(bytes: &[u8]) -> AppState {
+    let mut app = AppState::new("issue443".to_string());
+    app.window_base_index = 0;
+    app.pane_base_index = 0;
+    // Never shell out on yank; keeps the test hermetic.
+    app.copy_command = String::new();
+    app.set_clipboard = "off".to_string();
+    let pane = make_pane(0, ROWS, COLS);
+    pane.term.lock().expect("parser lock").process(bytes);
+    let mut win = make_window(0);
+    win.root = Node::Leaf(pane);
+    win.active_path = vec![];
+    app.windows.push(win);
+    app.active_idx = 0;
+    app
+}
+
+fn first_line(text: &str) -> String {
+    text.lines().next().unwrap_or_default().to_string()
+}
+
+fn newest_buffer(app: &AppState) -> String {
+    app.paste_buffers.first().cloned().unwrap_or_default()
+}
+
+/// The Win32 clipboard is a single process-global resource, and reading it
+/// (`GlobalLock` on the clipboard-owned handle) while another thread replaces
+/// it (`EmptyClipboard` frees that same handle) is a use-after-free. `cargo
+/// test` runs these in parallel, so every test that reaches
+/// `copy_to_system_clipboard` (`yank_selection`, `copy_end_of_line`) takes this
+/// lock first.
+static CLIPBOARD_LOCK: Mutex<()> = Mutex::new(());
+
+/// Serializes clipboard access for the duration of a test and puts the user's
+/// previous clipboard contents back afterwards, so running the suite locally
+/// does not silently clobber it.
+struct ClipboardGuard {
+    _lock: std::sync::MutexGuard<'static, ()>,
+    prev: Option<String>,
+}
+
+impl ClipboardGuard {
+    fn new() -> Self {
+        // A panicking test must not poison the lock for the rest of the suite.
+        let lock = CLIPBOARD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let prev = crate::clipboard::read_from_system_clipboard();
+        ClipboardGuard { _lock: lock, prev }
+    }
+}
+
+impl Drop for ClipboardGuard {
+    fn drop(&mut self) {
+        if let Some(prev) = self.prev.take() {
+            crate::clipboard::copy_to_system_clipboard(&prev);
+        }
+    }
+}
+
+fn select_all_of_row0(app: &mut AppState, mode: SelectionMode, last_col: u16) {
+    app.copy_anchor = Some((0, 0));
+    app.copy_pos = Some((0, last_col));
+    app.copy_selection_mode = mode;
+    app.copy_anchor_scroll_offset = 0;
+    app.copy_scroll_offset = 0;
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// push_capture_cell / capture_row_text: the shared serialization contract
+// ════════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn capture_row_text_backfills_cursor_skipped_cells() {
+    let mut parser = vt100::Parser::new(ROWS, COLS, 0);
+    parser.process(CUF_PAYLOAD);
+    let got = capture_row_text(parser.screen(), 0, 0..COLS);
+    assert_eq!(
+        got.trim_end(),
+        CUF_EXPECTED,
+        "cells skipped by CUF must serialize as spaces, not vanish"
+    );
+}
+
+#[test]
+fn capture_row_text_backfills_absolute_column_moves() {
+    let mut parser = vt100::Parser::new(ROWS, COLS, 0);
+    parser.process(b"CHAA\x1b[10GCHAB\x1b[20GCHAC");
+    let got = capture_row_text(parser.screen(), 0, 0..COLS);
+    assert_eq!(got.trim_end(), "CHAA     CHAB      CHAC", "CHA gaps must survive");
+}
+
+#[test]
+fn capture_row_text_leaves_no_phantom_column_after_wide_glyphs() {
+    let mut parser = vt100::Parser::new(ROWS, COLS, 0);
+    parser.process("WIDE:\u{4E2D}\u{6587}:END".as_bytes());
+    let got = capture_row_text(parser.screen(), 0, 0..COLS);
+    assert_eq!(
+        got.trim_end(),
+        "WIDE:\u{4E2D}\u{6587}:END",
+        "the trailing half of a wide glyph must not become a space"
+    );
+}
+
+#[test]
+fn capture_row_text_preserves_literal_spaces() {
+    let mut parser = vt100::Parser::new(ROWS, COLS, 0);
+    parser.process(b"SPCA    SPCB");
+    let got = capture_row_text(parser.screen(), 0, 0..COLS);
+    assert_eq!(got.trim_end(), "SPCA    SPCB", "written spaces are unaffected");
+}
+
+#[test]
+fn capture_row_text_honors_a_sub_range() {
+    let mut parser = vt100::Parser::new(ROWS, COLS, 0);
+    parser.process(CUF_PAYLOAD);
+    // Columns 0..12 cover "CUFA    CUFB" exactly.
+    let got = capture_row_text(parser.screen(), 0, 0..12);
+    assert_eq!(got, "CUFA    CUFB", "sub-range capture keeps interior gaps");
+}
+
+#[test]
+fn capture_row_text_on_an_untouched_row_is_all_spaces() {
+    let parser = vt100::Parser::new(ROWS, COLS, 0);
+    let got = capture_row_text(parser.screen(), 3, 0..COLS);
+    assert_eq!(got.len(), COLS as usize, "blank row yields one space per column");
+    assert!(got.chars().all(|c| c == ' '), "blank row is all spaces, got {got:?}");
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// capture_active_pane — `capture-pane` with no `-p` (into a paste buffer)
+// ════════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn capture_pane_into_buffer_keeps_cuf_gaps() {
+    let mut app = app_showing(CUF_PAYLOAD);
+    capture_active_pane(&mut app).expect("capture");
+    assert_eq!(
+        first_line(&newest_buffer(&app)),
+        CUF_EXPECTED,
+        "`capture-pane` (buffer variant) collapsed the CUF gaps"
+    );
+}
+
+#[test]
+fn capture_pane_into_buffer_keeps_no_phantom_column_after_wide_glyphs() {
+    let mut app = app_showing("WIDE:\u{4E2D}\u{6587}:END".as_bytes());
+    capture_active_pane(&mut app).expect("capture");
+    assert_eq!(
+        first_line(&newest_buffer(&app)),
+        "WIDE:\u{4E2D}\u{6587}:END",
+        "`capture-pane` (buffer variant) inserted a phantom column after a wide glyph"
+    );
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// yank_selection — copy-mode `y` / `M-w` / mouse drag, all selection modes
+// ════════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn yank_line_selection_keeps_cuf_gaps() {
+    let _clip = ClipboardGuard::new();
+    let mut app = app_showing(CUF_PAYLOAD);
+    select_all_of_row0(&mut app, SelectionMode::Line, COLS - 1);
+    yank_selection(&mut app).expect("yank");
+    assert_eq!(
+        first_line(&newest_buffer(&app)),
+        CUF_EXPECTED,
+        "line-mode yank collapsed the CUF gaps"
+    );
+}
+
+#[test]
+fn yank_char_selection_keeps_cuf_gaps() {
+    let _clip = ClipboardGuard::new();
+    let mut app = app_showing(CUF_PAYLOAD);
+    // Single-line char selection covering exactly "CUFA    CUFB".
+    select_all_of_row0(&mut app, SelectionMode::Char, 11);
+    yank_selection(&mut app).expect("yank");
+    assert_eq!(
+        newest_buffer(&app),
+        "CUFA    CUFB",
+        "char-mode yank collapsed the CUF gaps"
+    );
+}
+
+#[test]
+fn yank_rect_selection_keeps_cuf_gaps() {
+    let _clip = ClipboardGuard::new();
+    let mut app = app_showing(CUF_PAYLOAD);
+    select_all_of_row0(&mut app, SelectionMode::Rect, COLS - 1);
+    yank_selection(&mut app).expect("yank");
+    assert_eq!(
+        first_line(&newest_buffer(&app)),
+        CUF_EXPECTED,
+        "rect-mode yank collapsed the CUF gaps"
+    );
+}
+
+#[test]
+fn yank_selection_leaves_no_phantom_column_after_wide_glyphs() {
+    let _clip = ClipboardGuard::new();
+    let mut app = app_showing("WIDE:\u{4E2D}\u{6587}:END".as_bytes());
+    select_all_of_row0(&mut app, SelectionMode::Line, COLS - 1);
+    yank_selection(&mut app).expect("yank");
+    assert_eq!(
+        first_line(&newest_buffer(&app)),
+        "WIDE:\u{4E2D}\u{6587}:END",
+        "line-mode yank inserted a phantom column after a wide glyph"
+    );
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// copy_end_of_line — copy-mode `D`
+// ════════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn copy_end_of_line_keeps_cuf_gaps() {
+    let _clip = ClipboardGuard::new();
+    let mut app = app_showing(CUF_PAYLOAD);
+    app.copy_pos = Some((0, 0));
+    copy_end_of_line(&mut app).expect("copy to eol");
+    assert_eq!(
+        newest_buffer(&app),
+        CUF_EXPECTED,
+        "copy-to-end-of-line collapsed the CUF gaps"
+    );
+}
+
+#[test]
+fn copy_end_of_line_from_midline_keeps_cuf_gaps() {
+    let _clip = ClipboardGuard::new();
+    let mut app = app_showing(CUF_PAYLOAD);
+    // Start inside the first gap: columns 6.. are "  CUFB    CUFC".
+    app.copy_pos = Some((0, 6));
+    copy_end_of_line(&mut app).expect("copy to eol");
+    assert_eq!(
+        newest_buffer(&app),
+        "  CUFB    CUFC",
+        "copy-to-end-of-line dropped leading skipped cells"
+    );
+}

--- a/tests/test_issue443_cuf_capture.ps1
+++ b/tests/test_issue443_cuf_capture.ps1
@@ -1,54 +1,164 @@
-# Issue #443: capture-pane -p drops cells skipped by cursor-forward (CUF, ESC[nC),
-# collapsing words. Root cause: a never-written grid cell reports empty contents(),
-# so the capture serializer emitted nothing for it instead of a space. Fixed in
-# src/copy_mode.rs (push_capture_cell) for the -p, range, and -e (styled) paths.
+# Issue #443: cells skipped by a cursor advance must survive capture.
 #
-# The payload is emitted from a script file (tests/payload_issue443_cuf.ps1) rather
-# than through send-keys, because send-keys collapses interior whitespace in its
-# argument and would confound the capture assertions.
+# Root cause: a never-written grid cell reports empty contents(), so a
+# serializer that pushes contents() verbatim emitted nothing for it and the
+# on-screen gap closed up, fusing adjacent words. The boundary is written vs
+# never-written cells, not CUF vs CHA: literal spaces survive because they
+# materialize a real cell, and BOTH ESC[nC (CUF) and ESC[nG (CHA) leave the
+# skipped cells empty.
+#
+# src/copy_mode.rs::push_capture_cell backfills a space for every in-bounds
+# blank cell and skips the trailing half of a wide glyph (otherwise every
+# CJK/wide character would gain a phantom column). capture_row_text applies
+# that to a column range, and every capture/copy path routes through it:
+#   -p / ranged / -e   ... capture-pane text paths
+#   capture-pane       ... no -p, i.e. capture into a paste buffer
+#   copy-mode yank     ... Char/Line/Rect, and D (copy to end of line)
+#
+# The copy-mode yank paths need TUI key input, so they are covered by the Rust
+# tests in tests-rs/test_issue443_blank_cell_capture.rs (registered from
+# src/copy_mode.rs). This script covers the CLI-reachable capture paths.
+#
+# The payload is emitted from a script file (tests/payload_issue443_cuf.ps1)
+# rather than through send-keys, because send-keys collapses interior
+# whitespace in its argument and would confound the capture assertions.
+#
+# Isolation (AGENTS.md): runs under New-PsmuxTestEnv, which redirects
+# USERPROFILE/HOME to a throwaway dir and scrubs inherited PSMUX_*/TMUX vars,
+# plus a dedicated -L namespace. It therefore cannot see, disturb, or kill a
+# psmux session the user is running for real.
 
-$ErrorActionPreference = "Continue"
-$PSMUX = (Get-Command psmux).Source
-$S = "test_issue443"
-$payload = Join-Path $PSScriptRoot "payload_issue443_cuf.ps1"
+$ErrorActionPreference = "Stop"
 
-& $PSMUX kill-session -t $S 2>&1 | Out-Null
-Start-Sleep -Milliseconds 500
-& $PSMUX new-session -d -s $S -x 80 -y 24
-Start-Sleep -Seconds 3
-& $PSMUX send-keys -t $S 'clear' Enter
-Start-Sleep -Seconds 1
-& $PSMUX send-keys -t $S "chcp 65001 > `$null; [Console]::OutputEncoding=[Text.Encoding]::UTF8; powershell -NoProfile -ExecutionPolicy Bypass -File `"$payload`"" Enter
-Start-Sleep -Seconds 3
-
-$pass = 0; $fail = 0
-function Check($name,$got,$want){
-  if ($got -ceq $want) { Write-Host ("[PASS] {0}" -f $name) -ForegroundColor Green; $script:pass++ }
-  else { Write-Host ("[FAIL] {0}: got=[{1}] want=[{2}]" -f $name, ($got -replace ' ','.'), ($want -replace ' ','.')) -ForegroundColor Red; $script:fail++ }
+# ---------------------------------------------------------------------------
+# SAFETY GATE — please read before removing.
+#
+# This script starts a real server, so it is NOT safe on a machine running
+# psmux sessions you care about, and New-PsmuxTestEnv does not make it safe:
+#
+#   main.rs:223 calls reap_orphaned_servers() on EVERY psmux invocation,
+#   BEFORE -L is parsed. reap_orphaned_servers_in() bails out only when the
+#   data dir does NOT exist (the #474 guard). New-PsmuxTestEnv *creates* an
+#   empty .psmux under the throwaway home, so the guard passes with an empty
+#   registry. The reaper then enumerates loopback listeners MACHINE-WIDE
+#   (GetExtendedTcpTable), keeps every process whose image is psmux/tmux/pmux,
+#   and terminates each one older than ORPHAN_REAP_MIN_AGE that the empty
+#   registry does not account for — i.e. every psmux server on the box, in
+#   every namespace. -L cannot help: it is parsed after the reaper has run.
+#
+# Until that guard also covers "dir exists but registry is empty", this runs
+# only where terminating every server on the box is harmless: a CI runner
+# (detected automatically) or an explicit opt-in for a disposable Windows
+# account or VM:
+#
+#   $env:PSMUX_ALLOW_DESTRUCTIVE_TESTS = '1'
+#
+# CI is auto-detected on purpose. Requiring the opt-in there would make the
+# nightly integration suite skip this script and report a green pass for a test
+# that never ran, which is worse than not having it.
+#
+# The CUF/CHA/wide-glyph serialization contract this script exercises is also
+# covered, with no server at all, by the Rust tests in
+# tests-rs/test_issue443_blank_cell_capture.rs (run: cargo test --bin psmux
+# tests_issue443). Prefer those for local verification.
+# ---------------------------------------------------------------------------
+$isDisposable = $env:PSMUX_ALLOW_DESTRUCTIVE_TESTS -or $env:CI -or $env:GITHUB_ACTIONS
+if (-not $isDisposable) {
+    Write-Host "[SKIP] test_issue443_cuf_capture: starts a real server; psmux's orphan reaper" -ForegroundColor Yellow
+    Write-Host "       would terminate every psmux server on this machine (see header)." -ForegroundColor Yellow
+    Write-Host "       Set PSMUX_ALLOW_DESTRUCTIVE_TESTS=1 in a disposable environment to run it." -ForegroundColor Yellow
+    Write-Host "       Server-free coverage: cargo test --bin psmux tests_issue443" -ForegroundColor Yellow
+    exit 0
 }
 
-# Plain -p
-$cap = & $PSMUX capture-pane -t $S -p
-$g=@{}; $cap | ForEach-Object { if($_ -match "^SPCA"){$g.SPC=$_}elseif($_ -match "^CUFA"){$g.CUF=$_}elseif($_ -match "^CHAA"){$g.CHA=$_}elseif($_ -match "^WIDE:"){$g.WIDE=$_} }
-Write-Host "--- capture-pane -p ---"
-Check "CUF gaps (4 spaces each)" $g.CUF "CUFA    CUFB    CUFC    CUFD"
-Check "CHA gaps (5 then 6 spaces)" $g.CHA "CHAA     CHAB      CHAC"
-Check "literal spaces intact" $g.SPC "SPCA    SPCB    SPCC"
+. "$PSScriptRoot\psmux_test_helpers.ps1"
 
-# Wide/CJK regression guard (issue #441): the two CJK glyphs must sit adjacent
-# with NO phantom space between or around them. Assert via space-free structure
-# rather than a literal CJK string, since the outer console may not encode CJK
-# (it would ?-substitute the expected literal and give a false failure).
-$wideNoSpace = ($g.WIDE -notmatch ' ') -and ($g.WIDE.StartsWith("WIDE:")) -and ($g.WIDE.EndsWith(":END"))
-if ($wideNoSpace) { Write-Host "[PASS] wide/CJK no phantom spaces (#441 guard)" -ForegroundColor Green; $pass++ }
-else { Write-Host ("[FAIL] wide/CJK: got=[{0}]" -f ($g.WIDE -replace ' ','.')) -ForegroundColor Red; $fail++ }
+$ctx = New-PsmuxTestEnv -Tag 'i443'
+$PSMUX = $ctx.PsmuxExe
+$ns = Register-PsmuxNamespace -Ctx $ctx -Namespace "i443"
+$S = "i443"
+$payload = Join-Path $PSScriptRoot "payload_issue443_cuf.ps1"
 
-# Styled -e : strip SGR, verify structural spacing on the CUF line is preserved too
-$cape = & $PSMUX capture-pane -t $S -p -e
-$cufe = ($cape | Where-Object { $_ -match "CUFA" }) -replace "$([char]27)\[[0-9;]*m",""
-Write-Host "--- capture-pane -e (SGR-stripped) ---"
-Check "CUF gaps preserved in -e" $cufe "CUFA    CUFB    CUFC    CUFD"
+$pass = 0; $fail = 0
+function Check($name, $got, $want) {
+    if ($got -ceq $want) {
+        Write-Host ("  [PASS] {0}" -f $name) -ForegroundColor Green; $script:pass++
+    } else {
+        Write-Host ("  [FAIL] {0}: got=[{1}] want=[{2}]" -f $name, ($got -replace ' ', '.'), ($want -replace ' ', '.')) -ForegroundColor Red
+        $script:fail++
+    }
+}
 
-Write-Host "`nRESULT: PASS=$pass FAIL=$fail"
-& $PSMUX kill-session -t $S 2>&1 | Out-Null
+Write-Host ""
+Write-Host "=== #443 capture keeps cursor-skipped cells ===" -ForegroundColor Cyan
+Write-Host "  psmux: $PSMUX  namespace: $ns" -ForegroundColor DarkGray
+
+try {
+    & $PSMUX -L $ns new-session -d -s $S -x 80 -y 24 2>&1 | Out-Null
+    Start-Sleep -Seconds 3
+    & $PSMUX -L $ns send-keys -t $S 'clear' Enter 2>&1 | Out-Null
+    Start-Sleep -Seconds 1
+    & $PSMUX -L $ns send-keys -t $S "chcp 65001 > `$null; [Console]::OutputEncoding=[Text.Encoding]::UTF8; powershell -NoProfile -ExecutionPolicy Bypass -File `"$payload`"" Enter 2>&1 | Out-Null
+    Start-Sleep -Seconds 3
+
+    # Index the captured lines by their leading marker.
+    function Index-Lines($lines) {
+        $g = @{}
+        $lines | ForEach-Object {
+            if ($_ -match "^SPCA") { $g.SPC = $_ }
+            elseif ($_ -match "^CUFA") { $g.CUF = $_ }
+            elseif ($_ -match "^CHAA") { $g.CHA = $_ }
+            elseif ($_ -match "^WIDE:") { $g.WIDE = $_ }
+        }
+        return $g
+    }
+
+    # --- capture-pane -p (text path) ---
+    Write-Host "  --- capture-pane -p ---" -ForegroundColor DarkGray
+    $g = Index-Lines (& $PSMUX -L $ns capture-pane -t $S -p)
+    Check "CUF gaps (4 spaces each)"    $g.CUF "CUFA    CUFB    CUFC    CUFD"
+    Check "CHA gaps (5 then 6 spaces)"  $g.CHA "CHAA     CHAB      CHAC"
+    Check "literal spaces intact"       $g.SPC "SPCA    SPCB    SPCC"
+
+    # Wide/CJK regression guard (issue #441): the two CJK glyphs must sit
+    # adjacent with NO phantom space between or around them. Assert via
+    # space-free structure rather than a literal CJK string, since the outer
+    # console may not encode CJK (it would ?-substitute the expected literal
+    # and give a false failure).
+    $wideOk = ($g.WIDE -notmatch ' ') -and $g.WIDE.StartsWith("WIDE:") -and $g.WIDE.EndsWith(":END")
+    if ($wideOk) { Write-Host "  [PASS] wide/CJK no phantom spaces (#441 guard)" -ForegroundColor Green; $pass++ }
+    else { Write-Host ("  [FAIL] wide/CJK: got=[{0}]" -f ($g.WIDE -replace ' ', '.')) -ForegroundColor Red; $fail++ }
+
+    # --- capture-pane -e (styled path) ---
+    Write-Host "  --- capture-pane -p -e (SGR-stripped) ---" -ForegroundColor DarkGray
+    $cufe = ((& $PSMUX -L $ns capture-pane -t $S -p -e) | Where-Object { $_ -match "CUFA" }) -replace "$([char]27)\[[0-9;]*m", ""
+    Check "CUF gaps preserved in -e" $cufe "CUFA    CUFB    CUFC    CUFD"
+
+    # --- capture-pane with NO -p: capture into a paste buffer ---
+    # Same command, buffer variant. This path kept the old inline serializer
+    # and still collapsed the gaps; save-buffer is the CLI way to read it back.
+    Write-Host "  --- capture-pane (no -p) + save-buffer ---" -ForegroundColor DarkGray
+    $bufFile = Join-Path $ctx.Home "i443_buffer.txt"
+    & $PSMUX -L $ns capture-pane -t $S 2>&1 | Out-Null
+    Start-Sleep -Milliseconds 500
+    & $PSMUX -L $ns save-buffer $bufFile 2>&1 | Out-Null
+    Start-Sleep -Milliseconds 500
+    if (Test-Path $bufFile) {
+        $gb = Index-Lines (Get-Content $bufFile)
+        Check "buffer: CUF gaps"        $gb.CUF "CUFA    CUFB    CUFC    CUFD"
+        Check "buffer: CHA gaps"        $gb.CHA "CHAA     CHAB      CHAC"
+        Check "buffer: literal spaces"  $gb.SPC "SPCA    SPCB    SPCC"
+        $wideBufOk = ($gb.WIDE -notmatch ' ') -and $gb.WIDE.StartsWith("WIDE:") -and $gb.WIDE.EndsWith(":END")
+        if ($wideBufOk) { Write-Host "  [PASS] buffer: wide/CJK no phantom spaces" -ForegroundColor Green; $pass++ }
+        else { Write-Host ("  [FAIL] buffer: wide/CJK: got=[{0}]" -f ($gb.WIDE -replace ' ', '.')) -ForegroundColor Red; $fail++ }
+    } else {
+        Write-Host "  [FAIL] save-buffer produced no file at $bufFile" -ForegroundColor Red; $fail++
+    }
+}
+finally {
+    Remove-PsmuxTestEnv -Ctx $ctx
+}
+
+Write-Host ""
+Write-Host "RESULT: PASS=$pass FAIL=$fail"
 exit $fail


### PR DESCRIPTION
Fixes the remainder of #443.

## Overview

de119a0 fixed the three `capture-pane` text paths (`-p`, ranged, `-e`), but the other serializers still used the inline `push_str(cell.contents())`, so a cell the cursor merely skipped over contributed nothing and adjacent words still fused. The boundary is *written vs never-written* cells rather than CUF vs CHA, so these collapsed on both:

| Path | Reached by |
| --- | --- |
| `capture_active_pane` | `capture-pane` with **no `-p`** — the paste-buffer variant of the command in the report, readable via `save-buffer` |
| `yank_selection` | copy-mode `y`, `M-w`, mouse drag-release — Char, Line **and** Rect |
| `copy_end_of_line` | copy-mode `D` |

- Extract `capture_row_text(screen, row, cols)` over the existing `push_capture_cell` and route those three plus the three already-fixed paths through it, so the space backfill and the wide-glyph continuation skip have exactly one implementation and cannot drift apart again.
- `search_copy_mode` is deliberately left alone: it indexes matches by grid column, so it wants one char per column *including* the wide continuation.

## Audit

I checked all 35 `cell.contents()` sites rather than only the ones named in the issue. Everything else is already correct and is unchanged: `format.rs` (the five row builders behind `#{C:pattern}`, `mouse_line`, `mouse_word`, `copy_cursor_word`, `copy_cursor_line`), `layout.rs` (four renderers plus two has-content checks), `rendering.rs` (`w == 0` emits a space), `popup.rs`, `window_ops.rs`, and `copy_mode`'s `read_row_text`.

Two observations left out of this PR on purpose:

- `util.rs:68,78` (`infer_title_from_prompt`) has the same unguarded pattern, but the function is dead code — no callers anywhere in `src/**` or `tests-rs/`. The `types.rs:119,131` comments referring to it look stale. Flagging rather than touching it.
- `#{cursor_character}` (`format.rs:1520`) yields `""` when the cursor sits on a never-written cell. It is a single-cell read, so it cannot fuse words; whether it should be `" "` is a behaviour call for you.

## Tests

`tests-rs/test_issue443_blank_cell_capture.rs` (registered from `copy_mode.rs`) drives the real functions over a PTY-backed pane tree — **no server and no session**, so it is safe to run on a live machine. All six behavioural tests reproduce the reported `CUFACUFBCUFC` collapse before the change.

The clipboard-touching tests serialize on a mutex and restore the prior clipboard: `yank_selection` and `copy_end_of_line` call `copy_to_system_clipboard`, and concurrent `GlobalLock` against another thread's `EmptyClipboard` corrupts the heap under the default multithreaded runner.

`tests/test_issue443_cuf_capture.ps1` gains `capture-pane` (no `-p`) + `save-buffer` coverage and is moved onto `New-PsmuxTestEnv` + a dedicated `-L` namespace.

## Validation

- `cargo test --bin psmux tests_issue443` — 14 passed
- `cargo test --bin psmux copy_mode::` — 30 passed
- `cargo test --bin psmux` for `issue244` (11), `named_buffers` (22), `issue413` (4), `issue210` (37), `issue155`, `vt100` — all passed
- `cargo check --all-targets` — clean
- `tests/test_issue443_cuf_capture.ps1` — 9/9 on a real session
- Confirmed the default psmux session list was unchanged before and after validation, and that no test session leaked into it.

## One thing to decide

The ps1 is additionally gated behind `PSMUX_ALLOW_DESTRUCTIVE_TESTS`, because `New-PsmuxTestEnv` alone is **not** sufficient to make it safe — see #510, which I hit while validating this branch: it terminated the live session I was working in. That gate is a workaround for #510, not part of this fix. If you would rather keep the two separate, drop the second commit (`test(#443): isolate the capture script...`) and this PR still stands on the first.

The gate auto-detects CI (`CI` / `GITHUB_ACTIONS`) rather than requiring the opt-in there, so the nightly `integration.yml` run still executes it. Requiring the opt-in in CI would report a green pass for a test that never ran.

---
*Authored by Claude (Anthropic) at @acoliver's direction.*