### PR TITLE
fix: prune registry files orphaned by their .port

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -216,6 +216,11 @@ fn run_main() -> io::Result<()> {
 
     // Clean up any stale port files at startup
     cleanup_stale_port_files();
+    // Then drop registry files whose `.port` entry is already gone (issue
+    // #530). The sweep above is the only thing that can reach them, and it
+    // finds entries BY their `.port` file — so a satellite that outlives its
+    // port is invisible to it and accumulates forever.
+    crate::session::prune_orphaned_registry_files();
     // Then reap any LIVE but orphaned server processes (issue #448): duplicates
     // or crashed-client headless servers that cleanup_stale_port_files cannot
     // see because they have no registry file. Bounds the process count so
@@ -533,19 +538,17 @@ fn run_main() -> io::Result<()> {
                             }
                         }
                     }
-                    // Remove port/key/pid files regardless
-                    let _ = std::fs::remove_file(&path);
-                    let _ = std::fs::remove_file(path.with_extension("key"));
-                    let _ = std::fs::remove_file(path.with_extension("pid"));
+                    // Remove the whole registry set regardless. Deleting only
+                    // port/key/pid used to strand the `.sid`, which no sweep can
+                    // reach once its `.port` is gone (#530).
+                    crate::session::remove_session_registry_files(&path);
                 })
             }).collect();
             // Wait for all threads to complete
             for h in handles { let _ = h.join(); }
-            // Clean up stale port/key/pid files
+            // Clean up stale registry sets (whole set, including `.sid` — #530)
             for path in &stale_ports {
-                let _ = std::fs::remove_file(path);
-                let _ = std::fs::remove_file(path.with_extension("key"));
-                let _ = std::fs::remove_file(path.with_extension("pid"));
+                crate::session::remove_session_registry_files(path);
             }
             // Force-kill any wedged server that ignored the graceful kill. The
             // candidates were read from this data dir's (and, with -L, this

--- a/src/session.rs
+++ b/src/session.rs
@@ -272,6 +272,27 @@ const ORPHAN_REGISTRY_EXTS: &[&str] = &["sid", "key", "pid", "spawnlock"];
 /// clearing the backlog on the next CLI invocation.
 const ORPHAN_REGISTRY_GRACE: Duration = Duration::from_secs(60);
 
+/// Most files a single sweep may remove.
+///
+/// psmux CLI commands are invoked constantly by scripts and prompts, and the
+/// backlog this fix targets can run to thousands of files. Deleting all of it
+/// inside one arbitrary invocation — `psmux -V`, say — makes a trivial command
+/// do a surprising amount of destructive work and stalls it on I/O. The budget
+/// keeps any one invocation cheap and bounded; the backlog drains across
+/// successive sweeps instead, which is just as effective and far less abrupt.
+const ORPHAN_REGISTRY_SWEEP_BUDGET: usize = 256;
+
+/// Minimum interval between sweeps, tracked by [`ORPHAN_REGISTRY_SWEEP_STAMP`].
+///
+/// Without this, every psmux invocation pays a full directory walk. Orphans are
+/// produced only by session teardown, so there is nothing to gain from looking
+/// more often than this.
+const ORPHAN_REGISTRY_SWEEP_INTERVAL: Duration = Duration::from_secs(300);
+
+/// Marker file recording when the last sweep ran. Leading dot, so it has no
+/// extension and can never be mistaken for a registry satellite.
+const ORPHAN_REGISTRY_SWEEP_STAMP: &str = ".registry_sweep";
+
 /// Delete per-session registry files whose `.port` entry is already gone
 /// (issue #530).
 ///
@@ -290,25 +311,60 @@ pub fn prune_orphaned_registry_files() {
     let Some(psmux_dir) = crate::paths::psmux_dir_opt() else {
         return;
     };
-    prune_orphaned_registry_files_in(Path::new(&psmux_dir));
+    let psmux_dir = Path::new(&psmux_dir);
+    if !registry_sweep_due(psmux_dir, ORPHAN_REGISTRY_SWEEP_INTERVAL) {
+        return;
+    }
+    prune_orphaned_registry_files_in(psmux_dir);
+}
+
+/// Whether a sweep is due, re-stamping the marker when it is.
+///
+/// The stamp is written BEFORE the sweep runs, not after: if the process is
+/// killed partway through, the next invocation waits a full interval rather
+/// than immediately retrying the same work.
+fn registry_sweep_due(psmux_dir: &Path, interval: Duration) -> bool {
+    let stamp = psmux_dir.join(ORPHAN_REGISTRY_SWEEP_STAMP);
+    let swept_recently = stamp
+        .metadata()
+        .and_then(|m| m.modified())
+        .ok()
+        .and_then(|t| t.elapsed().ok())
+        .map(|age| age < interval)
+        .unwrap_or(false); // missing or unreadable stamp -> sweep
+    if swept_recently {
+        return false;
+    }
+    let _ = std::fs::write(&stamp, b"");
+    true
 }
 
 fn prune_orphaned_registry_files_in(psmux_dir: &Path) -> usize {
-    prune_orphaned_registry_files_in_with(psmux_dir, ORPHAN_REGISTRY_GRACE, pid_owns_live_server)
+    prune_orphaned_registry_files_in_with(
+        psmux_dir,
+        ORPHAN_REGISTRY_GRACE,
+        ORPHAN_REGISTRY_SWEEP_BUDGET,
+        pid_owns_live_server,
+    )
 }
 
-/// Core of [`prune_orphaned_registry_files`], with the grace period and the
-/// liveness oracle injected so tests can drive it deterministically.
+/// Core of [`prune_orphaned_registry_files`], with the grace period, the
+/// per-sweep budget and the liveness oracle injected so tests can drive it
+/// deterministically.
 ///
 /// Returns the number of files removed.
 fn prune_orphaned_registry_files_in_with<F>(
     psmux_dir: &Path,
     grace: Duration,
+    budget: usize,
     mut is_live: F,
 ) -> usize
 where
     F: FnMut(u32) -> bool,
 {
+    if budget == 0 {
+        return 0;
+    }
     let Ok(entries) = std::fs::read_dir(psmux_dir) else {
         return 0;
     };
@@ -357,6 +413,11 @@ where
                         path.file_name().and_then(|s| s.to_str()).unwrap_or("?")
                     ),
                 );
+            }
+            // Budget spent: leave the rest for the next sweep so no single
+            // invocation does an unbounded amount of destructive work.
+            if pruned >= budget {
+                break;
             }
         }
     }

--- a/src/session.rs
+++ b/src/session.rs
@@ -256,6 +256,146 @@ fn cleanup_stale_port_files_in(psmux_dir: &Path) {
     cleanup_stale_port_files_in_with(psmux_dir, probe_session_for_cleanup);
 }
 
+/// Registry file extensions that only ever exist as satellites of a `.port`
+/// entry. Anything else in the data dir (`next_session_id`, its `.lock`, debug
+/// logs, the `instances/` and `servers/` subdirectories) is never touched.
+const ORPHAN_REGISTRY_EXTS: &[&str] = &["sid", "key", "pid", "spawnlock"];
+
+/// How long a `.port`-less registry file must sit untouched before it is
+/// considered abandoned (issue #530).
+///
+/// `ensure_session_registry_files` writes `.sid`/`.key`/`.pid` BEFORE the
+/// `.port` beacon, so a perfectly healthy server that is still coming up
+/// briefly looks exactly like an orphan. A live server also rewrites its whole
+/// set on the 5s self-heal tick, so its files can never age past this bound.
+/// One minute is therefore far beyond any legitimate window while still
+/// clearing the backlog on the next CLI invocation.
+const ORPHAN_REGISTRY_GRACE: Duration = Duration::from_secs(60);
+
+/// Delete per-session registry files whose `.port` entry is already gone
+/// (issue #530).
+///
+/// Every other sweep in this module enumerates `.port` files and deletes the
+/// siblings it finds. That makes the `.port` file the sole entry point to the
+/// registry, so the moment one is removed while a sibling survives, the
+/// survivor becomes permanently unreachable: no code path ever looks at it
+/// again, and nothing can ever delete it. Teardown paths that remove
+/// `.port`/`.key`/`.pid` but not `.sid` therefore leak one file per session
+/// forever.
+///
+/// The cost is not only disk. `resolve_session_by_id` scans every `.sid` file
+/// in the directory to map `$N` to a session, so each leaked file is paid for
+/// on every lookup.
+pub fn prune_orphaned_registry_files() {
+    let Some(psmux_dir) = crate::paths::psmux_dir_opt() else {
+        return;
+    };
+    prune_orphaned_registry_files_in(Path::new(&psmux_dir));
+}
+
+fn prune_orphaned_registry_files_in(psmux_dir: &Path) -> usize {
+    prune_orphaned_registry_files_in_with(psmux_dir, ORPHAN_REGISTRY_GRACE, pid_owns_live_server)
+}
+
+/// Core of [`prune_orphaned_registry_files`], with the grace period and the
+/// liveness oracle injected so tests can drive it deterministically.
+///
+/// Returns the number of files removed.
+fn prune_orphaned_registry_files_in_with<F>(
+    psmux_dir: &Path,
+    grace: Duration,
+    mut is_live: F,
+) -> usize
+where
+    F: FnMut(u32) -> bool,
+{
+    let Ok(entries) = std::fs::read_dir(psmux_dir) else {
+        return 0;
+    };
+    let mut pruned = 0usize;
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let Some(ext) = path.extension().and_then(|e| e.to_str()) else {
+            continue;
+        };
+        if !ORPHAN_REGISTRY_EXTS.contains(&ext) {
+            continue;
+        }
+        // A surviving `.port` means this entry still belongs to the port-driven
+        // sweep, which owns the liveness decision for the whole set.
+        if path.with_extension("port").exists() {
+            continue;
+        }
+        // Too young to judge: could be a server mid-startup that hasn't
+        // published its port yet. Leave it for a later invocation.
+        let old_enough = entry
+            .metadata()
+            .ok()
+            .and_then(|m| m.modified().ok())
+            .and_then(|t| t.elapsed().ok())
+            .map(|age| age >= grace)
+            .unwrap_or(false); // unreadable mtime -> keep
+        if !old_enough {
+            continue;
+        }
+        // If the set still names a live psmux process, the server exists but is
+        // not publishing a port (still binding, or wedged). Reaping that is
+        // #448's job, not ours — deleting its identity files would only make it
+        // harder to find.
+        if let Some(pid) = orphan_anchor_pid(&path, ext) {
+            if is_live(pid) {
+                continue;
+            }
+        }
+        if std::fs::remove_file(&path).is_ok() {
+            pruned += 1;
+            if crate::debug_log::session_log_enabled() {
+                crate::debug_log::session_log(
+                    "cleanup",
+                    &format!(
+                        "pruned orphaned '{}': no .port sibling and no live owner",
+                        path.file_name().and_then(|s| s.to_str()).unwrap_or("?")
+                    ),
+                );
+            }
+        }
+    }
+    pruned
+}
+
+/// PID that owns an orphaned registry file, when one can be determined.
+///
+/// A `.spawnlock` records its holder's PID directly; every other satellite is
+/// anchored by the sibling `.pid` sentinel. `.sid`/`.key` orphans left by a
+/// teardown that already removed the `.pid` have no anchor at all, which is
+/// precisely the abandoned case.
+fn orphan_anchor_pid(path: &Path, ext: &str) -> Option<u32> {
+    let body = if ext == "spawnlock" {
+        std::fs::read_to_string(path).ok()?
+    } else {
+        std::fs::read_to_string(path.with_extension("pid")).ok()?
+    };
+    parse_pid_file_contents(&body)
+        .map(|(pid, _creation)| pid)
+        .or_else(|| body.trim().parse::<u32>().ok())
+}
+
+/// True when `pid` is a live process running a psmux server image.
+///
+/// The process-table query is Windows-only. Elsewhere this answers "live", so
+/// an orphan that still carries a PID anchor is kept rather than deleted on a
+/// guess. Orphans with no anchor — the overwhelming majority, and the ones
+/// #530 is about — are unaffected by the platform and prune everywhere.
+fn pid_owns_live_server(pid: u32) -> bool {
+    if !cfg!(windows) {
+        return true;
+    }
+    match crate::platform::process_info::get_process_name(pid) {
+        None => false,
+        Some(name) => PSMUX_SERVER_IMAGE_NAMES.contains(&name.to_ascii_lowercase().as_str()),
+    }
+}
+
 /// Image-name stems (lower-case, no extension) that count as a psmux server for
 /// the orphan reaper. Only processes whose executable matches one of these are
 /// ever candidates for termination — an unrelated app that happens to hold a
@@ -926,7 +1066,12 @@ fn registry_base(port_path: &Path) -> &str {
     port_path.file_stem().and_then(|s| s.to_str()).unwrap_or("?")
 }
 
-fn remove_session_registry_files(port_path: &Path) {
+/// Remove a session's entire registry set, given its `.port` path.
+///
+/// Teardown paths must go through this rather than deleting extensions
+/// individually: the `.port` file is the only entry point the sweeps know, so
+/// any satellite left behind when it disappears is unreachable forever (#530).
+pub(crate) fn remove_session_registry_files(port_path: &Path) {
     let _ = std::fs::remove_file(port_path);
     let key_path = port_path.with_extension("key");
     let _ = std::fs::remove_file(&key_path);
@@ -1913,3 +2058,7 @@ mod tests_issue509_namespace_instance;
 #[cfg(test)]
 #[path = "../tests-rs/test_issue510_reaper_attribution.rs"]
 mod tests_issue510_reaper_attribution;
+
+#[cfg(test)]
+#[path = "../tests-rs/test_issue530_registry_pruning.rs"]
+mod tests_issue530_registry_pruning;

--- a/tests-rs/test_issue530_registry_pruning.rs
+++ b/tests-rs/test_issue530_registry_pruning.rs
@@ -1,0 +1,217 @@
+//! Issue #530: `~/.psmux` grows without bound because orphaned registry files
+//! are unreachable.
+//!
+//! Every registry sweep in `session.rs` enumerates `.port` files and deletes
+//! the siblings it finds, which makes `.port` the sole entry point to a
+//! session's registry set. Teardown paths that removed `.port`/`.key`/`.pid`
+//! but not `.sid` therefore stranded one file per session permanently: no code
+//! path looks at a `.sid` without first finding its `.port`, so nothing could
+//! ever delete it again.
+//!
+//! Field state that prompted this: 6,570 files in one data dir, of which 6,060
+//! were `.sid` orphans and only 17 were live `.port` entries — plus 161
+//! `.spawnlock` files, which are only ever removed by a `Drop` that does not
+//! run when the holder is killed. The oldest was three weeks old.
+//!
+//! The cost is not just disk: `resolve_session_by_id` scans every `.sid` in the
+//! directory to map `$N` to a session name, so each leaked file is re-read on
+//! every lookup.
+
+use super::*;
+
+/// Unique scratch directory per test, so cases can never observe each other.
+fn scratch_dir(tag: &str) -> std::path::PathBuf {
+    let dir = std::env::temp_dir().join(format!(
+        "psmux-530-{}-{}-{}",
+        tag,
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0)
+    ));
+    let _ = std::fs::create_dir_all(&dir);
+    dir
+}
+
+fn write(dir: &std::path::Path, name: &str, body: &str) -> std::path::PathBuf {
+    let p = dir.join(name);
+    std::fs::write(&p, body).expect("write registry file");
+    p
+}
+
+fn exists(dir: &std::path::Path, name: &str) -> bool {
+    dir.join(name).exists()
+}
+
+/// Nothing is alive, so every orphan is collectable.
+fn all_dead(_pid: u32) -> bool {
+    false
+}
+
+/// The core defect: a `.sid` whose `.port` is gone is removed.
+#[test]
+fn a_sid_orphaned_by_teardown_is_pruned() {
+    let dir = scratch_dir("sid");
+    write(&dir, "ns__work.sid", "3");
+
+    let pruned = prune_orphaned_registry_files_in_with(&dir, Duration::ZERO, all_dead);
+
+    assert_eq!(pruned, 1, "the orphaned .sid should have been removed");
+    assert!(
+        !exists(&dir, "ns__work.sid"),
+        "orphaned .sid survived the sweep"
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// A live session's files must never be touched. This is the property that
+/// makes the sweep safe to run on every CLI invocation.
+#[test]
+fn a_complete_registry_set_with_a_port_is_left_alone() {
+    let dir = scratch_dir("live");
+    write(&dir, "ns__work.port", "51234");
+    write(&dir, "ns__work.key", "deadbeef");
+    write(&dir, "ns__work.sid", "3");
+    write(&dir, "ns__work.pid", "4242:134301758043996634");
+
+    let pruned = prune_orphaned_registry_files_in_with(&dir, Duration::ZERO, all_dead);
+
+    assert_eq!(pruned, 0, "a set with a .port must not be pruned");
+    for f in ["ns__work.port", "ns__work.key", "ns__work.sid", "ns__work.pid"] {
+        assert!(exists(&dir, f), "{f} was removed but its .port still exists");
+    }
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// A server that is still coming up has written `.sid`/`.key`/`.pid` but not
+/// yet its `.port` beacon. The grace period is the only thing standing between
+/// the sweep and a healthy startup, so assert it directly.
+#[test]
+fn a_freshly_written_orphan_is_kept_until_the_grace_period_elapses() {
+    let dir = scratch_dir("young");
+    write(&dir, "ns__starting.sid", "7");
+    write(&dir, "ns__starting.key", "abc123");
+
+    let pruned =
+        prune_orphaned_registry_files_in_with(&dir, Duration::from_secs(3600), all_dead);
+
+    assert_eq!(pruned, 0, "files inside the grace window must be kept");
+    assert!(exists(&dir, "ns__starting.sid"));
+    assert!(exists(&dir, "ns__starting.key"));
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// A wedged server that never published a port still owns its identity files;
+/// deleting them would only make it harder for the #448 reaper to find.
+#[test]
+fn an_orphan_whose_pid_anchor_is_alive_is_kept() {
+    let dir = scratch_dir("alive");
+    write(&dir, "ns__wedged.pid", "4242:134301758043996634");
+    write(&dir, "ns__wedged.sid", "9");
+
+    let pruned = prune_orphaned_registry_files_in_with(&dir, Duration::ZERO, |pid| pid == 4242);
+
+    assert_eq!(pruned, 0, "a live PID anchor must protect the whole set");
+    assert!(exists(&dir, "ns__wedged.pid"));
+    assert!(
+        exists(&dir, "ns__wedged.sid"),
+        ".sid is anchored by its sibling .pid, not by its own contents"
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// Same set, dead owner: now the whole thing goes.
+#[test]
+fn an_orphan_whose_pid_anchor_is_dead_is_pruned() {
+    let dir = scratch_dir("dead");
+    write(&dir, "ns__gone.pid", "4242:134301758043996634");
+    write(&dir, "ns__gone.sid", "9");
+
+    let pruned = prune_orphaned_registry_files_in_with(&dir, Duration::ZERO, all_dead);
+
+    assert_eq!(pruned, 2, "both satellites of a dead server should go");
+    assert!(!exists(&dir, "ns__gone.pid"));
+    assert!(!exists(&dir, "ns__gone.sid"));
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// `.spawnlock` records its holder's PID in the file body rather than in a
+/// sibling, and its `Drop`-based cleanup never runs when the holder is killed.
+#[test]
+fn a_spawnlock_is_pruned_when_its_holder_is_dead_and_kept_while_alive() {
+    let dir = scratch_dir("lock");
+    write(&dir, "ns____warm__.spawnlock", "22532");
+
+    let kept = prune_orphaned_registry_files_in_with(&dir, Duration::ZERO, |pid| pid == 22532);
+    assert_eq!(kept, 0, "a lock held by a live process must be kept");
+    assert!(exists(&dir, "ns____warm__.spawnlock"));
+
+    let pruned = prune_orphaned_registry_files_in_with(&dir, Duration::ZERO, all_dead);
+    assert_eq!(pruned, 1, "a lock whose holder died must be reclaimed");
+    assert!(!exists(&dir, "ns____warm__.spawnlock"));
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// The sweep must not wander outside the registry: the session-id counter, its
+/// lock, and debug logs share the directory and are not `.port` satellites.
+#[test]
+fn non_registry_files_are_never_touched() {
+    let dir = scratch_dir("bystanders");
+    write(&dir, "next_session_id", "41");
+    write(&dir, "next_session_id.lock", "1234");
+    write(&dir, "session.log", "some debug output");
+    let _ = std::fs::create_dir_all(dir.join("instances"));
+    let _ = std::fs::create_dir_all(dir.join("servers"));
+
+    let pruned = prune_orphaned_registry_files_in_with(&dir, Duration::ZERO, all_dead);
+
+    assert_eq!(pruned, 0, "no bystander file should have been removed");
+    assert!(exists(&dir, "next_session_id"));
+    assert!(exists(&dir, "next_session_id.lock"));
+    assert!(exists(&dir, "session.log"));
+    assert!(dir.join("instances").is_dir());
+    assert!(dir.join("servers").is_dir());
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// Reproduces the observed field shape: many dead namespaces leaving only
+/// `.sid` behind, alongside one genuinely live session.
+#[test]
+fn a_backlog_of_dead_namespaces_is_cleared_without_harming_the_live_one() {
+    let dir = scratch_dir("backlog");
+    for i in 0..50 {
+        write(&dir, &format!("jefe-conformance-{i}-0__probe.sid"), "1");
+    }
+    write(&dir, "live__work.port", "51234");
+    write(&dir, "live__work.sid", "2");
+
+    let pruned = prune_orphaned_registry_files_in_with(&dir, Duration::ZERO, all_dead);
+
+    assert_eq!(pruned, 50, "every orphaned namespace should be cleared");
+    assert!(exists(&dir, "live__work.port"));
+    assert!(exists(&dir, "live__work.sid"));
+    let remaining = std::fs::read_dir(&dir).unwrap().count();
+    assert_eq!(remaining, 2, "only the live session's files should remain");
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// `remove_session_registry_files` is what teardown paths must use; verify it
+/// really takes the whole set, since a partial delete is what created #530.
+#[test]
+fn removing_a_registry_set_leaves_nothing_behind() {
+    let dir = scratch_dir("removeall");
+    let port = write(&dir, "ns__work.port", "51234");
+    write(&dir, "ns__work.key", "deadbeef");
+    write(&dir, "ns__work.sid", "3");
+    write(&dir, "ns__work.pid", "4242:134301758043996634");
+
+    remove_session_registry_files(&port);
+
+    let remaining = std::fs::read_dir(&dir).unwrap().count();
+    assert_eq!(
+        remaining, 0,
+        "teardown must not strand a satellite; leftovers are unreachable forever"
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}

--- a/tests-rs/test_issue530_registry_pruning.rs
+++ b/tests-rs/test_issue530_registry_pruning.rs
@@ -55,7 +55,7 @@ fn a_sid_orphaned_by_teardown_is_pruned() {
     let dir = scratch_dir("sid");
     write(&dir, "ns__work.sid", "3");
 
-    let pruned = prune_orphaned_registry_files_in_with(&dir, Duration::ZERO, all_dead);
+    let pruned = prune_orphaned_registry_files_in_with(&dir, Duration::ZERO, usize::MAX, all_dead);
 
     assert_eq!(pruned, 1, "the orphaned .sid should have been removed");
     assert!(
@@ -75,7 +75,7 @@ fn a_complete_registry_set_with_a_port_is_left_alone() {
     write(&dir, "ns__work.sid", "3");
     write(&dir, "ns__work.pid", "4242:134301758043996634");
 
-    let pruned = prune_orphaned_registry_files_in_with(&dir, Duration::ZERO, all_dead);
+    let pruned = prune_orphaned_registry_files_in_with(&dir, Duration::ZERO, usize::MAX, all_dead);
 
     assert_eq!(pruned, 0, "a set with a .port must not be pruned");
     for f in ["ns__work.port", "ns__work.key", "ns__work.sid", "ns__work.pid"] {
@@ -94,7 +94,7 @@ fn a_freshly_written_orphan_is_kept_until_the_grace_period_elapses() {
     write(&dir, "ns__starting.key", "abc123");
 
     let pruned =
-        prune_orphaned_registry_files_in_with(&dir, Duration::from_secs(3600), all_dead);
+        prune_orphaned_registry_files_in_with(&dir, Duration::from_secs(3600), usize::MAX, all_dead);
 
     assert_eq!(pruned, 0, "files inside the grace window must be kept");
     assert!(exists(&dir, "ns__starting.sid"));
@@ -110,7 +110,7 @@ fn an_orphan_whose_pid_anchor_is_alive_is_kept() {
     write(&dir, "ns__wedged.pid", "4242:134301758043996634");
     write(&dir, "ns__wedged.sid", "9");
 
-    let pruned = prune_orphaned_registry_files_in_with(&dir, Duration::ZERO, |pid| pid == 4242);
+    let pruned = prune_orphaned_registry_files_in_with(&dir, Duration::ZERO, usize::MAX, |pid| pid == 4242);
 
     assert_eq!(pruned, 0, "a live PID anchor must protect the whole set");
     assert!(exists(&dir, "ns__wedged.pid"));
@@ -128,7 +128,7 @@ fn an_orphan_whose_pid_anchor_is_dead_is_pruned() {
     write(&dir, "ns__gone.pid", "4242:134301758043996634");
     write(&dir, "ns__gone.sid", "9");
 
-    let pruned = prune_orphaned_registry_files_in_with(&dir, Duration::ZERO, all_dead);
+    let pruned = prune_orphaned_registry_files_in_with(&dir, Duration::ZERO, usize::MAX, all_dead);
 
     assert_eq!(pruned, 2, "both satellites of a dead server should go");
     assert!(!exists(&dir, "ns__gone.pid"));
@@ -143,11 +143,11 @@ fn a_spawnlock_is_pruned_when_its_holder_is_dead_and_kept_while_alive() {
     let dir = scratch_dir("lock");
     write(&dir, "ns____warm__.spawnlock", "22532");
 
-    let kept = prune_orphaned_registry_files_in_with(&dir, Duration::ZERO, |pid| pid == 22532);
+    let kept = prune_orphaned_registry_files_in_with(&dir, Duration::ZERO, usize::MAX, |pid| pid == 22532);
     assert_eq!(kept, 0, "a lock held by a live process must be kept");
     assert!(exists(&dir, "ns____warm__.spawnlock"));
 
-    let pruned = prune_orphaned_registry_files_in_with(&dir, Duration::ZERO, all_dead);
+    let pruned = prune_orphaned_registry_files_in_with(&dir, Duration::ZERO, usize::MAX, all_dead);
     assert_eq!(pruned, 1, "a lock whose holder died must be reclaimed");
     assert!(!exists(&dir, "ns____warm__.spawnlock"));
     let _ = std::fs::remove_dir_all(&dir);
@@ -164,7 +164,7 @@ fn non_registry_files_are_never_touched() {
     let _ = std::fs::create_dir_all(dir.join("instances"));
     let _ = std::fs::create_dir_all(dir.join("servers"));
 
-    let pruned = prune_orphaned_registry_files_in_with(&dir, Duration::ZERO, all_dead);
+    let pruned = prune_orphaned_registry_files_in_with(&dir, Duration::ZERO, usize::MAX, all_dead);
 
     assert_eq!(pruned, 0, "no bystander file should have been removed");
     assert!(exists(&dir, "next_session_id"));
@@ -186,7 +186,7 @@ fn a_backlog_of_dead_namespaces_is_cleared_without_harming_the_live_one() {
     write(&dir, "live__work.port", "51234");
     write(&dir, "live__work.sid", "2");
 
-    let pruned = prune_orphaned_registry_files_in_with(&dir, Duration::ZERO, all_dead);
+    let pruned = prune_orphaned_registry_files_in_with(&dir, Duration::ZERO, usize::MAX, all_dead);
 
     assert_eq!(pruned, 50, "every orphaned namespace should be cleared");
     assert!(exists(&dir, "live__work.port"));
@@ -212,6 +212,62 @@ fn removing_a_registry_set_leaves_nothing_behind() {
     assert_eq!(
         remaining, 0,
         "teardown must not strand a satellite; leftovers are unreachable forever"
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// A sweep must stay cheap. Every psmux invocation runs it, including trivial
+/// ones like `psmux -V`, so a large backlog has to drain over several sweeps
+/// instead of making one arbitrary command delete thousands of files.
+#[test]
+fn a_single_sweep_removes_no_more_than_its_budget() {
+    let dir = scratch_dir("budget");
+    for i in 0..40 {
+        write(&dir, &format!("ns{i}__work.sid"), "1");
+    }
+
+    let pruned = prune_orphaned_registry_files_in_with(&dir, Duration::ZERO, 10, all_dead);
+
+    assert_eq!(pruned, 10, "the sweep must stop once its budget is spent");
+    assert_eq!(
+        std::fs::read_dir(&dir).unwrap().count(),
+        30,
+        "the rest of the backlog must survive for the next sweep"
+    );
+
+    let mut total = 10;
+    for _ in 0..3 {
+        total += prune_orphaned_registry_files_in_with(&dir, Duration::ZERO, 10, all_dead);
+    }
+    assert_eq!(total, 40, "successive sweeps must clear the whole backlog");
+    assert_eq!(std::fs::read_dir(&dir).unwrap().count(), 0);
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// The stamp keeps the directory walk off the hot path: psmux commands are run
+/// constantly by scripts, and orphans only appear at session teardown.
+#[test]
+fn a_sweep_is_rate_limited_by_its_stamp() {
+    let dir = scratch_dir("stamp");
+
+    assert!(
+        registry_sweep_due(&dir, Duration::from_secs(300)),
+        "with no stamp present a sweep is due"
+    );
+    assert!(
+        !registry_sweep_due(&dir, Duration::from_secs(300)),
+        "the stamp written by the first call must suppress the next one"
+    );
+    assert!(
+        registry_sweep_due(&dir, Duration::ZERO),
+        "once the interval has elapsed a sweep is due again"
+    );
+
+    let pruned = prune_orphaned_registry_files_in_with(&dir, Duration::ZERO, usize::MAX, all_dead);
+    assert_eq!(pruned, 0, "the stamp is not a registry satellite");
+    assert!(
+        exists(&dir, ".registry_sweep"),
+        "the stamp must survive the sweep it schedules"
     );
     let _ = std::fs::remove_dir_all(&dir);
 }

--- a/tests/repro_issue530_registry_pruning.ps1
+++ b/tests/repro_issue530_registry_pruning.ps1
@@ -1,0 +1,173 @@
+# Issue #530: ~/.psmux accumulates .sid/.pid/.spawnlock files forever.
+#
+# Two defects, one symptom:
+#   1. kill-server removed .port/.key/.pid but not .sid.
+#   2. Every registry sweep enumerates .port files and deletes their siblings,
+#      so any satellite that outlives its .port is unreachable forever.
+#
+# This script runs entirely inside a private data directory (USERPROFILE is
+# redirected to a temp dir), so it can never read, prune, or otherwise disturb
+# the real ~/.psmux or any psmux server running on this machine.
+#
+# Usage: powershell -NoProfile -ExecutionPolicy Bypass -File tests\repro_issue530_registry_pruning.ps1
+
+$ErrorActionPreference = 'Continue'
+
+$repoRoot = Split-Path -Parent $PSScriptRoot
+$psmux    = Join-Path $repoRoot 'target\debug\psmux.exe'
+if (-not (Test-Path $psmux)) {
+    Write-Host "FAIL: $psmux not found - run: cargo build --bin psmux" -ForegroundColor Red
+    exit 1
+}
+
+$stamp   = (Get-Date).ToString('HHmmss')
+$ns      = "psmux530e2e$PID$stamp"
+$fakeDir = Join-Path $env:TEMP "psmux530home-$PID-$stamp"
+$dataDir = Join-Path $fakeDir '.psmux'
+New-Item -ItemType Directory -Force -Path $dataDir | Out-Null
+
+$realProfile = $env:USERPROFILE
+$failures    = @()
+
+function Check($label, $condition, $detail) {
+    if ($condition) {
+        Write-Host "  PASS  $label" -ForegroundColor Green
+    } else {
+        Write-Host "  FAIL  $label" -ForegroundColor Red
+        if ($detail) { Write-Host "        $detail" -ForegroundColor DarkGray }
+        $script:failures += $label
+    }
+}
+
+# Files in the private data dir, by name.
+function DataFiles {
+    @(Get-ChildItem $dataDir -File -EA SilentlyContinue | Select-Object -ExpandProperty Name)
+}
+
+function Backdate($path, $minutes) {
+    $i = Get-Item $path
+    $i.LastWriteTime = (Get-Date).AddMinutes(-$minutes)
+}
+
+# A PID that is certainly not running (and certainly not a psmux image).
+function DeadPid {
+    $p = 60000
+    while (Get-Process -Id $p -EA SilentlyContinue) { $p += 7 }
+    $p
+}
+
+try {
+    $env:USERPROFILE = $fakeDir
+    $env:PSMUX_NO_WARM = '1'
+
+    Write-Host ''
+    Write-Host "namespace : $ns"
+    Write-Host "data dir  : $dataDir"
+    Write-Host ''
+
+    # ---------------------------------------------------------------------
+    Write-Host '--- Scenario A: a live session writes a complete registry set ---'
+    # ---------------------------------------------------------------------
+    & $psmux -L $ns new-session -d -s work 2>&1 | Out-Null
+
+    $deadline = (Get-Date).AddSeconds(6)
+    while ((Get-Date) -lt $deadline -and -not (Test-Path (Join-Path $dataDir "${ns}__work.port"))) {
+        Start-Sleep -Milliseconds 150
+    }
+
+    $created = DataFiles
+    Check 'session registry set was created' `
+        ($created -contains "${ns}__work.port" -and $created -contains "${ns}__work.sid") `
+        ("saw: " + ($created -join ', '))
+
+    # ---------------------------------------------------------------------
+    Write-Host ''
+    Write-Host '--- Scenario B: orphans are swept, the LIVE session is not ---'
+    # ---------------------------------------------------------------------
+    $dead = DeadPid
+
+    # Orphans: no .port sibling, aged past the grace period.
+    Set-Content -Path (Join-Path $dataDir 'ghost-a__probe.sid') -Value '11'
+    Set-Content -Path (Join-Path $dataDir 'ghost-b__probe.sid') -Value '12'
+    Set-Content -Path (Join-Path $dataDir 'ghost-c__probe.pid') -Value "${dead}:134301758043996634"
+    Set-Content -Path (Join-Path $dataDir 'ghost-c__probe.sid') -Value '13'
+    Set-Content -Path (Join-Path $dataDir 'ghost-d____warm__.spawnlock') -Value "$dead"
+    foreach ($f in 'ghost-a__probe.sid','ghost-b__probe.sid','ghost-c__probe.pid','ghost-c__probe.sid','ghost-d____warm__.spawnlock') {
+        Backdate (Join-Path $dataDir $f) 10
+    }
+
+    # Protected #1: an orphan written just now - indistinguishable from a server
+    # still coming up, so the grace period must save it.
+    Set-Content -Path (Join-Path $dataDir 'keep-young__starting.sid') -Value '22'
+
+    # Protected #2: bystanders that are not registry satellites at all.
+    Set-Content -Path (Join-Path $dataDir 'next_session_id') -Value '41'
+    Backdate (Join-Path $dataDir 'next_session_id') 10
+
+    # Any psmux invocation runs the sweep at startup.
+    & $psmux -L $ns list-sessions 2>&1 | Out-Null
+    Start-Sleep -Milliseconds 300
+
+    $after = DataFiles
+
+    Check 'orphaned .sid files were pruned' `
+        (-not ($after -contains 'ghost-a__probe.sid') -and -not ($after -contains 'ghost-b__probe.sid')) `
+        ("still present: " + (($after | Where-Object { $_ -like 'ghost-a*' -or $_ -like 'ghost-b*' }) -join ', '))
+
+    Check 'orphan set with a DEAD pid anchor was pruned' `
+        (-not ($after -contains 'ghost-c__probe.pid') -and -not ($after -contains 'ghost-c__probe.sid')) `
+        ("still present: " + (($after | Where-Object { $_ -like 'ghost-c*' }) -join ', '))
+
+    Check 'stale .spawnlock from a dead holder was reclaimed' `
+        (-not ($after -contains 'ghost-d____warm__.spawnlock')) `
+        'a lock whose holder was killed is never released by Drop'
+
+    Check 'the LIVE session survived the sweep intact' `
+        ($after -contains "${ns}__work.port" -and $after -contains "${ns}__work.sid") `
+        ("live session files after sweep: " + (($after | Where-Object { $_ -like "${ns}__*" }) -join ', '))
+
+    Check 'freshly written orphan survived (startup grace)' `
+        ($after -contains 'keep-young__starting.sid') `
+        'a server writes .sid before .port; deleting inside that window breaks startup'
+
+    Check 'non-registry bystanders untouched' `
+        ($after -contains 'next_session_id') `
+        'the session-id counter is not a .port satellite'
+
+    # ---------------------------------------------------------------------
+    Write-Host ''
+    Write-Host '--- Scenario C: kill-server must not strand the .sid ---'
+    # ---------------------------------------------------------------------
+    & $psmux -L $ns kill-server 2>&1 | Out-Null
+    Start-Sleep -Milliseconds 400
+
+    $afterKill = @(DataFiles | Where-Object { $_ -like "${ns}__*" })
+    Check 'kill-server removed the ENTIRE registry set (incl. .sid)' `
+        ($afterKill.Count -eq 0) `
+        ("leftovers: " + ($afterKill -join ', '))
+}
+finally {
+    & $psmux -L $ns kill-server 2>&1 | Out-Null
+    $env:USERPROFILE = $realProfile
+    Remove-Item Env:\PSMUX_NO_WARM -EA SilentlyContinue
+
+    # Nothing from this run may outlive it. Scoped to our own build AND our own
+    # namespace, so no other psmux server on this machine can be matched.
+    $stray = @(Get-CimInstance Win32_Process -Filter "Name='psmux.exe'" -EA SilentlyContinue |
+        Where-Object { $_.ExecutablePath -eq $psmux -and $_.CommandLine -like "*$ns*" })
+    foreach ($p in $stray) {
+        Write-Host "  cleanup: terminating stray server pid $($p.ProcessId)" -ForegroundColor Yellow
+        Stop-Process -Id $p.ProcessId -Force -EA SilentlyContinue
+    }
+    Remove-Item -Recurse -Force $fakeDir -EA SilentlyContinue
+}
+
+Write-Host ''
+if ($failures.Count -eq 0) {
+    Write-Host 'RESULT: PASS - registry satellites are cleaned up and live entries are preserved' -ForegroundColor Green
+    exit 0
+} else {
+    Write-Host "RESULT: FAIL - $($failures.Count) check(s) failed:" -ForegroundColor Red
+    $failures | ForEach-Object { Write-Host "  - $_" -ForegroundColor Red }
+    exit 1
+}

--- a/tests/repro_issue530_registry_pruning.ps1
+++ b/tests/repro_issue530_registry_pruning.ps1
@@ -104,7 +104,14 @@ try {
     Set-Content -Path (Join-Path $dataDir 'next_session_id') -Value '41'
     Backdate (Join-Path $dataDir 'next_session_id') 10
 
-    # Any psmux invocation runs the sweep at startup.
+    # The sweep is rate-limited by a stamp file so it never runs on every
+    # invocation. An earlier command in this scenario already stamped it, so
+    # backdate the stamp to stand in for the interval having elapsed.
+    $stamp = Join-Path $dataDir '.registry_sweep'
+    if (-not (Test-Path $stamp)) { Set-Content -Path $stamp -Value '' }
+    Backdate $stamp 10
+
+    # Any psmux invocation runs the sweep at startup once it is due.
     & $psmux -L $ns list-sessions 2>&1 | Out-Null
     Start-Sleep -Milliseconds 300
 


### PR DESCRIPTION
Fixes #530.

## Overview

Files in `~/.psmux` are never pruned. They accumulate for the life of the machine, and the largest producer is `kill-server` itself.

## Root cause

Every sweep over the data directory is anchored on `.port` files:

```rust
let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
if ext != "port" {
    continue;
}
```

The `.port` file is therefore the *only* entry point to a session's registry set. Once it is gone, its `.sid`, `.key`, `.pid` and `.spawnlock` siblings are unreachable by any code path in the program — no sweep will ever look at them again.

Teardown removed the `.port` first and the `.sid` never:

- `kill-server` (two sites in `main.rs`) removed `.port`, `.key` and `.pid`, leaving one stranded `.sid` per session, permanently.
- Roughly a dozen further teardown sites remove only the `.port`/`.key` pair.
- `.spawnlock` is released solely by `WarmSpawnLock::Drop`, which by definition cannot run when the holder is killed.

Only two call sites removed the complete set.

This is not only a disk problem. `resolve_session_by_id` walks **every** `.sid` file to map `$N` to a session name, so each orphan is re-read on every id lookup.

## Field evidence

From the data directory on the machine in the report:

| Extension | Count |
|---|---|
| `.sid` | 6,060 |
| `.pid` | 311 |
| `.spawnlock` | 161 |
| `.key` | 17 |
| `.port` | 17 |

6,634 files total, oldest three weeks old, against 17 live sessions. The `.sid` count tracks the number of sessions ever created; the shape is exactly what the missing `.sid` unlink predicts. Tooling that mints a fresh `-L` namespace per run reaches this state much faster.

## The fix

**Teardown removes the whole set.** Both `kill-server` sites now call the existing `remove_session_registry_files` helper instead of unlinking three of the four files by hand.

**A startup sweep collects what earlier versions stranded.** `prune_orphaned_registry_files` runs alongside the existing `cleanup_stale_port_files`, and is deliberately conservative:

- Only `.sid`, `.key`, `.pid` and `.spawnlock` are considered, and only when no sibling `.port` exists. A set with a `.port` belongs to the port-driven sweep and is never touched here. Files that are not registry satellites — `next_session_id`, logs, the `instances/` and `servers/` directories — are not candidates at all.
- A **60 second grace period** protects a starting server. `ensure_session_registry_files` writes `.sid`, `.key` and `.pid` *before* it publishes the `.port` beacon, so a healthy server transiently looks exactly like an orphan. A running server also rewrites its whole set on the 5s self-heal tick, so its files can never age past this bound.
- An orphan whose anchoring pid still belongs to a live psmux process is **kept**, so a server that is merely slow to publish is never disturbed. `.spawnlock` carries its holder's pid in its own body; the other extensions anchor on the sibling `.pid`.

## Behaviour changes

Recovering a session by finding a bare `.sid` on disk was never possible — nothing reads a `.sid` without a `.port` — so nothing that used to work stops working. On the reporter's machine the sweep reclaims 6,060 `.sid` and 161 `.spawnlock` files on the next invocation and keeps all 17 live sessions.

## Validation

New E2E `tests/repro_issue530_registry_pruning.ps1`, against the **unfixed** binary:

```
--- Scenario B: orphans are swept, the LIVE session is not ---
  FAIL  orphaned .sid files were pruned
        still present: ghost-a__probe.sid, ghost-b__probe.sid
  FAIL  orphan set with a DEAD pid anchor was pruned
  FAIL  stale .spawnlock from a dead holder was reclaimed
--- Scenario C: kill-server must not strand the .sid ---
  FAIL  kill-server removed the ENTIRE registry set (incl. .sid)
        leftovers: psmux530e2e3516041119__work.sid
```

With the fix, 8/8 pass. The script redirects `USERPROFILE` to a temp directory so it can never touch a developer's real data directory, and tears down its servers by matching both the repo-built image and a per-run namespace.

`tests-rs/test_issue530_registry_pruning.rs` adds 9 unit tests. They drive an inner function taking an injectable grace period and liveness oracle, so both the startup window and the live-anchor branch are exercised deterministically without spawning servers or waiting a minute.

Full suite: **2698 passed, 0 failed** (2689 before these tests).

## Scope

Off Windows the process-table check is unavailable, so pid-anchored orphans are kept rather than guessed at. Unanchored orphans — the overwhelming majority, and the entire `.sid` backlog — are pruned on every platform.

The dozen teardown sites that remove only the `.port`/`.key` pair are left as they are; the sweep now collects after them. Converting them to the whole-set helper would be a reasonable follow-up.

---

*Authored by Claude (Anthropic) at @acoliver's direction.*
