### PR TITLE
fix(send-keys): implement -H literal-byte injection

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -2908,6 +2908,47 @@ pub fn send_paste_to_active(app: &mut AppState, text: &str) -> io::Result<()> {
     Ok(())
 }
 
+/// Write raw bytes (decoded from `send-keys -H`) to whichever pane would
+/// receive input.
+///
+/// Valid UTF-8 is handed to `send_text_to_active` so every existing mode
+/// (copy, popup, confirm, menu, synchronized input) keeps its semantics.  A
+/// byte run that is not valid UTF-8 bypasses that and goes straight to the
+/// pane: callers that chunk their input can split a multi-byte character
+/// across two `send-keys` calls, and a lossy decode would corrupt it.
+pub fn send_bytes_to_active(app: &mut AppState, bytes: &[u8]) -> io::Result<()> {
+    if let Ok(text) = std::str::from_utf8(bytes) {
+        return send_text_to_active(app, text);
+    }
+    {
+        let win = &mut app.windows[app.active_idx];
+        if let Some(fi) = win.floating_focus {
+            if let Some(fp) = win.floating.get_mut(fi) {
+                let _ = fp.pane.writer.write_all(bytes);
+                let _ = fp.pane.writer.flush();
+                return Ok(());
+            }
+        }
+    }
+    if app.sync_input {
+        let win = &mut app.windows[app.active_idx];
+        fn write_all_panes(node: &mut Node, data: &[u8]) {
+            match node {
+                Node::Leaf(p) => { let _ = p.writer.write_all(data); let _ = p.writer.flush(); }
+                Node::Split { children, .. } => { for c in children { write_all_panes(c, data); } }
+            }
+        }
+        write_all_panes(&mut win.root, bytes);
+    } else {
+        let win = &mut app.windows[app.active_idx];
+        if let Some(p) = active_pane_mut(&mut win.root, &win.active_path) {
+            let _ = p.writer.write_all(bytes);
+            let _ = p.writer.flush();
+        }
+    }
+    Ok(())
+}
+
 pub fn send_text_to_active(app: &mut AppState, text: &str) -> io::Result<()> {
     // In clock mode, any input exits back to passthrough
     if matches!(app.mode, Mode::ClockMode) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1631,14 +1631,16 @@ fn run_main() -> io::Result<()> {
             "send-keys" | "send" | "send-key" => {
                 let mut literal = false;
                 let mut has_x = false;
+                let mut has_hex = false;
                 let mut keys: Vec<String> = Vec::new();
-                // Getopt-style parsing: -t consumes next arg, -l/-R/-X are flags
+                // Getopt-style parsing: -t consumes next arg, -l/-R/-X/-H are flags
                 let mut i = 1;
                 while i < cmd_args.len() {
                     match cmd_args[i].as_str() {
                         "-l" => { literal = true; }
                         "-R" => { keys.push("__RESET__".to_string()); }
                         "-X" => { has_x = true; }
+                        "-H" => { has_hex = true; }
                         "-t" => { i += 1; } // consume target value (already handled globally)
                         "-N" => { i += 1; } // repeat count, consume value
                         _ => { keys.push(cmd_args[i].to_string()); }
@@ -1648,6 +1650,7 @@ fn run_main() -> io::Result<()> {
                 let mut cmd = "send-keys".to_string();
                 if literal { cmd.push_str(" -l"); }
                 if has_x { cmd.push_str(" -X"); }
+                if has_hex { cmd.push_str(" -H"); }
                 // Quote arguments that contain spaces to preserve them
                 for k in keys { 
                     if k.contains(' ') || k.contains('\t') || k.contains('"') {

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -114,16 +114,29 @@ fn decode_send_command(line: &str) -> Option<(String, Vec<u8>)> {
     }
 
     let literal = any_short('l');
+    // -H marks every operand as one raw hexadecimal byte (tmux KEYC_LITERAL).
+    let literal_byte = any_short('H');
     let mut bytes: Vec<u8> = Vec::new();
     for (i, a) in args.iter().enumerate() {
         if a.starts_with('-') { continue; }
         if prev_consumes_operand(i) { continue; }
         // Hex codepoint?
         let s = *a;
+        if literal_byte {
+            match u8::from_str_radix(s, 16) {
+                Ok(byte) => { bytes.push(byte); continue; }
+                // Malformed operand: refuse to coalesce and let the send-keys
+                // handler decide what to do with the whole command.
+                Err(_) => return None,
+            }
+        }
         if let Some(rest) = s.strip_prefix("0x").or_else(|| s.strip_prefix("0X")) {
             if !rest.is_empty() && rest.chars().all(|c| c.is_ascii_hexdigit()) {
+                // `0xNN` is a codepoint (iTerm2's encoding for typed
+                // characters), so it is UTF-8 encoded here.  Raw bytes only
+                // ever arrive through -H above.  Encoding every value keeps
+                // 0x80-0xFF correct: they are Latin-1 codepoints, not bytes.
                 if let Ok(n) = u32::from_str_radix(rest, 16) {
-                    if n <= 0xff { bytes.push(n as u8); continue; }
                     if let Some(c) = char::from_u32(n) {
                         let mut buf = [0u8; 4];
                         bytes.extend_from_slice(c.encode_utf8(&mut buf).as_bytes());
@@ -140,14 +153,6 @@ fn decode_send_command(line: &str) -> Option<(String, Vec<u8>)> {
     }
 
     Some((target.unwrap_or_else(|| String::new()), bytes))
-}
-
-/// Quote a byte string as a single-quoted shell argument so it survives
-/// re-parsing by `parse_command_line`.  Embedded single quotes are escaped
-/// with the standard `'\''` trick.
-fn shell_quote_bytes(b: &[u8]) -> String {
-    let s: String = b.iter().map(|&c| c as char).collect();
-    format!("'{}'", s.replace('\'', "'\\''"))
 }
 
 /// Re-join already-tokenized command args into a single command string,
@@ -188,9 +193,14 @@ fn coalesce_send_commands(parts: Vec<String>) -> Vec<String> {
 
     fn flush(out: &mut Vec<String>, acc: &mut Vec<u8>, target: &mut Option<String>) {
         if acc.is_empty() { return; }
+        // Re-emit as `send -H`: a byte-exact, pure-ASCII command line.  The
+        // previous `send -l '<latin1>'` form ran every byte through a latin-1
+        // char round trip, which double-encoded anything the decoder had
+        // already turned into UTF-8 (a `send 0x4e2d` arrived as "ä¸­").
+        let hex: Vec<String> = acc.iter().map(|b| format!("{:02x}", b)).collect();
         let line = match target.as_deref() {
-            Some(t) if !t.is_empty() => format!("send -lt {} {}", t, shell_quote_bytes(acc)),
-            _ => format!("send -l {}", shell_quote_bytes(acc)),
+            Some(t) if !t.is_empty() => format!("send -H -t {} {}", t, hex.join(" ")),
+            _ => format!("send -H {}", hex.join(" ")),
         };
         out.push(line);
         acc.clear();
@@ -1339,6 +1349,7 @@ match cmd {
         let literal = flag_has('l');
         let paste_mode = flag_has('p');
         let has_x = flag_has('X');
+        let hex_mode = flag_has('H');
         // Parse -N <count> for repeat (look for any cluster ending in 'N')
         let mut repeat_count: usize = 1;
         if let Some(n_pos) = args.iter().position(|a| a.starts_with('-') && !a.starts_with("--") && a.ends_with('N')) {
@@ -1346,7 +1357,26 @@ match cmd {
                 repeat_count = count_str.parse::<usize>().unwrap_or(1).max(1);
             }
         }
-        if has_x {
+        if hex_mode {
+            // tmux `send-keys -H`: every operand is one hexadecimal BYTE value.
+            // tmux tags these keys KEYC_LITERAL and writes them to the pty as
+            // single bytes ("can't be more than 8 bits"), so this is a byte
+            // channel, not a codepoint channel.  Decode here and pass the raw
+            // bytes through untouched so UTF-8 sequences and escape sequences
+            // survive verbatim.
+            let mut bytes: Vec<u8> = Vec::new();
+            for (i, a) in args.iter().enumerate() {
+                if a.starts_with('-') || prev_consumes_operand(i) { continue; }
+                // A malformed operand is dropped rather than leaked into the
+                // pane as its literal token text.
+                if let Ok(byte) = u8::from_str_radix(a, 16) { bytes.push(byte); }
+            }
+            if !bytes.is_empty() {
+                for _ in 0..repeat_count {
+                    let _ = tx.send(CtrlReq::SendBytes(bytes.clone()));
+                }
+            }
+        } else if has_x {
             // send-keys -X copy-mode-command
             let cmd_parts: Vec<&str> = args.iter().enumerate()
                 .filter(|(i, a)| !a.starts_with('-') && !prev_consumes_operand(*i))
@@ -3445,6 +3475,25 @@ fn dispatch_control_command(
                 false
             };
             let literal = flag_has('l');
+            if flag_has('H') {
+                // tmux `send-keys -H`: every operand is one hexadecimal BYTE value.
+                // tmux tags these keys KEYC_LITERAL and writes them to the pty as
+                // single bytes ("can't be more than 8 bits"), so this is a byte
+                // channel, not a codepoint channel.  Decode here and pass the raw
+                // bytes through untouched so UTF-8 sequences and escape sequences
+                // survive verbatim.
+                let mut bytes: Vec<u8> = Vec::new();
+                for (i, a) in args.iter().enumerate() {
+                    if a.starts_with('-') || prev_consumes_operand(i) { continue; }
+                    // A malformed operand is dropped rather than leaked into the
+                    // pane as its literal token text.
+                    if let Ok(byte) = u8::from_str_radix(a, 16) { bytes.push(byte); }
+                }
+                if !bytes.is_empty() {
+                    let _ = tx.send(CtrlReq::SendBytes(bytes));
+                }
+                return true;
+            }
             // Convert real-tmux 0xNN hex codepoint syntax (used by iTerm2 for
             // every keystroke: `send -t %1 0xd` etc.) into literal characters.
             let keys: Vec<String> = args.iter().enumerate().filter(|(i, a)| {
@@ -4181,3 +4230,7 @@ fn dispatch_control_command(
 #[cfg(test)]
 #[path = "../../tests-rs/test_issue476_bindkey_quoting.rs"]
 mod tests_issue476_bindkey_quoting;
+
+#[cfg(test)]
+#[path = "../../tests-rs/test_send_keys_literal_byte.rs"]
+mod tests_send_keys_literal_byte;

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -25,7 +25,7 @@ use helpers::{collect_pane_paths_server, serialize_bindings_json, json_escape_st
     list_windows_json_with_tabs, combined_data_version, TMUX_COMMANDS};
 use options::{get_option_value, render_window_options, apply_set_option};
 
-use crate::input::{send_text_to_active, send_key_to_active, send_paste_to_active, move_focus, move_focus_preserving_zoom, find_best_pane_in_direction, find_wrap_target};
+use crate::input::{send_text_to_active, send_bytes_to_active, send_key_to_active, send_paste_to_active, move_focus, move_focus_preserving_zoom, find_best_pane_in_direction, find_wrap_target};
 use crate::copy_mode::{enter_copy_mode, exit_copy_mode, move_copy_cursor, current_prompt_pos,
     yank_selection, scroll_copy_up, scroll_copy_down, switch_with_copy_save,
     capture_active_pane_text, capture_active_pane_range, capture_active_pane_styled};
@@ -2358,6 +2358,9 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                     if let Some(p) = active_pane_mut(&mut win.root, &win.active_path) {
                         p.pane_style = Some(style);
                     }
+                }
+                CtrlReq::SendBytes(bytes) => {
+                    send_bytes_to_active(&mut app, &bytes)?;
                 }
                 CtrlReq::SendKeys(keys, literal) => {
                     let in_copy = matches!(app.mode, Mode::CopyMode | Mode::CopySearch { .. });

--- a/src/types.rs
+++ b/src/types.rs
@@ -1467,6 +1467,9 @@ pub enum CtrlReq {
     // re-split on whitespace — that collapsed runs of spaces inside quoted
     // arguments and stripped leading/trailing spaces.
     SendKeys(Vec<String>, bool),
+    /// send-keys -H: hexadecimal operands already decoded to raw bytes,
+    /// written to the pane verbatim.
+    SendBytes(Vec<u8>),
     SendKeysX(String),  // send-keys -X copy-mode-command
     SelectPane(String, bool),
     SelectWindow(usize),

--- a/tests-rs/test_send_keys_literal_byte.rs
+++ b/tests-rs/test_send_keys_literal_byte.rs
@@ -1,0 +1,114 @@
+// `send-keys -H` is a byte channel: every operand is one hexadecimal byte value
+// that reaches the pty verbatim (tmux flags those keys KEYC_LITERAL and
+// input_key.c writes them as single bytes). psmux accepted the flag but never
+// implemented it, so the operands fell through to the key-name lookup and were
+// echoed into the pane as literal text -- typing `echo` produced "65 63 68 6f".
+//
+// These tests pin the two pure functions the fix rests on:
+//   * decode_send_command  -- per-command operand decoding
+//   * coalesce_send_commands -- merging consecutive sub-commands on one line
+//
+// They deliberately start no server (see AGENTS.md).
+
+use super::*;
+
+fn decode(line: &str) -> Option<(String, Vec<u8>)> {
+    decode_send_command(line)
+}
+
+#[test]
+fn literal_byte_operands_decode_to_raw_bytes() {
+    // The repro: "echo" as bare hex bytes.
+    let (target, bytes) = decode("send-keys -H -t %1 65 63 68 6f").expect("must decode");
+    assert_eq!(target, "%1");
+    assert_eq!(bytes, b"echo");
+}
+
+#[test]
+fn literal_byte_carries_utf8_sequences_unchanged() {
+    // 中 = E4 B8 AD. A byte channel must not re-encode these.
+    let (_, bytes) = decode("send-keys -H -t %1 e4 b8 ad").expect("must decode");
+    assert_eq!(bytes, vec![0xe4, 0xb8, 0xad]);
+    assert_eq!(String::from_utf8(bytes).unwrap(), "中");
+}
+
+#[test]
+fn literal_byte_accepts_bytes_that_are_not_valid_utf8() {
+    // A caller may split a multi-byte character across chunked send-keys calls,
+    // so individual commands are not required to be valid UTF-8.
+    let (_, bytes) = decode("send-keys -H -t %1 41 00 ff 42").expect("must decode");
+    assert_eq!(bytes, vec![0x41, 0x00, 0xff, 0x42]);
+}
+
+#[test]
+fn hex_codepoint_operands_stay_codepoints() {
+    // `0xNN` is the iTerm2 encoding for typed characters and means a codepoint,
+    // so it is UTF-8 encoded. This is the opposite of -H and must stay that way.
+    let (_, bytes) = decode("send -t %1 0x4e2d").expect("must decode");
+    assert_eq!(bytes, vec![0xe4, 0xb8, 0xad], "0x4e2d is 中, encoded as UTF-8");
+
+    // Latin-1 range: a codepoint, not a byte.
+    let (_, bytes) = decode("send -t %1 0xe9").expect("must decode");
+    assert_eq!(bytes, vec![0xc3, 0xa9], "0xe9 is é, encoded as UTF-8");
+}
+
+#[test]
+fn malformed_literal_byte_operand_refuses_to_coalesce() {
+    // Returning None leaves the command to the send-keys handler rather than
+    // silently dropping or mangling it here.
+    assert!(decode("send-keys -H -t %1 zz").is_none());
+}
+
+#[test]
+fn coalescing_merges_mixed_encodings_into_one_write() {
+    // iTerm2 splits an arrow key into three differently-encoded sub-commands.
+    // They must merge into a single pty write, otherwise PSReadLine times out
+    // between the ESC and the "[A" and prints them as literal characters.
+    let parts = vec![
+        "send -H -t %1 1b".to_string(),
+        "send -t %1 0x5b".to_string(),
+        "send -lt %1 A".to_string(),
+    ];
+    let merged = coalesce_send_commands(parts);
+    assert_eq!(merged.len(), 1, "three sub-commands must merge into one");
+    assert_eq!(merged[0], "send -H -t %1 1b 5b 41");
+}
+
+#[test]
+fn coalesced_carrier_is_byte_exact_for_multibyte_input() {
+    // The carrier used to be `send -l '<latin-1>'`, which mapped each byte
+    // through `as char` and encoded already-UTF-8 bytes a second time: 中
+    // arrived at the pane as "ä¸­". The -H carrier has no such round trip.
+    let merged = coalesce_send_commands(vec!["send -t %1 0x4e2d".to_string()]);
+    assert_eq!(merged, vec!["send -H -t %1 e4 b8 ad"]);
+
+    // And the carrier re-decodes to exactly the bytes we started with.
+    let (_, bytes) = decode(&merged[0]).expect("carrier must decode");
+    assert_eq!(String::from_utf8(bytes).unwrap(), "中");
+}
+
+#[test]
+fn coalescing_keeps_distinct_targets_apart() {
+    let merged = coalesce_send_commands(vec![
+        "send -H -t %1 41".to_string(),
+        "send -H -t %2 42".to_string(),
+    ]);
+    assert_eq!(merged.len(), 2, "different panes must not be merged");
+    assert_eq!(merged[0], "send -H -t %1 41");
+    assert_eq!(merged[1], "send -H -t %2 42");
+}
+
+#[test]
+fn non_send_commands_pass_through_untouched() {
+    let parts = vec![
+        "send -H -t %1 41".to_string(),
+        "refresh-client -C 80,25".to_string(),
+        "send -H -t %1 42".to_string(),
+    ];
+    let merged = coalesce_send_commands(parts);
+    assert_eq!(
+        merged,
+        vec!["send -H -t %1 41", "refresh-client -C 80,25", "send -H -t %1 42"],
+        "an unrelated command between two sends must break the run and survive verbatim"
+    );
+}


### PR DESCRIPTION
## Context

tmux's `send-keys -H` is a **byte** channel: each operand is one hexadecimal
byte value that reaches the pty verbatim. tmux flags those keys `KEYC_LITERAL`
and `input_key.c` writes them out as single bytes ("Literal keys go as
themselves (can't be more than 8 bits)"). The man page wording "hexadecimal
number representing a Unicode codepoint" does not describe what the code does.

Confirmed against real tmux 3.7b:

```console
$ tmux -L probe new-session -d -s hex 'cat > out.bin'
$ tmux -L probe send-keys -H -t hex 41 e4 b8 ad 0a
$ xxd out.bin
00000000: 41e4 b8ad 0a                             A....
```

Five operands in, exactly those five bytes out.

## Current behaviour

psmux accepts `-H` but never gives it a meaning, so the hex operands are echoed
into the pane as literal text. Typing `echo` through a client that uses `-H`
puts `65 63 68 6f` on screen instead.

```console
$ psmux new-session -d -s demo
$ psmux send-keys -H -t demo 65 63 68 6f
$ psmux capture-pane -p -t demo | tail -1
PS C:\Users\me> 65 63 68 6f
```

The same happens through control mode, which is how gateway-style clients
drive psmux:

```console
$ printf 'send-keys -H -t %%1 65 63 68 6f\n' | psmux -C attach-session -t demo
```

This is not limited to one client. **iTerm2 3.7 routes every C0 control byte
(0x00–0x1F) through `send -H`** when the server reports 3.0a or newer — see
`iTermTmuxSendKeysEncodingLiteralByte` in its `TmuxGateway.m`, and the 3.7
release notes ("Control bytes 0x00–0x1F are now sent through send-keys with
the -H flag on tmux 3.0a or newer"). psmux reports `tmux 3.3.7`, so it takes
that path, and Enter, Tab, Escape and every Ctrl chord arrive as hex text.
`docs/iterm2-control-mode.md` predates that iTerm2 change.

## Root cause

The flag is dropped at three separate layers, and the operands then fall
through to the key-name lookup:

| Layer | Behaviour |
|---|---|
| `main.rs` CLI parsing | getopt handles `-l/-R/-X/-t/-N`; `-H` hits the catch-all and is pushed onto the key list |
| `server/connection.rs` dispatchers | both the control-mode and plain-TCP `send-keys` arms filter out every `-`-prefixed argument, so `-H` disappears |
| `server/mod.rs` key dispatch | bare `41` matches no key name, so it lands in `send_text_to_active` and is written to the pane as text |

`decode_send_command` also refuses to coalesce these commands, because bare hex
is neither a `0x`-prefixed operand nor literal-mode text.

## Fix

Decode the operands where the flag is parsed and carry them to the pane as
bytes through a new `CtrlReq::SendBytes`, in all three entry points.

Valid UTF-8 still goes through `send_text_to_active`, so copy mode, popups,
menus and synchronized input keep their existing behaviour. Only a byte run
that is not valid UTF-8 — which happens when a caller splits a multi-byte
character across two chunked `send-keys` calls — is written straight to the
pane, since reassembling it there is not possible and a lossy decode would
corrupt the input.

Send-coalescing has to understand the flag too. iTerm2 splits an arrow key
into three differently-encoded sub-commands on one line
(`send -H … 1b`, `send -t … 0x5b`, `send -lt … A`), and it is the coalescing
that merges them into a single pty write so PSReadLine does not time out
between the ESC and the `[A`. `decode_send_command` now decodes `-H` operands,
and the merged line is re-emitted as `send -H <hex>` instead of
`send -l '<latin-1>'`.

That carrier change fixes a second, pre-existing bug. The old quoting mapped
each accumulated byte through `as char`, so anything the decoder had already
encoded to UTF-8 was encoded a second time: `send -t %1 0x4e2d` (中) arrived at
the pane as `ä¸­`. With a byte-exact carrier the round trip is gone, and `0xNN`
can consistently mean a codepoint while raw bytes arrive only through `-H`.

## Verification

Driven through control mode against a real pwsh 7.6.4 pane, the same way a
gateway client does it (`psmux -C attach-session` with commands fed to stdin):

| Case | Before | After |
|---|---|---|
| `send-keys -H … 65 63 68 6f` | `65 63 68 6f` | `echo` |
| `send-keys -H … e4 b8 ad` (中) | `e4 b8 ad` | `中` |
| `send -lt %1 abc` | `abc` | `abc` |
| `send -t %1 0xe9` (é) | `é` | `é` |
| `send -t %1 0x4e2d` (中) | `ä¸­` | `中` |
| iTerm2 arrow key, three sub-commands merged | `echo MARKER0d1b[A` | recalls `echo MARKER` |
| `send-keys -lt %1 "a     b"` (#490) | `a     b` | `a     b` |

The last two rows are the regression checks that matter here: the existing
coalescing behaviour and the #490 whitespace fix both still hold.

`tests-rs/test_send_keys_literal_byte.rs` pins the two pure functions the fix
rests on -- `decode_send_command` and `coalesce_send_commands` -- covering byte
decoding, the `-H` (byte) versus `0xNN` (codepoint) distinction, non-UTF-8
operands, the merged `send -H` carrier, target separation and malformed
operands. They start no server, per AGENTS.md.
