### PR TITLE
conhost crash resilience: ConPTY sideloading, input-mode diagnostics, and positive-evidence server reaping

### DIFF
--- a/crates/portable-pty-psmux/Cargo.toml
+++ b/crates/portable-pty-psmux/Cargo.toml
@@ -97,6 +97,9 @@ version = "0.2"
 [dependencies.shell-words]
 version = "1.1"
 
+[dev-dependencies.parking_lot]
+version = "0.12"
+
 [dev-dependencies.futures]
 version = "0.3"
 

--- a/crates/portable-pty-psmux/src/win/psuedocon.rs
+++ b/crates/portable-pty-psmux/src/win/psuedocon.rs
@@ -178,6 +178,14 @@ fn supports_passthrough_mode() -> bool {
 /// always starts on a fresh screen, so inheriting the host cursor row buys
 /// nothing here.
 fn base_flags() -> DWORD {
+    // `PSMUX_NO_WIN32_INPUT=1` drops PSEUDOCONSOLE_WIN32_INPUT_MODE — a
+    // diagnostic escape hatch for conhost builds that crash around it.
+    if std::env::var("PSMUX_NO_WIN32_INPUT")
+        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false)
+    {
+        return PSEUDOCONSOLE_RESIZE_QUIRK;
+    }
     PSEUDOCONSOLE_RESIZE_QUIRK | PSEUDOCONSOLE_WIN32_INPUT_MODE
 }
 

--- a/crates/portable-pty-psmux/src/win/psuedocon.rs
+++ b/crates/portable-pty-psmux/src/win/psuedocon.rs
@@ -395,3 +395,7 @@ mod tests {
         assert_ne!(base_flags() & PSEUDOCONSOLE_WIN32_INPUT_MODE, 0);
     }
 }
+
+#[cfg(test)]
+#[path = "../../../../tests-rs/test_conpty_env_flags.rs"]
+mod tests_conpty_env_flags;

--- a/crates/portable-pty-psmux/src/win/psuedocon.rs
+++ b/crates/portable-pty-psmux/src/win/psuedocon.rs
@@ -45,13 +45,56 @@ shared_library!(ConPtyFuncs,
 );
 
 fn load_conpty() -> ConPtyFuncs {
-    // Always use the system kernel32.dll ConPTY implementation.
-    // Do NOT try to sideload conpty.dll — terminal emulators like WezTerm
-    // bundle their own conpty.dll + OpenConsole.exe, and the DLL search order
-    // can pick those up when psmux runs inside such a terminal.  Using a
-    // foreign conpty.dll causes blank panes and broken I/O because the
-    // bundled OpenConsole.exe may not be compatible with our ConPTY flags
-    // (PASSTHROUGH_MODE, WIN32_INPUT_MODE, etc.).
+    // Sideloading rules:
+    //
+    // - Never resolve "conpty.dll" through the default DLL search order:
+    //   terminal emulators like WezTerm bundle their own conpty.dll +
+    //   OpenConsole.exe and the search order can pick those up when psmux
+    //   runs inside such a terminal, yielding blank panes / broken I/O with
+    //   our flag set (PASSTHROUGH_MODE, WIN32_INPUT_MODE, etc.).
+    //
+    // - Absolute paths we control are fine, and are the standard way
+    //   (Windows Terminal / VS Code / WezTerm all ship their own conpty) to
+    //   escape bugs in the in-box conhost.exe, which only updates with the
+    //   OS.  Precedence:
+    //     1. PSMUX_CONPTY_DLL=<absolute path> (diagnostic override)
+    //     2. conpty.dll next to the psmux executable, only when the matching
+    //        OpenConsole.exe is present beside it (conpty.dll spawns
+    //        OpenConsole.exe from its own directory)
+    //     3. the system kernel32.dll implementation
+    if let Ok(path) = std::env::var("PSMUX_CONPTY_DLL") {
+        if !path.is_empty() {
+            match ConPtyFuncs::open(Path::new(&path)) {
+                Ok(funcs) => {
+                    log::info!("using ConPTY implementation from {path}");
+                    return funcs;
+                }
+                Err(err) => {
+                    log::warn!("PSMUX_CONPTY_DLL={path} failed to load ({err:?}), falling back");
+                }
+            }
+        }
+    }
+    if let Ok(exe) = std::env::current_exe() {
+        if let Some(dir) = exe.parent() {
+            let dll = dir.join("conpty.dll");
+            let open_console = dir.join("OpenConsole.exe");
+            if dll.is_file() && open_console.is_file() {
+                match ConPtyFuncs::open(&dll) {
+                    Ok(funcs) => {
+                        log::info!("using bundled ConPTY implementation from {}", dll.display());
+                        return funcs;
+                    }
+                    Err(err) => {
+                        log::warn!(
+                            "bundled {} failed to load ({err:?}), falling back to kernel32",
+                            dll.display()
+                        );
+                    }
+                }
+            }
+        }
+    }
     ConPtyFuncs::open(Path::new("kernel32.dll")).expect(
         "this system does not support conpty.  Windows 10 October 2018 or newer is required",
     )

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -2222,12 +2222,25 @@ fn execute_command_string_single(app: &mut AppState, cmd: &str) -> io::Result<()
                 if let Ok(port_str) = std::fs::read_to_string(&port_path) {
                     if let Ok(port) = port_str.trim().parse::<u16>() {
                         let addr = format!("127.0.0.1:{}", port);
-                        if std::net::TcpStream::connect_timeout(
+                        match std::net::TcpStream::connect_timeout(
                             &addr.parse().unwrap(),
                             std::time::Duration::from_millis(100),
-                        ).is_ok() {
-                            app.status_message = Some((format!("session '{}' already exists", name), Instant::now(), None));
-                            return Ok(());
+                        ) {
+                            Ok(_) => {
+                                app.status_message = Some((format!("session '{}' already exists", name), Instant::now(), None));
+                                return Ok(());
+                            }
+                            // An active refusal proves no listener: the file
+                            // is stale. A timeout means a busy-but-alive
+                            // server — the name is still taken, so report
+                            // "already exists" instead of deleting the file
+                            // out from under it (same rule as the cleanup
+                            // probe).
+                            Err(e) if e.kind() == std::io::ErrorKind::ConnectionRefused => {}
+                            Err(_) => {
+                                app.status_message = Some((format!("session '{}' already exists", name), Instant::now(), None));
+                                return Ok(());
+                            }
                         }
                     }
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -620,14 +620,21 @@ fn run_main() -> io::Result<()> {
                                     // PID-anchor fast path: a dead entry would
                                     // otherwise cost a full TCP connect timeout
                                     // here (dead loopback ports can time out
-                                    // rather than refuse on Windows). Reap it
-                                    // and move on without touching the network.
-                                    if crate::session::registry_pid_anchor_alive(base) == Some(false) {
-                                        crate::session::remove_session_registry(base);
-                                        continue;
-                                    }
+                                    // rather than refuse on Windows). But a dead
+                                    // anchor is a process-table guess, never
+                                    // proof of death: it can misread a live
+                                    // server (elevated/service spawn the client
+                                    // cannot open, renamed image, recycled PID)
+                                    // or be a leftover of a previously killed
+                                    // server that the replacement has not
+                                    // re-anchored yet. Only an ACTIVELY REFUSED
+                                    // connect below may reap; a session whose
+                                    // dead-looking anchor answers AUTH gets its
+                                    // .pid repaired instead.
+                                    let anchor_said_dead =
+                                        crate::session::registry_pid_anchor_alive(base) == Some(false);
                                     if let Ok(port_str) = std::fs::read_to_string(e.path()) {
-                                        if let Ok(_p) = port_str.trim().parse::<u16>() {
+                                        if let Ok(port) = port_str.trim().parse::<u16>() {
                                             let addr = format!("127.0.0.1:{}", port_str.trim());
                                             let conn = std::net::TcpStream::connect_timeout(
                                                 &addr.parse().unwrap(),
@@ -717,6 +724,14 @@ fn run_main() -> io::Result<()> {
                                                         if !passes { continue; }
                                                     }
                                                     println!("{}", display_name); 
+                                                }
+                                                // The session answered AUTH despite a
+                                                // dead-looking anchor: the anchor was a
+                                                // false negative. Re-anchor it so the
+                                                // next listing is fast again and no
+                                                // sweep can misjudge this live server.
+                                                if anchor_said_dead {
+                                                    crate::session::repair_session_pid_anchor(base, port);
                                                 }
                                             } else if refused {
                                                 // Actively refused → truly dead. Remove the WHOLE

--- a/src/main.rs
+++ b/src/main.rs
@@ -1009,13 +1009,20 @@ fn run_main() -> io::Result<()> {
                 let mut server_pid: Option<u32> = None;
                 if std::path::Path::new(&port_path).exists() {
                     // Verify server is actually running
+                    // Only an actively refused connect proves the server is
+                    // gone; a timeout means busy-but-alive and must not be
+                    // treated as dead (same rule as probe_session_for_cleanup).
                     let server_alive = if let Ok(port_str) = std::fs::read_to_string(&port_path) {
                         if let Ok(port) = port_str.trim().parse::<u16>() {
                             let addr = format!("127.0.0.1:{}", port);
-                            std::net::TcpStream::connect_timeout(
+                            match std::net::TcpStream::connect_timeout(
                                 &addr.parse().unwrap(),
                                 Duration::from_millis(100)
-                            ).is_ok()
+                            ) {
+                                Ok(_) => true,
+                                Err(e) if e.kind() == io::ErrorKind::ConnectionRefused => false,
+                                Err(_) => true,
+                            }
                         } else { false }
                     } else { false };
                     
@@ -3947,13 +3954,21 @@ fn run_main() -> io::Result<()> {
         // empty-scrollback server on every single bare/control-mode connection,
         // silently orphaning the running session. Mirrors the liveness check the
         // explicit `new-session` command path already performs above.
+        // Only an actively refused connect proves the session is dead; a
+        // timeout means a busy-but-alive server, which must keep its registry
+        // and skip the warm-claim/clobber path (same rule as the cleanup
+        // probe).
         let server_already_alive = std::fs::read_to_string(&port_path)
             .ok()
             .and_then(|s| s.trim().parse::<u16>().ok())
-            .map(|p| std::net::TcpStream::connect_timeout(
-                &format!("127.0.0.1:{}", p).parse().unwrap(),
-                Duration::from_millis(100),
-            ).is_ok())
+            .map(|p| {
+                let addr: std::net::SocketAddr = format!("127.0.0.1:{}", p).parse().unwrap();
+                match std::net::TcpStream::connect_timeout(&addr, Duration::from_millis(100)) {
+                    Ok(_) => true,
+                    Err(e) if e.kind() == io::ErrorKind::ConnectionRefused => false,
+                    Err(_) => true,
+                }
+            })
             .unwrap_or(false);
 
         // Try warm server claim first (fast path)

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -2849,6 +2849,44 @@ pub mod process_info {
         }
     }
 
+    /// Whether a process with the given PID exists in the system process
+    /// table.
+    ///
+    /// Unlike [`get_process_name`], this enumerates the toolhelp snapshot
+    /// without opening the target process, so it sees elevated,
+    /// service-spawned, and otherwise protected processes that a
+    /// lower-privilege caller cannot `OpenProcess`. Use it to tell "the PID
+    /// is gone" (dead) from "the PID exists but its image cannot be read"
+    /// (alive but unopenable — must never be declared dead).
+    ///
+    /// A snapshot failure (rare) conservatively reports the process as
+    /// present so callers escalate to the network probe instead of trusting
+    /// a broken query as proof of death.
+    pub fn process_exists(pid: u32) -> bool {
+        unsafe {
+            let snap = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
+            if snap == 0 || snap == INVALID_HANDLE {
+                return true;
+            }
+            let mut pe: PROCESSENTRY32W = std::mem::zeroed();
+            pe.dw_size = std::mem::size_of::<PROCESSENTRY32W>() as u32;
+            let mut found = false;
+            if Process32FirstW(snap, &mut pe) != 0 {
+                loop {
+                    if pe.th32_process_id == pid {
+                        found = true;
+                        break;
+                    }
+                    if Process32NextW(snap, &mut pe) == 0 {
+                        break;
+                    }
+                }
+            }
+            CloseHandle(snap);
+            found
+        }
+    }
+
     /// Get the current working directory of a process by PID.
     /// Reads the PEB → ProcessParameters → CurrentDirectory from the target process.
     pub fn get_process_cwd(pid: u32) -> Option<String> {
@@ -3352,6 +3390,7 @@ pub mod process_info {
 #[cfg(not(windows))]
 pub mod process_info {
     pub fn get_process_name(_pid: u32) -> Option<String> { None }
+    pub fn process_exists(_pid: u32) -> bool { false }
     pub fn get_process_cwd(_pid: u32) -> Option<String> { None }
     pub fn get_foreground_process_name(_pid: u32) -> Option<String> { None }
     pub fn get_foreground_cwd(_pid: u32) -> Option<String> { None }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -842,6 +842,15 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
         }
     };
 
+    // Re-assert the PID anchor the instant this process owns the name. A
+    // `.pid` left behind by a previously killed server for this session is a
+    // dead anchor; a concurrent CLI cleanup that reads it while this server
+    // is still coming up would trust it as proof of death and reap the whole
+    // registry out from under a live server. Writing it here — before the
+    // listener is even bound — closes that window; ensure_session_registry_files
+    // below then sees matching content and skips the rewrite.
+    crate::session::write_session_pid_file(&app.port_file_base(), std::process::id());
+
     // Bind the control listener BEFORE loading config so that run-shell
     // commands spawned by load_config can connect back to the server.
     let (tx, rx) = mpsc::channel::<CtrlReq>();

--- a/src/session.rs
+++ b/src/session.rs
@@ -1106,28 +1106,63 @@ const PID_REUSE_MARGIN_TICKS: u64 = 60 * 10_000_000; // 60s in 100ns ticks
 /// Returns:
 ///   Some(true)  - recorded PID is a live psmux-image process created no later
 ///                 than the `.pid` file was written -> genuinely our server.
-///   Some(false) - PID gone, recycled by a non-psmux image, or recycled by a
-///                 psmux process created long after the file -> server is dead.
-///   None        - no usable `.pid` anchor (pre-#448 registry) -> caller must
-///                 fall back to the network probe.
+///   Some(false) - PID absent from the process table, recycled by a non-psmux
+///                 image, or recycled by a psmux process created long after
+///                 the file -> server is dead.
+///   None        - no usable `.pid` anchor (pre-#448 registry) OR the process
+///                 exists but its image cannot be read (elevated/service
+///                 spawn at a different elevation/session) -> caller must
+///                 fall back to the network probe. A process that exists but
+///                 cannot be opened is NOT dead; declaring it dead is a false
+///                 negative that would reap a live server.
 fn pid_anchor_verdict(port_path: &Path) -> Option<bool> {
     // The process-table queries below are Windows-only; other platforms fall
     // back to the network probe rather than misreading stub returns as "dead".
     if !cfg!(windows) {
         return None;
     }
+    let base = registry_base(port_path);
+    let log_verdict = |reason: &str| {
+        if crate::debug_log::session_log_enabled() {
+            crate::debug_log::session_log("anchor", &format!("'{}': {}", base, reason));
+        }
+    };
     let pid_path = port_path.with_extension("pid");
     // Tolerate both `pid` and `pid:creation_filetime` bodies (the latter written
     // so kill-server can verify identity); the anchor only needs the pid.
-    let (pid, _creation) = parse_pid_file_contents(&std::fs::read_to_string(&pid_path).ok()?)?;
+    let (pid, _creation) = match parse_pid_file_contents(&std::fs::read_to_string(&pid_path).ok()?) {
+        Some(v) => v,
+        None => {
+            log_verdict("no usable .pid anchor -> network probe");
+            return None;
+        }
+    };
     let name = match crate::platform::process_info::get_process_name(pid) {
-        // No such process (a same-user psmux server is always openable with
-        // QUERY_LIMITED_INFORMATION, so an unopenable PID is not our server).
-        None => return Some(false),
+        // An unreadable PID is only "dead" when the process table no longer
+        // contains it. `get_process_name` also returns None when the process
+        // handle cannot be opened at all — a live elevated/service-spawned
+        // server that a lower-elevation CLI cannot open (field case: the
+        // sweep ran from a different elevation/session). Declaring that dead
+        // is the false negative that sent a live server's registry to the
+        // reaper; escalate it to the network probe as "alive-unknown"
+        // instead.
+        None => {
+            if crate::platform::process_info::process_exists(pid) {
+                log_verdict(&format!(
+                    "pid {}: process exists but its image cannot be read (elevated or other session?) -> alive-unknown, network probe",
+                    pid));
+                return None;
+            }
+            log_verdict(&format!("pid {}: no such process -> dead", pid));
+            return Some(false);
+        }
         Some(n) => n.to_ascii_lowercase(),
     };
     if !PSMUX_SERVER_IMAGE_NAMES.contains(&name.as_str()) {
         // PID recycled by an unrelated application; our server is gone.
+        log_verdict(&format!(
+            "pid {}: process is '{}', not a psmux server -> dead (recycled PID)",
+            pid, name));
         return Some(false);
     }
     // PID-reuse guard (same idea as the #447 reaper guard): a psmux process
@@ -1140,10 +1175,14 @@ fn pid_anchor_verdict(port_path: &Path) -> Option<bool> {
             .and_then(system_time_to_filetime_ticks)
         {
             if created_ft > mtime_ft.saturating_add(PID_REUSE_MARGIN_TICKS) {
+                log_verdict(&format!(
+                    "pid {}: process created after the .pid file was written -> dead (recycled PID)",
+                    pid));
                 return Some(false);
             }
         }
     }
+    log_verdict(&format!("pid {}: live psmux server -> keep (probe skipped)", pid));
     Some(true)
 }
 
@@ -1223,9 +1262,10 @@ enum CleanupDecision {
 /// renamed, when its PID was recycled, or when the `.pid` file itself is
 /// stale (a hard-killed server's leftover anchor that the replacement server
 /// has not rewritten yet). A dead anchor is therefore never proof of death on
-/// its own — only a stale network verdict (refused/timeout/rejected AUTH) may
-/// reap. An anchor that said dead but whose port authenticates gets repaired
-/// instead.
+/// its own — only a stale network verdict (actively refused connect, or a
+/// rejected AUTH by a port-reusing server) may reap; probe timeouts classify
+/// Inconclusive because a busy-but-alive server times out too. An anchor that
+/// said dead but whose port authenticates gets repaired instead.
 fn decide_registry_fate(anchor: Option<bool>, probe: PortProbeResult) -> CleanupDecision {
     match anchor {
         Some(true) => CleanupDecision::Keep,
@@ -1459,31 +1499,27 @@ fn probe_auth_identity(addr: std::net::SocketAddr, key: &str) -> Result<AuthProb
 /// that grabbed the same port after a crash or reboot — that false "alive"
 /// is exactly what left dead sessions showing `(not responding)` in the
 /// picker. This probe instead requires the AUTH key to match:
-///   - connection refused (or a full timeout with zero response) on every
-///     attempt                                    -> `Stale`
-///   - server accepts our key (`OK`)              -> `Alive`
+///   - connection ACTIVELY refused on every attempt -> `Stale`
+///   - server accepts our key (`OK`)                -> `Alive`
 ///   - server rejects our key (`ERROR`, reused port) -> `Stale`
-///   - anything ambiguous (no reply, slow, foreign process) -> `Inconclusive`
+///   - anything ambiguous (timeout, no reply, foreign process) -> `Inconclusive`
 ///
 /// Only definitive signals delete a file; ambiguous ones are left for the
 /// boot-time guard, so a live-but-busy server is never reaped by mistake.
 ///
-/// Issue #7 batch D: some environments (confirmed on this host via a raw
-/// `TcpClient.BeginConnect`/`WaitOne` probe against several unbound loopback
-/// ports) never return an immediate ECONNREFUSED for a closed loopback
-/// port — the SYN is silently dropped and the connect attempt runs the full
-/// `STALE_PORT_CONNECT_TIMEOUT` before giving up, surfacing as
-/// `ErrorKind::TimedOut` rather than `ConnectionRefused`. The original code
-/// treated any `TimedOut` as ambiguous ("maybe a live-but-slow server"),
-/// which on such a host means the network probe can NEVER return `Stale` —
-/// orphaned `.port`/`.key` files with no `.pid` anchor (the only registry
-/// shape old enough to still reach this probe) are kept forever. A real
-/// live server on loopback completes the AUTH handshake in well under a
-/// millisecond; three full timeouts in a row with no byte of response ever
-/// received is just as definitive a "nothing is there" signal as an
-/// instant refusal, so treat it the same — but ONLY when every attempt saw
-/// refused/timed-out and nothing else (any actual response, however
-/// unparseable, still keeps the conservative `Inconclusive` verdict).
+/// Timeouts are deliberately NOT proof of death. The server's control loop
+/// is a single-threaded FIFO: a burst of commands (e.g. concurrent
+/// snapshot/capture work) can saturate it so the AUTH round-trip times out
+/// on every attempt while the server is plainly alive — the field case where
+/// `refused=false, timed_out=true` reaped a live server whose `.pid` had
+/// just been re-asserted at startup. Some Windows environments also surface
+/// a closed loopback port as a silent connect-timeout rather than
+/// `ConnectionRefused`; both ambiguities resolve to `Inconclusive`, matching
+/// `probe_session_alive`'s conservatism ("a busy server must never be
+/// wrongly declared dead"). The cost of keeping a stale file is one probe on
+/// the next invocation; the cost of reaping a live server is a broken
+/// session. Only an active `ConnectionRefused` proves that no process is
+/// listening.
 fn probe_session_for_cleanup(key: &str, port: u16) -> PortProbeResult {
     let addr = std::net::SocketAddr::from(([127, 0, 0, 1], port));
     let mut saw_refused = false;
@@ -1517,17 +1553,36 @@ fn probe_session_for_cleanup(key: &str, port: u16) -> PortProbeResult {
         }
     }
 
-    if (saw_refused || saw_timed_out) && !saw_inconclusive {
+    classify_probe_verdict(port, saw_refused, saw_timed_out, saw_inconclusive)
+}
+
+/// Terminal verdict of the probe after all attempts, from what the attempts
+/// saw.
+///
+/// Only an ACTIVE `ConnectionRefused` — proof that no process is listening —
+/// may classify the port `Stale`. A `TimedOut` never counts toward staleness
+/// and in fact forces `Inconclusive`: the server's control loop is a
+/// single-threaded FIFO, and a burst of commands can saturate it so the AUTH
+/// round-trip times out on every attempt while the server is alive (field
+/// case: `refused=false, timed_out=true` reaped a live server). A timeout is
+/// therefore indistinguishable from "busy-but-alive" and must be kept.
+fn classify_probe_verdict(
+    port: u16,
+    saw_refused: bool,
+    saw_timed_out: bool,
+    saw_inconclusive: bool,
+) -> PortProbeResult {
+    if saw_refused && !saw_timed_out && !saw_inconclusive {
         if crate::debug_log::session_log_enabled() {
             crate::debug_log::session_log("probe", &format!(
-                "port {}: refused/timed-out on every attempt (refused={}, timed_out={}) -> stale",
-                port, saw_refused, saw_timed_out));
+                "port {}: actively refused on every attempt -> stale", port));
         }
         PortProbeResult::Stale
     } else {
         if crate::debug_log::session_log_enabled() {
             crate::debug_log::session_log("probe",
-                &format!("port {}: no definitive answer -> inconclusive (kept)", port));
+                &format!("port {}: no definitive answer (refused={}, timed_out={}, inconclusive={}) -> inconclusive (kept)",
+                    port, saw_refused, saw_timed_out, saw_inconclusive));
         }
         PortProbeResult::Inconclusive
     }
@@ -1926,7 +1981,9 @@ pub fn classify_sessions_parallel(
 /// PID-anchor liveness for the session registered under `base`, for
 /// enumeration paths (e.g. CLI `list-sessions`) that would otherwise pay a
 /// TCP connect timeout per dead entry. Some(false) = definitively dead
-/// (reap + skip), Some(true) = live, None = no anchor (probe as usual).
+/// (reap + skip), Some(true) = live, None = no usable anchor or an
+/// unopenable (elevated/other-session) process, which is not proof of death
+/// (probe as usual).
 pub fn registry_pid_anchor_alive(base: &str) -> Option<bool> {
     let port_path = crate::paths::port_file_opt(base)?;
     pid_anchor_verdict(Path::new(&port_path))

--- a/src/session.rs
+++ b/src/session.rs
@@ -165,10 +165,16 @@ pub fn remove_session_id_file(port_file_base: &str) {
 /// process anchor.
 pub fn write_session_pid_file(port_file_base: &str, pid: u32) {
     let pid_path = crate::paths::pid_file(port_file_base);
-    // `pid:creation_filetime` — same body as ensure_session_registry_files, so a
-    // freshly renamed session is force-kill-identifiable before the next re-ensure.
+    write_pid_anchor(&std::path::Path::new(&pid_path), pid);
+}
+
+/// Write `pid` (with its process creation time) into the `.pid` anchor at
+/// `pid_path`. Body is `pid:creation_filetime` — same as
+/// `ensure_session_registry_files`, so a freshly renamed session is
+/// force-kill-identifiable before the next re-ensure.
+fn write_pid_anchor(pid_path: &std::path::Path, pid: u32) {
     let creation = crate::platform::process_kill::process_creation_time(pid).unwrap_or(0);
-    let _ = std::fs::write(&pid_path, format_pid_file_contents(pid, creation));
+    let _ = std::fs::write(pid_path, format_pid_file_contents(pid, creation));
 }
 
 /// Remove the `.pid` file for a session.
@@ -1188,6 +1194,62 @@ fn cleanup_stale_port_files_in_with<F>(psmux_dir: &Path, mut probe: F)
 where
     F: FnMut(&str, u16) -> PortProbeResult,
 {
+    cleanup_stale_port_files_in_with_full(
+        psmux_dir,
+        &mut pid_anchor_verdict,
+        &mut probe,
+        &mut listener_pid_for_port,
+    );
+}
+
+/// Outcome of the stale-port sweep for one registry entry, given the `.pid`
+/// anchor verdict and the network probe result.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum CleanupDecision {
+    /// The entry belongs to a live server (anchor says live, or the probe
+    /// authenticated the port). Nothing to clean.
+    Keep,
+    /// The probe proved the port is served by a live psmux server while the
+    /// anchor said dead: repair the `.pid` in place rather than reap.
+    RepairAnchor,
+    /// The strongest available signal (anchor alive OR probe stale) says the
+    /// server is gone.
+    Reap,
+}
+
+/// Liveness decision for one registry entry. The `.pid` anchor is only a
+/// process-table guess: a live server can read as "dead" when the client
+/// cannot open its process (elevated/service spawns), when its image was
+/// renamed, when its PID was recycled, or when the `.pid` file itself is
+/// stale (a hard-killed server's leftover anchor that the replacement server
+/// has not rewritten yet). A dead anchor is therefore never proof of death on
+/// its own — only a stale network verdict (refused/timeout/rejected AUTH) may
+/// reap. An anchor that said dead but whose port authenticates gets repaired
+/// instead.
+fn decide_registry_fate(anchor: Option<bool>, probe: PortProbeResult) -> CleanupDecision {
+    match anchor {
+        Some(true) => CleanupDecision::Keep,
+        Some(false) => match probe {
+            PortProbeResult::Stale => CleanupDecision::Reap,
+            PortProbeResult::Alive => CleanupDecision::RepairAnchor,
+            PortProbeResult::Inconclusive => CleanupDecision::Keep,
+        },
+        None => match probe {
+            PortProbeResult::Stale => CleanupDecision::Reap,
+            PortProbeResult::Alive | PortProbeResult::Inconclusive => CleanupDecision::Keep,
+        },
+    }
+}
+
+/// Core of [`cleanup_stale_port_files_in_with`] with the liveness oracles
+/// injected so tests can drive every verdict deterministically on any
+/// platform (the real `pid_anchor_verdict` is Windows-only).
+fn cleanup_stale_port_files_in_with_full(
+    psmux_dir: &Path,
+    anchor: &mut dyn FnMut(&Path) -> Option<bool>,
+    probe: &mut dyn FnMut(&str, u16) -> PortProbeResult,
+    listener_pid: &mut dyn FnMut(u16) -> Option<u32>,
+) {
     let boot = system_boot_time();
     if let Ok(entries) = std::fs::read_dir(psmux_dir) {
         for entry in entries.flatten() {
@@ -1210,36 +1272,54 @@ where
                         }
                     }
                 }
-                // PID-anchor fast path (issue #448 sentinel): the process table
-                // answers liveness instantly and definitively, so registry
-                // entries with a `.pid` sibling never pay a network probe.
-                // Dead-port probes are not just slow (they can burn the full
-                // connect timeout per attempt on Windows loopback) - they are
-                // also inconclusive, so stale files were never reaped and the
-                // probe tax repeated on every subsequent CLI invocation.
-                match pid_anchor_verdict(&path) {
-                    Some(true) => continue, // live server; nothing to clean
-                    Some(false) => {
-                        if crate::debug_log::session_log_enabled() {
-                            crate::debug_log::session_log("cleanup", &format!(
-                                "reaping '{}': recorded server PID is dead or recycled",
-                                registry_base(&path)));
-                        }
-                        remove_session_registry_files(&path);
-                        continue;
-                    }
-                    None => {} // no .pid anchor; fall through to the network probe
+                // PID-anchor fast path (issue #448 sentinel): a LIVE anchor
+                // answers keep instantly and microsecond-cheap, so registry
+                // entries with a live `.pid` sibling never pay a network
+                // probe. Dead-port probes are not just slow (they can burn
+                // the full connect timeout per attempt on Windows loopback)
+                // - they are also inconclusive, so stale files were never
+                // reaped and the probe tax repeated on every subsequent CLI
+                // invocation.
+                //
+                // A DEAD anchor, however, is only a process-table guess and
+                // must not be trusted as proof of death: it can misread a
+                // live server (unopenable elevated/service-spawned process,
+                // renamed image, recycled PID) or be a leftover from a
+                // previous killed incarnation. Dead-anchor entries therefore
+                // escalate to the network probe; only the probe's verdict may
+                // reap. A probe that authenticates the port repairs the stale
+                // anchor in place instead of deleting the registry.
+                let verdict = anchor(&path);
+                if verdict == Some(true) {
+                    continue; // live server; nothing to clean
                 }
                 if let Ok(port_str) = std::fs::read_to_string(&path) {
                     if let Ok(port) = port_str.trim().parse::<u16>() {
                         let key = read_key_for_port_path(&path);
-                        if probe(&key, port) == PortProbeResult::Stale {
-                            if crate::debug_log::session_log_enabled() {
-                                crate::debug_log::session_log("cleanup", &format!(
-                                    "reaping '{}' (port {}): no psmux server authenticated as ours (stale)",
-                                    registry_base(&path), port));
+                        let result = probe(&key, port);
+                        match decide_registry_fate(verdict, result) {
+                            CleanupDecision::Keep => {}
+                            CleanupDecision::Reap => {
+                                if crate::debug_log::session_log_enabled() {
+                                    crate::debug_log::session_log("cleanup", &format!(
+                                        "reaping '{}' (port {}): recorded server PID is dead or recycled and the probe confirms no psmux server authenticated as ours",
+                                        registry_base(&path), port));
+                                }
+                                remove_session_registry_files(&path);
                             }
-                            remove_session_registry_files(&path);
+                            CleanupDecision::RepairAnchor => {
+                                if let Some(pid) = listener_pid(port) {
+                                    repair_stale_pid_anchor(&path, port, pid);
+                                } else if crate::debug_log::session_log_enabled() {
+                                    // Could not resolve the listener PID (port
+                                    // table unavailable or race); leave the
+                                    // stale anchor — the server's 5s registry
+                                    // self-heal rewrites it.
+                                    crate::debug_log::session_log("cleanup", &format!(
+                                        "kept '{}' (port {}): recorded server PID was dead or recycled but the probe shows a live psmux server; waiting for its .pid self-heal",
+                                        registry_base(&path), port));
+                                }
+                            }
                         }
                     } else {
                         if crate::debug_log::session_log_enabled() {
@@ -1258,6 +1338,51 @@ where
 /// Display name (file stem) of a registry path, for logging.
 fn registry_base(port_path: &Path) -> &str {
     port_path.file_stem().and_then(|s| s.to_str()).unwrap_or("?")
+}
+
+/// Resolve the PID currently listening on loopback `port`, when the OS can
+/// say. Used to repair a stale `.pid` anchor after a network probe proved a
+/// live psmux server owns the port. Windows-only: elsewhere the port table is
+/// unavailable and the server's own registry self-heal repairs the anchor.
+pub fn listener_pid_for_port(port: u16) -> Option<u32> {
+    crate::platform::process_kill::loopback_listener_pids()
+        .into_iter()
+        .find(|(_, p)| *p == port)
+        .map(|(pid, _)| pid)
+}
+
+/// Best-effort repair of a stale `.pid` anchor: resolve the PID listening on
+/// `port` (the caller's AUTH round-trip already proved the listener is a live
+/// psmux server) and rewrite the anchor to name it.
+///
+/// Returns false when the listener PID cannot be resolved; the server's 5s
+/// registry self-heal rewrites the anchor then, so a false return is safe.
+pub fn repair_session_pid_anchor(port_file_base: &str, port: u16) -> bool {
+    let Some(pid) = listener_pid_for_port(port) else {
+        return false;
+    };
+    let pid_path = crate::paths::pid_file(port_file_base);
+    write_pid_anchor(&std::path::Path::new(&pid_path), pid);
+    if crate::debug_log::session_log_enabled() {
+        crate::debug_log::session_log("cleanup", &format!(
+            "repaired '{}' .pid anchor: recorded server PID was dead or recycled but port {} is served by a live psmux server (pid {})",
+            port_file_base, port, pid));
+    }
+    true
+}
+
+/// Rewrite the `.pid` anchor next to `port_path` to name `pid`, which the
+/// caller's AUTH round-trip proved is the live psmux server for that port.
+/// Writes next to the `.port` file (the same directory-relative convention as
+/// [`remove_session_registry_files`]) so the sweep never touches the profile
+/// dir it does not own.
+fn repair_stale_pid_anchor(port_path: &Path, port: u16, pid: u32) {
+    write_pid_anchor(&port_path.with_extension("pid"), pid);
+    if crate::debug_log::session_log_enabled() {
+        crate::debug_log::session_log("cleanup", &format!(
+            "repaired '{}' .pid anchor: recorded server PID was dead or recycled but port {} is served by a live psmux server (pid {})",
+            registry_base(port_path), port, pid));
+    }
 }
 
 /// Remove a session's entire registry set, given its `.port` path.

--- a/tests-rs/test_conpty_env_flags.rs
+++ b/tests-rs/test_conpty_env_flags.rs
@@ -1,0 +1,123 @@
+// Regression tests for the ConPTY diagnostic escape hatches (42ca018) and
+// the sideloading rules (87055f6).
+//
+//   - PSMUX_NO_WIN32_INPUT=1 / =true drops PSEUDOCONSOLE_WIN32_INPUT_MODE
+//     from every CreatePseudoConsole flag set (same shape as
+//     PSMUX_NO_PASSTHROUGH), so a conhost build that crashes around that
+//     mode can be diagnosed without rebuilding.
+//   - PSMUX_NO_PASSTHROUGH=1 short-circuits supports_passthrough_mode()
+//     before any OS version probing.
+//
+// These tests lock the env branches only: no DLL is loaded and no pseudo
+// console is created, so they are safe on any Windows CI. The sideload
+// precedence inside load_conpty() (explicit PSMUX_CONPTY_DLL, then a
+// bundled conpty.dll + OpenConsole.exe beside the exe, then kernel32) is
+// not closed-testable without actually loading DLLs, so it is deliberately
+// not exercised here.
+//
+// This file lives under src/win/, which is cfg(windows): macOS never
+// compiles it. Env is process-global, so the tests serialize on ENV_LOCK
+// and restore the previous value via a Drop guard.
+
+use super::*;
+
+use parking_lot::Mutex;
+
+static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+/// Restores a mutated env var on drop, so a failure mid-test cannot leak
+/// the value into other tests.
+struct EnvGuard {
+    var: &'static str,
+    prev: Option<std::ffi::OsString>,
+}
+
+impl EnvGuard {
+    fn set(var: &'static str, value: &str) -> EnvGuard {
+        let prev = std::env::var_os(var);
+        std::env::set_var(var, value);
+        EnvGuard { var, prev }
+    }
+
+    fn remove(var: &'static str) -> EnvGuard {
+        let prev = std::env::var_os(var);
+        std::env::remove_var(var);
+        EnvGuard { var, prev }
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        match &self.prev {
+            Some(value) => std::env::set_var(self.var, value),
+            None => std::env::remove_var(self.var),
+        }
+    }
+}
+
+/// PSMUX_NO_WIN32_INPUT=1 drops PSEUDOCONSOLE_WIN32_INPUT_MODE entirely:
+/// the base flag set collapses to the resize quirk alone.
+#[test]
+fn no_win32_input_drops_win32_input_mode() {
+    let _lock = ENV_LOCK.lock();
+    let _g = EnvGuard::set("PSMUX_NO_WIN32_INPUT", "1");
+    assert_eq!(
+        base_flags(),
+        PSEUDOCONSOLE_RESIZE_QUIRK,
+        "the escape hatch must remove WIN32_INPUT_MODE"
+    );
+    assert_eq!(base_flags() & PSEUDOCONSOLE_WIN32_INPUT_MODE, 0);
+}
+
+/// The same escape hatch accepts the boolean-true spellings used by the
+/// other PSMUX_NO_* switches.
+#[test]
+fn no_win32_input_true_spellings_also_disable() {
+    let _lock = ENV_LOCK.lock();
+    for value in ["true", "TRUE", "True"] {
+        let _g = EnvGuard::set("PSMUX_NO_WIN32_INPUT", value);
+        assert_eq!(
+            base_flags() & PSEUDOCONSOLE_WIN32_INPUT_MODE,
+            0,
+            "PSMUX_NO_WIN32_INPUT={value} must disable WIN32_INPUT_MODE"
+        );
+    }
+}
+
+/// Unset or "0" keeps the standard flag set — the escape hatch must not
+/// leak into normal operation.
+#[test]
+fn no_win32_input_unset_or_zero_keeps_win32_input_mode() {
+    let _lock = ENV_LOCK.lock();
+    let _unset = EnvGuard::remove("PSMUX_NO_WIN32_INPUT");
+    assert_ne!(base_flags() & PSEUDOCONSOLE_WIN32_INPUT_MODE, 0);
+    assert_ne!(base_flags() & PSEUDOCONSOLE_RESIZE_QUIRK, 0);
+
+    let _zero = EnvGuard::set("PSMUX_NO_WIN32_INPUT", "0");
+    assert_ne!(base_flags() & PSEUDOCONSOLE_WIN32_INPUT_MODE, 0);
+}
+
+/// PSMUX_NO_PASSTHROUGH short-circuits the passthrough probe before any OS
+/// call, in every accepted spelling.
+#[test]
+fn no_passthrough_short_circuits_before_os_probing() {
+    let _lock = ENV_LOCK.lock();
+    for value in ["1", "true", "TRUE", "True"] {
+        let _g = EnvGuard::set("PSMUX_NO_PASSTHROUGH", value);
+        assert!(
+            !supports_passthrough_mode(),
+            "PSMUX_NO_PASSTHROUGH={value} must force passthrough off"
+        );
+    }
+}
+
+/// The escape hatch and the default path agree on the resize quirk: even
+/// with WIN32_INPUT_MODE dropped, the resize quirk stays.
+#[test]
+fn resize_quirk_survives_both_escape_hatches() {
+    let _lock = ENV_LOCK.lock();
+    let _a = EnvGuard::set("PSMUX_NO_WIN32_INPUT", "1");
+    let _b = EnvGuard::set("PSMUX_NO_PASSTHROUGH", "1");
+    assert_ne!(base_flags() & PSEUDOCONSOLE_RESIZE_QUIRK, 0);
+    assert!(!supports_passthrough_mode());
+}

--- a/tests-rs/test_startup_stale_port_tax.rs
+++ b/tests-rs/test_startup_stale_port_tax.rs
@@ -1,16 +1,30 @@
-// Regression tests for the stale-port startup tax.
+// Regression tests for the stale-port startup tax and for the PID-anchor
+// false-death fix.
 //
-// Root cause proven by measurement: every CLI invocation ran
-// cleanup_stale_port_files(), which TCP-probed each .port file serially
-// (3 attempts x 100ms connect timeout). On Windows hosts where a dead
-// loopback port never sends RST (stealth firewall), each probe attempt
-// burned its full connect timeout AND classified as Inconclusive, so the
-// stale files were never reaped: ~350-400ms per stale file on EVERY psmux
-// command, forever. Six stale files made `psmux new-session` take ~2.4s
-// (and cold start ~4.9s, since the spawned server pays the tax again).
+// Tax root cause: every CLI invocation ran cleanup_stale_port_files(), which
+// TCP-probed each .port file serially (3 attempts x 100ms connect timeout).
+// On Windows hosts where a dead loopback port never sends RST (stealth
+// firewall), each probe attempt burned its full connect timeout AND
+// classified as Inconclusive, so the stale files were never reaped:
+// ~350-400ms per stale file on EVERY psmux command, forever. Six stale files
+// made `psmux new-session` take ~2.4s (and cold start ~4.9s, since the
+// spawned server pays the tax again).
 //
-// The fix consults the .pid sentinel (issue #448) first: a dead PID is a
-// definitive, microsecond-cheap stale verdict with no network round-trip.
+// The #448 fix consults the .pid sentinel first: a LIVE PID is a definitive,
+// microsecond-cheap keep with no network round-trip, and that fast path is
+// still in effect (see live_pid_anchor_skips_the_network_probe).
+//
+// False-death root cause: a DEAD anchor is only a process-table guess. A live
+// server can read as "dead" when the client cannot open its process
+// (elevated/service spawns), when its image was renamed, when its PID was
+// recycled, or when the .pid file itself is stale (a hard-killed server's
+// leftover anchor that the replacement server has not rewritten yet). The
+// old code treated that guess as proof of death and deleted the whole
+// registry of a LIVE server, producing intermittent "no server running on
+// session X" failures until the server's 5s registry self-heal rewrote the
+// files. The fix escalates dead-anchor verdicts to the AUTH network probe and
+// reaps only when the probe confirms; a probe that authenticates the port
+// repairs the stale .pid anchor in place instead.
 
 use super::*;
 
@@ -41,75 +55,214 @@ fn write_registry(dir: &std::path::Path, session: &str, port: &str) -> (PathBuf,
     (port_path, key_path, sid_path)
 }
 
-/// Spawn a short-lived real process and return its PID after it has exited.
-/// This produces a PID that is genuinely dead (not fabricated), matching what
-/// a hard-killed session server leaves behind in its .pid file.
-#[cfg(windows)]
-fn dead_pid() -> u32 {
-    let mut child = std::process::Command::new("cmd")
-        .args(["/c", "exit"])
-        .spawn()
-        .expect("spawn cmd");
-    let pid = child.id();
-    let _ = child.wait();
-    pid
+/// A dead-looking anchor: a PID body that no live psmux process can match
+/// (the real pid_anchor_verdict is Windows-only, so tests inject the verdict
+/// directly; the body just needs to parse like the real sentinel).
+const STALE_ANCHOR: &str = "999999:134301758043996634";
+
+/// Drive the stale-port sweep with fully injected oracles so every verdict is
+/// deterministic on any platform.
+fn sweep_with(
+    dir: &std::path::Path,
+    anchor: impl FnMut(&Path) -> Option<bool>,
+    probe: impl FnMut(&str, u16) -> PortProbeResult,
+    listener_pid: impl FnMut(u16) -> Option<u32>,
+) {
+    let mut anchor = anchor;
+    let mut probe = probe;
+    let mut listener_pid = listener_pid;
+    cleanup_stale_port_files_in_with_full(&dir, &mut anchor, &mut probe, &mut listener_pid);
 }
 
-#[cfg(windows)]
+/// (a) Dead .pid + alive probe: the registry must NOT be reaped — the dead
+/// anchor is a false negative, and the probe proves a live server owns the
+/// port. The .pid anchor is repaired in place to name the live listener.
 #[test]
-fn dead_pid_anchor_reaps_registry_without_any_network_probe() {
-    let dir = temp_psmux_dir("pid_anchor_dead");
-    let (port_path, key_path, sid_path) = write_registry(&dir, "crashed", "54329");
+fn dead_pid_anchor_with_alive_probe_keeps_and_repairs_registry() {
+    let dir = temp_psmux_dir("anchor_dead_probe_alive");
+    let (port_path, key_path, sid_path) = write_registry(&dir, "vibex__tmex", "54329");
+    let pid_path = dir.join("vibex__tmex.pid");
+    fs::write(&pid_path, STALE_ANCHOR).unwrap();
+
+    let mut probes = 0;
+    sweep_with(
+        &dir,
+        |_| Some(false),
+        |_, _| {
+            probes += 1;
+            PortProbeResult::Alive
+        },
+        |port| {
+            assert_eq!(port, 54329, "the probe port must be the one under scrutiny");
+            Some(424242)
+        },
+    );
+
+    assert_eq!(probes, 1, "a dead anchor must escalate to the network probe");
+    assert!(port_path.exists(), "alive probe must preserve the .port of a live server");
+    assert!(key_path.exists(), "alive probe must preserve the .key");
+    assert!(sid_path.exists(), "alive probe must preserve the .sid");
+    let repaired = fs::read_to_string(&pid_path).unwrap();
+    let (pid, _) = parse_pid_file_contents(&repaired).expect("repaired .pid must parse");
+    assert_eq!(pid, 424242, "the .pid anchor must be repaired to the live listener's PID");
+    let _ = fs::remove_dir_all(dir.parent().unwrap());
+}
+
+/// An alive probe with a resolvable listener PID is repaired even when the
+/// sweep's listener oracle fails, the stale anchor must be left in place —
+/// never reaped (the server's own 5s self-heal rewrites it).
+#[test]
+fn dead_pid_anchor_with_alive_probe_and_no_listener_pid_is_kept() {
+    let dir = temp_psmux_dir("anchor_dead_probe_alive_no_listener");
+    let (port_path, _, _) = write_registry(&dir, "vibex__warm", "54340");
+    fs::write(dir.join("vibex__warm.pid"), STALE_ANCHOR).unwrap();
+
+    sweep_with(&dir, |_| Some(false), |_, _| PortProbeResult::Alive, |_| None);
+
+    assert!(port_path.exists(), "an unresolvable listener must still not cause a reap");
+    assert!(dir.join("vibex__warm.pid").exists(), "stale anchor left for the server self-heal");
+    let _ = fs::remove_dir_all(dir.parent().unwrap());
+}
+
+/// (b) Dead .pid + refused probe: the probe confirms the server is really
+/// gone, so the whole registry is reaped as before.
+#[test]
+fn dead_pid_anchor_with_stale_probe_reaps_registry() {
+    let dir = temp_psmux_dir("anchor_dead_probe_stale");
+    let (port_path, key_path, sid_path) = write_registry(&dir, "crashed", "54330");
     let pid_path = dir.join("crashed.pid");
-    fs::write(&pid_path, dead_pid().to_string()).unwrap();
+    fs::write(&pid_path, STALE_ANCHOR).unwrap();
 
-    // The probe must never run: a dead .pid anchor is definitive on its own.
-    cleanup_stale_port_files_in_with(&dir, |_, _| {
-        panic!("network probe must not run when the .pid anchor says dead");
-    });
+    let mut probes = 0;
+    sweep_with(
+        &dir,
+        |_| Some(false),
+        |_, _| {
+            probes += 1;
+            PortProbeResult::Stale
+        },
+        |_| None,
+    );
 
-    assert!(!port_path.exists(), ".port of a dead-PID session must be reaped");
-    assert!(!key_path.exists(), ".key of a dead-PID session must be reaped");
-    assert!(!sid_path.exists(), ".sid of a dead-PID session must be reaped");
-    assert!(!pid_path.exists(), ".pid sentinel itself must be reaped");
+    assert_eq!(probes, 1, "a dead anchor must escalate to the network probe");
+    assert!(!port_path.exists(), "probe-confirmed stale .port must be reaped");
+    assert!(!key_path.exists(), "matching .key must be reaped");
+    assert!(!sid_path.exists(), "matching .sid must be reaped");
+    assert!(!pid_path.exists(), "the dead .pid sentinel itself must be reaped");
     let _ = fs::remove_dir_all(dir.parent().unwrap());
 }
 
-#[cfg(windows)]
+/// A dead anchor whose probe is ambiguous must be kept: cleanup may only reap
+/// when liveness is disproven by the strongest available signal, never on a
+/// guess.
 #[test]
-fn pid_recycled_by_unrelated_image_is_reaped_without_probe() {
-    // The current test process is alive but its image is not `psmux.exe`
-    // (cargo test binaries are named psmux-<hash>), which models a PID that
-    // was recycled by an unrelated application after the server died.
-    let dir = temp_psmux_dir("pid_anchor_recycled");
-    let (port_path, _, _) = write_registry(&dir, "recycled", "54330");
-    fs::write(dir.join("recycled.pid"), std::process::id().to_string()).unwrap();
+fn dead_pid_anchor_with_inconclusive_probe_is_kept() {
+    let dir = temp_psmux_dir("anchor_dead_probe_inconclusive");
+    let (port_path, key_path, sid_path) = write_registry(&dir, "busy", "54333");
+    fs::write(dir.join("busy.pid"), STALE_ANCHOR).unwrap();
 
-    cleanup_stale_port_files_in_with(&dir, |_, _| {
-        panic!("network probe must not run when the PID belongs to another image");
-    });
+    let mut probes = 0;
+    sweep_with(
+        &dir,
+        |_| Some(false),
+        |_, _| {
+            probes += 1;
+            PortProbeResult::Inconclusive
+        },
+        |_| None,
+    );
 
-    assert!(!port_path.exists(), "recycled-PID registry must be reaped");
+    assert_eq!(probes, 1);
+    assert!(port_path.exists(), "inconclusive probe must not remove .port");
+    assert!(key_path.exists(), "inconclusive probe must not remove .key");
+    assert!(sid_path.exists(), "inconclusive probe must not remove .sid");
     let _ = fs::remove_dir_all(dir.parent().unwrap());
 }
 
+/// The live-PID fast path stays probe-free: only dead-anchor verdicts are
+/// escalated, so a healthy server's entry never pays a network round-trip.
+#[test]
+fn live_pid_anchor_skips_the_network_probe() {
+    let dir = temp_psmux_dir("anchor_live");
+    write_registry(&dir, "serving", "54331");
+    fs::write(dir.join("serving.pid"), "4242:1").unwrap();
+
+    let mut probes = 0;
+    sweep_with(
+        &dir,
+        |_| Some(true),
+        |_, _| {
+            probes += 1;
+            PortProbeResult::Stale
+        },
+        |_| None,
+    );
+
+    assert_eq!(probes, 0, "live-PID fast path must stay probe-free");
+    assert!(dir.join("serving.port").exists(), "live entry must be kept");
+    assert!(dir.join("serving.pid").exists());
+    let _ = fs::remove_dir_all(dir.parent().unwrap());
+}
+
+/// (c) The namespace-token prune follows the same sweep: a namespace whose
+/// registry survives (dead anchor, alive probe) keeps its identity token.
+/// Deleting the token here would look like a server restart to a supervisor
+/// watching #{server_instance}.
+#[test]
+fn namespace_token_survives_sweep_when_probe_shows_live_server() {
+    let dir = temp_psmux_dir("token_survives");
+    let t = crate::paths::namespace_instance_file(&dir, Some("vibex-dev"));
+    fs::create_dir_all(t.parent().unwrap()).unwrap();
+    fs::write(&t, "a1b2c3d4e5f60718").unwrap();
+    write_registry(&dir, "vibex-dev__tmex", "54332");
+    fs::write(dir.join("vibex-dev__tmex.pid"), STALE_ANCHOR).unwrap();
+
+    // The full sweep as main.rs runs it: stale-port cleanup first, then the
+    // namespace-token prune. A false-negative anchor must not cascade into
+    // the namespace losing its identity.
+    sweep_with(&dir, |_| Some(false), |_, _| PortProbeResult::Alive, |_| Some(424242));
+
+    let pruned = prune_orphaned_instance_tokens_in_with(&dir, Duration::ZERO, usize::MAX);
+    assert_eq!(pruned, 0, "the live namespace's token must not be pruned");
+    assert!(t.exists(), "the namespace token must survive the sweep");
+    let _ = fs::remove_dir_all(dir.parent().unwrap());
+}
+
+/// Pre-#448 registries have no .pid file; behavior must be unchanged: the
+/// probe runs, and Inconclusive keeps the files.
 #[test]
 fn missing_pid_anchor_falls_back_to_network_probe() {
-    // Pre-#448 registries have no .pid file; behavior must be unchanged:
-    // the probe runs, and Inconclusive keeps the files.
     let dir = temp_psmux_dir("pid_anchor_missing");
     let (port_path, key_path, sid_path) = write_registry(&dir, "legacy", "54331");
 
     let mut probe_ran = false;
-    cleanup_stale_port_files_in_with(&dir, |_, _| {
-        probe_ran = true;
-        PortProbeResult::Inconclusive
-    });
+    sweep_with(
+        &dir,
+        |_| None,
+        |_, _| {
+            probe_ran = true;
+            PortProbeResult::Inconclusive
+        },
+        |_| None,
+    );
 
     assert!(probe_ran, "without a .pid anchor the network probe must still run");
     assert!(port_path.exists(), "inconclusive probe must keep .port");
     assert!(key_path.exists(), "inconclusive probe must keep .key");
     assert!(sid_path.exists(), "inconclusive probe must keep .sid");
+    let _ = fs::remove_dir_all(dir.parent().unwrap());
+}
+
+/// An alive probe on an anchorless registry keeps the entry (there is no
+/// anchor to repair; the server writes one on its next registry tick).
+#[test]
+fn alive_probe_without_anchor_keeps_registry() {
+    let dir = temp_psmux_dir("no_anchor_probe_alive");
+    let (port_path, _, _) = write_registry(&dir, "legacy_alive", "54334");
+
+    sweep_with(&dir, |_| None, |_, _| PortProbeResult::Alive, |_| None);
+
+    assert!(port_path.exists(), "an authenticating port must keep the registry");
     let _ = fs::remove_dir_all(dir.parent().unwrap());
 }
 
@@ -120,35 +273,48 @@ fn unparseable_pid_anchor_falls_back_to_network_probe() {
     fs::write(dir.join("garbled.pid"), "not-a-pid").unwrap();
 
     let mut probe_ran = false;
-    cleanup_stale_port_files_in_with(&dir, |_, _| {
-        probe_ran = true;
-        PortProbeResult::Inconclusive
-    });
+    sweep_with(
+        &dir,
+        |_| None,
+        |_, _| {
+            probe_ran = true;
+            PortProbeResult::Inconclusive
+        },
+        |_| None,
+    );
 
     assert!(probe_ran, "garbage .pid must fall back to the network probe");
     assert!(port_path.exists(), "inconclusive fallback must keep files");
     let _ = fs::remove_dir_all(dir.parent().unwrap());
 }
 
-#[cfg(windows)]
+/// The measured defect was 6 stale files costing ~2.4s (serial network
+/// probes). With the #448 sentinel plus the probe escalation, dead anchors
+/// with a fast-stale probe must still clean up in well under the cost of a
+/// single 100ms probe attempt — the escalation is what makes a dead anchor
+/// reapable, not an excuse to re-introduce the tax.
 #[test]
-fn cleanup_with_many_dead_pid_registries_is_fast() {
-    // The measured defect: 6 stale files cost ~2.4s (serial network probes).
-    // With the PID anchor, even 6 dead registries must clean up in well under
-    // the cost of a single 100ms probe attempt.
-    let dir = temp_psmux_dir("pid_anchor_speed");
-    let dead = dead_pid();
+fn cleanup_with_many_dead_anchor_registries_is_fast() {
+    let dir = temp_psmux_dir("anchor_speed");
     for i in 0..6 {
         write_registry(&dir, &format!("dead{i}"), &format!("5430{i}"));
-        fs::write(dir.join(format!("dead{i}.pid")), dead.to_string()).unwrap();
+        fs::write(dir.join(format!("dead{i}.pid")), STALE_ANCHOR).unwrap();
     }
 
     let start = Instant::now();
-    cleanup_stale_port_files_in_with(&dir, |_, _| {
-        panic!("no network probes expected for dead-PID registries");
-    });
+    let mut probes = 0;
+    sweep_with(
+        &dir,
+        |_| Some(false),
+        |_, _| {
+            probes += 1;
+            PortProbeResult::Stale
+        },
+        |_| None,
+    );
     let elapsed = start.elapsed();
 
+    assert_eq!(probes, 6, "every dead anchor must be verified once");
     assert!(
         elapsed < Duration::from_millis(250),
         "cleanup of 6 dead registries took {:?}; the stale-port tax is back",

--- a/tests-rs/test_startup_stale_port_tax.rs
+++ b/tests-rs/test_startup_stale_port_tax.rs
@@ -25,6 +25,13 @@
 // files. The fix escalates dead-anchor verdicts to the AUTH network probe and
 // reaps only when the probe confirms; a probe that authenticates the port
 // repairs the stale .pid anchor in place instead.
+//
+// Timeout rule: only an ACTIVELY refused connect proves no listener exists.
+// A probe timeout is never proof of death — the server's single-threaded
+// FIFO can be saturated (concurrent snapshot/capture) so the AUTH round-trip
+// times out on every attempt while the server is alive (field case:
+// refused=false, timed_out=true reaped a live server). Every timed-out probe
+// classifies Inconclusive and keeps the registry.
 
 use super::*;
 
@@ -124,8 +131,11 @@ fn dead_pid_anchor_with_alive_probe_and_no_listener_pid_is_kept() {
     let _ = fs::remove_dir_all(dir.parent().unwrap());
 }
 
-/// (b) Dead .pid + refused probe: the probe confirms the server is really
-/// gone, so the whole registry is reaped as before.
+/// (b) Dead .pid + refused probe: the probe ACTIVELY refused on every
+/// attempt (no listener), confirming the server is really gone, so the whole
+/// registry is reaped as before. `Stale` is only produced by an active
+/// refusal now — a timed-out probe classifies Inconclusive instead (see
+/// busy_server_timeout_probe_with_dead_anchor_is_kept).
 #[test]
 fn dead_pid_anchor_with_stale_probe_reaps_registry() {
     let dir = temp_psmux_dir("anchor_dead_probe_stale");
@@ -177,6 +187,77 @@ fn dead_pid_anchor_with_inconclusive_probe_is_kept() {
     assert!(key_path.exists(), "inconclusive probe must not remove .key");
     assert!(sid_path.exists(), "inconclusive probe must not remove .sid");
     let _ = fs::remove_dir_all(dir.parent().unwrap());
+}
+
+/// (d) The field regression: a busy-but-alive server (single-threaded FIFO
+/// saturated by concurrent snapshot/capture commands) times out the AUTH
+/// round-trip on every probe attempt while a stale-looking PID anchor
+/// escalates. Every attempt times out -> the probe must classify
+/// Inconclusive and the sweep must keep the whole registry. Only an active
+/// refusal may reap.
+#[test]
+fn busy_server_timeout_probe_with_dead_anchor_is_kept() {
+    let dir = temp_psmux_dir("busy_server_timeout");
+    // A listener that completes the TCP handshake but never answers the AUTH
+    // line: the stand-in for a live server whose event loop is saturated.
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let (port_path, key_path, sid_path) = write_registry(&dir, "vibex__tmex", &port.to_string());
+    fs::write(dir.join("vibex__tmex.pid"), STALE_ANCHOR).unwrap();
+
+    // The REAL probe function, not an injected verdict.
+    sweep_with(&dir, |_| Some(false), probe_session_for_cleanup, |_| None);
+
+    assert!(port_path.exists(), "a busy server's registry must survive a timed-out probe");
+    assert!(key_path.exists(), "matching .key must survive");
+    assert!(sid_path.exists(), "matching .sid must survive");
+    assert!(dir.join("vibex__tmex.pid").exists(), "the anchor must survive too");
+    let _ = fs::remove_dir_all(dir.parent().unwrap());
+}
+
+/// Every probe attempt timed out and nothing refused: the exact field
+/// signature (`refused=false, timed_out=true`) that used to reap a live,
+/// busy server. A timeout proves nothing about the listener, so it must
+/// classify Inconclusive.
+#[test]
+fn probe_verdict_timeout_alone_is_inconclusive() {
+    assert_eq!(
+        classify_probe_verdict(54321, false, true, false),
+        PortProbeResult::Inconclusive
+    );
+}
+
+/// An active refusal on every attempt with no other signal is the only
+/// probe-side proof of death.
+#[test]
+fn probe_verdict_refused_alone_is_stale() {
+    assert_eq!(
+        classify_probe_verdict(54321, true, false, false),
+        PortProbeResult::Stale
+    );
+}
+
+/// A single timeout poisons staleness even when other attempts refused: "no
+/// listener" was never actually proven, and the server may simply be busy.
+#[test]
+fn probe_verdict_refused_with_timeout_is_inconclusive() {
+    assert_eq!(
+        classify_probe_verdict(54321, true, true, false),
+        PortProbeResult::Inconclusive
+    );
+}
+
+/// Any response byte (however unparseable) keeps the conservative verdict.
+#[test]
+fn probe_verdict_any_inconclusive_signal_is_inconclusive() {
+    assert_eq!(
+        classify_probe_verdict(54321, false, false, true),
+        PortProbeResult::Inconclusive
+    );
+    assert_eq!(
+        classify_probe_verdict(54321, true, true, true),
+        PortProbeResult::Inconclusive
+    );
 }
 
 /// The live-PID fast path stays probe-free: only dead-anchor verdicts are


### PR DESCRIPTION
## Context

psmux runs as the persistent terminal backend for [tmex](https://github.com/krhougs/tmex)'s Windows gateway (Vibe X is tmex's commercial distribution); sessions are expected to survive for weeks on end-user machines, unattended.

## Problems

A single conhost crash cascaded into total session loss through two independent weaknesses:

1. **In-box ConPTY crash bugs.** conhost.exe only updates with the OS; specific builds carry crash bugs — 10.0.26100.8737 access-violates on teardown of some alt-screen TUI apps, taking the pane's console *and shell* with it. Windows Terminal, VS Code and WezTerm all escape such bugs by shipping their own conpty.dll + OpenConsole.exe; psmux had no way to.
2. **Post-crash misreaping.** After such a crash the startup reaper could kill a *live* server: a stale PID anchor alone was treated as proof of death, and an inconclusive port probe (timeout, transient error) was treated the same as an actively refused connection. Users lost every session that had in fact survived.

## Fix

- **ConPTY sideloading** (opt-in, zero behavior change by default): load order is `PSMUX_CONPTY_DLL` explicit override → `conpty.dll` next to the psmux executable, only when its matching `OpenConsole.exe` sits beside it → the system kernel32 implementation. Absolute paths only, so the default-DLL-search-order hijack concern does not apply.
- **`PSMUX_NO_WIN32_INPUT` diagnostic switch** (same shape as `PSMUX_NO_PASSTHROUGH`): create the pseudo console without `PSEUDOCONSOLE_WIN32_INPUT_MODE`, for isolating conhost faults tied to that mode — this is how we bisected the crash above.
- **Reaping tightened to positive evidence only**: a stale PID anchor alone never reaps; only an actively refused probe may prove a server dead. Inconclusive probes leave the server alone.

## Tests

Extended `tests-rs/test_startup_stale_port_tax.rs` pins the reaping rules; new `tests-rs/test_conpty_env_flags.rs` locks the env-switch branches (no DLL loading in tests). Verified on Windows.
