### PR TITLE
fix(server): guard the warm session name so a namespace keeps exactly one warm server (#459)

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -759,10 +759,11 @@ pub(crate) fn read_fresh_config_warnings(since_epoch: u64) -> Vec<String> {
 /// Release before acquiring so renaming a session onto a name it already holds
 /// cannot block on itself. A refused acquire is not fatal: the rename has
 /// already happened, so we simply run unguarded rather than abandon the session.
-/// Warm servers stay exempt (the pool intentionally runs several at once).
+/// Warm servers are guarded too: a namespace holds exactly one `__warm__`
+/// server, and releasing that name here is precisely what lets the replacement
+/// warm spawned after a claim acquire it (issue #459).
 fn rekey_session_guard(guard: &mut Option<crate::platform::SessionMutex>, new_base: &str) {
     *guard = None; // drop releases + closes the old name's mutex
-    if crate::session::is_warm_session(new_base) { return; }
     *guard = crate::platform::acquire_session_mutex(new_base);
     if guard.is_none() {
         warm_debug(&format!("session guard: '{}' already owned by a live server — running unguarded", new_base));
@@ -813,15 +814,15 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
     // a cold-spawn race (has-session false-negatived under load, or two
     // `new-session -s X` raced) — exit cleanly so the winner stays the single
     // source of truth. Two servers on one name desync the .port/.key files and
-    // wedge the session ("appears lost"). Warm (standby) servers are exempt (the
-    // warm pool intentionally runs several). Fail-open: any FFI hiccup yields a
-    // live guard, never a blocked legitimate start.
+    // wedge the session ("appears lost"). Warm (standby) servers are guarded on
+    // the same terms: `__warm__.port` is a single file, so a namespace can only
+    // ever publish one warm server, and an unguarded warm name let every failed
+    // or slow registration strand another live process (issue #459). Fail-open:
+    // any FFI hiccup yields a live guard, never a blocked legitimate start.
     // Re-keyed on every rename/claim, see rekey_session_guard (issue #505).
     let mut session_guard = {
         let base = app.port_file_base();
-        if crate::session::is_warm_session(&base) {
-            None
-        } else {
+        {
             match crate::platform::acquire_session_mutex(&base) {
                 Some(g) => Some(g),
                 None => {
@@ -3165,8 +3166,9 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                         let _ = std::fs::write(&new_path, port.to_string());
                     }
                     app.session_name = name;
-                    // A warm server skipped the startup guard (the pool runs several),
-                    // so the name it just claimed picks the guard up here (#505).
+                    // Move the guard from `__warm__` onto the claimed name (#505).
+                    // Releasing the warm name is what frees it for the replacement
+                    // warm spawned further below (issue #459).
                     rekey_session_guard(&mut session_guard, &app.port_file_base());
                     // Warm server's created_at is the warm process start time, not the
                     // user's session-creation time — reset on claim or list-sessions /
@@ -6086,3 +6088,7 @@ mod test_issue167_startup_log;
 #[cfg(test)]
 #[path = "../../tests-rs/test_issue370_startup_error_passthrough.rs"]
 mod test_issue370_startup_error_passthrough;
+
+#[cfg(test)]
+#[path = "../../tests-rs/test_issue459_warm_single_instance.rs"]
+mod test_issue459_warm_single_instance;

--- a/tests-rs/test_issue459_warm_single_instance.rs
+++ b/tests-rs/test_issue459_warm_single_instance.rs
@@ -1,0 +1,149 @@
+// Issue #459: "psmux spawns an unbounded, continuously-growing number of
+// psmux.exe processes".
+//
+// Every real session is protected by the single-server-per-name mutex (issue
+// #2): a second server that finds the name already owned exits immediately
+// instead of running as a duplicate. Warm (`__warm__`) servers were explicitly
+// exempted from that guard, on the stated rationale that "the warm pool
+// intentionally runs several at once".
+//
+// There is no pool. `spawn_warm_server` early-returns when it verifies a live
+// warm, and the handoff is a SINGLE file per namespace (`__warm__.port`), so a
+// namespace can only ever publish one warm server no matter how many are
+// running. Everything past the first is unreachable and immortal: nothing
+// attaches to it, nothing claims it, and nothing ever kills it.
+//
+// The only exclusion left for warm was `acquire_warm_spawn_lock`, which is
+// strictly weaker than a mutex in three ways that all showed up in the field:
+//
+//   * it is advisory and time-boxed — held for at most ~3s while waiting for the
+//     new warm's `.port` to appear, then released whether or not it ever did;
+//   * it is a plain file whose `Drop` never runs when the owner is killed, so a
+//     dead owner leaves a lock that is only cleared by a 20s staleness steal;
+//   * it guards the check->spawn window only, so *sequential* spawns seconds
+//     apart — exactly what was observed — sail straight through it.
+//
+// The captured evidence was a five-deep parent chain of live `server -s __warm__`
+// processes in the default namespace, spawned 1-4s apart, with NO `__warm__.port`
+// present at all: each one failed to register, so the next caller saw "no warm
+// exists" and started another.
+//
+// These tests assert the guard now covers warm names, and that the guard is
+// still handed off on claim so a namespace does not end up with no warm at all.
+// Ownership probes run on a SPAWNED THREAD because a Windows mutex is recursive
+// for its owning thread: probing from the holder would always report "free".
+
+use super::*;
+
+/// Try to take `name` from a fresh thread. `true` means no live owner.
+fn name_is_free(name: &str) -> bool {
+    let owned = name.to_string();
+    std::thread::spawn(move || crate::platform::acquire_session_mutex(&owned).is_some())
+        .join()
+        .expect("probe thread panicked")
+}
+
+/// Unique per-test namespace so a parallel run never collides, and so these
+/// tests never contend with a real warm server on the developer's machine.
+fn warm_base(suffix: &str) -> String {
+    format!("psmux-t459-{}-{}____warm__", std::process::id(), suffix)
+}
+
+#[test]
+#[cfg(windows)]
+fn a_second_warm_server_cannot_take_the_warm_name() {
+    let warm = warm_base("dup");
+
+    let first = crate::platform::acquire_session_mutex(&warm);
+    assert!(first.is_some(), "first warm should acquire '{}'", warm);
+
+    // This is the #459 regression guard. Before the fix the warm name was never
+    // locked, so this probe succeeded and the second warm ran on as an immortal,
+    // unreachable process — repeated once per failed registration.
+    assert!(
+        !name_is_free(&warm),
+        "BUG #459: a second warm server was able to take '{}'",
+        warm
+    );
+
+    drop(first);
+    assert!(name_is_free(&warm), "dropping the warm guard must free '{}'", warm);
+}
+
+#[test]
+#[cfg(windows)]
+fn warm_names_are_isolated_per_namespace() {
+    // `-L` namespaces must not block each other: jefe runs one warm per agent
+    // namespace concurrently and all of them are legitimate.
+    let a = warm_base("ns-a");
+    let b = warm_base("ns-b");
+
+    let held_a = crate::platform::acquire_session_mutex(&a);
+    assert!(held_a.is_some(), "should acquire '{}'", a);
+
+    assert!(
+        name_is_free(&b),
+        "namespace '{}' must not be blocked by a warm in '{}'",
+        b,
+        a
+    );
+    drop(held_a);
+}
+
+#[test]
+#[cfg(windows)]
+fn claiming_a_warm_frees_the_warm_name_for_its_replacement() {
+    let warm = warm_base("handoff");
+    let claimed = format!("psmux-t459-{}-claimed", std::process::id());
+
+    // A warm server now starts holding the warm name.
+    let mut guard = crate::platform::acquire_session_mutex(&warm);
+    assert!(guard.is_some(), "warm should hold '{}'", warm);
+
+    // `new-session` claims it: the server renames itself, and rekey_session_guard
+    // moves the guard onto the claimed name. This ordering matters — the server
+    // spawns its replacement warm AFTER the rekey (see CtrlReq::ClaimSession), so
+    // the warm name must already be free by then or the namespace would be left
+    // with no warm server at all and every later open would be a cold start.
+    rekey_session_guard(&mut guard, &claimed);
+
+    assert!(guard.is_some(), "claimed name '{}' must be guarded", claimed);
+    assert!(
+        name_is_free(&warm),
+        "claim must release '{}' so the replacement warm can start",
+        warm
+    );
+
+    // The replacement warm starts and takes the name back.
+    let replacement = crate::platform::acquire_session_mutex(&warm);
+    assert!(
+        replacement.is_some(),
+        "replacement warm should acquire '{}'",
+        warm
+    );
+
+    drop(replacement);
+    drop(guard);
+}
+
+#[test]
+#[cfg(windows)]
+fn warm_and_claimed_names_do_not_alias() {
+    // `port_file_base()` for a namespaced warm is `<ns>____warm__`; a real session
+    // in the same namespace is `<ns>__<session>`. A warm guard must not
+    // accidentally block a legitimate session name in its own namespace.
+    let ns = format!("psmux-t459-{}-alias", std::process::id());
+    let warm = format!("{}____warm__", ns);
+    let session = format!("{}__work", ns);
+
+    let held = crate::platform::acquire_session_mutex(&warm);
+    assert!(held.is_some(), "should acquire '{}'", warm);
+
+    assert!(
+        name_is_free(&session),
+        "warm guard on '{}' must not block session '{}'",
+        warm,
+        session
+    );
+    drop(held);
+}

--- a/tests-rs/test_issue505_rename_session_guard.rs
+++ b/tests-rs/test_issue505_rename_session_guard.rs
@@ -141,19 +141,26 @@ fn rekey_onto_the_same_name_keeps_it_guarded() {
 
 #[test]
 #[cfg(windows)]
-fn warm_name_is_exempt_from_the_guard() {
+fn warm_name_is_guarded_like_any_other_name() {
     let old = key("warm-old");
+    // Namespaced warm base, so this test never contends with the real
+    // `__warm__` server that may be running on this machine.
+    let warm = format!("{}____warm__", key("warm-ns"));
 
     let mut guard = crate::platform::acquire_session_mutex(&old);
     assert!(guard.is_some(), "setup: should have acquired '{}'", old);
 
-    // The warm pool intentionally runs several standby servers, so the warm name
-    // must never be locked by one of them.
-    rekey_session_guard(&mut guard, "__warm__");
+    rekey_session_guard(&mut guard, &warm);
 
-    assert!(guard.is_none(), "warm sessions must not hold a name guard");
+    // Changed by issue #459. The warm name used to be exempt here, on the theory
+    // that "the pool runs several". There is no pool: `__warm__.port` is a single
+    // file, so a namespace can only ever publish one warm server. Leaving the name
+    // unguarded meant every warm that failed or was slow to register left another
+    // live process behind, which is the unbounded-growth mechanism in #459.
+    assert!(guard.is_some(), "warm name '{}' must be guarded", warm);
+    assert!(!name_is_free(&warm), "'{}' must read as held", warm);
     assert!(name_is_free(&old), "old name '{}' must still be released", old);
-    assert!(name_is_free("__warm__"), "'__warm__' must stay unguarded");
+    drop(guard);
 }
 
 #[test]
@@ -161,10 +168,15 @@ fn warm_name_is_exempt_from_the_guard() {
 fn claiming_a_warm_server_guards_the_claimed_name() {
     let claimed = key("claimed");
 
-    // A warm server starts with no guard at all (it is exempt at startup); the
-    // claim is what turns it into a real named session.
-    let mut guard: Option<crate::platform::SessionMutex> = None;
+    // A warm server reaches the claim holding the `__warm__` name (issue #459);
+    // the claim is what turns it into a real named session.
+    let warm = format!("{}____warm__", key("claim-ns"));
+    let mut guard = crate::platform::acquire_session_mutex(&warm);
+    assert!(guard.is_some(), "setup: warm should hold '{}'", warm);
     rekey_session_guard(&mut guard, &claimed);
+
+    // Releasing the warm name is what lets the replacement warm start.
+    assert!(name_is_free(&warm), "claim must release '{}'", warm);
 
     assert!(guard.is_some(), "claim should acquire '{}'", claimed);
     assert!(!name_is_free(&claimed), "claimed name '{}' must be guarded", claimed);

--- a/tests/repro_issue459_warm_duplicates.ps1
+++ b/tests/repro_issue459_warm_duplicates.ps1
@@ -1,0 +1,112 @@
+# Issue #459: unbounded psmux.exe growth from duplicate warm servers.
+#
+# Warm (`__warm__`) servers were exempt from the single-server-per-name mutex,
+# so any number of them could coexist in one namespace. Since the handoff is a
+# single `__warm__.port` file, everything past the first was unreachable and
+# immortal. This script starts two warm servers in a private namespace and
+# asserts that only one survives.
+#
+# SAFETY: every process this script touches is matched on BOTH
+#   (a) an image path under this repo's target\ directory, and
+#   (b) a command line containing this run's unique namespace,
+# so it can never affect an installed psmux, another agent's server, or the
+# session this script is running inside. Teardown is in a finally block.
+
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = Split-Path -Parent $PSScriptRoot
+$exe = Join-Path $repoRoot 'target\debug\psmux.exe'
+if (-not (Test-Path $exe)) { throw "build first: cargo build --bin psmux  (missing $exe)" }
+
+# Unique per-run namespace. Nothing else on this machine can match it.
+$ns = "psmux459e2e-$PID-$(Get-Random -Maximum 99999)"
+$psmuxDir = Join-Path $env:USERPROFILE '.psmux'
+$warmBase = "$($ns)____warm__"
+
+function Get-NsProcesses {
+    # Both conditions required: our build AND our namespace.
+    Get-CimInstance Win32_Process -Filter "Name='psmux.exe'" -EA SilentlyContinue |
+        Where-Object { $_.ExecutablePath -like "$repoRoot\target\*" -and $_.CommandLine -like "*$ns*" }
+}
+
+function Start-Warm {
+    Start-Process -FilePath $exe `
+        -ArgumentList @('server', '-s', '__warm__', '-L', $ns, '-x', '80', '-y', '24') `
+        -WindowStyle Hidden -PassThru
+}
+
+$failures = @()
+function Check($name, $cond, $detail) {
+    if ($cond) { Write-Host "  PASS  $name" -ForegroundColor Green }
+    else { Write-Host "  FAIL  $name -- $detail" -ForegroundColor Red; $script:failures += $name }
+}
+
+try {
+    Write-Host "namespace: $ns"
+    Write-Host ''
+
+    # --- scenario 1: a second warm server must exit as a duplicate ----------
+    Write-Host 'scenario 1: two warm servers, one namespace'
+    $first = Start-Warm
+    $portFile = Join-Path $psmuxDir "$warmBase.port"
+    $deadline = (Get-Date).AddSeconds(15)
+    while ((Get-Date) -lt $deadline -and -not (Test-Path $portFile)) { Start-Sleep -Milliseconds 200 }
+    Check 'first warm registers its .port' (Test-Path $portFile) "no $portFile after 15s"
+
+    $second = Start-Warm
+    Start-Sleep -Seconds 3
+
+    $alive = @(Get-NsProcesses)
+    Check 'exactly one warm server survives' ($alive.Count -eq 1) `
+        "found $($alive.Count): $(($alive | ForEach-Object { $_.ProcessId }) -join ', ')"
+    Check 'the survivor is the first warm' `
+        ($alive.Count -eq 1 -and $alive[0].ProcessId -eq $first.Id) `
+        "expected pid $($first.Id), got $(($alive | ForEach-Object { $_.ProcessId }) -join ', ')"
+    Check 'the duplicate exited on its own' `
+        (-not (Get-Process -Id $second.Id -EA SilentlyContinue)) `
+        "pid $($second.Id) is still running"
+
+    # The duplicate must not have clobbered the winner's readiness beacon.
+    Check 'winner .port still present after duplicate exit' (Test-Path $portFile) 'port file was removed'
+
+    Write-Host ''
+
+    # --- scenario 2: a claim must free the warm name for a replacement ------
+    # Regression guard for the fix itself: if the claim did not release the warm
+    # name, the namespace would be left with no warm server and every later open
+    # would be a cold start.
+    Write-Host 'scenario 2: claim hands the warm name over'
+    & $exe -L $ns new-session -d -s work 2>&1 | Out-Null
+    Start-Sleep -Seconds 4
+
+    $sessions = (& $exe -L $ns list-sessions 2>&1 | Out-String)
+    Check 'claimed session exists' ($sessions -match 'work') "list-sessions: $($sessions.Trim())"
+
+    $after = @(Get-NsProcesses)
+    # One claimed session server + one replacement warm.
+    Check 'namespace settles at 2 servers (session + replacement warm)' `
+        ($after.Count -le 2) `
+        "found $($after.Count): $(($after | ForEach-Object { $_.ProcessId }) -join ', ')"
+
+    Write-Host ''
+    if ($failures.Count -eq 0) { Write-Host 'RESULT: PASS' -ForegroundColor Green }
+    else { Write-Host "RESULT: FAIL ($($failures -join '; '))" -ForegroundColor Red }
+}
+finally {
+    Write-Host ''
+    Write-Host 'teardown...'
+    # Namespace-scoped kill-server first (never a bare kill-server).
+    & $exe -L $ns kill-server 2>&1 | Out-Null
+    Start-Sleep -Milliseconds 800
+    # Force-kill anything left, still matched on repo path AND namespace.
+    foreach ($p in @(Get-NsProcesses)) {
+        Write-Host "  force-killing leftover pid $($p.ProcessId)"
+        Stop-Process -Id $p.ProcessId -Force -EA SilentlyContinue
+    }
+    # Registry files for this namespace only (see issue #530 -- nothing prunes these).
+    Get-ChildItem $psmuxDir -Filter "$ns*" -EA SilentlyContinue | Remove-Item -Force -EA SilentlyContinue
+    Write-Host 'teardown complete'
+}
+
+if ($failures.Count -gt 0) { exit 1 }
+exit 0


### PR DESCRIPTION
## Overview

Fixes the unbounded warm-server growth in #459.

Every real session is protected by the single-server-per-name mutex (#2): a second server that finds the name already owned exits immediately rather than running as a duplicate. Warm (`__warm__`) servers were explicitly exempted:

```rust
if crate::session::is_warm_session(&base) {
    None                                    // warm: no guard
} else {
    match crate::platform::acquire_session_mutex(&base) { ... }
}
```

The stated rationale, in both `run_server` and `rekey_session_guard`, was that "the warm pool intentionally runs several at once".

**There is no pool.** `spawn_warm_server` early-returns as soon as it verifies a live warm, and the handoff is a *single* `__warm__.port` file per namespace. A namespace can only ever publish one warm server no matter how many are running, so everything past the first is unreachable and immortal — nothing attaches to it, nothing claims it, and nothing ever kills it.

That left `acquire_warm_spawn_lock` as warm's only exclusion mechanism, and it is weaker than a mutex in three ways that all showed up in the field:

- **time-boxed** — held only while waiting for the new warm's `.port` to appear, then released after ~3s whether or not it ever did;
- **not crash-safe** — a plain file whose `Drop` never runs when the owner is killed, so a dead owner leaves a lock cleared only by the 20s staleness steal;
- **wrong scope** — it guards the check→spawn window, so *sequential* spawns seconds apart pass straight through.

### Field evidence

From the inventory I posted on #459: a five-deep parent chain of live `server -s __warm__` processes in the default namespace, spawned 1–4s apart, each one's parent the previous psmux — and **no `__warm__.port` file present at all**. Every warm failed to register, so the next caller saw "no warm exists" and started another. The chain stopped only because the last lock owner was killed and left a stale lock behind.

## The fix

Warm names take the guard on the same terms as every other session name. A duplicate warm now exits at startup exactly like a duplicate session server, before touching the winner's `.port`/`.key`/`.sid`.

The claim handoff still works, and the ordering already in the code is what makes it safe: `CtrlReq::ClaimSession` calls `rekey_session_guard` onto the claimed name *before* calling `spawn_warm_server`, so `__warm__` is already free when the replacement starts. Without that ordering this change would have left namespaces with no warm server at all.

Using the named mutex also fixes the killed-owner case for free: Windows reports `WAIT_ABANDONED` and the next warm takes ownership immediately, where the lock file required a 20-second staleness steal.

`acquire_warm_spawn_lock` is left in place — it still usefully collapses genuinely concurrent spawn attempts before they cost a process launch. It is simply no longer the only thing standing between a slow registration and a permanent leak.

## Behaviour change

`tests-rs/test_issue505_rename_session_guard.rs` had a test asserting the exemption (`warm_name_is_exempt_from_the_guard`). It is updated to assert the new behaviour and renamed accordingly; its sibling `claiming_a_warm_server_guards_the_claimed_name` now starts from a warm server that holds the warm name, which is the real startup state after this change.

## Validation

- 4 new unit tests in `tests-rs/test_issue459_warm_single_instance.rs`: a second warm cannot take the name; warm names stay isolated per `-L` namespace; a claim frees the warm name and a replacement can acquire it; a warm guard does not block a real session name in the same namespace. Ownership is probed from a spawned thread, since a Windows mutex is recursive for its owning thread and would otherwise always report "free".
- New E2E `tests/repro_issue459_warm_duplicates.ps1`, verified to **fail on unfixed code and pass with the fix**:

```
  (unfixed)                                (fixed)
  FAIL  exactly one warm server survives   PASS  exactly one warm server survives
        -- found 2: 19760, 31664           PASS  the survivor is the first warm
  FAIL  the duplicate exited on its own    PASS  the duplicate exited on its own
  FAIL  namespace settles at 2 servers     PASS  namespace settles at 2 servers
        -- found 3: 19760, 31664, 23404
```

Note the unfixed scenario-2 line: after a claim the namespace held **three** servers — the claimed session, its replacement warm, and the orphaned duplicate that will now never die.

- Full suite: **2693 passed, 0 failed** (162.90s), up from 2689 on master.

The E2E matches processes on **both** an image path under the repo's `target\` directory **and** this run's unique random namespace, so it cannot touch an installed psmux or any other server on the machine; teardown is in a `finally` and uses namespace-scoped `kill-server` before any force-kill. I verified the process set was identical before and after the run, and that it left no registry files behind.

## Scope

This addresses the warm-server replication mechanism specifically. `cac2dcf` earlier fixed hook accumulation under the same issue number; both contribute to #459, and I have not tried to establish whether the reporter's ~100 processes were all from this path.

---

*Authored by Claude (Anthropic) at @acoliver's direction.*
