### PR TITLE
fix(#510): reap only servers this data dir can positively claim

### DIFF
--- a/src/paths.rs
+++ b/src/paths.rs
@@ -104,6 +104,25 @@ pub fn port_file(session: impl AsRef<str>) -> String {
     format!("{}\\{}.port", psmux_dir(), session.as_ref())
 }
 
+/// Directory holding one ownership marker per server process this data dir
+/// started (issue #510).
+///
+/// The startup reaper enumerates candidate servers machine-wide, but its
+/// registry only describes one data dir. Without a per-process record of
+/// "this one is mine" it cannot tell an orphan of its own from another
+/// instance's healthy server, and killing on that ambiguity destroyed live
+/// sessions belonging to a different USERPROFILE/HOME. A server writes its
+/// marker into its OWN data dir, so ownership is self-declared and needs no
+/// inspection of other processes.
+pub fn server_marker_dir() -> String {
+    format!("{}\\servers", psmux_dir())
+}
+
+/// Path to one server process's ownership marker (see `server_marker_dir`).
+pub fn server_marker_file(pid: u32) -> String {
+    format!("{}\\{}", server_marker_dir(), pid)
+}
+
 /// Fallible variant of [`port_file`]: `None` when no data directory can be
 /// determined. Lets a call site early-exit on the same condition without having
 /// to know that `port_file` routes through `psmux_dir`.

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -127,6 +127,14 @@ fn ensure_session_registry_files(app: &AppState) {
         let _ = std::fs::write(&pid_path, &pid_value);
     }
 
+    // Claim this process for this data dir (issue #510). Keyed by PID and kept
+    // outside the per-session registry on purpose: the `.pid` entry above is
+    // removed with its session, but the reaper still needs to recognise a
+    // server as its own AFTER that happens - a spawn-race duplicate, or a
+    // registry wipe, is exactly the case it must clean up. Re-ensured here so
+    // the claim self-heals if the file is deleted underneath a live server.
+    crate::session::write_server_marker(self_pid);
+
     // .port goes LAST: it is the readiness beacon (see comment above).
     if std::fs::read_to_string(&port_path)
         .map(|s| s.trim() != port_value)

--- a/src/session.rs
+++ b/src/session.rs
@@ -177,6 +177,46 @@ pub fn remove_session_pid_file(port_file_base: &str) {
     let _ = std::fs::remove_file(&pid_path);
 }
 
+/// Record that server process `pid` belongs to THIS data dir (issue #510).
+///
+/// Keyed by PID rather than by session, and deliberately independent of the
+/// session registry lifecycle: the whole point is to still identify a server as
+/// ours after its `.port`/`.pid` entries are gone, which is exactly the state a
+/// spawn-race duplicate or a registry wipe leaves behind. Body is the same
+/// `pid:creation_filetime` as the `.pid` sentinel so a reused PID cannot
+/// inherit a dead process's claim.
+pub fn write_server_marker(pid: u32) {
+    let dir = crate::paths::server_marker_dir();
+    if std::fs::create_dir_all(&dir).is_err() {
+        return;
+    }
+    let creation = crate::platform::process_kill::process_creation_time(pid).unwrap_or(0);
+    let _ = std::fs::write(
+        crate::paths::server_marker_file(pid),
+        format_pid_file_contents(pid, creation),
+    );
+}
+
+/// Server processes `psmux_dir` claims, as `pid -> recorded creation filetime`.
+///
+/// The PID is read from the file body rather than its name so a truncated or
+/// hand-copied marker cannot assert a claim over an arbitrary PID.
+pub fn read_owned_server_pids(psmux_dir: &Path) -> std::collections::HashMap<u32, Option<u64>> {
+    let mut owned = std::collections::HashMap::new();
+    let Ok(entries) = std::fs::read_dir(psmux_dir.join("servers")) else {
+        return owned;
+    };
+    for entry in entries.flatten() {
+        let Ok(body) = std::fs::read_to_string(entry.path()) else {
+            continue;
+        };
+        if let Some((pid, creation)) = parse_pid_file_contents(&body) {
+            owned.insert(pid, creation);
+        }
+    }
+    owned
+}
+
 /// Resolve a tmux session ID (`$N`) to the port file base name of the
 /// session that owns that ID. Returns `None` if no session has that ID.
 pub fn resolve_session_by_id(id: usize) -> Option<String> {
@@ -258,6 +298,7 @@ fn select_orphan_pids(
     candidates: &[ServerCandidate],
     tracked_ports: &std::collections::HashSet<u16>,
     tracked_pids: &std::collections::HashSet<u32>,
+    owned_pids: &std::collections::HashMap<u32, Option<u64>>,
     self_pid: u32,
     age_cutoff_ft: u64,
 ) -> Vec<u32> {
@@ -266,6 +307,22 @@ fn select_orphan_pids(
         if c.pid == self_pid { continue; }
         if tracked_pids.contains(&c.pid) { continue; }
         if c.ports.iter().any(|p| tracked_ports.contains(p)) { continue; }
+        // Issue #510: reap only what this data dir can positively claim.
+        //
+        // The candidate list is machine-wide, so "no registry entry references
+        // it" covers two very different processes: an orphan we started, and a
+        // perfectly healthy server belonging to another USERPROFILE/HOME. The
+        // old rule could not tell them apart and killed both. An absent
+        // ownership marker now means "not ours, not our business" rather than
+        // "orphan" - unknown must never justify termination.
+        let Some(&recorded_creation) = owned_pids.get(&c.pid) else { continue; };
+        // Same identity gate force_kill_targets applies: without a recorded
+        // creation time there is nothing to distinguish this process from an
+        // unrelated one that inherited the PID, so it is not a candidate.
+        match recorded_creation {
+            Some(ft) if ft == c.creation_ft => {}
+            _ => continue,
+        }
         // Only reap processes old enough to have finished registering.
         if age_cutoff_ft != 0 && c.creation_ft > age_cutoff_ft { continue; }
         out.push(c.pid);
@@ -439,13 +496,52 @@ fn reap_orphaned_servers_in(psmux_dir: &Path) {
         candidates.push(ServerCandidate { pid, ports, creation_ft });
     }
 
-    let orphans = select_orphan_pids(&candidates, &tracked_ports, &tracked_pids, self_pid, age_cutoff_ft);
+    let owned_pids = read_owned_server_pids(psmux_dir);
+    let orphans = select_orphan_pids(
+        &candidates, &tracked_ports, &tracked_pids, &owned_pids, self_pid, age_cutoff_ft);
     for pid in orphans {
         if crate::debug_log::session_log_enabled() {
             crate::debug_log::session_log("reaper", &format!(
-                "terminating orphaned psmux server pid {} (no registry entry references it)", pid));
+                "terminating orphaned psmux server pid {} (this data dir claims it, no registry entry references it)", pid));
         }
         process_kill::terminate_server_pid(pid, Some(now_ft));
+    }
+
+    prune_stale_server_markers(psmux_dir, &owned_pids);
+}
+
+/// Delete ownership markers whose process is gone or whose PID now belongs to
+/// something else, so the directory tracks live servers rather than growing
+/// without bound. Kept separate from reaping: a marker is only a claim, and
+/// dropping a claim never terminates anything.
+///
+/// This is the sole reclamation path rather than a removal on server shutdown:
+/// a server can exit down several routes (exit-empty, kill-session, a crash)
+/// and a marker missed by any of them would linger forever, so the invariant is
+/// "markers are reconciled against the process table", not "every exit tidies
+/// up after itself". A lingering marker is harmless in the meantime — it names
+/// either a dead PID or, after reuse, a process whose creation time no longer
+/// matches, and neither can authorise a kill.
+fn prune_stale_server_markers(
+    psmux_dir: &Path,
+    owned_pids: &std::collections::HashMap<u32, Option<u64>>,
+) {
+    for (&pid, &recorded_creation) in owned_pids {
+        let live_creation = crate::platform::process_kill::process_creation_time(pid);
+        let still_ours = match (live_creation, recorded_creation) {
+            // Process is gone.
+            (None, _) => false,
+            // Same PID, different process: the original exited and the PID was
+            // reused, so this claim is stale.
+            (Some(live), Some(recorded)) => live == recorded,
+            // No recorded creation time to compare against. Keep it: a marker
+            // that cannot be identity-checked can never authorise a kill
+            // either, so leaving it costs nothing.
+            (Some(_), None) => true,
+        };
+        if !still_ours {
+            let _ = std::fs::remove_file(psmux_dir.join("servers").join(pid.to_string()));
+        }
     }
 }
 
@@ -1614,3 +1710,7 @@ mod tests_startup_stale_port_tax;
 #[cfg(test)]
 #[path = "../tests-rs/test_l_socket_tmux_precedence.rs"]
 mod tests_l_socket_tmux_precedence;
+
+#[cfg(test)]
+#[path = "../tests-rs/test_issue510_reaper_attribution.rs"]
+mod tests_issue510_reaper_attribution;

--- a/tests-rs/test_issue448_orphan_reaper.rs
+++ b/tests-rs/test_issue448_orphan_reaper.rs
@@ -5,10 +5,18 @@
 // against the real production code — no OS process enumeration, so they are
 // deterministic and cross-platform. The end-to-end proof that a live orphan
 // process is actually terminated lives in the PowerShell E2E test.
+//
+// Issue #510 added a precondition to every case below: being unreferenced by
+// the registry is no longer sufficient to reap a process, because the candidate
+// list is machine-wide and an unreferenced server may simply belong to a
+// different data dir. A process must additionally be CLAIMED by this data dir
+// (an ownership marker, identity-gated on creation time). The scenarios here
+// are unchanged in intent — an orphan of ours still gets reaped — so each one
+// now supplies the marker its server would have written.
 
 use super::*;
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
@@ -29,13 +37,25 @@ fn cand(pid: u32, ports: &[u16], creation_ft: u64) -> ServerCandidate {
 fn ports(list: &[u16]) -> HashSet<u16> { list.iter().copied().collect() }
 fn pids(list: &[u32]) -> HashSet<u32> { list.iter().copied().collect() }
 
+/// Ownership markers this data dir holds: `pid -> recorded creation time`.
+fn owned(list: &[(u32, u64)]) -> HashMap<u32, Option<u64>> {
+    list.iter().map(|&(p, c)| (p, Some(c))).collect()
+}
+
+/// Every candidate is claimed by this data dir, at its true creation time.
+/// The default for tests about registry/grace policy rather than ownership.
+fn owning_all(candidates: &[ServerCandidate]) -> HashMap<u32, Option<u64>> {
+    candidates.iter().map(|c| (c.pid, Some(c.creation_ft))).collect()
+}
+
 // ── select_orphan_pids: core policy ──────────────────────────────────────
 
 #[test]
 fn orphan_with_no_registry_reference_is_reaped() {
-    // A live server on port 5000 that no .port file references -> orphan.
+    // A live server of OURS on port 5000 that no .port file references -> orphan.
     let cands = vec![cand(1000, &[5000], 100)];
-    let got = select_orphan_pids(&cands, &ports(&[]), &pids(&[]), 42, u64::MAX);
+    let got = select_orphan_pids(
+        &cands, &ports(&[]), &pids(&[]), &owning_all(&cands), 42, u64::MAX);
     assert_eq!(got, vec![1000], "untracked live server must be selected for reaping");
 }
 
@@ -44,7 +64,8 @@ fn server_with_tracked_port_is_never_reaped() {
     // Legitimate session: its port IS in a .port file -> keep it, even though
     // its PID is not in tracked_pids (backward-compat with pre-#448 servers).
     let cands = vec![cand(1000, &[5000], 100)];
-    let got = select_orphan_pids(&cands, &ports(&[5000]), &pids(&[]), 42, u64::MAX);
+    let got = select_orphan_pids(
+        &cands, &ports(&[5000]), &pids(&[]), &owning_all(&cands), 42, u64::MAX);
     assert!(got.is_empty(), "a server whose port is registered must be preserved");
 }
 
@@ -52,14 +73,16 @@ fn server_with_tracked_port_is_never_reaped() {
 fn server_with_tracked_pid_is_never_reaped() {
     // Belt-and-suspenders: PID recorded in a .pid file is protected.
     let cands = vec![cand(1000, &[5000], 100)];
-    let got = select_orphan_pids(&cands, &ports(&[]), &pids(&[1000]), 42, u64::MAX);
+    let got = select_orphan_pids(
+        &cands, &ports(&[]), &pids(&[1000]), &owning_all(&cands), 42, u64::MAX);
     assert!(got.is_empty(), "a tracked PID must be preserved");
 }
 
 #[test]
 fn self_pid_is_never_reaped() {
     let cands = vec![cand(42, &[5000], 100)];
-    let got = select_orphan_pids(&cands, &ports(&[]), &pids(&[]), 42, u64::MAX);
+    let got = select_orphan_pids(
+        &cands, &ports(&[]), &pids(&[]), &owning_all(&cands), 42, u64::MAX);
     assert!(got.is_empty(), "the reaping process must never terminate itself");
 }
 
@@ -67,7 +90,8 @@ fn self_pid_is_never_reaped() {
 fn young_process_is_skipped_by_grace_window() {
     // creation_ft (200) is LATER than the age cutoff (150) -> too young, skip.
     let cands = vec![cand(1000, &[5000], 200)];
-    let got = select_orphan_pids(&cands, &ports(&[]), &pids(&[]), 42, 150);
+    let got = select_orphan_pids(
+        &cands, &ports(&[]), &pids(&[]), &owning_all(&cands), 42, 150);
     assert!(got.is_empty(), "a process younger than the grace window must be skipped");
 }
 
@@ -75,7 +99,8 @@ fn young_process_is_skipped_by_grace_window() {
 fn old_process_passes_grace_window() {
     // creation_ft (100) is at/older than the cutoff (150) -> eligible.
     let cands = vec![cand(1000, &[5000], 100)];
-    let got = select_orphan_pids(&cands, &ports(&[]), &pids(&[]), 42, 150);
+    let got = select_orphan_pids(
+        &cands, &ports(&[]), &pids(&[]), &owning_all(&cands), 42, 150);
     assert_eq!(got, vec![1000], "a process older than the grace window must be reaped");
 }
 
@@ -84,20 +109,22 @@ fn multi_port_server_kept_if_any_port_tracked() {
     // A server listening on two ports where only one is registered is still a
     // legitimate server (the reaper must not kill it).
     let cands = vec![cand(1000, &[5000, 5001], 100)];
-    let got = select_orphan_pids(&cands, &ports(&[5001]), &pids(&[]), 42, u64::MAX);
+    let got = select_orphan_pids(
+        &cands, &ports(&[5001]), &pids(&[]), &owning_all(&cands), 42, u64::MAX);
     assert!(got.is_empty(), "any tracked port must protect the whole process");
 }
 
 #[test]
 fn mixed_fleet_only_orphans_selected() {
     let cands = vec![
-        cand(10, &[6000], 100), // orphan (untracked)
+        cand(10, &[6000], 100), // orphan (untracked, ours)
         cand(11, &[6001], 100), // legit (port tracked)
         cand(12, &[6002], 100), // legit (pid tracked)
-        cand(13, &[6003], 100), // orphan (untracked)
+        cand(13, &[6003], 100), // orphan (untracked, ours)
         cand(42, &[6004], 100), // self
     ];
-    let mut got = select_orphan_pids(&cands, &ports(&[6001]), &pids(&[12]), 42, u64::MAX);
+    let mut got = select_orphan_pids(
+        &cands, &ports(&[6001]), &pids(&[12]), &owning_all(&cands), 42, u64::MAX);
     got.sort();
     assert_eq!(got, vec![10, 13], "exactly the untracked non-self servers must be selected");
 }
@@ -147,7 +174,11 @@ fn end_to_end_selection_over_registry_files() {
         cand(500, &[7000], 100),  // the tracked session server
         cand(501, &[7777], 100),  // an orphaned duplicate, nothing points at it
     ];
-    let got = select_orphan_pids(&cands, &tp, &tpid, 1, u64::MAX);
+    // Both are ours: the duplicate wrote its own ownership marker at startup,
+    // which is what still identifies it after the spawn race overwrote the
+    // shared .port/.pid entries with the winner's.
+    let got = select_orphan_pids(
+        &cands, &tp, &tpid, &owned(&[(500, 100), (501, 100)]), 1, u64::MAX);
     assert_eq!(got, vec![501], "only the orphaned duplicate must be reaped");
     let _ = std::fs::remove_dir_all(&dir);
 }

--- a/tests-rs/test_issue510_reaper_attribution.rs
+++ b/tests-rs/test_issue510_reaper_attribution.rs
@@ -1,0 +1,248 @@
+// Issue #510: the startup reaper must never terminate a server it cannot
+// positively attribute to THIS data dir.
+//
+// `reap_orphaned_servers` enumerates candidates machine-wide (loopback
+// listeners filtered by image name) but draws its authority from a single
+// ~/.psmux resolved from USERPROFILE/HOME. Anything that registry did not
+// account for was classified as an orphan and killed, so any invocation
+// resolving a different home reaped every other instance's servers: a
+// redirected-HOME test harness, an MSYS2/Git-Bash shell (#474's family), a
+// second account or service context, or jefe running under changed identity
+// material (vybestack/llxprt-jefe#547).
+//
+// The defect was the polarity. A server was reaped when we could not prove it
+// was ours, rather than only when we could prove it was — absence of evidence
+// treated as evidence of orphanhood. These tests pin the inverted rule:
+// unknown means leave it alone.
+//
+// The ownership marker is what supplies the proof. A server writes it into its
+// own data dir, so no inspection of another process is required.
+
+use super::*;
+
+use std::collections::{HashMap, HashSet};
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+static TMP_COUNTER: AtomicUsize = AtomicUsize::new(0);
+
+fn temp_dir() -> PathBuf {
+    let mut p = std::env::temp_dir();
+    let n = TMP_COUNTER.fetch_add(1, Ordering::SeqCst);
+    p.push(format!("psmux_issue510_{}_{}", std::process::id(), n));
+    let _ = std::fs::create_dir_all(&p);
+    p
+}
+
+fn cand(pid: u32, ports: &[u16], creation_ft: u64) -> ServerCandidate {
+    ServerCandidate { pid, ports: ports.to_vec(), creation_ft }
+}
+
+fn ports(list: &[u16]) -> HashSet<u16> { list.iter().copied().collect() }
+fn pids(list: &[u32]) -> HashSet<u32> { list.iter().copied().collect() }
+
+fn owned(list: &[(u32, u64)]) -> HashMap<u32, Option<u64>> {
+    list.iter().map(|&(p, c)| (p, Some(c))).collect()
+}
+
+// ── The core rule: no claim, no kill ─────────────────────────────────────
+
+#[test]
+fn foreign_server_is_never_reaped() {
+    // The incident in miniature: a live psmux server belonging to another data
+    // dir, which our registry knows nothing about. The old rule read
+    // "not tracked -> orphan -> kill" and destroyed it.
+    let cands = vec![cand(1000, &[5000], 100)];
+    let got = select_orphan_pids(&cands, &ports(&[]), &pids(&[]), &owned(&[]), 42, u64::MAX);
+    assert!(got.is_empty(), "a server this data dir cannot claim must be left alone, got {got:?}");
+}
+
+#[test]
+fn foreign_servers_survive_a_populated_local_registry() {
+    // The guard that would NOT have been enough. Refusing to reap only when the
+    // registry is empty protects the first invocation under a fresh HOME, but
+    // as soon as the harness creates its own session the registry is non-empty
+    // again and every foreign server is back in scope. Attribution has to be
+    // per candidate, not a global "does my view look usable" check.
+    let cands = vec![
+        cand(1000, &[5000], 100), // ours, tracked
+        cand(2000, &[6000], 100), // another instance's server
+        cand(2001, &[6001], 100), // another instance's server
+    ];
+    let got = select_orphan_pids(
+        &cands, &ports(&[5000]), &pids(&[1000]), &owned(&[(1000, 100)]), 42, u64::MAX);
+    assert!(got.is_empty(), "foreign servers must survive a non-empty local registry, got {got:?}");
+}
+
+#[test]
+fn only_the_claimed_orphan_is_reaped_among_foreign_servers() {
+    // Both halves of the contract at once: our own orphan still dies, and the
+    // servers we cannot account for still live.
+    let cands = vec![
+        cand(1000, &[5000], 100), // ours, orphaned  -> reap
+        cand(2000, &[6000], 100), // foreign         -> keep
+        cand(2001, &[6001], 100), // foreign         -> keep
+    ];
+    let got = select_orphan_pids(
+        &cands, &ports(&[]), &pids(&[]), &owned(&[(1000, 100)]), 42, u64::MAX);
+    assert_eq!(got, vec![1000], "exactly the claimed orphan must be reaped");
+}
+
+// ── The claim is identity-gated ──────────────────────────────────────────
+
+#[test]
+fn claim_with_mismatched_creation_time_is_not_honoured() {
+    // Our marker names PID 1000, but the live PID 1000 was created at a
+    // different time: the process we claimed exited and an unrelated one
+    // inherited its PID. A stale claim must not authorise a kill (#447).
+    let cands = vec![cand(1000, &[5000], 999)];
+    let got = select_orphan_pids(
+        &cands, &ports(&[]), &pids(&[]), &owned(&[(1000, 100)]), 42, u64::MAX);
+    assert!(got.is_empty(), "a claim whose creation time disagrees must not reap, got {got:?}");
+}
+
+#[test]
+fn claim_without_recorded_creation_time_is_not_honoured() {
+    // A bare-pid marker cannot be identity-checked, so it is not a kill
+    // authority — the same policy force_kill_targets applies to bare .pid files.
+    let mut markers: HashMap<u32, Option<u64>> = HashMap::new();
+    markers.insert(1000, None);
+    let cands = vec![cand(1000, &[5000], 100)];
+    let got = select_orphan_pids(&cands, &ports(&[]), &pids(&[]), &markers, 42, u64::MAX);
+    assert!(got.is_empty(), "an un-gated claim must not reap, got {got:?}");
+}
+
+// ── Existing protections still apply on top of ownership ─────────────────
+
+#[test]
+fn claimed_but_tracked_server_is_not_reaped() {
+    // Owning a process is a licence to reap it only when nothing references it.
+    let cands = vec![cand(1000, &[5000], 100)];
+    let got = select_orphan_pids(
+        &cands, &ports(&[5000]), &pids(&[]), &owned(&[(1000, 100)]), 42, u64::MAX);
+    assert!(got.is_empty(), "a claimed server with a tracked port must be preserved");
+}
+
+#[test]
+fn claimed_self_is_not_reaped() {
+    let cands = vec![cand(42, &[5000], 100)];
+    let got = select_orphan_pids(
+        &cands, &ports(&[]), &pids(&[]), &owned(&[(42, 100)]), 42, u64::MAX);
+    assert!(got.is_empty(), "the reaping process must never terminate itself");
+}
+
+#[test]
+fn claimed_but_young_server_is_not_reaped() {
+    // Still inside the grace window: it may not have finished registering.
+    let cands = vec![cand(1000, &[5000], 200)];
+    let got = select_orphan_pids(
+        &cands, &ports(&[]), &pids(&[]), &owned(&[(1000, 200)]), 42, 150);
+    assert!(got.is_empty(), "a claimed server younger than the grace window must be skipped");
+}
+
+// ── read_owned_server_pids: markers on disk ──────────────────────────────
+
+#[test]
+fn reads_markers_written_by_this_data_dir() {
+    let dir = temp_dir();
+    let servers = dir.join("servers");
+    std::fs::create_dir_all(&servers).unwrap();
+    std::fs::write(servers.join("1000"), "1000:100").unwrap();
+    std::fs::write(servers.join("1001"), "1001:200").unwrap();
+
+    let got = read_owned_server_pids(&dir);
+    assert_eq!(got.get(&1000), Some(&Some(100)), "marker 1000 must be read with its creation time");
+    assert_eq!(got.get(&1001), Some(&Some(200)), "marker 1001 must be read with its creation time");
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn missing_marker_dir_claims_nothing() {
+    // A data dir that has never run a server claims no process on the machine.
+    // This is the fresh-HOME harness case: the reaper finds a full machine of
+    // live servers and must conclude that none of them are its business.
+    let dir = temp_dir();
+    let got = read_owned_server_pids(&dir);
+    assert!(got.is_empty(), "a data dir with no marker dir must claim nothing, got {got:?}");
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn pid_is_taken_from_marker_body_not_filename() {
+    // A truncated or hand-copied marker must not be able to assert a claim over
+    // whatever PID its filename happens to spell.
+    let dir = temp_dir();
+    let servers = dir.join("servers");
+    std::fs::create_dir_all(&servers).unwrap();
+    std::fs::write(servers.join("7777"), "1000:100").unwrap();
+
+    let got = read_owned_server_pids(&dir);
+    assert_eq!(got.get(&1000), Some(&Some(100)), "the body's pid is authoritative");
+    assert!(!got.contains_key(&7777), "the filename must not create a claim");
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn unreadable_marker_is_skipped_not_fatal() {
+    let dir = temp_dir();
+    let servers = dir.join("servers");
+    std::fs::create_dir_all(&servers).unwrap();
+    std::fs::write(servers.join("1000"), "1000:100").unwrap();
+    std::fs::write(servers.join("garbage"), "not-a-pid").unwrap();
+
+    let got = read_owned_server_pids(&dir);
+    assert_eq!(got.get(&1000), Some(&Some(100)), "valid markers must still be read");
+    assert_eq!(got.len(), 1, "a malformed marker must be skipped, got {got:?}");
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+// ── End to end over real files: the incident, reconstructed ──────────────
+
+#[test]
+fn harness_data_dir_does_not_reap_the_users_servers() {
+    // A redirected-HOME test harness (New-PsmuxTestEnv) after it has created
+    // its own session: its registry is populated and its marker dir claims only
+    // its own server. The user's live sessions — the agent's own psmux among
+    // them — are listening, untracked here, and must survive.
+    let harness = temp_dir();
+    std::fs::write(harness.join("i443__probe.port"), "5000").unwrap();
+    std::fs::write(harness.join("i443__probe.pid"), "1000:100").unwrap();
+    let servers = harness.join("servers");
+    std::fs::create_dir_all(&servers).unwrap();
+    std::fs::write(servers.join("1000"), "1000:100").unwrap();
+
+    let (tp, tpid) = read_tracked_registry(&harness);
+    let owned_pids = read_owned_server_pids(&harness);
+
+    let cands = vec![
+        cand(1000, &[5000], 100),  // the harness's own server
+        cand(22316, &[7001], 100), // the agent's live session
+        cand(5772, &[7002], 100),  // a second agent's session
+        cand(22420, &[7003], 100), // the warm-pane server
+    ];
+    let got = select_orphan_pids(&cands, &tp, &tpid, &owned_pids, 1, u64::MAX);
+    assert!(got.is_empty(), "a harness data dir must not reap the user's servers, got {got:?}");
+    let _ = std::fs::remove_dir_all(&harness);
+}
+
+#[test]
+fn wiped_registry_still_reaps_our_own_orphan() {
+    // run_all_tests.ps1 deletes ~/.psmux\*.port and *.key, which is one way a
+    // live server of ours loses its registry entry. The marker dir is outside
+    // that pattern, so the server is still identifiable as ours and #448's
+    // cleanup still works — this is the case the ownership marker exists to
+    // keep working after the polarity flip.
+    let dir = temp_dir();
+    let servers = dir.join("servers");
+    std::fs::create_dir_all(&servers).unwrap();
+    std::fs::write(servers.join("1000"), "1000:100").unwrap();
+
+    let (tp, tpid) = read_tracked_registry(&dir);
+    let owned_pids = read_owned_server_pids(&dir);
+    assert!(tp.is_empty() && tpid.is_empty(), "registry was wiped");
+
+    let cands = vec![cand(1000, &[5000], 100)];
+    let got = select_orphan_pids(&cands, &tp, &tpid, &owned_pids, 1, u64::MAX);
+    assert_eq!(got, vec![1000], "our own orphan must still be reaped after a registry wipe");
+    let _ = std::fs::remove_dir_all(&dir);
+}

--- a/tests/test_issue510_foreign_server_survives.ps1
+++ b/tests/test_issue510_foreign_server_survives.ps1
@@ -1,0 +1,117 @@
+# Issue #510: a psmux invocation resolving one data dir must never terminate
+# servers belonging to another.
+#
+# The startup reaper enumerates candidates machine-wide but drew its authority
+# from a single ~/.psmux resolved from USERPROFILE/HOME, so anything that
+# registry did not account for was killed as an "orphan". Any invocation under a
+# different home therefore destroyed every other instance's live sessions.
+#
+# WHAT THIS TEST DOES: stands up a victim server under home A, then runs a
+# read-only psmux command under home B and proves the victim survives. Both
+# homes are throwaway temp dirs, so the real ~/.psmux and any live user or agent
+# sessions are never in scope either way.
+#
+# WHY IT IS GATED: it starts real psmux servers. Get-PsmuxExe resolves the
+# locally BUILT binary (PSMUX_EXE, then target\release, then target\debug) and
+# never PATH, so it cannot accidentally exercise an installed build - which
+# matters here, because running this scenario against a pre-fix binary is
+# precisely the operation that kills the user's sessions.
+
+$ErrorActionPreference = "Continue"
+. (Join-Path $PSScriptRoot 'psmux_test_helpers.ps1')
+
+$isDisposable = $env:PSMUX_ALLOW_DESTRUCTIVE_TESTS -or $env:CI -or $env:GITHUB_ACTIONS
+if (-not $isDisposable) {
+    Write-Host "[SKIP] test_issue510_foreign_server_survives.ps1 starts real psmux servers." -ForegroundColor DarkYellow
+    Write-Host "       Set PSMUX_ALLOW_DESTRUCTIVE_TESTS=1 to run (CI sets CI/GITHUB_ACTIONS)." -ForegroundColor DarkYellow
+    exit 0
+}
+
+$script:Passed = 0
+$script:Failed = 0
+function Write-Pass($m) { Write-Host "  [PASS] $m" -ForegroundColor Green; $script:Passed++ }
+function Write-Fail($m) { Write-Host "  [FAIL] $m" -ForegroundColor Red; $script:Failed++ }
+
+function Is-PidAlive($procId) {
+    if (-not ("$procId" -match '^\d+$')) { return $false }
+    $p = Get-Process -Id ([int]$procId) -EA SilentlyContinue
+    return ($null -ne $p -and -not $p.HasExited)
+}
+
+Write-Host "`n=== Issue #510: a foreign data dir must not reap our servers ===" -ForegroundColor Cyan
+
+$exe = Get-PsmuxExe
+Write-Host "    binary under test: $exe" -ForegroundColor DarkGray
+
+$victim = $null
+$intruderHome = $null
+$savedProfile = $env:USERPROFILE
+$savedHome = $env:HOME
+
+try {
+    # ---- Home A: the victim, a perfectly healthy server ---------------------
+    $victim = New-PsmuxTestEnv -Tag 'i510victim' -Exe $exe
+    $ns = Register-PsmuxNamespace -Ctx $victim -Namespace 'i510victim'
+    & $exe -L $ns new-session -d -s survivor 2>&1 | Out-Null
+    Start-Sleep -Seconds 3
+
+    $pidFile = Join-Path $victim.PsmuxDir "${ns}__survivor.pid"
+    if (-not (Test-Path $pidFile)) {
+        Write-Fail "victim server did not register a .pid ($pidFile); cannot run the scenario"
+        throw "setup failed"
+    }
+    $victimPid = ((Get-Content $pidFile -Raw).Trim() -split ':')[0]
+    if (Is-PidAlive $victimPid) { Write-Pass "victim server $victimPid is live under home A" }
+    else { Write-Fail "victim server $victimPid is not alive"; throw "setup failed" }
+
+    # The reaper spares anything inside its 10s grace window, so a young victim
+    # would survive even a buggy build. Age past the grace to make this real.
+    Write-Host "    aging victim past the 10s reap grace window..." -ForegroundColor DarkGray
+    Start-Sleep -Seconds 12
+    if (-not (Is-PidAlive $victimPid)) { Write-Fail "victim died while aging"; throw "setup failed" }
+
+    # ---- Home B: an unrelated invocation that must keep its hands off -------
+    # A fresh, EMPTY data dir is the harness/MSYS2/second-account case: it can
+    # account for nothing on this machine, so it must claim nothing.
+    $intruderHome = Join-Path $env:TEMP ("psmux_i510intruder_" + [guid]::NewGuid().ToString('N').Substring(0, 8))
+    New-Item -ItemType Directory -Path (Join-Path $intruderHome '.psmux') -Force | Out-Null
+    $env:USERPROFILE = $intruderHome
+    $env:HOME = $intruderHome
+
+    & $exe -L i510intruder list-sessions 2>&1 | Out-Null
+    Start-Sleep -Seconds 2
+
+    if (Is-PidAlive $victimPid) {
+        Write-Pass "victim server $victimPid SURVIVED a foreign-home invocation"
+    } else {
+        Write-Fail "victim server $victimPid was reaped by a foreign-home invocation (#510)"
+    }
+
+    # Repeat: the reaper runs on EVERY invocation, so one survival could be luck.
+    for ($i = 0; $i -lt 3; $i++) {
+        & $exe -L i510intruder list-sessions 2>&1 | Out-Null
+        Start-Sleep -Milliseconds 400
+    }
+    if (Is-PidAlive $victimPid) { Write-Pass "victim survived repeated foreign-home reaper passes" }
+    else { Write-Fail "victim was reaped by a later foreign-home reaper pass" }
+
+    # ---- The intruder's own view stays correct -----------------------------
+    # Not seeing another home's sessions is right; killing them is not.
+    $seen = (& $exe -L i510intruder list-sessions 2>&1 | Out-String).Trim()
+    if ($seen -notmatch 'survivor') { Write-Pass "intruder correctly does not see home A's session" }
+    else { Write-Fail "intruder unexpectedly listed home A's session: $seen" }
+
+    $env:USERPROFILE = $savedProfile
+    $env:HOME = $savedHome
+}
+finally {
+    $env:USERPROFILE = $savedProfile
+    $env:HOME = $savedHome
+    if ($intruderHome) { Remove-Item -Recurse -Force $intruderHome -EA SilentlyContinue }
+    if ($victim) { Remove-PsmuxTestEnv -Ctx $victim }
+}
+
+Write-Host "`n=== Results ===" -ForegroundColor Cyan
+Write-Host "  Passed: $($script:Passed)" -ForegroundColor Green
+Write-Host "  Failed: $($script:Failed)" -ForegroundColor $(if ($script:Failed -gt 0) { "Red" } else { "Green" })
+exit $script:Failed

--- a/tests/test_issue510_foreign_server_survives.ps1
+++ b/tests/test_issue510_foreign_server_survives.ps1
@@ -6,23 +6,32 @@
 # registry did not account for was killed as an "orphan". Any invocation under a
 # different home therefore destroyed every other instance's live sessions.
 #
-# WHAT THIS TEST DOES: stands up a victim server under home A, then runs a
-# read-only psmux command under home B and proves the victim survives. Both
-# homes are throwaway temp dirs, so the real ~/.psmux and any live user or agent
-# sessions are never in scope either way.
+# SHAPE OF THE TEST
+#   victim   - a real server in the NORMAL data dir under a unique -L namespace,
+#              per AGENTS.md. It must outlive the reaper's 10s grace window to
+#              be eligible for reaping at all, which is why it cannot live in a
+#              throwaway home: psmux servers under a redirected USERPROFILE/HOME
+#              shut themselves down after ~10s on Windows (reproducible with the
+#              reaper compiled out, so it is unrelated to this fix), and would
+#              vanish before the scenario begins.
+#   intruder - a read-only command run under a throwaway home. That empty data
+#              dir can account for nothing on this machine, which is exactly the
+#              redirected-HOME harness / MSYS2 / second-account case.
 #
-# WHY IT IS GATED: it starts real psmux servers. Get-PsmuxExe resolves the
-# locally BUILT binary (PSMUX_EXE, then target\release, then target\debug) and
-# never PATH, so it cannot accidentally exercise an installed build - which
-# matters here, because running this scenario against a pre-fix binary is
-# precisely the operation that kills the user's sessions.
+# The assertion is that the victim survives the intruder.
+#
+# SAFETY: Get-PsmuxExe resolves the locally BUILT binary (PSMUX_EXE, then
+# target\release, then target\debug) and never PATH. That matters more here than
+# in most tests: the intruder step against a PRE-FIX binary is precisely the
+# operation that kills every psmux session on the machine, including the user's
+# own. Do not point PSMUX_EXE at an installed build.
 
 $ErrorActionPreference = "Continue"
 . (Join-Path $PSScriptRoot 'psmux_test_helpers.ps1')
 
 $isDisposable = $env:PSMUX_ALLOW_DESTRUCTIVE_TESTS -or $env:CI -or $env:GITHUB_ACTIONS
 if (-not $isDisposable) {
-    Write-Host "[SKIP] test_issue510_foreign_server_survives.ps1 starts real psmux servers." -ForegroundColor DarkYellow
+    Write-Host "[SKIP] test_issue510_foreign_server_survives.ps1 starts a real psmux server." -ForegroundColor DarkYellow
     Write-Host "       Set PSMUX_ALLOW_DESTRUCTIVE_TESTS=1 to run (CI sets CI/GITHUB_ACTIONS)." -ForegroundColor DarkYellow
     exit 0
 }
@@ -31,7 +40,6 @@ $script:Passed = 0
 $script:Failed = 0
 function Write-Pass($m) { Write-Host "  [PASS] $m" -ForegroundColor Green; $script:Passed++ }
 function Write-Fail($m) { Write-Host "  [FAIL] $m" -ForegroundColor Red; $script:Failed++ }
-
 function Is-PidAlive($procId) {
     if (-not ("$procId" -match '^\d+$')) { return $false }
     $p = Get-Process -Id ([int]$procId) -EA SilentlyContinue
@@ -43,36 +51,43 @@ Write-Host "`n=== Issue #510: a foreign data dir must not reap our servers ===" 
 $exe = Get-PsmuxExe
 Write-Host "    binary under test: $exe" -ForegroundColor DarkGray
 
-$victim = $null
+$ns = "i510victim"
+$psmuxDir = Join-Path $env:USERPROFILE '.psmux'
 $intruderHome = $null
 $savedProfile = $env:USERPROFILE
 $savedHome = $env:HOME
 
+# Snapshot every live psmux server up front. The whole point of the fix is that
+# this set is untouched by an unrelated invocation, so it doubles as the blast
+# radius check: if the fix regressed, this is what names the casualties.
+$liveBefore = @(Get-Process -Name psmux, pmux, tmux -EA SilentlyContinue | ForEach-Object { $_.Id })
+Write-Host "    live psmux servers before: $($liveBefore -join ', ')" -ForegroundColor DarkGray
+
 try {
-    # ---- Home A: the victim, a perfectly healthy server ---------------------
-    $victim = New-PsmuxTestEnv -Tag 'i510victim' -Exe $exe
-    $ns = Register-PsmuxNamespace -Ctx $victim -Namespace 'i510victim'
+    # ---- The victim: a healthy server in the normal data dir ---------------
     & $exe -L $ns new-session -d -s survivor 2>&1 | Out-Null
     Start-Sleep -Seconds 3
 
-    $pidFile = Join-Path $victim.PsmuxDir "${ns}__survivor.pid"
+    $pidFile = Join-Path $psmuxDir "${ns}__survivor.pid"
     if (-not (Test-Path $pidFile)) {
-        Write-Fail "victim server did not register a .pid ($pidFile); cannot run the scenario"
+        Write-Fail "victim did not register a .pid ($pidFile); cannot run the scenario"
         throw "setup failed"
     }
     $victimPid = ((Get-Content $pidFile -Raw).Trim() -split ':')[0]
-    if (Is-PidAlive $victimPid) { Write-Pass "victim server $victimPid is live under home A" }
+    if (Is-PidAlive $victimPid) { Write-Pass "victim server $victimPid is live" }
     else { Write-Fail "victim server $victimPid is not alive"; throw "setup failed" }
 
     # The reaper spares anything inside its 10s grace window, so a young victim
-    # would survive even a buggy build. Age past the grace to make this real.
+    # would survive even a pre-fix build and prove nothing.
     Write-Host "    aging victim past the 10s reap grace window..." -ForegroundColor DarkGray
     Start-Sleep -Seconds 12
-    if (-not (Is-PidAlive $victimPid)) { Write-Fail "victim died while aging"; throw "setup failed" }
+    if (-not (Is-PidAlive $victimPid)) {
+        Write-Fail "victim died while aging; environment cannot sustain the scenario"
+        throw "setup failed"
+    }
+    Write-Pass "victim survived to eligible age (reaping is now possible)"
 
-    # ---- Home B: an unrelated invocation that must keep its hands off -------
-    # A fresh, EMPTY data dir is the harness/MSYS2/second-account case: it can
-    # account for nothing on this machine, so it must claim nothing.
+    # ---- The intruder: an unrelated home that must keep its hands off ------
     $intruderHome = Join-Path $env:TEMP ("psmux_i510intruder_" + [guid]::NewGuid().ToString('N').Substring(0, 8))
     New-Item -ItemType Directory -Path (Join-Path $intruderHome '.psmux') -Force | Out-Null
     $env:USERPROFILE = $intruderHome
@@ -80,14 +95,10 @@ try {
 
     & $exe -L i510intruder list-sessions 2>&1 | Out-Null
     Start-Sleep -Seconds 2
+    if (Is-PidAlive $victimPid) { Write-Pass "victim $victimPid SURVIVED a foreign-home invocation" }
+    else { Write-Fail "victim $victimPid was reaped by a foreign-home invocation (#510)" }
 
-    if (Is-PidAlive $victimPid) {
-        Write-Pass "victim server $victimPid SURVIVED a foreign-home invocation"
-    } else {
-        Write-Fail "victim server $victimPid was reaped by a foreign-home invocation (#510)"
-    }
-
-    # Repeat: the reaper runs on EVERY invocation, so one survival could be luck.
+    # The reaper runs on EVERY invocation, so one survival could be luck.
     for ($i = 0; $i -lt 3; $i++) {
         & $exe -L i510intruder list-sessions 2>&1 | Out-Null
         Start-Sleep -Milliseconds 400
@@ -95,11 +106,10 @@ try {
     if (Is-PidAlive $victimPid) { Write-Pass "victim survived repeated foreign-home reaper passes" }
     else { Write-Fail "victim was reaped by a later foreign-home reaper pass" }
 
-    # ---- The intruder's own view stays correct -----------------------------
-    # Not seeing another home's sessions is right; killing them is not.
+    # Not SEEING another home's sessions is correct; killing them is not.
     $seen = (& $exe -L i510intruder list-sessions 2>&1 | Out-String).Trim()
-    if ($seen -notmatch 'survivor') { Write-Pass "intruder correctly does not see home A's session" }
-    else { Write-Fail "intruder unexpectedly listed home A's session: $seen" }
+    if ($seen -notmatch 'survivor') { Write-Pass "intruder correctly does not see the victim's session" }
+    else { Write-Fail "intruder unexpectedly listed the victim's session: $seen" }
 
     $env:USERPROFILE = $savedProfile
     $env:HOME = $savedHome
@@ -108,8 +118,18 @@ finally {
     $env:USERPROFILE = $savedProfile
     $env:HOME = $savedHome
     if ($intruderHome) { Remove-Item -Recurse -Force $intruderHome -EA SilentlyContinue }
-    if ($victim) { Remove-PsmuxTestEnv -Ctx $victim }
+    # Scoped teardown only: never a bare kill-server, which would hit every
+    # namespace including the user's own sessions (AGENTS.md).
+    & $exe -L $ns kill-server 2>&1 | Out-Null
+    Start-Sleep -Milliseconds 500
+    Remove-Item (Join-Path $psmuxDir "${ns}__*") -Force -EA SilentlyContinue
 }
+
+# Nothing outside the victim's namespace may have died.
+$liveAfter = @(Get-Process -Name psmux, pmux, tmux -EA SilentlyContinue | ForEach-Object { $_.Id })
+$lost = @($liveBefore | Where-Object { $_ -notin $liveAfter })
+if ($lost.Count -eq 0) { Write-Pass "no pre-existing psmux server was terminated by this test" }
+else { Write-Fail "pre-existing psmux servers were terminated: $($lost -join ', ')" }
 
 Write-Host "`n=== Results ===" -ForegroundColor Cyan
 Write-Host "  Passed: $($script:Passed)" -ForegroundColor Green


### PR DESCRIPTION
## Overview

Fixes #510. The startup reaper enumerates candidate servers machine-wide
(loopback listeners filtered by image name) but draws its authority from a
single `~/.psmux` resolved from `USERPROFILE`/`HOME`. Anything that registry
did not account for was classified as an orphan and terminated, so any
invocation resolving a different home reaped every other instance's live
servers.

The defect was the polarity: a server was reaped when we could not prove it
was ours, rather than only when we could prove it was.

## The fix

Servers now write an ownership marker into their own data dir
(`~/.psmux/servers/<pid>`), carrying the same `pid:creation_filetime` identity
gate as the `.pid` sentinel. `select_orphan_pids` honours a marker only when
the live process's creation time still matches, so an absent or stale marker
means "not ours" instead of "orphan".

The marker is deliberately independent of the per-session registry lifecycle,
because the states #448 exists to clean up - a spawn-race duplicate, a wiped
registry - are exactly the ones where `.port`/`.pid` are already gone. It is
reconciled against the process table on each pass rather than removed on
shutdown, since a server can exit down several routes and a marker missed by
any of them would linger forever. A lingering marker is inert: it names either
a dead PID or, after reuse, a process whose creation time no longer matches.

**Note on a weaker fix that was considered and rejected.** Refusing to reap
only when the registry is empty is not sufficient. A redirected-HOME harness
repopulates its registry the moment it creates its own session, which puts
every foreign server back in scope on the very next invocation. Attribution
has to be per candidate.

## Compatibility

A server started by an older build writes no marker, so it is never reaped.
That is the safe direction (under-kill, not over-kill), and it means orphan
reaping only resumes for servers started by a build containing this change.

## Validation

- 14 new unit tests (`tests-rs/test_issue510_reaper_attribution.rs`) covering
  the foreign-server rule, the identity gate, marker parsing, and both the
  harness and wiped-registry scenarios end to end over real files.
- The 11 existing #448 unit tests are updated, not weakened: every scenario
  keeps its original intent and now supplies the marker its server would have
  written. `orphan_with_no_registry_reference_is_reaped` still asserts an
  orphan is reaped.
- TDD: the first test failed against the pre-fix code with
  `a server this data dir cannot claim must be left alone, got [1000]`.
- Verified on a live machine that the exact operation from the issue - a
  read-only command under a throwaway home - now leaves all three live servers
  running, and that a real server does write its marker.
- `tests/test_issue510_foreign_server_survives.ps1`: 6/6 PASS.
- Confirmed the default psmux session list was unchanged, no registry files
  were left behind, and no pre-existing psmux server was terminated.

## One thing found while validating

psmux servers under a redirected `USERPROFILE`/`HOME` shut themselves down
after ~10s on Windows. This is pre-existing and unrelated to the reaper (it
reproduces with the reaper compiled out), but it is worth knowing: a test
built on `New-PsmuxTestEnv` cannot keep a session alive past that, which is
why the E2E here keeps its victim in the normal data dir under a unique `-L`
namespace and runs only the intruder under a throwaway home. Happy to file
this separately if it is news.

*Authored by Claude (Anthropic) at @acoliver's direction.*