### PR TITLE
fix(#509): give each -L namespace a stable server identity

### DIFF
--- a/docs/integration.md
+++ b/docs/integration.md
@@ -413,9 +413,22 @@ row per object. The full catalogue, including the human facing status bar variab
 | `#{client_pid}` | `32944` | PID of the attached client |
 | `#{client_key_table}` | `root` | Key table the client is currently in |
 | `#{version}` | `3.3.7` | psmux version, for capability gating |
-| `#{pid}` / `#{server_pid}` | `19004` | PID of the psmux server |
+| `#{pid}` / `#{server_pid}` | `19004` | PID of the server process that answered — **session-scoped**, see below |
+| `#{server_instance}` | `b644f0a347fa5e14` | Stable identity of the `-L` namespace — poll this to detect a real restart |
 | `#{socket_path}` | `C:\Users\me/.psmux/default` | Server discovery path |
 | `#{host}` / `#{host_short}` / `#{user}` | `BOX` / `me` | Host and user identity |
+
+> **Supervising a namespace.** Unlike tmux, psmux runs one server process per
+> session, so `#{pid}` (and its alias `#{server_pid}`) report whichever session's
+> server handled the request — creating a session changes the value even though
+> nothing restarted. A watchdog that polls `#{pid}` to answer *"is this still the
+> server I was talking to?"* will read every new session as a server restart.
+>
+> Poll `#{server_instance}` instead. It is minted by the first server in a `-L`
+> namespace, reported identically by every server in that namespace, and changes
+> only when the namespace has genuinely gone away and come back. An unknown or
+> not-yet-started namespace reports an empty value, which should be treated as
+> *unknown* rather than as a restart.
 
 Any option name also resolves inside `#{...}`, which is usually cheaper and more reliable than
 parsing `show-options` output:

--- a/docs/scripting.md
+++ b/docs/scripting.md
@@ -417,7 +417,8 @@ bind-key -n C-h if-shell -F "#{pane_at_left}" "send-keys C-h" "select-pane -L"
 | `#{host}` / `#{hostname}` | Full hostname |
 | `#{host_short}` | Hostname up to the first dot |
 | `#{user}` / `#{username}` | Current user name |
-| `#{pid}` / `#{server_pid}` | PID of the psmux server |
+| `#{pid}` / `#{server_pid}` | PID of the server process that answered the request. psmux runs one server per session, so this is session-scoped and changes when a session is created — use `#{server_instance}` to identify the namespace |
+| `#{server_instance}` | Stable identity of the `-L` namespace. Constant while the namespace is up, whichever of its servers answers; changes only after a genuine restart. Empty for a namespace that has no server |
 | `#{version}` | psmux version, for example `3.3.7` |
 | `#{start_time}` | Server start time |
 | `#{socket_path}` | Path of the server's discovery files |

--- a/src/format.rs
+++ b/src/format.rs
@@ -1150,6 +1150,10 @@ pub fn expand_var(var: &str, app: &AppState, win_idx: usize) -> String {
                     .map(|d| d.to_string_lossy().into_owned())
                     .unwrap_or_default(),
                 "pid" | "server_pid" => std::process::id().to_string(),
+                "server_instance" => {
+                    crate::session::read_namespace_instance(app.socket_name.as_deref())
+                        .unwrap_or_default()
+                }
                 "version" => VERSION.to_string(),
                 "host" | "hostname" => hostname_cached(),
                 "host_short" => { let h = hostname_cached(); h.split('.').next().unwrap_or(&h).to_string() }
@@ -1736,7 +1740,18 @@ pub fn expand_var(var: &str, app: &AppState, win_idx: usize) -> String {
         "host" | "hostname" => hostname_cached(),
         "host_short" => { let h = hostname_cached(); h.split('.').next().unwrap_or(&h).to_string() }
         "user" | "username" => env::var("USERNAME").or_else(|_| env::var("USER")).unwrap_or_else(|_| "unknown".into()),
+        // NOTE: `#{pid}`/`#{server_pid}` are SESSION-scoped on psmux, not
+        // namespace-scoped as they are on tmux: psmux runs one server process
+        // per session, so this is the pid of whichever session's server answered
+        // the request. Use `#{server_instance}` to identify the namespace.
         "pid" | "server_pid" => std::process::id().to_string(),
+        // Namespace-scoped identity (issue #509): constant for the life of this
+        // `-L` namespace's server set, and different after a genuine restart.
+        // Every server in the namespace reads the same token, so the value does
+        // not depend on which one answered.
+        "server_instance" => {
+            crate::session::read_namespace_instance(app.socket_name.as_deref()).unwrap_or_default()
+        }
         "version" => VERSION.to_string(),
         "start_time" => app.created_at.timestamp().to_string(),
         "socket_path" => {

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -131,6 +131,44 @@ pub fn spawnlock_file(session: impl AsRef<str>) -> String {
     format!("{}\\{}.spawnlock", psmux_dir(), session.as_ref())
 }
 
+/// Directory holding one namespace-identity file per `-L` namespace (issue #509).
+///
+/// A subdirectory rather than a `<ns>.instance` sibling: session files are named
+/// `<ns>__<session>.<ext>`, and the default namespace uses a bare `<session>`,
+/// so any flat naming risks colliding with a legitimately-named session.
+pub fn instance_dir_in(dir: &std::path::Path) -> std::path::PathBuf {
+    dir.join("instances")
+}
+
+/// Path to a namespace's identity file. `ns` is the `-L` value, or `None` for
+/// the default namespace.
+///
+/// The file name is a readable prefix plus a hash of the *full* namespace name.
+/// `-L` values come from the user and may contain characters that are illegal in
+/// a filename (or that would collide once sanitised — `a/b` and `a_b` both
+/// become `a_b`), so the hash, not the prefix, is what guarantees isolation.
+pub fn namespace_instance_file(dir: &std::path::Path, ns: Option<&str>) -> std::path::PathBuf {
+    let name = match ns {
+        None => "default-0000000000000000".to_string(),
+        Some(n) => {
+            use std::hash::{Hash, Hasher};
+            // A fixed-seed hasher: the file name must be identical across
+            // processes and runs, so `RandomState` (used for the random session
+            // key) is deliberately NOT used here.
+            let mut h = std::collections::hash_map::DefaultHasher::new();
+            n.hash(&mut h);
+            let digest = h.finish();
+            let prefix: String = n
+                .chars()
+                .filter(|c| c.is_ascii_alphanumeric() || *c == '-' || *c == '_')
+                .take(32)
+                .collect();
+            format!("{}-{:016x}", prefix, digest)
+        }
+    };
+    instance_dir_in(dir).join(name)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -127,6 +127,13 @@ fn ensure_session_registry_files(app: &AppState) {
         let _ = std::fs::write(&pid_path, &pid_value);
     }
 
+    // Establish the namespace's stable identity (issue #509) before the .port
+    // beacon, so a client that sees a ready server can immediately query
+    // `#{server_instance}` and get a value. Minted by the namespace's first
+    // server and left alone by every later one; re-ensured here so it self-heals
+    // if the file is lost while the namespace is still up.
+    let _ = crate::session::ensure_namespace_instance(app.socket_name.as_deref(), self_pid);
+
     // .port goes LAST: it is the readiness beacon (see comment above).
     if std::fs::read_to_string(&port_path)
         .map(|s| s.trim() != port_value)

--- a/src/session.rs
+++ b/src/session.rs
@@ -384,6 +384,156 @@ pub fn confirms_identity(queried: Option<u64>, expected: u64) -> bool {
     queried == Some(expected)
 }
 
+/// `.pid` registry entries belonging to namespace `ns`, excluding `self_pid`
+/// (issue #509).
+///
+/// Membership is decided by the file-name convention: a `-L` namespace writes
+/// `<ns>__<session>.pid`, while the default namespace writes a bare
+/// `<session>.pid`. The warm helper is included in both cases — it is a real
+/// server, so while it lives the namespace has not gone away.
+pub fn namespace_peer_pids(dir: &Path, ns: Option<&str>, self_pid: u32) -> Vec<PidTarget> {
+    let mut peers = Vec::new();
+    let Ok(entries) = std::fs::read_dir(dir) else { return peers; };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().map(|e| e != "pid").unwrap_or(true) {
+            continue;
+        }
+        let Some(stem) = path.file_stem().and_then(|s| s.to_str()) else { continue };
+        let mine = match ns {
+            Some(n) => stem.starts_with(&format!("{}__", n)),
+            // A bare session name has no `__` separator; the default namespace's
+            // own warm helper is the one exception.
+            None => !stem.contains("__") || stem == "__warm__",
+        };
+        if !mine {
+            continue;
+        }
+        if let Ok(contents) = std::fs::read_to_string(&path) {
+            if let Some((pid, Some(creation_time))) = parse_pid_file_contents(&contents) {
+                if pid != self_pid {
+                    peers.push(PidTarget { pid, creation_time });
+                }
+            }
+        }
+    }
+    peers
+}
+
+/// Whether the calling server is the first live server in its namespace, i.e.
+/// no peer from the registry is still running under its recorded identity.
+///
+/// `creation_of` supplies each pid's current creation FILETIME (`None` when the
+/// process is gone or unreadable) so the decision is testable without OS process
+/// enumeration. A pid whose creation time no longer matches has been recycled
+/// and is somebody else's process, not our peer.
+pub fn is_first_server_in_namespace(
+    peers: &[PidTarget],
+    creation_of: impl Fn(u32) -> Option<u64>,
+) -> bool {
+    !peers
+        .iter()
+        .any(|p| confirms_identity(creation_of(p.pid), p.creation_time))
+}
+
+/// Mint a fresh namespace identity token.
+fn mint_instance_token() -> String {
+    use std::collections::hash_map::RandomState;
+    use std::hash::{BuildHasher, Hasher};
+    let s = RandomState::new();
+    let mut h = s.build_hasher();
+    h.write_u64(
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos() as u64,
+    );
+    h.write_u64(std::process::id() as u64);
+    format!("{:016x}", h.finish())
+}
+
+/// Establish this namespace's stable identity (issue #509), returning the token
+/// now in force.
+///
+/// psmux runs one server process per session, so a per-process value such as
+/// `#{pid}` changes every time a session is created and a supervisor reads that
+/// as a server restart. Every server in a namespace instead reads one shared
+/// token file, so it does not matter which server answers a query.
+///
+/// The token is minted by the namespace's first server and left alone by every
+/// later one. It is re-minted only when no peer is still alive — that is a
+/// genuine restart, and a supervisor must be able to see it. Reclamation is
+/// therefore self-healing: a token left behind by a namespace that died is
+/// replaced by the next server to start, so nothing needs to delete it on exit
+/// (a server can exit via exit-empty, kill-session, or a crash).
+pub fn ensure_namespace_instance_in(
+    dir: &Path,
+    ns: Option<&str>,
+    self_pid: u32,
+    creation_of: impl Fn(u32) -> Option<u64>,
+) -> Option<String> {
+    let path = crate::paths::namespace_instance_file(dir, ns);
+
+    let peers = namespace_peer_pids(dir, ns, self_pid);
+    if is_first_server_in_namespace(&peers, creation_of) {
+        // The namespace this token described is gone; do not inherit its identity.
+        let _ = std::fs::remove_file(&path);
+    }
+
+    if let Some(parent) = path.parent() {
+        if std::fs::create_dir_all(parent).is_err() {
+            return None;
+        }
+    }
+
+    // `create_new` so a concurrent first-start cannot clobber the winner's token.
+    match std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&path)
+    {
+        Ok(mut f) => {
+            use std::io::Write as _;
+            let _ = write!(f, "{}", mint_instance_token());
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {}
+        Err(_) => return None,
+    }
+
+    read_namespace_instance_in(dir, ns)
+}
+
+/// Read a namespace's identity token, or `None` when the namespace has none.
+///
+/// Reading never mints: only a starting server may establish identity, so a
+/// client query against an unknown namespace reports nothing rather than
+/// inventing a value.
+pub fn read_namespace_instance_in(dir: &Path, ns: Option<&str>) -> Option<String> {
+    let path = crate::paths::namespace_instance_file(dir, ns);
+    let contents = std::fs::read_to_string(path).ok()?;
+    let token = contents.trim();
+    if token.is_empty() {
+        None
+    } else {
+        Some(token.to_string())
+    }
+}
+
+/// Production wrapper for [`ensure_namespace_instance_in`] against the real data
+/// directory and live process table.
+pub fn ensure_namespace_instance(ns: Option<&str>, self_pid: u32) -> Option<String> {
+    let dir = crate::paths::psmux_dir_opt()?;
+    ensure_namespace_instance_in(Path::new(&dir), ns, self_pid, |pid| {
+        crate::platform::process_kill::process_creation_time(pid)
+    })
+}
+
+/// Production wrapper for [`read_namespace_instance_in`].
+pub fn read_namespace_instance(ns: Option<&str>) -> Option<String> {
+    let dir = crate::paths::psmux_dir_opt()?;
+    read_namespace_instance_in(Path::new(&dir), ns)
+}
+
 /// Terminate live psmux *server* processes that no registry entry accounts for
 /// (issue #448). Complements `cleanup_stale_port_files`, which only removes
 /// registry files for servers already proven dead: this pass finds a live but
@@ -1614,3 +1764,7 @@ mod tests_startup_stale_port_tax;
 #[cfg(test)]
 #[path = "../tests-rs/test_l_socket_tmux_precedence.rs"]
 mod tests_l_socket_tmux_precedence;
+
+#[cfg(test)]
+#[path = "../tests-rs/test_issue509_namespace_instance.rs"]
+mod tests_issue509_namespace_instance;

--- a/tests-rs/test_issue509_namespace_instance.rs
+++ b/tests-rs/test_issue509_namespace_instance.rs
@@ -1,0 +1,337 @@
+// Issue #509: no stable per-namespace server identity.
+//
+// psmux runs one `psmux.exe server` process per session, so `#{pid}` (and its
+// alias `#{server_pid}`) resolve to whichever session's server answered the
+// request. Creating a session therefore changes the value for the whole
+// namespace, which a supervisor following the tmux idiom reads as "the server
+// restarted" — marking every already-running session as having lost its server.
+//
+// The fix is a namespace-scoped instance token: minted by the first server in a
+// namespace, read (never re-minted) by every later server, and re-minted only
+// when the namespace has genuinely gone away and come back. Because every server
+// in the namespace reads the SAME file, it does not matter which one answers the
+// query — they all report the same token.
+//
+// These tests exercise the pure decision logic and the on-disk format against
+// the real production code. Peer liveness is injected, so there is no OS process
+// enumeration and the tests are deterministic and cross-platform. The end-to-end
+// proof (the issue's own three-session reproduction) lives in the PowerShell E2E.
+
+use super::*;
+
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+static TMP_COUNTER: AtomicUsize = AtomicUsize::new(0);
+
+fn temp_dir() -> PathBuf {
+    let mut p = std::env::temp_dir();
+    let n = TMP_COUNTER.fetch_add(1, Ordering::SeqCst);
+    p.push(format!("psmux_issue509_{}_{}", std::process::id(), n));
+    let _ = std::fs::create_dir_all(&p);
+    p
+}
+
+/// Write a `.pid` registry entry for `base` naming `pid` with `creation_ft`.
+fn write_pid_entry(dir: &Path, base: &str, pid: u32, creation_ft: u64) {
+    let _ = std::fs::write(
+        dir.join(format!("{}.pid", base)),
+        format_pid_file_contents(pid, creation_ft),
+    );
+}
+
+/// A liveness oracle: every pid in the list is alive with the given creation time.
+fn alive(entries: &[(u32, u64)]) -> impl Fn(u32) -> Option<u64> + '_ {
+    move |pid| entries.iter().find(|(p, _)| *p == pid).map(|(_, ft)| *ft)
+}
+
+/// A liveness oracle where nothing is alive.
+fn all_dead(_pid: u32) -> Option<u64> {
+    None
+}
+
+// ---------------------------------------------------------------------------
+// Namespace membership: which .pid entries belong to which namespace
+// ---------------------------------------------------------------------------
+
+#[test]
+fn named_namespace_claims_only_its_own_prefixed_entries() {
+    let dir = temp_dir();
+    write_pid_entry(&dir, "alpha__one", 100, 11);
+    write_pid_entry(&dir, "alpha__two", 101, 12);
+    write_pid_entry(&dir, "beta__one", 200, 21);
+    write_pid_entry(&dir, "solo", 300, 31);
+
+    let peers = namespace_peer_pids(&dir, Some("alpha"), 0);
+    let pids: HashSet<u32> = peers.iter().map(|t| t.pid).collect();
+    assert_eq!(
+        pids,
+        HashSet::from([100, 101]),
+        "a named namespace must see only its own sessions, got {:?}",
+        pids
+    );
+}
+
+#[test]
+fn named_namespace_includes_its_warm_server() {
+    // The warm helper is a real server in the namespace; if it is alive the
+    // namespace has not gone away, so it must count as a peer.
+    let dir = temp_dir();
+    write_pid_entry(&dir, "alpha____warm__", 100, 11);
+
+    let peers = namespace_peer_pids(&dir, Some("alpha"), 0);
+    assert_eq!(
+        peers.iter().map(|t| t.pid).collect::<Vec<_>>(),
+        vec![100],
+        "the namespace's warm server must be counted as a peer"
+    );
+}
+
+#[test]
+fn default_namespace_does_not_claim_named_namespace_entries() {
+    let dir = temp_dir();
+    write_pid_entry(&dir, "solo", 300, 31);
+    write_pid_entry(&dir, "alpha__one", 100, 11);
+
+    let peers = namespace_peer_pids(&dir, None, 0);
+    let pids: HashSet<u32> = peers.iter().map(|t| t.pid).collect();
+    assert_eq!(
+        pids,
+        HashSet::from([300]),
+        "the default namespace must not adopt `-L` namespace servers, got {:?}",
+        pids
+    );
+}
+
+#[test]
+fn default_namespace_includes_its_own_warm_server() {
+    let dir = temp_dir();
+    write_pid_entry(&dir, "__warm__", 400, 41);
+
+    let peers = namespace_peer_pids(&dir, None, 0);
+    assert_eq!(
+        peers.iter().map(|t| t.pid).collect::<Vec<_>>(),
+        vec![400],
+        "the default namespace's warm server must be counted as a peer"
+    );
+}
+
+#[test]
+fn self_is_never_its_own_peer() {
+    let dir = temp_dir();
+    write_pid_entry(&dir, "alpha__one", 100, 11);
+
+    let peers = namespace_peer_pids(&dir, Some("alpha"), 100);
+    assert!(
+        peers.is_empty(),
+        "the calling server must not count itself as a peer, got {:?}",
+        peers.iter().map(|t| t.pid).collect::<Vec<_>>()
+    );
+}
+
+// ---------------------------------------------------------------------------
+// "Am I the first server in this namespace?"
+// ---------------------------------------------------------------------------
+
+#[test]
+fn no_peers_at_all_means_first_server() {
+    assert!(is_first_server_in_namespace(&[], all_dead));
+}
+
+#[test]
+fn a_live_peer_means_not_first() {
+    let peers = vec![PidTarget { pid: 100, creation_time: 11 }];
+    assert!(
+        !is_first_server_in_namespace(&peers, alive(&[(100, 11)])),
+        "a live peer means the namespace is still up, so the token must be kept"
+    );
+}
+
+#[test]
+fn a_dead_peer_does_not_keep_the_namespace_alive() {
+    let peers = vec![PidTarget { pid: 100, creation_time: 11 }];
+    assert!(
+        is_first_server_in_namespace(&peers, all_dead),
+        "a registry entry for a dead process must not preserve a stale token"
+    );
+}
+
+#[test]
+fn a_recycled_pid_does_not_keep_the_namespace_alive() {
+    // Same pid, different creation time: the original exited and the OS handed
+    // the number to an unrelated process. That is not our peer.
+    let peers = vec![PidTarget { pid: 100, creation_time: 11 }];
+    assert!(
+        is_first_server_in_namespace(&peers, alive(&[(100, 99)])),
+        "a pid whose creation time no longer matches must not preserve the token"
+    );
+}
+
+#[test]
+fn one_live_peer_among_dead_ones_is_enough() {
+    let peers = vec![
+        PidTarget { pid: 100, creation_time: 11 },
+        PidTarget { pid: 101, creation_time: 12 },
+        PidTarget { pid: 102, creation_time: 13 },
+    ];
+    assert!(
+        !is_first_server_in_namespace(&peers, alive(&[(102, 13)])),
+        "a single surviving peer must keep the namespace's token stable"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The token itself: mint once, then keep — this is the actual #509 fix
+// ---------------------------------------------------------------------------
+
+#[test]
+fn first_server_mints_a_token() {
+    let dir = temp_dir();
+    let token = ensure_namespace_instance_in(&dir, Some("alpha"), 100, all_dead);
+    assert!(token.is_some(), "the first server in a namespace must mint a token");
+    assert!(
+        !token.as_deref().unwrap_or_default().is_empty(),
+        "the minted token must not be empty"
+    );
+}
+
+#[test]
+fn later_servers_keep_the_first_servers_token() {
+    // This is issue #509 in one assertion: creating more sessions must not
+    // change the namespace's identity.
+    let dir = temp_dir();
+
+    write_pid_entry(&dir, "alpha__one", 100, 11);
+    let first = ensure_namespace_instance_in(&dir, Some("alpha"), 100, all_dead)
+        .expect("first server mints");
+
+    for (pid, ft, base) in [(101u32, 12u64, "alpha__two"), (102, 13, "alpha__three")] {
+        write_pid_entry(&dir, base, pid, ft);
+        let seen = ensure_namespace_instance_in(
+            &dir,
+            Some("alpha"),
+            pid,
+            alive(&[(100, 11), (101, 12), (102, 13)]),
+        );
+        assert_eq!(
+            seen.as_deref(),
+            Some(first.as_str()),
+            "creating session {} changed the namespace token — this is #509",
+            base
+        );
+    }
+}
+
+#[test]
+fn every_server_in_the_namespace_reports_the_same_token() {
+    // Whichever server answers `display-message`, the value must agree, because
+    // they all read the same file.
+    let dir = temp_dir();
+    write_pid_entry(&dir, "alpha__one", 100, 11);
+    let minted = ensure_namespace_instance_in(&dir, Some("alpha"), 100, all_dead).unwrap();
+
+    let readings: HashSet<String> = [100u32, 101, 102]
+        .iter()
+        .filter_map(|_| read_namespace_instance_in(&dir, Some("alpha")))
+        .collect();
+
+    assert_eq!(
+        readings,
+        HashSet::from([minted]),
+        "all servers in a namespace must report one identity"
+    );
+}
+
+#[test]
+fn a_genuinely_restarted_namespace_gets_a_new_token() {
+    // Every server died, then a new one starts: that IS a restart and a
+    // supervisor must be able to see it.
+    let dir = temp_dir();
+    write_pid_entry(&dir, "alpha__one", 100, 11);
+    let before = ensure_namespace_instance_in(&dir, Some("alpha"), 100, all_dead).unwrap();
+
+    // The namespace goes away; the stale registry entry is left behind.
+    let after = ensure_namespace_instance_in(&dir, Some("alpha"), 500, all_dead).unwrap();
+
+    assert_ne!(
+        before, after,
+        "a namespace that fully died and restarted must present a new identity"
+    );
+}
+
+#[test]
+fn namespaces_have_independent_identities() {
+    let dir = temp_dir();
+    let a = ensure_namespace_instance_in(&dir, Some("alpha"), 100, all_dead).unwrap();
+    let b = ensure_namespace_instance_in(&dir, Some("beta"), 200, all_dead).unwrap();
+    assert_ne!(a, b, "separate namespaces must not share an identity");
+}
+
+#[test]
+fn default_namespace_has_its_own_identity() {
+    let dir = temp_dir();
+    let named = ensure_namespace_instance_in(&dir, Some("alpha"), 100, all_dead).unwrap();
+    let default = ensure_namespace_instance_in(&dir, None, 200, all_dead).unwrap();
+    assert_ne!(
+        named, default,
+        "the default namespace must not share the identity of a `-L` namespace"
+    );
+}
+
+#[test]
+fn reading_an_unknown_namespace_yields_nothing() {
+    let dir = temp_dir();
+    assert_eq!(
+        read_namespace_instance_in(&dir, Some("never-existed")),
+        None,
+        "an unknown namespace must read as absent, not as some other namespace's token"
+    );
+}
+
+#[test]
+fn reading_does_not_mint() {
+    // A client-side read must never create identity; only a starting server may.
+    let dir = temp_dir();
+    assert_eq!(read_namespace_instance_in(&dir, Some("alpha")), None);
+    assert_eq!(
+        read_namespace_instance_in(&dir, Some("alpha")),
+        None,
+        "reading must have no side effect"
+    );
+}
+
+#[test]
+fn a_missing_data_dir_is_not_fatal() {
+    let mut missing = temp_dir();
+    missing.push("does-not-exist");
+    // Must not panic, and must not claim an identity it cannot store.
+    let _ = ensure_namespace_instance_in(&missing, Some("alpha"), 100, all_dead);
+    let _ = read_namespace_instance_in(&missing, Some("alpha"));
+}
+
+#[test]
+fn a_namespace_name_that_is_not_a_safe_filename_is_still_isolated() {
+    // `-L` values come from the user; two different names must never collide on
+    // one file, whatever characters they contain.
+    let dir = temp_dir();
+    let a = ensure_namespace_instance_in(&dir, Some("a/b"), 100, all_dead);
+    let b = ensure_namespace_instance_in(&dir, Some("a_b"), 200, all_dead);
+    if let (Some(a), Some(b)) = (a, b) {
+        assert_ne!(a, b, "distinct namespace names must not share a token file");
+    }
+}
+
+#[test]
+fn an_existing_token_is_returned_verbatim() {
+    let dir = temp_dir();
+    write_pid_entry(&dir, "alpha__one", 100, 11);
+    let minted = ensure_namespace_instance_in(&dir, Some("alpha"), 100, all_dead).unwrap();
+    let read_back = read_namespace_instance_in(&dir, Some("alpha")).unwrap();
+    assert_eq!(minted, read_back, "the stored token must round-trip unchanged");
+    assert!(
+        !read_back.contains('\n') && !read_back.contains('\r'),
+        "the token must be a single line so `display-message -p` output is usable, got {:?}",
+        read_back
+    );
+}

--- a/tests/test_issue509_namespace_instance.ps1
+++ b/tests/test_issue509_namespace_instance.ps1
@@ -1,0 +1,147 @@
+# Issue #509: a `-L` namespace must present a stable server identity.
+#
+# psmux runs one server process per session, so `#{pid}` (and its alias
+# `#{server_pid}`) resolve to whichever session's server answered the request.
+# Creating a session therefore changes the value for the whole namespace, and a
+# supervisor following the tmux idiom reads that as "the server restarted" —
+# marking every already-running session as having lost its server.
+#
+# This is the issue's own reproduction, plus the two properties that make the new
+# `#{server_instance}` token actually useful to a supervisor:
+#   * it does NOT change when a session is created, and
+#   * it DOES change when the namespace genuinely dies and comes back.
+#
+# The test uses a unique `-L` namespace in the real data directory and tears down
+# only what it created. It never runs a bare `kill-server`.
+
+$ErrorActionPreference = 'Stop'
+. "$PSScriptRoot\psmux_test_helpers.ps1"
+
+$exe = Get-PsmuxExe
+$psmuxDir = Join-Path $env:USERPROFILE '.psmux'
+$ns = "i509t$(Get-Random -Maximum 999999)"
+$failures = 0
+$checks = 0
+
+function Check($label, $condition, $detail) {
+    $script:checks++
+    if ($condition) {
+        Write-Host "  PASS  $label"
+    } else {
+        $script:failures++
+        Write-Host "  FAIL  $label" -ForegroundColor Red
+        if ($detail) { Write-Host "        $detail" -ForegroundColor Red }
+    }
+}
+
+function Query($namespace, $fmt) {
+    # A namespace with no server answers on stderr ("no server running"), which
+    # is a legitimate outcome here — an absent namespace has no identity. Keep
+    # that from terminating the script under `$ErrorActionPreference = 'Stop'`.
+    $previous = $ErrorActionPreference
+    $ErrorActionPreference = 'Continue'
+    try {
+        $out = (& $exe -f NUL -L $namespace display-message -p $fmt 2>&1 | Out-String).Trim()
+    } catch {
+        $out = ''
+    } finally {
+        $ErrorActionPreference = $previous
+    }
+    if ($out -match 'no server running') { return '' }
+    $out
+}
+
+function Remove-Namespace($namespace) {
+    & $exe -L $namespace kill-server 2>&1 | Out-Null
+    Start-Sleep -Milliseconds 1500
+    Remove-Item (Join-Path $psmuxDir "$namespace*") -Force -ErrorAction SilentlyContinue
+}
+
+Write-Host "issue #509: stable per-namespace server identity (namespace: $ns)"
+
+try {
+    # ---------------------------------------------------------------------
+    # The issue's reproduction: three sessions, one namespace, no restart.
+    # ---------------------------------------------------------------------
+    $instances = @()
+    $pids = @()
+    foreach ($s in 'alpha', 'bravo', 'charlie') {
+        & $exe -f NUL -L $ns new-session -d -s $s 2>&1 | Out-Null
+        Start-Sleep -Milliseconds 900
+        $pids += Query $ns '#{pid}'
+        $instances += Query $ns '#{server_instance}'
+    }
+
+    Check "a namespace reports an identity at all" `
+        ($instances[0] -match '^[0-9a-f]{16}$') `
+        "got '$($instances[0])'"
+
+    $distinct = @($instances | Sort-Object -Unique)
+    Check "#{server_instance} is unchanged by creating sessions" `
+        ($distinct.Count -eq 1) `
+        "saw $($distinct.Count) different values across three sessions: $($instances -join ', ')"
+
+    # Documents the behaviour that motivated the issue. This is deliberately NOT
+    # changed by the fix: #{pid} is legitimately the answering server's pid, and
+    # #{server_instance} is the value a supervisor should poll instead.
+    $distinctPids = @($pids | Sort-Object -Unique)
+    Check "#{pid} remains session-scoped (unchanged behaviour)" `
+        ($distinctPids.Count -gt 1) `
+        "expected per-session pids to differ, all were '$($pids[0])'"
+
+    # All three sessions really are one namespace, so the identity above is
+    # describing a live multi-session namespace rather than a collapsed one.
+    $sessions = (& $exe -f NUL -L $ns list-sessions 2>&1 | Out-String)
+    Check "all three sessions are live in one namespace" `
+        (($sessions -match 'alpha') -and ($sessions -match 'bravo') -and ($sessions -match 'charlie')) `
+        "list-sessions returned: $($sessions.Trim())"
+
+    $beforeRestart = $instances[0]
+
+    # ---------------------------------------------------------------------
+    # A genuine restart MUST be visible: kill the namespace, start it again.
+    # ---------------------------------------------------------------------
+    Remove-Namespace $ns
+    & $exe -f NUL -L $ns new-session -d -s alpha 2>&1 | Out-Null
+    Start-Sleep -Milliseconds 900
+    $afterRestart = Query $ns '#{server_instance}'
+
+    Check "a genuinely restarted namespace reports a NEW identity" `
+        ($afterRestart -ne $beforeRestart -and $afterRestart -match '^[0-9a-f]{16}$') `
+        "before='$beforeRestart' after='$afterRestart'"
+
+    # ---------------------------------------------------------------------
+    # Namespaces must not share an identity.
+    # ---------------------------------------------------------------------
+    $ns2 = "${ns}b"
+    try {
+        & $exe -f NUL -L $ns2 new-session -d -s alpha 2>&1 | Out-Null
+        Start-Sleep -Milliseconds 900
+        $other = Query $ns2 '#{server_instance}'
+        Check "separate namespaces have separate identities" `
+            ($other -ne $afterRestart -and $other -match '^[0-9a-f]{16}$') `
+            "ns='$afterRestart' ns2='$other'"
+    } finally {
+        Remove-Namespace $ns2
+    }
+
+    # ---------------------------------------------------------------------
+    # An unknown namespace must report nothing rather than another's token.
+    # ---------------------------------------------------------------------
+    $unknown = Query "${ns}-never-existed" '#{server_instance}'
+    Check "an unknown namespace reports no identity" `
+        ([string]::IsNullOrWhiteSpace($unknown) -or $unknown -notmatch '^[0-9a-f]{16}$') `
+        "got '$unknown'"
+}
+finally {
+    Remove-Namespace $ns
+    Remove-Item (Join-Path $psmuxDir "instances\$ns*") -Force -ErrorAction SilentlyContinue
+}
+
+Write-Host ""
+if ($failures -gt 0) {
+    Write-Host "issue #509: $failures of $checks checks FAILED" -ForegroundColor Red
+    exit 1
+}
+Write-Host "issue #509: all $checks checks passed" -ForegroundColor Green
+exit 0


### PR DESCRIPTION
## Overview

Fixes #509.

psmux runs one `psmux.exe server` process per session, so `#{pid}` — and its
alias `#{server_pid}` — resolve to whichever session's server answered the
request. Creating a session changes the value for the whole namespace, and a
supervisor following the tmux idiom reads that as *"the server restarted"*,
marking every already-running session as having lost its server.

This adds `#{server_instance}`, a namespace-scoped identity:

- **Minted** by the first server in a `-L` namespace, stored under
  `<data dir>/instances/`.
- **Read, never re-minted,** by every later server in that namespace — so the
  reported value does not depend on which server replied.
- **Re-minted only when no peer is still alive,** so a genuine restart remains
  visible to a watchdog.

Peer liveness reuses the existing `.pid` identity gate (`confirms_identity`): a
pid whose recorded creation time no longer matches has been recycled and is
somebody else's process, so it cannot keep a dead namespace's token alive.

## Design notes

**Reclamation is self-healing, not explicit.** A server can exit via
`exit-empty`, `kill-session`, or a crash, so nothing reliably runs on the way
out. Rather than deleting the token on exit, it is replaced by the next server
that finds no live peer.

**No pruning pass, deliberately.** Wrongly deleting a *live* namespace's token
would cause the next re-ensure to mint a fresh one and signal a restart that
never happened — the exact defect being fixed. A stale token is a few bytes and
is reused whenever that namespace name is used again; accumulation is bounded by
distinct namespace names, exactly as it already is for `.port`/`.key`/`.sid`/`.pid`.

**`#{pid}` / `#{server_pid}` are unchanged.** They correctly report the
answering server, and changing them would break anyone relying on current
semantics. The docs no longer describe them as "PID of the psmux server", state
that they are session-scoped, and point supervisors at `#{server_instance}`.

**Out of scope:** making unattached `display-message` resolve against the
namespace rather than the newest session (direction 2 in the issue). That
overlaps #485 and changes existing behaviour, so it is left as a separate call
for the maintainer.

**Filename isolation:** `-L` values come from the user and may contain
characters that are illegal in a filename, or that collide once sanitised
(`a/b` and `a_b` both become `a_b`). The identity file name is a readable
prefix plus a fixed-seed hash of the *full* namespace name, so isolation does
not depend on the prefix.

## Validation

- **The issue's own three-session reproduction**, against the built binary:

  ```
  after creating alpha    #{pid}=24892   #{server_instance}=b644f0a347fa5e14
  after creating bravo    #{pid}=16088   #{server_instance}=b644f0a347fa5e14
  after creating charlie  #{pid}=25344   #{server_instance}=b644f0a347fa5e14
  ```

  `#{pid}` still varies (behaviour preserved); `#{server_instance}` holds constant.

- **21 new unit tests** (`tests-rs/test_issue509_namespace_instance.rs`) covering
  namespace membership (including each namespace's warm helper, and the default
  namespace not adopting `-L` entries), the first-server decision under dead and
  recycled pids, mint-once/keep semantics, re-mint after a genuine restart,
  namespace independence, and that reading never mints. Peer liveness is
  injected, so there is no OS process enumeration and the tests are
  deterministic and cross-platform.

- **7 end-to-end checks** (`tests/test_issue509_namespace_instance.ps1`): the
  reproduction, a real kill-and-restart producing a new token, two namespaces
  not sharing an identity, and an unknown namespace reporting nothing. Runs in a
  unique `-L` namespace and tears down only what it created — never a bare
  `kill-server`.

- **Full unit suite: 2589 passed, 0 failed.** `cargo check --all-targets` clean.

- Confirmed the default psmux session list was unchanged, and that no server
  outside the test namespace was affected.

---

*Authored by Claude (Anthropic) at @acoliver's direction.*