### PR TITLE
fix(capture): honor -t pane targets and -N trailing-space preservation

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1637,7 +1637,9 @@ pub fn run_remote(terminal: &mut Terminal<crate::platform::PsmuxBackend>, input:
     let mut paste_stage2_last_len: usize = 0;
     // Suppression window: after right-click copy, discard text key events
     // for a short period to prevent VS Code ConPTY duplicate injection.
-    #[cfg(windows)]
+    // Declared on every platform because the right-click handler assigns it
+    // unconditionally; only the Windows code paths ever read it.
+    #[allow(unused_variables)]
     let mut paste_suppress_until: Option<Instant> = None;
 
     // Track whether a modified Enter Press was already handled this keypress

--- a/src/copy_mode.rs
+++ b/src/copy_mode.rs
@@ -605,14 +605,39 @@ fn capture_row_text(screen: &vt100::Screen, row: u16, cols: std::ops::Range<u16>
     out
 }
 
-pub fn capture_active_pane_text(app: &mut AppState) -> io::Result<Option<String>> {
-    let win = &mut app.windows[app.active_idx];
-    let p = match active_pane_mut(&mut win.root, &win.active_path) { Some(p) => p, None => return Ok(None) };
+/// Resolve the (window index, tree path) a capture should read.
+///
+/// An explicit `-t %N` pane id wins and is searched across every window
+/// (same pane-by-id lookup as kill-pane); a missing or unresolvable id
+/// falls back to the active pane of the active window, keeping the
+/// pre-targeting behavior and error shape.
+fn capture_target(app: &AppState, pane_id: Option<usize>) -> (usize, Vec<usize>) {
+    if let Some(pid) = pane_id {
+        if let Some((wi, path)) = app.windows.iter().enumerate().find_map(|(wi, win)| {
+            crate::tree::find_path_by_id(&win.root, pid).map(|path| (wi, path))
+        }) {
+            return (wi, path);
+        }
+    }
+    (app.active_idx, app.windows[app.active_idx].active_path.clone())
+}
+
+pub fn capture_active_pane_text(app: &mut AppState, pane_id: Option<usize>, preserve_trailing: bool) -> io::Result<Option<String>> {
+    let (win_idx, path) = capture_target(app, pane_id);
+    let win = &mut app.windows[win_idx];
+    let p = match active_pane_mut(&mut win.root, &path) { Some(p) => p, None => return Ok(None) };
     let parser = match p.term.lock() { Ok(g) => g, Err(_) => return Ok(None) };
     let screen = parser.screen();
     let mut text = String::new();
     for r in 0..p.last_rows {
-        text.push_str(capture_row_text(screen, r, 0..p.last_cols).trim_end());
+        let row = capture_row_text(screen, r, 0..p.last_cols);
+        // -N (preserve_trailing) keeps the full row width, trailing spaces
+        // included; without it, trim like tmux does by default.
+        if preserve_trailing {
+            text.push_str(&row);
+        } else {
+            text.push_str(row.trim_end());
+        }
         text.push('\n');
     }
     // Trim trailing all-empty lines so iTerm2 doesn't advance its cursor
@@ -968,9 +993,10 @@ pub fn compute_capture_range(s: Option<i32>, e: Option<i32>, last_row: u16) -> (
     (start, end)
 }
 
-pub fn capture_active_pane_range(app: &mut AppState, s: Option<i32>, e: Option<i32>) -> io::Result<Option<String>> {
-    let win = &mut app.windows[app.active_idx];
-    let p = match active_pane_mut(&mut win.root, &win.active_path) { Some(p) => p, None => return Ok(None) };
+pub fn capture_active_pane_range(app: &mut AppState, s: Option<i32>, e: Option<i32>, pane_id: Option<usize>, preserve_trailing: bool) -> io::Result<Option<String>> {
+    let (win_idx, path) = capture_target(app, pane_id);
+    let win = &mut app.windows[win_idx];
+    let p = match active_pane_mut(&mut win.root, &path) { Some(p) => p, None => return Ok(None) };
     let mut parser = match p.term.lock() { Ok(g) => g, Err(_) => return Ok(None) };
     let rows = p.last_rows;
     let cols = p.last_cols;
@@ -983,7 +1009,13 @@ pub fn capture_active_pane_range(app: &mut AppState, s: Option<i32>, e: Option<i
         let screen = parser.screen();
         let mut text = String::new();
         for r in start..=end {
-            text.push_str(capture_row_text(screen, r, 0..cols).trim_end());
+            let row = capture_row_text(screen, r, 0..cols);
+            // -N keeps trailing spaces per row; default trims them.
+            if preserve_trailing {
+                text.push_str(&row);
+            } else {
+                text.push_str(row.trim_end());
+            }
             text.push('\n');
         }
         // An explicit range (-S/-E) is honored line for line, matching tmux:
@@ -1038,7 +1070,13 @@ pub fn capture_active_pane_range(app: &mut AppState, s: Option<i32>, e: Option<i
 
         for aline in read_start..=read_end {
             let r = (aline + actual_sb) as u16;
-            text.push_str(capture_row_text(parser.screen(), r, 0..cols).trim_end());
+            let row = capture_row_text(parser.screen(), r, 0..cols);
+            // -N keeps trailing spaces per row; default trims them.
+            if preserve_trailing {
+                text.push_str(&row);
+            } else {
+                text.push_str(row.trim_end());
+            }
             text.push('\n');
         }
         next_abs = read_end + 1;
@@ -1058,12 +1096,15 @@ pub fn capture_active_pane_range(app: &mut AppState, s: Option<i32>, e: Option<i
     Ok(Some(text))
 }
 
-/// Capture the active pane's screen content with ANSI escape sequences preserved.
+/// Capture a pane's screen content with ANSI escape sequences preserved.
 /// This is the `-e` flag for capture-pane.  Supports optional start/end range.
 /// Negative -S values read from scrollback history; i32::MIN means all retained history.
-pub fn capture_active_pane_styled(app: &mut AppState, s: Option<i32>, e: Option<i32>) -> io::Result<Option<String>> {
-    let win = &mut app.windows[app.active_idx];
-    let p = match active_pane_mut(&mut win.root, &win.active_path) { Some(p) => p, None => return Ok(None) };
+/// `pane_id` is an explicit `-t %N` target (None = active pane); `preserve_trailing`
+/// is the `-N` flag (keep trailing spaces per row, styled ones included).
+pub fn capture_active_pane_styled(app: &mut AppState, s: Option<i32>, e: Option<i32>, pane_id: Option<usize>, preserve_trailing: bool) -> io::Result<Option<String>> {
+    let (win_idx, path) = capture_target(app, pane_id);
+    let win = &mut app.windows[win_idx];
+    let p = match active_pane_mut(&mut win.root, &path) { Some(p) => p, None => return Ok(None) };
     let mut parser = match p.term.lock() { Ok(g) => g, Err(_) => return Ok(None) };
     let rows = p.last_rows;
     let cols = p.last_cols;
@@ -1165,8 +1206,15 @@ pub fn capture_active_pane_styled(app: &mut AppState, s: Option<i32>, e: Option<
                 row_chars.push(" ".to_string());
             }
         }
-        let last_non_ws = row_chars.iter().rposition(|s| !s.is_empty() && s.trim() != "");
-        let trim_end = match last_non_ws { Some(pos) => pos + 1, None => 0 };
+        // -N (preserve_trailing): emit the full row width so styled trailing
+        // spaces (e.g. a TUI's background fill painted to end-of-line) keep
+        // their SGR when the capture is replayed. Without -N, trim after the
+        // last non-whitespace cell like tmux does by default.
+        let trim_end = if preserve_trailing {
+            row_chars.len()
+        } else {
+            match row_chars.iter().rposition(|s| !s.is_empty() && s.trim() != "") { Some(pos) => pos + 1, None => 0 }
+        };
         for c in 0..trim_end {
             if let Some(ref sgr) = row_sgr[c] { text.push_str(sgr); }
             text.push_str(&row_chars[c]);
@@ -1634,3 +1682,7 @@ pub fn select_a_word_big(app: &mut AppState) {
 #[cfg(test)]
 #[path = "../tests-rs/test_issue443_blank_cell_capture.rs"]
 mod tests_issue443_blank_cell_capture;
+
+#[cfg(test)]
+#[path = "../tests-rs/test_capture_pane_fidelity.rs"]
+mod tests_capture_pane_fidelity;

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -2143,6 +2143,14 @@ pub mod mouse_inject {
 
 #[cfg(not(windows))]
 pub mod mouse_inject {
+    // Win32 MOUSE_EVENT flag values (winuser.h). The stubs below ignore them,
+    // but callers reference the constants directly so they must exist on
+    // every platform.
+    pub const FROM_LEFT_1ST_BUTTON_PRESSED: u32 = 0x0001;
+    pub const RIGHTMOST_BUTTON_PRESSED: u32 = 0x0002;
+    pub const FROM_LEFT_2ND_BUTTON_PRESSED: u32 = 0x0004;
+    pub const MOUSE_MOVED: u32 = 0x0001;
+    pub const MOUSE_WHEELED: u32 = 0x0004;
     pub fn get_child_pid(_child: &dyn portable_pty::Child) -> Option<u32> { None }
     pub fn send_mouse_event(_pid: u32, _col: i16, _row: i16, _btn: u32, _flags: u32, _reattach: bool) -> bool { false }
     pub fn send_vt_sequence(_pid: u32, _sequence: &[u8]) -> bool { false }

--- a/src/proxy_pane.rs
+++ b/src/proxy_pane.rs
@@ -99,6 +99,18 @@ impl MasterPty for ProxyMasterPty {
             .map(|s| -> Box<dyn Write + Send> { Box::new(s) })
             .ok_or_else(|| anyhow::anyhow!("writer already taken"))
     }
+
+    // The proxied PTY lives in another process; there is no local fd or
+    // termios to expose. `pid_t` is `i32` on every unix target, so the
+    // plain alias is written out to avoid a `libc` dependency here.
+    #[cfg(unix)]
+    fn process_group_leader(&self) -> Option<i32> { None }
+
+    #[cfg(unix)]
+    fn as_raw_fd(&self) -> Option<std::os::unix::io::RawFd> { None }
+
+    #[cfg(unix)]
+    fn tty_name(&self) -> Option<std::path::PathBuf> { None }
 }
 
 // ── ProxyChild ──────────────────────────────────────────────────────────

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -713,10 +713,13 @@ if control_echo || control_noecho {
                 } else {
                     let _ = tx_ctrl.send(CtrlReq::FocusPaneByIndex(pid));
                 }
-            } else if !matches!(cmd_name, "swap-pane" | "swapp" | "resize-window" | "resizew") {
+            } else if !matches!(cmd_name, "swap-pane" | "swapp" | "resize-window" | "resizew")
+                && !(ctrl_pane_is_id && matches!(cmd_name, "capture-pane" | "capturep")) {
                 // swap-pane resolves its own target and swaps it with the *current*
                 // active pane.  Temporarily focusing the target here would make
                 // active == target, turning the swap into a no-op (so skip it).
+                // capture-pane with a -t %N target resolves the pane id inside
+                // the capture itself, so a temporary focus is not needed.
                 if ctrl_pane_is_id {
                     let _ = tx_ctrl.send(CtrlReq::FocusPaneTemp(pid));
                 } else {
@@ -957,9 +960,14 @@ let targeted_kill_pane_id = if matches!(cmd, "kill-pane" | "killp") && pane_is_i
 } else {
     None
 };
+// capture-pane resolves a -t %N target by pane id inside the capture
+// itself (any window), so a temporary focus would only churn the active
+// window for other clients. Non-id targets (-t 0.1) still use the
+// temporary-focus path below.
+let capture_pane_by_id = matches!(cmd, "capture-pane" | "capturep") && pane_is_id && target_pane.is_some();
 // swap-pane swaps the target with the *current* active pane; focusing the
 // target first would make active == target and turn the swap into a no-op.
-let skip_pane_focus = matches!(cmd, "display-message" | "display" | "swap-pane" | "swapp") || skip_target_focus;
+let skip_pane_focus = matches!(cmd, "display-message" | "display" | "swap-pane" | "swapp") || skip_target_focus || capture_pane_by_id;
 if !skip_pane_focus && targeted_kill_pane_id.is_none() {
     if let Some(pid) = target_pane {
         if is_focus_cmd {
@@ -1066,6 +1074,10 @@ match cmd {
         let print_stdout = crate::cli::has_short_flag(&args, 'p');
         let join_lines = crate::cli::has_short_flag(&args, 'J');
         let escape_seqs = crate::cli::has_short_flag(&args, 'e');
+        // -N: preserve trailing spaces at the end of each line (tmux parity).
+        let preserve_trailing = crate::cli::has_short_flag(&args, 'N');
+        // -t %N target: resolved server-side by pane id across all windows.
+        let capture_pane_id = if pane_is_id { target_pane } else { None };
         // Parse -S start and -E end (negative = scrollback offset, - = entire scrollback)
         let s_arg = args.windows(2).find(|w| w[0] == "-S").map(|w| w[1]);
         let e_arg = args.windows(2).find(|w| w[0] == "-E").map(|w| w[1]);
@@ -1081,11 +1093,11 @@ match cmd {
         };
         let (rtx, rrx) = mpsc::channel::<String>();
         if escape_seqs {
-            let _ = tx.send(CtrlReq::CapturePaneStyled(rtx, start, end));
+            let _ = tx.send(CtrlReq::CapturePaneStyled(rtx, start, end, capture_pane_id, preserve_trailing));
         } else if s_arg.is_some() || e_arg.is_some() {
-            let _ = tx.send(CtrlReq::CapturePaneRange(rtx, start, end));
+            let _ = tx.send(CtrlReq::CapturePaneRange(rtx, start, end, capture_pane_id, preserve_trailing));
         } else {
-            let _ = tx.send(CtrlReq::CapturePane(rtx));
+            let _ = tx.send(CtrlReq::CapturePane(rtx, capture_pane_id, preserve_trailing));
         }
         if let Ok(mut text) = rrx.recv() {
             if join_lines {
@@ -3595,13 +3607,17 @@ fn dispatch_control_command(
             let start = args.windows(2).find(|w| w[0] == "-S").and_then(|w| if w[1] == "-" { Some(i32::MIN) } else { w[1].parse::<i32>().ok() });
             let end = args.windows(2).find(|w| w[0] == "-E").and_then(|w| w[1].parse::<i32>().ok());
             let styled = crate::cli::has_short_flag(&args, 'e');
+            // -N: preserve trailing spaces at the end of each line (tmux parity).
+            let preserve_trailing = crate::cli::has_short_flag(&args, 'N');
+            // -t %N target: resolved server-side by pane id across all windows.
+            let capture_pane_id = if pane_is_id { target_pane } else { None };
             let (rtx, rrx) = mpsc::channel::<String>();
             if styled {
-                let _ = tx.send(CtrlReq::CapturePaneStyled(rtx, start, end));
+                let _ = tx.send(CtrlReq::CapturePaneStyled(rtx, start, end, capture_pane_id, preserve_trailing));
             } else if start.is_some() || end.is_some() {
-                let _ = tx.send(CtrlReq::CapturePaneRange(rtx, start, end));
+                let _ = tx.send(CtrlReq::CapturePaneRange(rtx, start, end, capture_pane_id, preserve_trailing));
             } else {
-                let _ = tx.send(CtrlReq::CapturePane(rtx));
+                let _ = tx.send(CtrlReq::CapturePane(rtx, capture_pane_id, preserve_trailing));
             }
             if let Ok(text) = rrx.recv_timeout(Duration::from_secs(5)) {
                 let _ = resp_tx.send(text);

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -543,6 +543,11 @@ fn drain_plugin_req(
 ///
 /// Best-effort: any error writing the log is swallowed (we are already
 /// reporting the original failure up the call chain).
+///
+/// Windows-only: the log exists to explain detached-server spawn failures
+/// (ConPTY `CreateProcessW` errors); the diagnostic it collects
+/// (`encode_wide` environment sizes) is meaningless elsewhere.
+#[cfg(windows)]
 pub(crate) fn write_startup_error_log(err: &dyn std::fmt::Display) {
     let Some(dir) = crate::paths::psmux_dir_opt() else {
         return;
@@ -1103,6 +1108,7 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
         // failure to a log file the user can find with their next breath
         // ("look in ~/.psmux/server-startup.log") instead of asking them
         // to rerun `psmux server` interactively to see the error.
+        #[cfg(windows)]
         write_startup_error_log(&e);
         // Clean up port and key files so stale entries are not left
         // behind when the pane command fails to spawn (issue #204).
@@ -6207,6 +6213,7 @@ mod test_issue202;
 mod test_new_session_env;
 
 #[cfg(test)]
+#[cfg(windows)]
 #[path = "../../tests-rs/test_issue167_startup_log.rs"]
 mod test_issue167_startup_log;
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1719,20 +1719,20 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                     if let Some(cmds) = app.hooks.get("before-kill-pane") { let cmds = cmds.clone(); for cmd in &cmds { let _ = execute_command_string(&mut app, cmd); } }
                     unzoom_if_zoomed(&mut app); let _ = kill_pane_by_id(&mut app, pid); resize_all_panes(&mut app); meta_dirty = true; hook_event = Some("after-kill-pane");
                 }
-                CtrlReq::CapturePane(resp) => {
+                CtrlReq::CapturePane(resp, pane_id, preserve_trailing) => {
                     // Note: do NOT gate on is_active_pane_squelched here.
                     // Returning empty during the cd+cls squelch window makes
                     // iTerm2's initial attach paint a blank screen, since
                     // capture-pane is only requested once on attach.  Return
                     // current parser screen content; it's just cell text and
                     // any stale frame is harmless (subsequent %output rewrites).
-                    if let Some(text) = capture_active_pane_text(&mut app)? { let _ = resp.send(text); } else { let _ = resp.send(String::new()); }
+                    if let Some(text) = capture_active_pane_text(&mut app, pane_id, preserve_trailing)? { let _ = resp.send(text); } else { let _ = resp.send(String::new()); }
                 }
-                CtrlReq::CapturePaneStyled(resp, s, e) => {
-                    if let Some(text) = capture_active_pane_styled(&mut app, s, e)? { let _ = resp.send(text); } else { let _ = resp.send(String::new()); }
+                CtrlReq::CapturePaneStyled(resp, s, e, pane_id, preserve_trailing) => {
+                    if let Some(text) = capture_active_pane_styled(&mut app, s, e, pane_id, preserve_trailing)? { let _ = resp.send(text); } else { let _ = resp.send(String::new()); }
                 }
-                CtrlReq::CapturePaneRange(resp, s, e) => {
-                    if let Some(text) = capture_active_pane_range(&mut app, s, e)? { let _ = resp.send(text); } else { let _ = resp.send(String::new()); }
+                CtrlReq::CapturePaneRange(resp, s, e, pane_id, preserve_trailing) => {
+                    if let Some(text) = capture_active_pane_range(&mut app, s, e, pane_id, preserve_trailing)? { let _ = resp.send(text); } else { let _ = resp.send(String::new()); }
                 }
                 CtrlReq::FocusWindow(wid) => {
                     // wid is a display index (same as tmux window number), convert to internal array index

--- a/src/ssh_input.rs
+++ b/src/ssh_input.rs
@@ -1405,6 +1405,11 @@ fn ssh_debug_log(msg: &str) {
     }
 }
 
+/// No-op on non-Windows: the SSH reader thread and its log file are
+/// Windows-only (`SSH_LOG` above is not built there).
+#[cfg(not(windows))]
+fn ssh_debug_log(_msg: &str) {}
+
 /// True when verbose per-event logging is enabled.
 #[cfg(windows)]
 fn ssh_verbose() -> bool {

--- a/src/types.rs
+++ b/src/types.rs
@@ -1409,8 +1409,13 @@ pub enum CtrlReq {
     },
     KillPane,
     KillPaneById(usize),
-    CapturePane(mpsc::Sender<String>),
-    CapturePaneStyled(mpsc::Sender<String>, Option<i32>, Option<i32>),
+    /// Capture a pane's plain text. Fields: resp, target pane id
+    /// (`-t %N`, None = active pane), preserve trailing spaces (`-N`).
+    CapturePane(mpsc::Sender<String>, Option<usize>, bool),
+    /// Capture a pane's text with ANSI SGR sequences. Fields: resp,
+    /// start (-S), end (-E), target pane id (`-t %N`, None = active pane),
+    /// preserve trailing spaces (`-N`).
+    CapturePaneStyled(mpsc::Sender<String>, Option<i32>, Option<i32>, Option<usize>, bool),
     FocusWindow(usize),
     /// Focus window by @N id lookup
     FocusWindowById(usize),
@@ -1432,7 +1437,10 @@ pub enum CtrlReq {
     /// string. Drop-in compat with iTerm2 and other CC clients that always
     /// pass `-F` to get structured output.
     SessionInfoFormat(mpsc::Sender<String>, String),
-    CapturePaneRange(mpsc::Sender<String>, Option<i32>, Option<i32>),
+    /// Capture a plain-text row range. Fields: resp, start (-S), end (-E),
+    /// target pane id (`-t %N`, None = active pane), preserve trailing
+    /// spaces (`-N`).
+    CapturePaneRange(mpsc::Sender<String>, Option<i32>, Option<i32>, Option<usize>, bool),
     ClientAttach(u64),
     ClientDetach(u64),
     DumpLayout(mpsc::Sender<String>),

--- a/tests-rs/test_capture_pane_fidelity.rs
+++ b/tests-rs/test_capture_pane_fidelity.rs
@@ -1,0 +1,303 @@
+// Regression tests for capture-pane fidelity fixes:
+//
+//   1. -N preserves trailing cells that carry a non-default background SGR,
+//      so replaying a styled capture of a full-screen TUI keeps its painted
+//      background (the old renderer trimmed every row after the last
+//      non-whitespace character, dropping the right-hand background fill).
+//   2. -t %N captures the targeted pane's content even when it is not the
+//      active pane (and not in the active window); an unresolvable target
+//      falls back to the active pane with no error.
+//
+// The capture functions only read `Pane::term` / `last_rows` / `last_cols`,
+// so these tests use a dummy PTY (no real spawn) and stay hermetic and
+// portable across Windows and Unix hosts.
+
+use super::*;
+
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicU8};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use crate::types::Node;
+
+const ROWS: u16 = 6;
+const COLS: u16 = 40;
+
+// ── PTY-free pane scaffolding ──────────────────────────────────────────────
+
+#[derive(Debug)]
+struct DummyChild;
+
+#[derive(Debug)]
+struct DummyWriter;
+
+struct DummyMaster;
+
+impl std::io::Write for DummyWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> { Ok(buf.len()) }
+    fn flush(&mut self) -> std::io::Result<()> { Ok(()) }
+}
+
+impl portable_pty::ChildKiller for DummyChild {
+    fn kill(&mut self) -> std::io::Result<()> { Ok(()) }
+    fn clone_killer(&self) -> Box<dyn portable_pty::ChildKiller + Send + Sync> {
+        Box::new(DummyChild)
+    }
+}
+
+impl portable_pty::Child for DummyChild {
+    fn try_wait(&mut self) -> std::io::Result<Option<portable_pty::ExitStatus>> {
+        Ok(Some(portable_pty::ExitStatus::with_exit_code(0)))
+    }
+    fn wait(&mut self) -> std::io::Result<portable_pty::ExitStatus> {
+        Ok(portable_pty::ExitStatus::with_exit_code(0))
+    }
+    fn process_id(&self) -> Option<u32> { None }
+    #[cfg(windows)]
+    fn as_raw_handle(&self) -> Option<std::os::windows::io::RawHandle> { None }
+}
+
+impl portable_pty::MasterPty for DummyMaster {
+    fn resize(&self, _size: portable_pty::PtySize) -> Result<(), anyhow::Error> { Ok(()) }
+    fn get_size(&self) -> Result<portable_pty::PtySize, anyhow::Error> {
+        Ok(portable_pty::PtySize { rows: ROWS, cols: COLS, pixel_width: 0, pixel_height: 0 })
+    }
+    fn try_clone_reader(&self) -> Result<Box<dyn std::io::Read + Send>, anyhow::Error> {
+        Ok(Box::new(std::io::empty()))
+    }
+    fn take_writer(&self) -> Result<Box<dyn std::io::Write + Send>, anyhow::Error> {
+        Ok(Box::new(DummyWriter))
+    }
+    #[cfg(unix)]
+    fn process_group_leader(&self) -> Option<i32> { None }
+    #[cfg(unix)]
+    fn as_raw_fd(&self) -> Option<std::os::unix::io::RawFd> { None }
+    #[cfg(unix)]
+    fn tty_name(&self) -> Option<std::path::PathBuf> { None }
+}
+
+fn make_pane(id: usize, rows: u16, cols: u16) -> crate::types::Pane {
+    let term = Arc::new(Mutex::new(vt100::Parser::new(rows, cols, 0)));
+    let epoch = Instant::now() - Duration::from_secs(2);
+    crate::types::Pane {
+        master: Box::new(DummyMaster),
+        writer: Box::new(DummyWriter),
+        child: Box::new(DummyChild),
+        term,
+        last_rows: rows,
+        last_cols: cols,
+        id,
+        title: format!("pane{id}"),
+        title_locked: false,
+        child_pid: None,
+        data_version: Arc::new(AtomicU64::new(0)),
+        last_title_check: epoch,
+        last_infer_title: epoch,
+        dead: false,
+        last_text_input: None,
+        last_special_key: None,
+        vt_bridge_cache: None,
+        vti_mode_cache: None,
+        mouse_input_cache: None,
+        scroll_fg_cache: None,
+        cursor_shape: Arc::new(AtomicU8::new(0)),
+        bell_pending: Arc::new(AtomicBool::new(false)),
+        cpr_pending: Arc::new(AtomicBool::new(false)),
+        color_query_pending: Arc::new(std::sync::atomic::AtomicU32::new(0)),
+        copy_state: None,
+        pane_style: None,
+        squelch_until: None,
+        output_ring: Arc::new(Mutex::new(std::collections::VecDeque::new())),
+        spawned_at: None,
+    }
+}
+
+fn make_window(id: usize) -> crate::types::Window {
+    crate::types::Window {
+        root: Node::Split { kind: crate::types::LayoutKind::Horizontal, sizes: vec![], children: vec![] },
+        active_path: vec![],
+        name: "w".to_string(),
+        id,
+        area: ratatui::layout::Rect::new(0, 0, 120, 30),
+        window_size: None,
+        activity_flag: false,
+        bell_flag: false,
+        silence_flag: false,
+        last_output_time: Instant::now(),
+        last_seen_version: 0,
+        manual_rename: false,
+        layout_index: 0,
+        pane_mru: vec![],
+        zoom_saved: None,
+        linked_from: None,
+        floating: Vec::new(),
+        floating_focus: None,
+    }
+}
+
+/// One window, one pane (root is the leaf so `active_path` stays empty), with
+/// `bytes` already fed through the pane's vt100 parser.
+fn app_showing(bytes: &[u8]) -> AppState {
+    let mut app = AppState::new("fidelity".to_string());
+    app.window_base_index = 0;
+    app.pane_base_index = 0;
+    app.copy_command = String::new();
+    app.set_clipboard = "off".to_string();
+    let pane = make_pane(0, ROWS, COLS);
+    pane.term.lock().expect("parser lock").process(bytes);
+    let mut win = make_window(0);
+    win.root = Node::Leaf(pane);
+    win.active_path = vec![];
+    app.windows.push(win);
+    app.active_idx = 0;
+    app
+}
+
+/// Two windows, each with one pane carrying distinct content. The first
+/// window stays active, so pane 1 is a valid -t %N target that is NOT the
+/// active pane.
+fn app_two_windows() -> AppState {
+    let mut app = AppState::new("fidelity".to_string());
+    app.window_base_index = 0;
+    app.pane_base_index = 0;
+    app.copy_command = String::new();
+    app.set_clipboard = "off".to_string();
+
+    let pane0 = make_pane(0, ROWS, COLS);
+    pane0.term.lock().expect("parser lock").process(b"ALPHA-WINDOW");
+    let mut win0 = make_window(0);
+    win0.root = Node::Leaf(pane0);
+    win0.active_path = vec![];
+
+    let pane1 = make_pane(1, ROWS, COLS);
+    pane1.term.lock().expect("parser lock").process(b"BETA-WINDOW");
+    let mut win1 = make_window(1);
+    win1.root = Node::Leaf(pane1);
+    win1.active_path = vec![];
+
+    app.windows.push(win0);
+    app.windows.push(win1);
+    app.active_idx = 0;
+    app
+}
+
+// ════════════════════════════════════════════════════════════════════════
+// -N: preserve trailing styled cells (background SGR) at end of line
+// ════════════════════════════════════════════════════════════════════════
+
+/// Red background active, "TUI" written, then EL-to-EOL: a minimal
+/// stand-in for a full-screen app painting its background across the
+/// whole row.
+const BG_PAYLOAD: &[u8] = b"\x1b[48;5;196mTUI\x1b[K\x1b[0m";
+const BG_ROW_TAIL: usize = (COLS - 3) as usize; // columns 3..COLS carry bg 196
+
+#[test]
+fn styled_capture_without_N_trims_trailing_cells() {
+    let mut app = app_showing(BG_PAYLOAD);
+    let out = capture_active_pane_styled(&mut app, None, None, None, false)
+        .expect("capture").expect("some text");
+    let first = out.lines().next().expect("row 0");
+    // Trimmed: exactly the three text cells plus the row-end reset. The
+    // renderer emits a leading "0" reset param on every SGR change.
+    assert_eq!(first, "\x1b[0;48;5;196mTUI\x1b[0m",
+        "without -N the styled row must drop the trailing background cells");
+}
+
+#[test]
+fn styled_capture_with_N_keeps_trailing_background_cells() {
+    let mut app = app_showing(BG_PAYLOAD);
+    let out = capture_active_pane_styled(&mut app, None, None, None, true)
+        .expect("capture").expect("some text");
+    let first = out.lines().next().expect("row 0");
+    assert!(first.starts_with("\x1b[0;48;5;196mTUI"),
+        "row must open with the text under the background SGR, got: {:?}", first);
+    let tail = &first["\x1b[0;48;5;196mTUI".len()..];
+    assert_eq!(tail, format!("{}\x1b[0m", " ".repeat(BG_ROW_TAIL)),
+        "with -N the full row width must be emitted, trailing styled spaces and all");
+}
+
+#[test]
+fn styled_capture_with_N_keeps_a_fully_styled_blank_row() {
+    // A row that is entirely styled spaces (no text at all) must still emit
+    // its background when -N is set — the old trim dropped it completely.
+    let mut app = app_showing(b"\x1b[48;5;21m\x1b[K\x1b[0m");
+    let out = capture_active_pane_styled(&mut app, None, None, None, true)
+        .expect("capture").expect("some text");
+    let first = out.lines().next().expect("row 0");
+    assert_eq!(first, format!("\x1b[0;48;5;21m{}\x1b[0m", " ".repeat(COLS as usize)),
+        "an all-background row must emit its SGR plus the full-width spaces, got: {:?}", first);
+}
+
+#[test]
+fn plain_capture_with_N_keeps_trailing_spaces() {
+    let mut app = app_showing(BG_PAYLOAD);
+    // Plain no-range path.
+    let kept = capture_active_pane_text(&mut app, None, true).expect("capture").expect("text");
+    let first = kept.lines().next().expect("row 0");
+    assert_eq!(first, format!("TUI{}", " ".repeat(BG_ROW_TAIL)),
+        "-N on the plain capture must keep trailing spaces");
+
+    let trimmed = capture_active_pane_text(&mut app, None, false).expect("capture").expect("text");
+    assert_eq!(trimmed.lines().next().expect("row 0"), "TUI",
+        "without -N the plain capture keeps trimming trailing spaces");
+}
+
+#[test]
+fn range_capture_with_N_keeps_trailing_spaces() {
+    let mut app = app_showing(BG_PAYLOAD);
+    let kept = capture_active_pane_range(&mut app, None, None, None, true)
+        .expect("capture").expect("text");
+    assert_eq!(kept.lines().next().expect("row 0"),
+        format!("TUI{}", " ".repeat(BG_ROW_TAIL)));
+
+    let trimmed = capture_active_pane_range(&mut app, None, None, None, false)
+        .expect("capture").expect("text");
+    assert_eq!(trimmed.lines().next().expect("row 0"), "TUI");
+}
+
+// ════════════════════════════════════════════════════════════════════════
+// -t %N: capture a pane that is not the active pane
+// ════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn styled_capture_targets_non_active_pane_by_id() {
+    let mut app = app_two_windows();
+    // Active window is 0; pane 1 lives in window 1.
+    let out = capture_active_pane_styled(&mut app, None, None, Some(1), false)
+        .expect("capture").expect("text");
+    assert!(out.contains("BETA-WINDOW"),
+        "capture of -t %1 must read pane 1, got: {:?}", out);
+    assert!(!out.contains("ALPHA-WINDOW"),
+        "capture of -t %1 must not read the active pane, got: {:?}", out);
+}
+
+#[test]
+fn plain_and_range_capture_target_non_active_pane_by_id() {
+    let mut app = app_two_windows();
+    let text = capture_active_pane_text(&mut app, Some(1), false).expect("capture").expect("text");
+    assert!(text.contains("BETA-WINDOW"), "plain -t %1 capture, got: {:?}", text);
+
+    let range = capture_active_pane_range(&mut app, None, None, Some(1), false)
+        .expect("capture").expect("text");
+    assert!(range.contains("BETA-WINDOW"), "range -t %1 capture, got: {:?}", range);
+}
+
+#[test]
+fn unresolvable_pane_target_falls_back_to_active_pane() {
+    let mut app = app_two_windows();
+    // No pane 999 exists: must silently fall back to the active pane
+    // (window 0) instead of erroring or returning empty.
+    let out = capture_active_pane_styled(&mut app, None, None, Some(999), false)
+        .expect("capture").expect("text");
+    assert!(out.contains("ALPHA-WINDOW"),
+        "missing -t target must fall back to the active pane, got: {:?}", out);
+}
+
+#[test]
+fn none_target_captures_active_pane_as_before() {
+    let mut app = app_two_windows();
+    let out = capture_active_pane_styled(&mut app, None, None, None, false)
+        .expect("capture").expect("text");
+    assert!(out.contains("ALPHA-WINDOW"),
+        "no -t target must keep capturing the active pane, got: {:?}", out);
+}


### PR DESCRIPTION
## Context

We ship psmux as the tmux stand-in behind [tmex](https://github.com/krhougs/tmex)'s Windows gateway (tmex is an open-source terminal-multiplexer web frontend; Vibe X is its commercial distribution). The gateway drives psmux exclusively through control mode and rebuilds pane screens with `capture-pane -p -e -J -N -t %N` whenever a client reattaches or switches windows — exactly how iTerm2-style tmux integrations restore state.

## Problems

Two fidelity gaps surfaced on real user machines through that path:

1. **`-t %N` was accepted but ignored** on the one-shot capture paths: `CtrlReq::CapturePane/CapturePaneStyled/CapturePaneRange` carried no target, so every capture read the *active* pane of the *active* window. Restoring a background window painted it with another pane's content; the styled path also temporarily focus-switched to work around this, disturbing the active window.
2. **`-N` was parsed but never honored**: styled captures unconditionally trimmed trailing cells. Full-screen alt-screen TUIs (opencode, vim with themes) paint their background via colored trailing blanks — after trimming, a restored screen lost its entire background color and only text islands kept theirs.

## Fix

- Thread an optional pane target through the three capture requests; the server resolves `%N` across windows via the pane tree and falls back to the active pane when absent (old behavior preserved). Id-targeted captures no longer take the temporary-focus path, so background captures stop disturbing the foreground.
- Thread `preserve_trailing` through styled/plain/range rendering: with `-N`, rows render at full width including trailing styled blanks; without it, the tmux default trim is unchanged.

## Tests

`tests-rs/test_capture_pane_fidelity.rs`: 9 closed tests on a dummy PTY (no server, no spawn — per AGENTS.md) covering trailing-background preservation, fully-styled blank rows, cross-window `-t` targeting, absent-target fallback, and default-trim compatibility. The first commit allows the crate to compile and run these closed suites on non-Windows hosts too (dev convenience; no runtime behavior change on Windows).

Verified on Windows (all 9 pass) and macOS.
