### PR TITLE
fix(input): dispatch copy-mode key tables on the live client/server path

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -51,6 +51,76 @@ fn write_mouse_event(master: &mut dyn std::io::Write, button: u8, col: u16, row:
     }
 }
 
+/// Look up a copy-mode key binding for `key`, honouring `mode-keys`.
+///
+/// The table name selection matches tmux: `mode-keys vi` uses `copy-mode-vi`,
+/// anything else uses `copy-mode`.
+pub fn copy_mode_binding(app: &AppState, key: (KeyCode, KeyModifiers)) -> Option<crate::types::Action> {
+    let table_name = if app.mode_keys == "vi" { "copy-mode-vi" } else { "copy-mode" };
+    let key_tuple = normalize_key_for_binding(key);
+    app.key_tables
+        .get(table_name)?
+        .iter()
+        .find(|b| b.key == key_tuple)
+        .map(|b| b.action.clone())
+}
+
+/// Run a resolved copy-mode binding.
+///
+/// Returns `true` when the binding was handled and the caller must NOT fall
+/// through to the built-in copy-mode key handling.
+///
+/// `send-keys -X <cmd>` is by far the most common action in these tables (it is
+/// how tmux-yank and every copy-mode rebind is written), and its implementation
+/// lives in the server loop's own `CtrlReq::SendKeysX` arm. Since this function
+/// is itself called from the loop, it queues the request rather than trying to
+/// re-enter that arm — see `AppState::control_tx`. Everything else goes through
+/// the normal action executor.
+pub fn run_copy_mode_binding(app: &mut AppState, action: &crate::types::Action) -> bool {
+    use crate::types::Action;
+    if let Action::Command(cmd) = action {
+        let parts: Vec<&str> = cmd.split_whitespace().collect();
+        if matches!(parts.first(), Some(&"send-keys") | Some(&"send"))
+            && parts.iter().any(|p| *p == "-X")
+        {
+            // Everything after the flags is the copy-mode command name plus its
+            // arguments, e.g. `copy-pipe-and-cancel "clip.exe"`. Rebuild it from
+            // the ORIGINAL string rather than the whitespace split so a quoted
+            // argument containing spaces survives.
+            if let Some(x_pos) = cmd.find("-X") {
+                let rest = cmd[x_pos + 2..].trim();
+                if !rest.is_empty() {
+                    if let Some(tx) = app.control_tx.as_ref() {
+                        let _ = tx.send(crate::types::CtrlReq::SendKeysX(rest.to_string()));
+                        return true;
+                    }
+                }
+            }
+            // No sender (or nothing after -X): fall through to the built-ins
+            // rather than silently swallowing the key.
+            return false;
+        }
+    }
+    crate::commands::execute_action(app, action).is_ok()
+}
+
+/// **This function is currently unreachable.** `grep -rn "handle_key(" src/`
+/// returns only this definition.
+///
+/// It is the input dispatcher from the pre-server, single-process architecture.
+/// The live path is client -> TCP -> `CtrlReq::SendKey` -> `send_key_to_active`
+/// (named keys) and `handle_copy_mode_char` (printable characters), none of
+/// which come through here.
+///
+/// That mattered: this was the ONLY code that consulted the `copy-mode-vi` /
+/// `copy-mode` key tables, so those bindings parsed, stored, and listed
+/// correctly while never actually firing. `switch-client -T <table>` below is
+/// still in exactly that state. Before fixing a key-handling bug here, check
+/// whether the code you are editing runs at all.
+///
+/// Kept rather than deleted because it is still the most readable statement of
+/// the intended key semantics, and because deleting ~600 lines is a change that
+/// deserves its own review.
 pub fn handle_key(app: &mut AppState, key: KeyEvent) -> io::Result<bool> {
     // Fold NUL onto C-Space up front, for the same reason as the client input
     // loop: the raw `is_prefix` tuple comparisons below must see C-Space when
@@ -709,14 +779,15 @@ pub fn handle_key(app: &mut AppState, key: KeyEvent) -> io::Result<bool> {
             Ok(false)
         }
         Mode::CopyMode => {
-            // Check copy-mode key table for user bindings first (used by plugins like tmux-yank)
-            let table_name = if app.mode_keys == "vi" { "copy-mode-vi" } else { "copy-mode" };
-            let key_tuple = normalize_key_for_binding((key.code, key.modifiers));
-            if let Some(bind) = app.key_tables.get(table_name)
-                .and_then(|t| t.iter().find(|b| b.key == key_tuple))
-                .cloned()
-            {
-                return execute_action(app, &bind.action);
+            // Check copy-mode key table for user bindings first (used by plugins like tmux-yank).
+            // Shares its lookup with the LIVE dispatch path (send_key_to_active
+            // / handle_copy_mode_char) rather than keeping a second copy — the
+            // second copy is what let the live path go years without consulting
+            // these tables at all.
+            if let Some(action) = copy_mode_binding(app, (key.code, key.modifiers)) {
+                if run_copy_mode_binding(app, &action) {
+                    return Ok(false);
+                }
             }
             // Handle register pending state (waiting for a-z after ")
             if app.copy_register_pending {
@@ -3031,6 +3102,24 @@ pub fn send_text_to_active(app: &mut AppState, text: &str) -> io::Result<()> {
 
 /// Dispatch a single character as a copy-mode action.
 fn handle_copy_mode_char(app: &mut AppState, c: char) -> io::Result<()> {
+    // User bindings from `bind -T copy-mode-vi` / `-T copy-mode` win over the
+    // built-ins below.
+    //
+    // These tables parsed, stored, and showed up in `list-keys`, but nothing in
+    // the live client/server path ever consulted them: the only lookup lived in
+    // `input::handle_key`, which has no callers (it is dead code from the
+    // pre-server architecture). So a rebind like
+    // `bind -T copy-mode-vi y send-keys -X copy-pipe-and-cancel "clip.exe"`
+    // appeared to work only because `y` happens to coincide with the hardcoded
+    // vi default — the user's pipe never ran.
+    //
+    // Checked BEFORE the pending-state handling below, matching tmux: a bound
+    // key is a bound key.
+    if let Some(action) = copy_mode_binding(app, (KeyCode::Char(c), KeyModifiers::NONE)) {
+        if run_copy_mode_binding(app, &action) {
+            return Ok(());
+        }
+    }
     // Handle text-object pending state (waiting for w/W after a/i)
     if let Some(prefix) = app.copy_text_object_pending.take() {
         match (prefix, c) {
@@ -3291,6 +3380,18 @@ pub fn send_key_to_active(app: &mut AppState, k: &str) -> io::Result<()> {
 
     // --- Copy mode: full vi-style key table ---
     if matches!(app.mode, Mode::CopyMode) {
+        // User `bind -T copy-mode-vi` / `-T copy-mode` bindings win over the
+        // built-in defaults below. See handle_copy_mode_char for why this was
+        // missing. `k` is a canonical key NAME here ("escape", "C-v", ...), so
+        // it goes back through the same parser the config used to produce the
+        // table's keys — that keeps one definition of what a key name means.
+        if let Some((code, mods)) = crate::config::parse_key_string(k) {
+            if let Some(action) = copy_mode_binding(app, (code, mods)) {
+                if run_copy_mode_binding(app, &action) {
+                    return Ok(());
+                }
+            }
+        }
         match k {
             "esc" | "q" => {
                 exit_copy_mode(app);
@@ -3657,3 +3758,7 @@ mod tests_pane_last_special_key;
 #[cfg(test)]
 #[path = "../tests-rs/test_issue413_copy_count.rs"]
 mod tests_issue413_copy_count;
+
+#[cfg(test)]
+#[path = "../tests-rs/test_copy_mode_key_tables.rs"]
+mod tests_copy_mode_key_tables;

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -836,6 +836,9 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
     // commands spawned by load_config can connect back to the server.
     let (tx, rx) = mpsc::channel::<CtrlReq>();
     app.control_rx = Some(rx);
+    // Keep a sender in AppState so loop-resident code can queue follow-up work
+    // (see the field's doc comment — copy-mode key tables need this).
+    app.control_tx = Some(tx.clone());
     let listener = TcpListener::bind(("127.0.0.1", 0))?;
     let port = listener.local_addr()?.port();
     app.control_port = Some(port);

--- a/src/types.rs
+++ b/src/types.rs
@@ -581,6 +581,18 @@ pub struct AppState {
     /// Current key table for switch-client -T (None = normal mode)
     pub current_key_table: Option<String>,
     pub control_rx: Option<mpsc::Receiver<CtrlReq>>,
+    /// Sender for the same channel `control_rx` receives on, so code already
+    /// running ON the server loop can queue follow-up work for a later
+    /// iteration instead of recursing.
+    ///
+    /// Used by the copy-mode key tables: a `bind -T copy-mode-vi y send-keys -X
+    /// copy-pipe-and-cancel "clip.exe"` resolves while handling a keystroke, and
+    /// the `send-keys -X` implementation lives in the loop's own
+    /// `CtrlReq::SendKeysX` arm. Re-entering it directly is not possible, and
+    /// routing back out through `execute_command_string` would make the server
+    /// open a TCP connection to itself while the loop is blocked doing so —
+    /// a deadlock. Queueing costs one loop iteration and cannot deadlock.
+    pub control_tx: Option<mpsc::Sender<CtrlReq>>,
     pub control_port: Option<u16>,
     pub session_key: String,
     /// Receiver for async run-shell results (title, output).
@@ -1151,6 +1163,7 @@ impl AppState {
             key_tables: std::collections::HashMap::new(),
             current_key_table: None,
             control_rx: None,
+            control_tx: None,
             control_port: None,
             session_key: String::new(),
             run_shell_rx: None,

--- a/tests-rs/test_copy_mode_key_tables.rs
+++ b/tests-rs/test_copy_mode_key_tables.rs
@@ -1,0 +1,195 @@
+//! `bind -T copy-mode-vi` / `-T copy-mode` bindings must actually fire.
+//!
+//! These tables parsed, were stored in `app.key_tables`, and showed up in
+//! `list-keys` — but nothing on the live client/server path ever consulted
+//! them. The only lookup lived in `input::handle_key`, which has no callers
+//! (dead code from the pre-server architecture). The live path hardcodes
+//! copy-mode keys in `send_key_to_active` and `handle_copy_mode_char`.
+//!
+//! The failure was near-invisible, which is why it lasted: the common rebinds
+//! (`v` begin-selection, `y` copy, `Escape` cancel) coincide with psmux's
+//! hardcoded vi defaults, so the keys did something reasonable. What silently
+//! did not happen was the user's own action — for
+//! `bind -T copy-mode-vi y send-keys -X copy-pipe-and-cancel "clip.exe"`, the
+//! selection was yanked to the internal buffer but never piped to `clip.exe`.
+
+use super::*;
+
+fn app_vi() -> AppState {
+    let mut a = AppState::new("copytbl".to_string());
+    a.window_base_index = 0;
+    a.mode_keys = "vi".to_string();
+    a
+}
+
+fn bind_copy_key(app: &mut AppState, table: &str, key: &str, cmd: &str) {
+    crate::config::parse_config_line(app, &format!("bind -T {} {} {}", table, key, cmd));
+}
+
+// ───────────────────────── table selection ─────────────────────────
+
+#[test]
+fn vi_mode_keys_selects_the_copy_mode_vi_table() {
+    let mut a = app_vi();
+    bind_copy_key(&mut a, "copy-mode-vi", "y", "send-keys -X copy-pipe-and-cancel \"clip.exe\"");
+
+    let action = copy_mode_binding(&a, (KeyCode::Char('y'), KeyModifiers::NONE));
+    assert!(
+        action.is_some(),
+        "a copy-mode-vi binding must resolve when mode-keys is vi"
+    );
+}
+
+#[test]
+fn emacs_mode_keys_selects_the_copy_mode_table() {
+    let mut a = app_vi();
+    a.mode_keys = "emacs".to_string();
+    bind_copy_key(&mut a, "copy-mode", "w", "send-keys -X copy-selection");
+
+    assert!(
+        copy_mode_binding(&a, (KeyCode::Char('w'), KeyModifiers::NONE)).is_some(),
+        "a copy-mode binding must resolve when mode-keys is not vi"
+    );
+}
+
+#[test]
+fn the_wrong_table_is_not_consulted() {
+    let mut a = app_vi(); // vi -> copy-mode-vi
+    bind_copy_key(&mut a, "copy-mode", "w", "send-keys -X copy-selection");
+
+    assert!(
+        copy_mode_binding(&a, (KeyCode::Char('w'), KeyModifiers::NONE)).is_none(),
+        "a copy-mode binding must NOT fire while mode-keys is vi"
+    );
+}
+
+#[test]
+fn an_unbound_key_resolves_to_nothing() {
+    let a = app_vi();
+    assert!(
+        copy_mode_binding(&a, (KeyCode::Char('j'), KeyModifiers::NONE)).is_none(),
+        "unbound keys must fall through to the built-in copy-mode handling"
+    );
+}
+
+/// Shift is stripped when matching, so a binding on `V` is found by the
+/// shifted keypress that produces it.
+#[test]
+fn shift_is_normalised_away_when_matching() {
+    let mut a = app_vi();
+    bind_copy_key(&mut a, "copy-mode-vi", "V", "send-keys -X select-line");
+
+    assert!(
+        copy_mode_binding(&a, (KeyCode::Char('V'), KeyModifiers::SHIFT)).is_some(),
+        "a shifted character keypress must match its binding"
+    );
+}
+
+#[test]
+fn modified_keys_resolve() {
+    let mut a = app_vi();
+    bind_copy_key(&mut a, "copy-mode-vi", "C-v", "send-keys -X rectangle-toggle");
+
+    assert!(
+        copy_mode_binding(&a, (KeyCode::Char('v'), KeyModifiers::CONTROL)).is_some(),
+        "C-v in a copy-mode table must resolve for a real Ctrl+v keypress"
+    );
+}
+
+// ───────────────────────── dispatch ─────────────────────────
+
+/// `send-keys -X` is queued back onto the server loop, where the copy-mode
+/// command implementation lives.
+#[test]
+fn send_keys_x_bindings_are_queued_with_their_arguments_intact() {
+    let mut a = app_vi();
+    let (tx, rx) = std::sync::mpsc::channel();
+    a.control_tx = Some(tx);
+    bind_copy_key(&mut a, "copy-mode-vi", "y", "send-keys -X copy-pipe-and-cancel \"clip.exe\"");
+
+    let action = copy_mode_binding(&a, (KeyCode::Char('y'), KeyModifiers::NONE)).unwrap();
+    assert!(run_copy_mode_binding(&mut a, &action), "binding should be handled");
+
+    match rx.try_recv() {
+        Ok(crate::types::CtrlReq::SendKeysX(cmd)) => {
+            assert!(
+                cmd.starts_with("copy-pipe-and-cancel"),
+                "queued the wrong copy-mode command: {:?}",
+                cmd
+            );
+            assert!(
+                cmd.contains("clip.exe"),
+                "the pipe target was dropped: {:?} — yanking would work but the \
+                 user's clip.exe would never run, which is the original bug",
+                cmd
+            );
+        }
+        other => panic!("expected a queued SendKeysX, got {:?}", other.is_ok()),
+    }
+}
+
+/// A quoted argument containing spaces must survive — the command is rebuilt
+/// from the original string, not from a whitespace split.
+#[test]
+fn a_quoted_argument_with_spaces_survives() {
+    let mut a = app_vi();
+    let (tx, rx) = std::sync::mpsc::channel();
+    a.control_tx = Some(tx);
+    bind_copy_key(
+        &mut a,
+        "copy-mode-vi",
+        "y",
+        "send-keys -X copy-pipe-and-cancel \"pwsh -NoProfile -Command Set-Clipboard\"",
+    );
+
+    let action = copy_mode_binding(&a, (KeyCode::Char('y'), KeyModifiers::NONE)).unwrap();
+    run_copy_mode_binding(&mut a, &action);
+
+    match rx.try_recv() {
+        Ok(crate::types::CtrlReq::SendKeysX(cmd)) => assert!(
+            cmd.contains("-NoProfile") && cmd.contains("Set-Clipboard"),
+            "multi-word pipe command was truncated: {:?}",
+            cmd
+        ),
+        _ => panic!("expected a queued SendKeysX"),
+    }
+}
+
+/// With no sender wired the binding must decline to handle the key, so the
+/// caller falls through to the built-in behaviour instead of the key doing
+/// nothing at all.
+#[test]
+fn without_a_control_sender_the_binding_declines_rather_than_swallowing() {
+    let mut a = app_vi();
+    a.control_tx = None;
+    bind_copy_key(&mut a, "copy-mode-vi", "y", "send-keys -X copy-selection");
+
+    let action = copy_mode_binding(&a, (KeyCode::Char('y'), KeyModifiers::NONE)).unwrap();
+    assert!(
+        !run_copy_mode_binding(&mut a, &action),
+        "with no way to queue the command the key must fall through, not vanish"
+    );
+}
+
+/// The four bindings from the reported config all resolve.
+#[test]
+fn the_reported_config_bindings_all_resolve() {
+    let mut a = app_vi();
+    bind_copy_key(&mut a, "copy-mode-vi", "v", "send-keys -X begin-selection");
+    bind_copy_key(&mut a, "copy-mode-vi", "C-v", "send-keys -X rectangle-toggle");
+    bind_copy_key(&mut a, "copy-mode-vi", "y", "send-keys -X copy-pipe-and-cancel \"clip.exe\"");
+    bind_copy_key(&mut a, "copy-mode-vi", "Escape", "send-keys -X cancel");
+
+    for (code, mods, label) in [
+        (KeyCode::Char('v'), KeyModifiers::NONE, "v"),
+        (KeyCode::Char('v'), KeyModifiers::CONTROL, "C-v"),
+        (KeyCode::Char('y'), KeyModifiers::NONE, "y"),
+        (KeyCode::Esc, KeyModifiers::NONE, "Escape"),
+    ] {
+        assert!(
+            copy_mode_binding(&a, (code, mods)).is_some(),
+            "copy-mode-vi binding for {} did not resolve",
+            label
+        );
+    }
+}


### PR DESCRIPTION
# input

## Problem

`bind -T copy-mode-vi` / `-T copy-mode` bindings parsed, were stored in key_tables, and showed up in list-keys. However, nothing on the live path ever consulted them. The only lookup lived in `input::handle_key`, which has no callers (dead code from the pre-server architecture). The live path hardcodes copy-mode keys in `send_key_to_active` and `handle_copy_mode_char`.

The failure was near-invisible. The common rebinds (`v` begin-selection, `y` copy, `Escape` cancel) coincide with the hardcoded vi defaults, so the keys did something reasonable. What silently did not happen was the user's own action. A config that looks like:

`bind -T copy-mode-vi y send-keys -X copy-pipe-and-cancel "clip.exe"`

the selection was yanked to the internal buffer but never piped to clip.exe.

## Fix

- Extract the table lookup into copy_mode_binding / run_copy_mode_binding and call them from both live entry points before the built-in defaults so a bound key wins and an unbound key falls through unchanged.
- `send-keys -X` is queued back onto the server loop via a new AppState.control_tx (the copy-mode command implementation lives in the loop's own SendKeysX arm. Re-entering it or routing back out through a self-connection would deadlock). The command is rebuilt from the original string so a quoted argument with spaces survives.

## Tests

tests-rs/test_copy_mode_key_tables.rs covers table selection by `mode-keys`, key normalization (Shift/Ctrl), that `send-keys -X` is queued with arguments intact, and the fall-through path for unbound keys.