### PR TITLE
feat(pty): expose ConPTY passthrough mode

### DIFF
--- a/crates/portable-pty-psmux/src/lib.rs
+++ b/crates/portable-pty-psmux/src/lib.rs
@@ -101,6 +101,16 @@ pub trait MasterPty: Downcast + Send {
     /// It is invalid to take the writer more than once.
     fn take_writer(&self) -> Result<Box<dyn std::io::Write + Send>, Error>;
 
+    /// Whether this is a ConPTY created with passthrough mode enabled.
+    ///
+    /// `None` means that the pty implementation is not ConPTY, or does not
+    /// expose this implementation-specific detail.  The result should be
+    /// queried after spawning a child: ConPTY can fall back to a newly-created
+    /// non-passthrough console when process creation rejects passthrough mode.
+    fn conpty_passthrough_mode(&self) -> Option<bool> {
+        None
+    }
+
     /// If applicable to the type of the tty, return the local process id
     /// of the process group or session leader
     #[cfg(unix)]
@@ -124,6 +134,18 @@ pub trait MasterPty: Downcast + Send {
     }
 }
 impl_downcast!(MasterPty);
+
+#[cfg(all(test, not(windows)))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn non_conpty_master_reports_no_passthrough_mode() {
+        let pair = native_pty_system().openpty(PtySize::default()).unwrap();
+
+        assert_eq!(pair.master.conpty_passthrough_mode(), None);
+    }
+}
 
 /// Represents a child process spawned into the pty.
 /// This handle can be used to wait for or terminate that child process.

--- a/crates/portable-pty-psmux/src/win/conpty.rs
+++ b/crates/portable-pty-psmux/src/win/conpty.rs
@@ -141,6 +141,10 @@ impl MasterPty for ConPtyMasterPty {
                 .ok_or_else(|| anyhow::anyhow!("writer already taken"))?,
         ))
     }
+
+    fn conpty_passthrough_mode(&self) -> Option<bool> {
+        Some(self.inner.lock().unwrap().con.used_passthrough)
+    }
 }
 
 impl SlavePty for ConPtySlavePty {
@@ -196,4 +200,39 @@ impl SlavePty for ConPtySlavePty {
 fn is_invalid_parameter(e: &anyhow::Error) -> bool {
     let msg = format!("{}", e);
     msg.contains("os error 87")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::process::Command;
+
+    const CHILD_ENV: &str = "PORTABLE_PTY_CONPTY_PASSTHROUGH_TEST_CHILD";
+
+    #[test]
+    fn reports_when_passthrough_is_disabled_by_environment() {
+        if std::env::var_os(CHILD_ENV).is_some() {
+            let pair = ConPtySystem::default().openpty(PtySize::default()).unwrap();
+
+            assert_eq!(pair.master.conpty_passthrough_mode(), Some(false));
+            return;
+        }
+
+        let exe = std::env::current_exe().unwrap();
+        let output = Command::new(exe)
+            .args([
+                "--exact",
+                "win::conpty::tests::reports_when_passthrough_is_disabled_by_environment",
+            ])
+            .env("PSMUX_NO_PASSTHROUGH", "1")
+            .env(CHILD_ENV, "1")
+            .output()
+            .unwrap();
+
+        assert!(
+            output.status.success(),
+            "child test failed:\n{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
 }


### PR DESCRIPTION
Follows on from your note in #533, that `CreateProcessW` rejects a passthrough HPCON on Windows 11 build 26200 and portable-pty falls back to plain ConPTY. We are on that build, and we have a scrollback finding of our own that we attributed to passthrough — so we wanted to know which side we were actually on, and found we could not ask.

Passthrough is decided twice: at creation, gated on the build and `PSMUX_NO_PASSTHROUGH`, and again inside `spawn_command`, where an `ERROR_INVALID_PARAMETER` rebuilds the console without the flag and retries. Both are right. Neither is visible from outside: `used_passthrough` is `pub`, but `win::psuedocon` is private and `ConPtyMasterPty`'s `inner` is private, so nothing reachable from `native_pty_system().openpty()` can read it. A successful fallback and a successful passthrough are the same observation. The `log::warn!` is the only signal, and a consumer that never wired up a logger — ours had not — sees nothing.

This adds a defaulted `MasterPty::conpty_passthrough_mode(&self) -> Option<bool>`. `Option<bool>` rather than a transport enum because the state you already keep is a bool and `None` covers the backends with no answer; an enum would add public surface for states that do not exist yet. It reads from the master rather than from `openpty`'s return, because the second fallback happens during spawn — a value read before spawning would be wrong in exactly the case worth asking about.

## On testing

The environment-disabled path is covered on Windows. The test deliberately does not set `PSMUX_NO_PASSTHROUGH` in its own process: it re-runs its own binary with `--exact` for the child case and passes the variable through `Command::env`, so nothing else in this binary or any other can observe it set. That mattered here because the variable's reader is ConPTY creation itself, which the `ENV_MUTEX` pattern in `tests-rs/test_config_exhaustive.rs` could not have serialised against.

The post-spawn fallback is **not** covered, and it is the interesting one. It fires only when the OS rejects the flag, and there is no seam in the tree to force that, so a test would either depend on a particular build or assert nothing. I would rather say so than ship something that looks like coverage. If you have a seam in mind, I am glad to add it.

`cargo fmt --check` does not pass on this tree, but not because of this change — `build.rs` and parts of `win/` are already unformatted at `db303ae`. I matched rustfmt's output by hand for the added lines rather than sweep unrelated files into the diff. Per `AGENTS.md` I did not run the full `cargo test --all-targets`; targeted `cargo test -p portable-pty-psmux` and `cargo check` are green.
