### PR TITLE
control mode: bounded buffering for slow clients, atomic command blocks, bounded output lines

### DIFF
--- a/src/control.rs
+++ b/src/control.rs
@@ -660,3 +660,11 @@ mod tests {
         assert_eq!(line, "%subscription-changed test_sub $1 @2 3 %4 : ");
     }
 }
+
+#[cfg(test)]
+#[path = "../tests-rs/test_control_slow_client_backlog.rs"]
+mod tests_control_slow_client_backlog;
+
+#[cfg(test)]
+#[path = "../tests-rs/test_control_output_chunking.rs"]
+mod tests_control_output_chunking;

--- a/src/control.rs
+++ b/src/control.rs
@@ -219,6 +219,38 @@ pub fn try_send_notification(client: &ControlClient, notif: ControlNotification)
     let _ = client.output_tx.send(output);
 }
 
+/// Maximum raw payload carried by a single %output / %extended-output line.
+/// tmux emits one notification per PTY read (bounded by its event-buffer read
+/// size), so clients never face a single multi-hundred-KB line. Splitting on
+/// UTF-8 boundaries keeps each chunk independently escapable.
+pub const OUTPUT_CHUNK_MAX: usize = 4096;
+
+/// Split pane output into chunks of at most `OUTPUT_CHUNK_MAX` bytes without
+/// cutting through a UTF-8 sequence.
+pub fn chunk_output(data: &str) -> impl Iterator<Item = &str> {
+    let mut rest = data;
+    std::iter::from_fn(move || {
+        if rest.is_empty() {
+            return None;
+        }
+        if rest.len() <= OUTPUT_CHUNK_MAX {
+            let chunk = rest;
+            rest = "";
+            return Some(chunk);
+        }
+        let mut split = OUTPUT_CHUNK_MAX;
+        while split > 0 && !rest.is_char_boundary(split) {
+            split -= 1;
+        }
+        if split == 0 {
+            split = rest.len();
+        }
+        let (chunk, tail) = rest.split_at(split);
+        rest = tail;
+        Some(chunk)
+    })
+}
+
 /// Emit the initial state burst to a freshly-attached control mode client.
 /// This mirrors what real tmux sends right after `-CC attach` so that
 /// integrations like iTerm2's tmux mode can bootstrap their UI without
@@ -279,6 +311,35 @@ mod tests {
     #[test]
     fn test_escape_output_printable() {
         assert_eq!(escape_output("hello world"), "hello world");
+    }
+
+    #[test]
+    fn test_chunk_output_short_passthrough() {
+        let chunks: Vec<&str> = chunk_output("hello").collect();
+        assert_eq!(chunks, vec!["hello"]);
+        assert_eq!(chunk_output("").count(), 0);
+    }
+
+    #[test]
+    fn test_chunk_output_splits_large_payload() {
+        let data = "x".repeat(OUTPUT_CHUNK_MAX * 2 + 100);
+        let chunks: Vec<&str> = chunk_output(&data).collect();
+        assert_eq!(chunks.len(), 3);
+        assert!(chunks.iter().all(|c| c.len() <= OUTPUT_CHUNK_MAX));
+        assert_eq!(chunks.concat(), data);
+    }
+
+    #[test]
+    fn test_chunk_output_never_splits_utf8_sequence() {
+        // Fill so a 3-byte CJK glyph straddles the chunk boundary.
+        let mut data = "a".repeat(OUTPUT_CHUNK_MAX - 1);
+        data.push_str("终端输出");
+        let chunks: Vec<&str> = chunk_output(&data).collect();
+        assert!(chunks.len() >= 2);
+        assert_eq!(chunks.concat(), data);
+        for chunk in &chunks {
+            assert!(std::str::from_utf8(chunk.as_bytes()).is_ok());
+        }
     }
 
     #[test]

--- a/src/control.rs
+++ b/src/control.rs
@@ -1,4 +1,4 @@
-use crate::types::{AppState, ControlNotification, Node, LayoutKind, Window};
+use crate::types::{AppState, ControlClient, ControlNotification, ControlOutput, Node, LayoutKind, Window};
 use ratatui::layout::Rect;
 
 /// Compute tmux's 16-bit rotating checksum over the layout body.
@@ -173,15 +173,19 @@ pub fn emit_notification(app: &AppState, notif: ControlNotification) {
                 continue;
             }
         }
-        let _ = client.notification_tx.try_send(notif.clone());
+        try_send_notification(client, notif.clone());
     }
 }
 
 /// Send a notification to a single control client by id (no-op if unknown).
 pub fn emit_to_client(app: &AppState, client_id: u64, notif: ControlNotification) {
     if let Some(client) = app.control_clients.get(&client_id) {
-        let _ = client.notification_tx.try_send(notif);
+        try_send_notification(client, notif);
     }
+}
+
+pub fn try_send_notification(client: &ControlClient, notif: ControlNotification) {
+    let _ = client.output_tx.try_send(ControlOutput::Notification(notif));
 }
 
 /// Emit the initial state burst to a freshly-attached control mode client.
@@ -388,7 +392,7 @@ mod tests {
             client_id: 1,
             cmd_counter: 0,
             echo_enabled: true,
-            notification_tx: tx,
+            output_tx: tx,
             paused_panes: std::collections::HashSet::new(),
             subscriptions: std::collections::HashMap::new(),
             subscription_values: std::collections::HashMap::new(),
@@ -410,7 +414,7 @@ mod tests {
             client_id: 1,
             cmd_counter: 0,
             echo_enabled: false,
-            notification_tx: tx,
+            output_tx: tx,
             paused_panes: std::collections::HashSet::new(),
             subscriptions: std::collections::HashMap::new(),
             subscription_values: std::collections::HashMap::new(),
@@ -423,7 +427,10 @@ mod tests {
         });
         emit_notification(&app, ControlNotification::WindowAdd { window_id: 5 });
         let notif = rx.try_recv().unwrap();
-        assert!(matches!(notif, ControlNotification::WindowAdd { window_id: 5 }));
+        assert!(matches!(
+            notif,
+            ControlOutput::Notification(ControlNotification::WindowAdd { window_id: 5 })
+        ));
     }
 
     #[test]
@@ -436,7 +443,7 @@ mod tests {
             client_id: 1,
             cmd_counter: 0,
             echo_enabled: false,
-            notification_tx: tx,
+            output_tx: tx,
             paused_panes: paused,
             subscriptions: std::collections::HashMap::new(),
             subscription_values: std::collections::HashMap::new(),

--- a/src/control.rs
+++ b/src/control.rs
@@ -165,7 +165,8 @@ pub fn format_error(timestamp: i64, cmd_number: u64) -> String {
 }
 
 /// Emit a control notification to all connected control mode clients.
-/// Non-blocking: if a client's channel is full, the notification is dropped for that client.
+/// Non-blocking: a slow client sheds `%output` frames past a backlog
+/// threshold, but structural notifications are always queued.
 pub fn emit_notification(app: &AppState, notif: ControlNotification) {
     for client in app.control_clients.values() {
         if let ControlNotification::Output { pane_id, .. } = &notif {
@@ -184,8 +185,38 @@ pub fn emit_to_client(app: &AppState, client_id: u64, notif: ControlNotification
     }
 }
 
+/// Backlog level past which pane output frames are shed for a slow client.
+/// Dropped frames are harmless: any client resynchronizes the screen with
+/// capture-pane, exactly as after tmux pauses a pane.
+pub const OUTPUT_BACKLOG_SOFT_MAX: usize = 4 * 1024 * 1024;
+/// Backlog level past which everything is shed; a reader this far behind is
+/// effectively gone and only the TCP connection teardown will reap it.
+pub const OUTPUT_BACKLOG_HARD_MAX: usize = 64 * 1024 * 1024;
+
+/// Approximate wire cost of one queued control output, used for backlog
+/// accounting. Must be applied symmetrically by the enqueue and the writer.
+pub fn output_cost(output: &ControlOutput) -> usize {
+    match output {
+        ControlOutput::Notification(ControlNotification::Output { data, .. }) => data.len() + 32,
+        ControlOutput::Notification(ControlNotification::ExtendedOutput { data, .. }) => data.len() + 48,
+        ControlOutput::Notification(_) => 128,
+        ControlOutput::CommandBlock(block) => block.len(),
+    }
+}
+
 pub fn try_send_notification(client: &ControlClient, notif: ControlNotification) {
-    let _ = client.output_tx.try_send(ControlOutput::Notification(notif));
+    use std::sync::atomic::Ordering;
+    let backlog = client.backlog.load(Ordering::Relaxed);
+    let droppable = matches!(
+        notif,
+        ControlNotification::Output { .. } | ControlNotification::ExtendedOutput { .. }
+    );
+    if backlog >= OUTPUT_BACKLOG_HARD_MAX || (droppable && backlog >= OUTPUT_BACKLOG_SOFT_MAX) {
+        return;
+    }
+    let output = ControlOutput::Notification(notif);
+    client.backlog.fetch_add(output_cost(&output), Ordering::Relaxed);
+    let _ = client.output_tx.send(output);
 }
 
 /// Emit the initial state burst to a freshly-attached control mode client.
@@ -387,12 +418,13 @@ mod tests {
     #[test]
     fn test_has_control_clients_with_client() {
         let mut app = AppState::new("test".to_string());
-        let (tx, _rx) = std::sync::mpsc::sync_channel(16);
+        let (tx, _rx) = std::sync::mpsc::channel();
         app.control_clients.insert(1, crate::types::ControlClient {
             client_id: 1,
             cmd_counter: 0,
             echo_enabled: true,
             output_tx: tx,
+            backlog: std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0)),
             paused_panes: std::collections::HashSet::new(),
             subscriptions: std::collections::HashMap::new(),
             subscription_values: std::collections::HashMap::new(),
@@ -409,12 +441,13 @@ mod tests {
     #[test]
     fn test_emit_notification_to_clients() {
         let mut app = AppState::new("test".to_string());
-        let (tx, rx) = std::sync::mpsc::sync_channel(16);
+        let (tx, rx) = std::sync::mpsc::channel();
         app.control_clients.insert(1, crate::types::ControlClient {
             client_id: 1,
             cmd_counter: 0,
             echo_enabled: false,
             output_tx: tx,
+            backlog: std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0)),
             paused_panes: std::collections::HashSet::new(),
             subscriptions: std::collections::HashMap::new(),
             subscription_values: std::collections::HashMap::new(),
@@ -436,7 +469,7 @@ mod tests {
     #[test]
     fn test_emit_notification_skips_paused_pane() {
         let mut app = AppState::new("test".to_string());
-        let (tx, rx) = std::sync::mpsc::sync_channel(16);
+        let (tx, rx) = std::sync::mpsc::channel();
         let mut paused = std::collections::HashSet::new();
         paused.insert(3usize);
         app.control_clients.insert(1, crate::types::ControlClient {
@@ -444,6 +477,7 @@ mod tests {
             cmd_counter: 0,
             echo_enabled: false,
             output_tx: tx,
+            backlog: std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0)),
             paused_panes: paused,
             subscriptions: std::collections::HashMap::new(),
             subscription_values: std::collections::HashMap::new(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -4746,3 +4746,7 @@ mod readiness_tests {
         assert!(!detached_list_windows_ready("ERROR: Invalid session key\n"));
     }
 }
+
+#[cfg(test)]
+#[path = "../tests-rs/test_client_debug_log_truncation.rs"]
+mod tests_client_debug_log_truncation;

--- a/src/main.rs
+++ b/src/main.rs
@@ -4432,9 +4432,16 @@ fn run_control_mode(mode: u8) -> io::Result<()> {
                 Ok(0) | Err(_) => break,
                 Ok(_) => {
                     if let Some(ref mut f) = log_file {
+                        // Truncate on a char boundary: a byte slice at 200 can
+                        // land inside a multi-byte glyph (TUI box drawing) and
+                        // panic, killing the whole control client.
+                        let mut cut = line.len().min(200);
+                        while cut > 0 && !line.is_char_boundary(cut) {
+                            cut -= 1;
+                        }
                         let _ = writeln!(f, "[{:>8.3}s] OUT ({} bytes): {:?}",
                             start.elapsed().as_secs_f64(), line.len(),
-                            &line[..line.len().min(200)]);
+                            &line[..cut]);
                     }
                     let mut out = stdout.lock();
                     let _ = out.write_all(line.as_bytes());

--- a/src/pane.rs
+++ b/src/pane.rs
@@ -410,7 +410,18 @@ pub fn warm_pane_is_live(wp: &mut crate::types::WarmPane) -> bool {
 /// its reader thread already running — by the time the user creates a new window
 /// (typically 500ms+), pwsh will have fully loaded its profile and the prompt
 /// is ready.
-pub fn spawn_warm_pane(pty_system: &dyn portable_pty::PtySystem, app: &mut AppState) -> io::Result<crate::types::WarmPane> {
+pub(crate) struct WarmPaneSpawnSpec {
+    size: PtySize,
+    shell_cmd: CommandBuilder,
+    pane_id: usize,
+    history_limit: usize,
+    allow_alternate_screen: bool,
+}
+
+/// Snapshot every `AppState` value needed by a warm-pane spawn. This runs on
+/// the server thread; the resulting owned spec can safely cross to a worker
+/// without giving that worker access to mutable session state.
+pub(crate) fn prepare_warm_pane_spawn(app: &mut AppState) -> io::Result<WarmPaneSpawnSpec> {
     if !app.warm_enabled {
         return Err(io::Error::new(io::ErrorKind::Other, "warm panes disabled"));
     }
@@ -418,9 +429,6 @@ pub fn spawn_warm_pane(pty_system: &dyn portable_pty::PtySystem, app: &mut AppSt
     let rows = if area.height > 1 { area.height } else { 30 }.max(MIN_PANE_DIM);
     let cols = if area.width > 1 { area.width } else { 120 }.max(MIN_PANE_DIM);
     let size = PtySize { rows, cols, pixel_width: 0, pixel_height: 0 };
-    let pair = pty_system
-        .openpty(size)
-        .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("openpty error: {e}")))?;
     // Expand format variables like #{pane_current_path} at spawn time (#111).
     let expanded_shell = crate::format::expand_format(&app.default_shell, app);
     let mut shell_cmd = if !expanded_shell.is_empty() {
@@ -433,13 +441,37 @@ pub fn spawn_warm_pane(pty_system: &dyn portable_pty::PtySystem, app: &mut AppSt
     set_tmux_env(&mut shell_cmd, pane_id, app.control_port, app.socket_name.as_deref(), &app.session_name, app.claude_code_fix_tty, app.claude_code_force_interactive);
     set_host_colors_env(&mut shell_cmd, app.host_colors.as_ref());
     apply_user_environment(&mut shell_cmd, &app.environment);
-    let child = pair.slave
+    Ok(WarmPaneSpawnSpec {
+        size,
+        shell_cmd,
+        pane_id,
+        history_limit: app.history_limit,
+        allow_alternate_screen: app.allow_alternate_screen,
+    })
+}
+
+/// Perform only the OS-facing portion of a warm-pane spawn. The input is an
+/// immutable snapshot, so this function may run on a worker thread.
+pub(crate) fn spawn_warm_pane_from_spec(
+    pty_system: &dyn portable_pty::PtySystem,
+    spec: WarmPaneSpawnSpec,
+) -> io::Result<crate::types::WarmPane> {
+    let WarmPaneSpawnSpec {
+        size,
+        shell_cmd,
+        pane_id,
+        history_limit,
+        allow_alternate_screen,
+    } = spec;
+    let pair = pty_system
+        .openpty(size)
+        .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("openpty error: {e}")))?;
+    let mut child = pair.slave
         .spawn_command(shell_cmd)
         .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("spawn shell error: {e}")))?;
     drop(pair.slave);
-    let scrollback = app.history_limit as u32;
-    let mut parser = vt100::Parser::new(rows, cols, scrollback as usize);
-    parser.screen_mut().set_allow_alternate_screen(app.allow_alternate_screen);
+    let mut parser = vt100::Parser::new(size.rows, size.cols, history_limit);
+    parser.screen_mut().set_allow_alternate_screen(allow_alternate_screen);
     let term: Arc<Mutex<vt100::Parser>> = Arc::new(Mutex::new(parser));
     let term_reader = term.clone();
     let data_version = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
@@ -452,16 +484,39 @@ pub fn spawn_warm_pane(pty_system: &dyn portable_pty::PtySystem, app: &mut AppSt
     let cpr_writer = cpr_pending.clone();
     let color_query_pending = std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0));
     let cq_writer = color_query_pending.clone();
-    let reader = pair.master
-        .try_clone_reader()
-        .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("clone reader error: {e}")))?;
+    let reader = match pair.master.try_clone_reader() {
+        Ok(reader) => reader,
+        Err(error) => {
+            child.kill().ok();
+            return Err(io::Error::new(
+                io::ErrorKind::Other,
+                format!("clone reader error: {error}"),
+            ));
+        }
+    };
     let output_ring = std::sync::Arc::new(std::sync::Mutex::new(std::collections::VecDeque::<u8>::new()));
-    spawn_reader_thread(reader, term_reader, dv_writer, cs_writer, bell_writer, cpr_writer, cq_writer, output_ring.clone(), pane_id);
     let child_pid = crate::platform::mouse_inject::get_child_pid(&*child);
-    let mut pty_writer = pair.master.take_writer()
-        .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("take writer error: {e}")))?;
+    let mut pty_writer = match pair.master.take_writer() {
+        Ok(writer) => writer,
+        Err(error) => {
+            child.kill().ok();
+            return Err(io::Error::new(
+                io::ErrorKind::Other,
+                format!("take writer error: {error}"),
+            ));
+        }
+    };
+    spawn_reader_thread(reader, term_reader, dv_writer, cs_writer, bell_writer, cpr_writer, cq_writer, output_ring.clone(), pane_id);
     conpty_preemptive_dsr_response(&mut *pty_writer);
-    Ok(crate::types::WarmPane { master: pair.master, writer: pty_writer, child, term, data_version, cursor_shape, bell_pending, cpr_pending, color_query_pending, child_pid, pane_id, rows, cols, output_ring })
+    Ok(crate::types::WarmPane { master: pair.master, writer: pty_writer, child, term, data_version, cursor_shape, bell_pending, cpr_pending, color_query_pending, child_pid, pane_id, rows: size.rows, cols: size.cols, output_ring })
+}
+
+pub fn spawn_warm_pane(
+    pty_system: &dyn portable_pty::PtySystem,
+    app: &mut AppState,
+) -> io::Result<crate::types::WarmPane> {
+    let spec = prepare_warm_pane_spawn(app)?;
+    spawn_warm_pane_from_spec(pty_system, spec)
 }
 
 pub fn split_active(app: &mut AppState, kind: LayoutKind) -> io::Result<()> {

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -32,7 +32,6 @@ fn auth_debug(msg: &str) {
 use crate::commands::parse_command_line;
 use super::helpers::TMUX_COMMANDS;
 
-const CONTROL_WRITE_TIMEOUT: Duration = Duration::from_secs(5);
 
 #[derive(Debug, PartialEq)]
 enum ControlCommandResponse {
@@ -597,13 +596,18 @@ if control_echo || control_noecho {
             Err(_) => return,
         },
     };
-    let _ = write_stream.set_write_timeout(Some(CONTROL_WRITE_TIMEOUT));
+    // No write timeout here: a slow control reader must be buffered, not
+    // disconnected (tmux keeps an unbounded evbuffer per control client).
+    // Backpressure is handled by backlog accounting — %output frames are
+    // shed past a threshold while structural notifications always queue —
+    // and a dead peer surfaces as a hard write error via TCP reset.
     let _connection_guard = ControlConnectionGuard {
         client_id: ctrl_client_id,
         request_tx: tx.clone(),
     };
 
-    let (output_tx, output_rx) = std::sync::mpsc::sync_channel::<ControlOutput>(4096);
+    let (output_tx, output_rx) = std::sync::mpsc::channel::<ControlOutput>();
+    let output_backlog = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
 
     // For -CC (no-echo) mode, emit the DCS opening sequence "\033P1000p"
     // before anything else. Real tmux writes exactly 7 bytes with NO
@@ -638,10 +642,14 @@ if control_echo || control_noecho {
     }
 
     crate::types::register_persistent_stream(ctrl_client_id, &write_stream);
+    let writer_backlog = output_backlog.clone();
     std::thread::spawn(move || {
         let _writer_guard = writer_guard;
         while let Ok(output) = output_rx.recv() {
-            match write_control_output(&mut write_stream, output) {
+            let cost = crate::control::output_cost(&output);
+            let result = write_control_output(&mut write_stream, output);
+            writer_backlog.fetch_sub(cost, std::sync::atomic::Ordering::Relaxed);
+            match result {
                 Ok(false) => {}
                 Ok(true) | Err(_) => return,
             }
@@ -657,6 +665,7 @@ if control_echo || control_noecho {
         client_id: ctrl_client_id,
         echo: control_echo,
         output_tx: output_tx.clone(),
+        backlog: output_backlog.clone(),
     }).is_err() {
         return;
     }
@@ -728,7 +737,9 @@ if control_echo || control_noecho {
                 cmd_counter,
                 Some(Ok(ControlCommandResponse::empty())),
             );
-            if output_tx.send(ControlOutput::CommandBlock(block)).is_err() {
+            let block_output = ControlOutput::CommandBlock(block);
+            output_backlog.fetch_add(crate::control::output_cost(&block_output), std::sync::atomic::Ordering::Relaxed);
+            if output_tx.send(block_output).is_err() {
                 break;
             }
             continue;
@@ -853,7 +864,9 @@ if control_echo || control_noecho {
             cmd_counter,
             response_result,
         );
-        if output_tx.send(ControlOutput::CommandBlock(block)).is_err() {
+        let block_output = ControlOutput::CommandBlock(block);
+        output_backlog.fetch_add(crate::control::output_cost(&block_output), std::sync::atomic::Ordering::Relaxed);
+        if output_tx.send(block_output).is_err() {
             break;
         }
     }

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -4457,3 +4457,7 @@ mod tests_send_keys_literal_byte;
 #[cfg(test)]
 #[path = "../../tests-rs/test_control_mode_liveness.rs"]
 mod tests_control_mode_liveness;
+
+#[cfg(test)]
+#[path = "../../tests-rs/test_capture_pane_wait_bound.rs"]
+mod tests_capture_pane_wait_bound;

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -1162,22 +1162,34 @@ match cmd {
         } else {
             let _ = tx.send(CtrlReq::CapturePane(rtx));
         }
-        if let Ok(mut text) = rrx.recv() {
-            if join_lines {
-                // Remove trailing whitespace from each line (join wrapped lines)
-                text = text.lines().map(|l| l.trim_end()).collect::<Vec<_>>().join("\n");
-            }
-            if print_stdout {
-                // Write text directly — it already ends with \n from capture
-                if persistent {
-                    let _ = tx.send(CtrlReq::ShowTextPopup("capture-pane".to_string(), text));
-                } else {
-                    let _ = write_stream.write_all(text.as_bytes());
-                    let _ = write_stream.flush();
+        // Bounded wait, mirroring the control-mode capture path: if the server
+        // loop is wedged the client must fail with an error instead of
+        // blocking forever on the response channel.
+        match rrx.recv_timeout(Duration::from_secs(5)) {
+            Ok(mut text) => {
+                if join_lines {
+                    // Remove trailing whitespace from each line (join wrapped lines)
+                    text = text.lines().map(|l| l.trim_end()).collect::<Vec<_>>().join("\n");
                 }
-                if !persistent { break; }
-            } else {
-                let _ = tx.send(CtrlReq::SetBuffer(text));
+                if print_stdout {
+                    // Write text directly — it already ends with \n from capture
+                    if persistent {
+                        let _ = tx.send(CtrlReq::ShowTextPopup("capture-pane".to_string(), text));
+                    } else {
+                        let _ = write_stream.write_all(text.as_bytes());
+                        let _ = write_stream.flush();
+                    }
+                    if !persistent { break; }
+                } else {
+                    let _ = tx.send(CtrlReq::SetBuffer(text));
+                }
+            }
+            Err(_) => {
+                if !persistent {
+                    let _ = writeln!(write_stream, "ERROR: capture-pane timed out");
+                    let _ = write_stream.flush();
+                    break;
+                }
             }
         }
     }

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -3,7 +3,7 @@ use std::sync::mpsc;
 use std::time::Duration;
 use std::net::TcpStream;
 
-use crate::types::{CtrlReq, LayoutKind, WaitForOp, ControlNotification};
+use crate::types::{CtrlReq, LayoutKind, WaitForOp, ControlNotification, ControlOutput};
 use crate::cli::{parse_target, extract_flag_value};
 use crate::util::base64_decode;
 use crate::control;
@@ -31,6 +31,110 @@ fn auth_debug(msg: &str) {
 }
 use crate::commands::parse_command_line;
 use super::helpers::TMUX_COMMANDS;
+
+const CONTROL_WRITE_TIMEOUT: Duration = Duration::from_secs(5);
+
+#[derive(Debug, PartialEq)]
+enum ControlCommandResponse {
+    Success(String),
+    Error(String),
+}
+
+impl ControlCommandResponse {
+    fn empty() -> Self {
+        Self::Success(String::new())
+    }
+
+    fn success(body: impl Into<String>) -> Self {
+        Self::Success(body.into())
+    }
+
+    fn error(body: impl std::fmt::Display) -> Self {
+        Self::Error(body.to_string())
+    }
+}
+
+struct ControlConnectionGuard {
+    client_id: u64,
+    request_tx: mpsc::Sender<CtrlReq>,
+}
+
+impl Drop for ControlConnectionGuard {
+    fn drop(&mut self) {
+        // Deregistration drops the server's output sender. The writer then
+        // drains queued command blocks before it closes the shared socket.
+        let _ = self.request_tx.send(CtrlReq::ControlDeregister {
+            client_id: self.client_id,
+        });
+    }
+}
+
+struct ControlWriterGuard {
+    client_id: u64,
+    shutdown: TcpStream,
+}
+
+impl Drop for ControlWriterGuard {
+    fn drop(&mut self) {
+        crate::types::deregister_persistent_stream(self.client_id);
+        let _ = self.shutdown.shutdown(std::net::Shutdown::Both);
+    }
+}
+
+fn write_control_output(stream: &mut TcpStream, output: ControlOutput) -> io::Result<bool> {
+    let (text, exit) = match output {
+        ControlOutput::Notification(notification) => {
+            let exit = matches!(notification, ControlNotification::Exit { .. });
+            (format!("{}\n", control::format_notification(&notification)), exit)
+        }
+        ControlOutput::CommandBlock(block) => (block, false),
+    };
+    stream.write_all(text.as_bytes())?;
+    stream.flush()?;
+    Ok(exit)
+}
+
+fn format_control_command_block(
+    echo: bool,
+    command: &str,
+    timestamp: i64,
+    command_number: u64,
+    response: Option<Result<ControlCommandResponse, mpsc::RecvError>>,
+) -> String {
+    let mut block = String::new();
+    if echo {
+        block.push_str(command);
+        block.push('\n');
+    }
+    block.push_str(&control::format_begin(timestamp, command_number));
+    block.push('\n');
+    match response {
+        Some(Ok(response)) => {
+            let (is_error, body) = match response {
+                ControlCommandResponse::Success(body) => (false, body),
+                ControlCommandResponse::Error(body) => (true, body),
+            };
+            if !body.is_empty() {
+                block.push_str(&body);
+                if !body.ends_with('\n') {
+                    block.push('\n');
+                }
+            }
+            block.push_str(&if is_error {
+                control::format_error(timestamp, command_number)
+            } else {
+                control::format_end(timestamp, command_number)
+            });
+        }
+        Some(Err(_)) => {
+            block.push_str("command response unavailable\n");
+            block.push_str(&control::format_error(timestamp, command_number));
+        }
+        None => block.push_str(&control::format_end(timestamp, command_number)),
+    }
+    block.push('\n');
+    block
+}
 
 /// Split a command line on top-level `;` separators, respecting single and
 /// double quotes and `\` escapes. Real tmux's parser treats `;` as a command
@@ -486,36 +590,20 @@ if control_echo || control_noecho {
     let _ = r.get_ref().set_read_timeout(Some(Duration::from_millis(5000)));
 
     let ctrl_client_id = crate::types::next_client_id();
-    crate::types::register_persistent_stream(ctrl_client_id, &write_stream);
+    let writer_guard = ControlWriterGuard {
+        client_id: ctrl_client_id,
+        shutdown: match write_stream.try_clone() {
+            Ok(stream) => stream,
+            Err(_) => return,
+        },
+    };
+    let _ = write_stream.set_write_timeout(Some(CONTROL_WRITE_TIMEOUT));
+    let _connection_guard = ControlConnectionGuard {
+        client_id: ctrl_client_id,
+        request_tx: tx.clone(),
+    };
 
-    let (notif_tx, notif_rx) = std::sync::mpsc::sync_channel::<ControlNotification>(4096);
-
-    // Wrap the write stream in a mutex so that the notification writer
-    // thread and the command-response loop never interleave bytes on
-    // the TCP socket.  Real tmux is single-threaded, so it never has
-    // this problem; we need explicit synchronization.
-    let write_lock = std::sync::Arc::new(std::sync::Mutex::new(write_stream));
-
-    // Spawn notification writer thread BEFORE writing DCS or registering,
-    // so it is ready to drain notifications as soon as they arrive.
-    let ws_notif = write_lock.clone();
-    let notif_thread = std::thread::spawn(move || {
-        while let Ok(notif) = notif_rx.recv() {
-            let is_exit = matches!(notif, ControlNotification::Exit { .. });
-            let formatted = control::format_notification(&notif);
-            let mut ws = match ws_notif.lock() {
-                Ok(ws) => ws,
-                Err(_) => break,
-            };
-            if writeln!(ws, "{}", formatted).is_err() { break; }
-            if ws.flush().is_err() { break; }
-            // Exit notification written — now signal the client to exit.
-            // Writing %exit through the DCS stream (before TCP close) lets
-            // iTerm2 receive it as a DCS message and close native windows
-            // immediately.  Then we break so the server can close the TCP.
-            if is_exit { break; }
-        }
-    });
+    let (output_tx, output_rx) = std::sync::mpsc::sync_channel::<ControlOutput>(4096);
 
     // For -CC (no-echo) mode, emit the DCS opening sequence "\033P1000p"
     // before anything else. Real tmux writes exactly 7 bytes with NO
@@ -534,31 +622,44 @@ if control_echo || control_noecho {
     //   - flag=0 (server-originated) creates a synthetic currentCommand_
     //     and the matching %end fires tmuxInitialCommandDidCompleteSuccessfully
     //     which kicks off iTerm's tmux integration (phony-command, ping, etc.).
-    {
-        let mut ws = write_lock.lock().unwrap();
+    let init_result = (|| -> io::Result<()> {
         if control_noecho {
             let init_ts = chrono::Utc::now().timestamp();
-            // DCS opener (no newline) immediately followed by %begin
-            let _ = ws.write_all(b"\x1bP1000p");
-            let _ = writeln!(ws, "%begin {} 1 0", init_ts);
-            let _ = writeln!(ws, "%end {} 1 0", init_ts);
+            write_stream.write_all(b"\x1bP1000p")?;
+            writeln!(write_stream, "%begin {} 1 0", init_ts)?;
+            writeln!(write_stream, "%end {} 1 0", init_ts)?;
         } else {
-            // -C (echo) mode: no DCS, just a blank ready line
-            let _ = writeln!(ws);
+            writeln!(write_stream)?;
         }
-        let _ = ws.flush();
+        write_stream.flush()
+    })();
+    if init_result.is_err() {
+        return;
     }
+
+    crate::types::register_persistent_stream(ctrl_client_id, &write_stream);
+    std::thread::spawn(move || {
+        let _writer_guard = writer_guard;
+        while let Ok(output) = output_rx.recv() {
+            match write_control_output(&mut write_stream, output) {
+                Ok(false) => {}
+                Ok(true) | Err(_) => return,
+            }
+        }
+    });
 
     // NOW register with the server. This triggers emit_initial_state()
     // which sends %session-changed and other notifications through the
     // notification channel. Because we flushed the DCS + %begin/%end
     // above, those bytes are already in the kernel send buffer and will
     // arrive at the client before any notifications.
-    let _ = tx.send(CtrlReq::ControlRegister {
+    if tx.send(CtrlReq::ControlRegister {
         client_id: ctrl_client_id,
         echo: control_echo,
-        notif_tx: notif_tx,
-    });
+        output_tx: output_tx.clone(),
+    }).is_err() {
+        return;
+    }
 
     // Control mode command loop: read lines, dispatch, wrap in %begin/%end/%error
     let mut cmd_counter: u64 = 0;
@@ -614,18 +715,22 @@ if control_echo || control_noecho {
         cmd_counter += 1;
         let ts = chrono::Utc::now().timestamp();
 
-        // Dispatch the command (before acquiring write lock)
+        // Dispatch the command before handing its completed block to the
+        // single control writer.
         let parsed = crate::cli::normalize_flag_equals(parse_command_line(trimmed));
         let raw_cmd = parsed.first().map(|s| s.as_str()).unwrap_or("");
 
         if raw_cmd.is_empty() {
-            let mut ws = write_lock.lock().unwrap();
-            if control_echo {
-                let _ = writeln!(ws, "{}", trimmed);
+            let block = format_control_command_block(
+                control_echo,
+                trimmed,
+                ts,
+                cmd_counter,
+                Some(Ok(ControlCommandResponse::empty())),
+            );
+            if output_tx.send(ControlOutput::CommandBlock(block)).is_err() {
+                break;
             }
-            let _ = writeln!(ws, "{}", control::format_begin(ts, cmd_counter));
-            let _ = writeln!(ws, "{}", control::format_end(ts, cmd_counter));
-            let _ = ws.flush();
             continue;
         }
 
@@ -726,76 +831,33 @@ if control_echo || control_noecho {
         }
 
         // Dispatch command (use a oneshot for the response)
-        let (resp_s, resp_r) = mpsc::channel::<String>();
+        let (resp_s, resp_r) = mpsc::channel::<ControlCommandResponse>();
         let dispatched = dispatch_control_command(
             cmd_name, &filtered_args, &tx_ctrl, resp_s,
             ctrl_target_pane, ctrl_pane_is_id, ctrl_raw_target.as_deref(),
             ctrl_client_id,
         );
 
-        // Collect the response BEFORE acquiring the write lock, so the
-        // notification thread can still write while we wait.
+        // The dispatcher runs synchronously and each handled command must
+        // complete its oneshot exactly once. The writer remains independent,
+        // so waiting here never blocks control-socket output.
         let response_result = if dispatched {
-            Some(resp_r.recv_timeout(Duration::from_secs(5)))
+            Some(resp_r.recv())
         } else {
             None
         };
-
-        // Acquire write lock for the ENTIRE %begin … %end sequence so
-        // notifications from the notification thread never interleave
-        // with command responses.  This matches real tmux's single-
-        // threaded behaviour where command output and notifications are
-        // serialized on one bufferevent.
-        let mut ws = write_lock.lock().unwrap();
-
-        // Echo the command if -C mode
-        if control_echo {
-            let _ = writeln!(ws, "{}", trimmed);
+        let block = format_control_command_block(
+            control_echo,
+            trimmed,
+            ts,
+            cmd_counter,
+            response_result,
+        );
+        if output_tx.send(ControlOutput::CommandBlock(block)).is_err() {
+            break;
         }
-
-        // Send %begin
-        let _ = writeln!(ws, "{}", control::format_begin(ts, cmd_counter));
-
-        match response_result {
-            Some(Ok(response)) => {
-                // Sentinel-encoded error: dispatcher signals %error
-                // instead of %end by prefixing with \u{0001}ERR\u{0001}.
-                let (is_error, body) = if let Some(stripped) = response.strip_prefix("\u{0001}ERR\u{0001}") {
-                    (true, stripped.to_string())
-                } else {
-                    (false, response)
-                };
-                if !body.is_empty() {
-                    let _ = write!(ws, "{}", body);
-                    if !body.ends_with('\n') {
-                        let _ = writeln!(ws);
-                    }
-                }
-                let footer = if is_error {
-                    control::format_error(ts, cmd_counter)
-                } else {
-                    control::format_end(ts, cmd_counter)
-                };
-                let _ = writeln!(ws, "{}", footer);
-            }
-            Some(Err(_)) => {
-                let _ = writeln!(ws, "command timed out");
-                let _ = writeln!(ws, "{}", control::format_error(ts, cmd_counter));
-            }
-            None => {
-                // Command dispatched without response channel (fire and forget)
-                let _ = writeln!(ws, "{}", control::format_end(ts, cmd_counter));
-            }
-        }
-        let _ = ws.flush();
-        drop(ws);
     }
 
-    // Deregister and clean up.
-    // The CLIENT emits %exit + ST to stdout (matching real tmux's
-    // client.c), so the server does not need to write ST here.
-    let _ = tx.send(CtrlReq::ControlDeregister { client_id: ctrl_client_id });
-    drop(notif_thread);
     return;
 }
 
@@ -3355,13 +3417,40 @@ match cmd {
 } // end command loop
 }
 
+fn recv_control_response<T>(
+    command: &str,
+    receiver: mpsc::Receiver<T>,
+    timeout: Duration,
+) -> Result<T, String> {
+    receiver.recv_timeout(timeout).map_err(|error| match error {
+        mpsc::RecvTimeoutError::Timeout => format!("{} timed out", command),
+        mpsc::RecvTimeoutError::Disconnected => {
+            format!("{} response channel disconnected", command)
+        }
+    })
+}
+
+fn forward_control_response(
+    command: &str,
+    receiver: mpsc::Receiver<String>,
+    response_tx: &mpsc::Sender<ControlCommandResponse>,
+    timeout: Duration,
+) {
+    let response = match recv_control_response(command, receiver, timeout) {
+        Ok(body) => ControlCommandResponse::success(body),
+        Err(error) => ControlCommandResponse::error(error),
+    };
+    let _ = response_tx.send(response);
+}
+
 /// Dispatch a command from a control mode client.
-/// Returns true if a response was sent through `resp_tx`, false for fire-and-forget commands.
+/// Returns true when the caller must wait for exactly one response through
+/// `resp_tx`, or false for a fire-and-forget command.
 fn dispatch_control_command(
     cmd: &str,
     args: &[&str],
     tx: &mpsc::Sender<CtrlReq>,
-    resp_tx: mpsc::Sender<String>,
+    resp_tx: mpsc::Sender<ControlCommandResponse>,
     target_pane: Option<usize>,
     pane_is_id: bool,
     raw_target: Option<&str>,
@@ -3376,9 +3465,7 @@ fn dispatch_control_command(
             } else {
                 let _ = tx.send(CtrlReq::ListWindowsTmux(rtx));
             }
-            if let Ok(text) = rrx.recv_timeout(Duration::from_secs(5)) {
-                let _ = resp_tx.send(text);
-            }
+            forward_control_response(cmd, rrx, &resp_tx, Duration::from_secs(5));
             true
         }
         "list-panes" | "lsp" => {
@@ -3399,9 +3486,7 @@ fn dispatch_control_command(
                     let _ = tx.send(CtrlReq::ListPanes(rtx));
                 }
             }
-            if let Ok(text) = rrx.recv_timeout(Duration::from_secs(5)) {
-                let _ = resp_tx.send(text);
-            }
+            forward_control_response(cmd, rrx, &resp_tx, Duration::from_secs(5));
             true
         }
         "display-message" | "display" => {
@@ -3423,9 +3508,7 @@ fn dispatch_control_command(
             } else {
                 let _ = tx.send(CtrlReq::DisplayMessage(rtx, fmt, target_pane_idx, !print_mode, None));
             }
-            if let Ok(text) = rrx.recv_timeout(Duration::from_secs(5)) {
-                let _ = resp_tx.send(text);
-            }
+            forward_control_response(cmd, rrx, &resp_tx, Duration::from_secs(5));
             true
         }
         "new-pane" | "newp" => {
@@ -3433,7 +3516,7 @@ fn dispatch_control_command(
             if p.print {
                 let (rtx, rrx) = mpsc::channel::<String>();
                 let _ = tx.send(CtrlReq::NewFloat { command: p.command, x: p.x, y: p.y, w: p.w, h: p.h, border: p.border, title: p.title, start_dir: p.start_dir, detached: p.detached, empty: p.empty, resp: Some(rtx) });
-                if let Ok(text) = rrx.recv_timeout(Duration::from_secs(2)) { let _ = resp_tx.send(text); }
+                forward_control_response(cmd, rrx, &resp_tx, Duration::from_secs(2));
                 true
             } else {
                 let _ = tx.send(CtrlReq::NewFloat { command: p.command, x: p.x, y: p.y, w: p.w, h: p.h, border: p.border, title: p.title, start_dir: p.start_dir, detached: p.detached, empty: p.empty, resp: None });
@@ -3477,13 +3560,11 @@ fn dispatch_control_command(
             if print_info {
                 let (rtx, rrx) = mpsc::channel::<String>();
                 let _ = tx.send(CtrlReq::NewWindowPrint(cmd_str, name, detached, start_dir, format_str, rtx, title, empty, env_sets));
-                if let Ok(text) = rrx.recv_timeout(Duration::from_secs(5)) {
-                    let _ = resp_tx.send(text);
-                }
+                forward_control_response(cmd, rrx, &resp_tx, Duration::from_secs(5));
                 true
             } else {
                 let _ = tx.send(CtrlReq::NewWindow(cmd_str, name, detached, start_dir, title, empty, env_sets));
-                let _ = resp_tx.send(String::new());
+                let _ = resp_tx.send(ControlCommandResponse::empty());
                 true
             }
         }
@@ -3520,9 +3601,7 @@ fn dispatch_control_command(
             } else {
                 let _ = tx.send(CtrlReq::SplitWindow(kind, cmd_str, detached, start_dir, split_size, rtx, title, env_sets));
             }
-            if let Ok(text) = rrx.recv_timeout(Duration::from_secs(5)) {
-                let _ = resp_tx.send(text);
-            }
+            forward_control_response(cmd, rrx, &resp_tx, Duration::from_secs(5));
             true
         }
         "send-keys" | "send" => {
@@ -3558,6 +3637,7 @@ fn dispatch_control_command(
                 if !bytes.is_empty() {
                     let _ = tx.send(CtrlReq::SendBytes(bytes));
                 }
+                let _ = resp_tx.send(ControlCommandResponse::empty());
                 return true;
             }
             // Convert real-tmux 0xNN hex codepoint syntax (used by iTerm2 for
@@ -3588,7 +3668,7 @@ fn dispatch_control_command(
             // #490: hand the tokens over UNJOINED so quoted arguments keep
             // their exact whitespace end to end.
             let _ = tx.send(CtrlReq::SendKeys(keys, effective_literal));
-            let _ = resp_tx.send(String::new());
+            let _ = resp_tx.send(ControlCommandResponse::empty());
             true
         }
         "capture-pane" | "capturep" => {
@@ -3603,9 +3683,7 @@ fn dispatch_control_command(
             } else {
                 let _ = tx.send(CtrlReq::CapturePane(rtx));
             }
-            if let Ok(text) = rrx.recv_timeout(Duration::from_secs(5)) {
-                let _ = resp_tx.send(text);
-            }
+            forward_control_response(cmd, rrx, &resp_tx, Duration::from_secs(5));
             true
         }
         "kill-pane" | "killp" => {
@@ -3616,7 +3694,7 @@ fn dispatch_control_command(
             } else {
                 let _ = tx.send(CtrlReq::KillPane);
             }
-            let _ = resp_tx.send(String::new());
+            let _ = resp_tx.send(ControlCommandResponse::empty());
             true
         }
         "kill-window" | "killw" => {
@@ -3636,23 +3714,23 @@ fn dispatch_control_command(
                     resp: resp_s,
                 });
                 match resp_r.recv_timeout(Duration::from_secs(5)) {
-                    Ok(Err(e)) => { let _ = resp_tx.send(format!("\u{0001}ERR\u{0001}{}", e)); }
-                    _ => { let _ = resp_tx.send(String::new()); }
+                    Ok(Err(e)) => { let _ = resp_tx.send(ControlCommandResponse::error(e)); }
+                    _ => { let _ = resp_tx.send(ControlCommandResponse::empty()); }
                 }
             } else {
                 let _ = tx.send(CtrlReq::KillWindow);
-                let _ = resp_tx.send(String::new());
+                let _ = resp_tx.send(ControlCommandResponse::empty());
             }
             true
         }
         "unlink-window" | "unlinkw" => {
             let _ = tx.send(CtrlReq::UnlinkWindow);
-            let _ = resp_tx.send(String::new());
+            let _ = resp_tx.send(ControlCommandResponse::empty());
             true
         }
         "select-window" | "selectw" => {
             // Already handled by target focus above
-            let _ = resp_tx.send(String::new());
+            let _ = resp_tx.send(ControlCommandResponse::empty());
             true
         }
         "select-pane" | "selectp" => {
@@ -3660,21 +3738,21 @@ fn dispatch_control_command(
             if let Some(t) = args.windows(2).find(|w| w[0] == "-T").map(|w| w[1].trim_matches('"').to_string()) {
                 let _ = tx.send(CtrlReq::SetPaneTitle(t));
             }
-            let _ = resp_tx.send(String::new());
+            let _ = resp_tx.send(ControlCommandResponse::empty());
             true
         }
         "rename-window" | "renamew" => {
             if let Some(name) = args.last() {
                 let _ = tx.send(CtrlReq::RenameWindow(name.trim_matches('"').to_string()));
             }
-            let _ = resp_tx.send(String::new());
+            let _ = resp_tx.send(ControlCommandResponse::empty());
             true
         }
         "rename-session" | "rename" => {
             if let Some(name) = args.last() {
                 let _ = tx.send(CtrlReq::RenameSession(name.trim_matches('"').to_string()));
             }
-            let _ = resp_tx.send(String::new());
+            let _ = resp_tx.send(ControlCommandResponse::empty());
             true
         }
         "set-option" | "set" | "set-window-option" | "setw" => {
@@ -3726,7 +3804,7 @@ fn dispatch_control_command(
                     let _ = tx.send(CtrlReq::SetOptionToggle(positional[0].to_string()));
                 }
             }
-            let _ = resp_tx.send(String::new());
+            let _ = resp_tx.send(ControlCommandResponse::empty());
             true
         }
         "show-options" | "show" | "show-window-options" | "showw"
@@ -3768,8 +3846,8 @@ fn dispatch_control_command(
             } else {
                 let _ = tx.send(CtrlReq::ShowOptions(rtx));
             }
-            if let Ok(text) = rrx.recv_timeout(Duration::from_secs(5)) {
-                if value_only && !has_opt_name {
+            match recv_control_response(cmd, rrx, Duration::from_secs(5)) {
+                Ok(text) if value_only && !has_opt_name => {
                     // Strip option names, keep values only
                     let values_only: String = text.lines()
                         .filter_map(|line| {
@@ -3779,9 +3857,13 @@ fn dispatch_control_command(
                         })
                         .collect::<Vec<_>>()
                         .join("\n");
-                    let _ = resp_tx.send(values_only);
-                } else {
-                    let _ = resp_tx.send(text);
+                    let _ = resp_tx.send(ControlCommandResponse::success(values_only));
+                }
+                Ok(text) => {
+                    let _ = resp_tx.send(ControlCommandResponse::success(text));
+                }
+                Err(error) => {
+                    let _ = resp_tx.send(ControlCommandResponse::error(error));
                 }
             }
             true
@@ -3789,9 +3871,7 @@ fn dispatch_control_command(
         "list-keys" | "lsk" => {
             let (rtx, rrx) = mpsc::channel::<String>();
             let _ = tx.send(CtrlReq::ListKeys(rtx));
-            if let Ok(text) = rrx.recv_timeout(Duration::from_secs(5)) {
-                let _ = resp_tx.send(text);
-            }
+            forward_control_response(cmd, rrx, &resp_tx, Duration::from_secs(5));
             true
         }
         "list-sessions" | "ls" => {
@@ -3802,9 +3882,7 @@ fn dispatch_control_command(
             } else {
                 let _ = tx.send(CtrlReq::SessionInfo(rtx));
             }
-            if let Ok(text) = rrx.recv_timeout(Duration::from_secs(5)) {
-                let _ = resp_tx.send(text);
-            }
+            forward_control_response(cmd, rrx, &resp_tx, Duration::from_secs(5));
             true
         }
         "list-buffers" | "lsb" => {
@@ -3815,37 +3893,46 @@ fn dispatch_control_command(
             } else {
                 let _ = tx.send(CtrlReq::ListBuffers(rtx));
             }
-            if let Ok(text) = rrx.recv_timeout(Duration::from_secs(5)) {
-                let _ = resp_tx.send(text);
-            }
+            forward_control_response(cmd, rrx, &resp_tx, Duration::from_secs(5));
             true
         }
         "show-buffer" | "showb" => {
             let buf_name: Option<String> = args.windows(2).find(|w| w[0] == "-b").map(|w| w[1].to_string());
-            let text: Option<String> = if let Some(name) = buf_name {
+            let text = if let Some(name) = buf_name {
                 let (rtx, rrx) = mpsc::channel::<Option<String>>();
                 if let Ok(idx) = name.parse::<usize>() {
                     let _ = tx.send(CtrlReq::ShowBufferAt(rtx, idx));
                 } else {
                     let _ = tx.send(CtrlReq::ShowNamedBuffer(rtx, name));
                 }
-                rrx.recv_timeout(Duration::from_secs(5)).ok().flatten()
+                recv_control_response(cmd, rrx, Duration::from_secs(5))
+                    .and_then(|text| text.ok_or_else(|| "buffer not found".to_string()))
             } else {
                 let (rtx, rrx) = mpsc::channel::<String>();
                 let _ = tx.send(CtrlReq::ShowBuffer(rtx));
-                rrx.recv_timeout(Duration::from_secs(5)).ok()
+                recv_control_response(cmd, rrx, Duration::from_secs(5))
             };
-            if let Some(text) = text {
-                let _ = resp_tx.send(text);
-            }
+            let response = match text {
+                Ok(body) => ControlCommandResponse::success(body),
+                Err(error) => ControlCommandResponse::error(error),
+            };
+            let _ = resp_tx.send(response);
             true
         }
         "has-session" | "has" => {
             let (rtx, rrx) = mpsc::channel::<bool>();
             let _ = tx.send(CtrlReq::HasSession(rtx));
-            if let Ok(exists) = rrx.recv_timeout(Duration::from_secs(5)) {
-                let _ = resp_tx.send(if exists { String::new() } else { "session not found".to_string() });
-            }
+            let response = recv_control_response(cmd, rrx, Duration::from_secs(5))
+                .and_then(|exists| {
+                    if exists {
+                        Ok(String::new())
+                    } else {
+                        Err("session not found".to_string())
+                    }
+                })
+                .map(ControlCommandResponse::success)
+                .unwrap_or_else(ControlCommandResponse::error);
+            let _ = resp_tx.send(response);
             true
         }
         "list-clients" | "lsc" => {
@@ -3856,9 +3943,7 @@ fn dispatch_control_command(
             } else {
                 let _ = tx.send(CtrlReq::ListClients(rtx));
             }
-            if let Ok(text) = rrx.recv_timeout(Duration::from_secs(5)) {
-                let _ = resp_tx.send(text);
-            }
+            forward_control_response(cmd, rrx, &resp_tx, Duration::from_secs(5));
             true
         }
         "detach-client" | "detach" => {
@@ -3887,29 +3972,29 @@ fn dispatch_control_command(
                 // No flags from CLI: detach all clients of this session.
                 let _ = tx.send(CtrlReq::DetachAllClients(kill_parent));
             }
-            let _ = resp_tx.send(String::new());
+            let _ = resp_tx.send(ControlCommandResponse::empty());
             true
         }
         "kill-session" => {
             let _ = tx.send(CtrlReq::KillSession);
-            let _ = resp_tx.send(String::new());
+            let _ = resp_tx.send(ControlCommandResponse::empty());
             true
         }
         "kill-server" => {
             let _ = tx.send(CtrlReq::KillServer);
-            let _ = resp_tx.send(String::new());
+            let _ = resp_tx.send(ControlCommandResponse::empty());
             true
         }
         "select-layout" | "selectl" => {
             if let Some(layout) = args.first() {
                 let _ = tx.send(CtrlReq::SelectLayout(layout.to_string()));
             }
-            let _ = resp_tx.send(String::new());
+            let _ = resp_tx.send(ControlCommandResponse::empty());
             true
         }
         "next-layout" | "nextl" => {
             let _ = tx.send(CtrlReq::NextLayout);
-            let _ = resp_tx.send(String::new());
+            let _ = resp_tx.send(ControlCommandResponse::empty());
             true
         }
         "resize-pane" | "resizep" => {
@@ -3937,7 +4022,7 @@ fn dispatch_control_command(
                     else { "D" };
                 let _ = tx.send(CtrlReq::ResizePane(dir.to_string(), amount));
             }
-            let _ = resp_tx.send(String::new());
+            let _ = resp_tx.send(ControlCommandResponse::empty());
             true
         }
         "swap-pane" | "swapp" => {
@@ -3972,7 +4057,7 @@ fn dispatch_control_command(
                     let _ = tx.send(CtrlReq::SwapPane(direction));
                 }
             }
-            let _ = resp_tx.send(String::new());
+            let _ = resp_tx.send(ControlCommandResponse::empty());
             true
         }
         "bind-key" | "bind" => {
@@ -3997,7 +4082,7 @@ fn dispatch_control_command(
                 let command = requote_command_tail(&args[i + 1..]);
                 let _ = tx.send(CtrlReq::BindKey(table_name, key, command, repeat));
             }
-            let _ = resp_tx.send(String::new());
+            let _ = resp_tx.send(ControlCommandResponse::empty());
             true
         }
         "unbind-key" | "unbind" => {
@@ -4039,14 +4124,14 @@ fn dispatch_control_command(
                     let _ = tx.send(CtrlReq::UnbindKey(key.to_string(), table));
                 }
             }
-            let _ = resp_tx.send(String::new());
+            let _ = resp_tx.send(ControlCommandResponse::empty());
             true
         }
         "source-file" | "source" => {
             if let Some(path) = args.first() {
                 let _ = tx.send(CtrlReq::SourceFile(path.trim_matches('"').to_string()));
             }
-            let _ = resp_tx.send(String::new());
+            let _ = resp_tx.send(ControlCommandResponse::empty());
             true
         }
         "set-environment" | "setenv" => {
@@ -4060,15 +4145,13 @@ fn dispatch_control_command(
             } else if positional.len() >= 2 {
                 let _ = tx.send(CtrlReq::SetEnvironment(positional[0].to_string(), positional[1].to_string()));
             }
-            let _ = resp_tx.send(String::new());
+            let _ = resp_tx.send(ControlCommandResponse::empty());
             true
         }
         "show-environment" | "showenv" => {
             let (rtx, rrx) = mpsc::channel::<String>();
             let _ = tx.send(CtrlReq::ShowEnvironment(rtx));
-            if let Ok(text) = rrx.recv_timeout(Duration::from_secs(5)) {
-                let _ = resp_tx.send(text);
-            }
+            forward_control_response(cmd, rrx, &resp_tx, Duration::from_secs(5));
             true
         }
         "set-hook" => {
@@ -4089,75 +4172,67 @@ fn dispatch_control_command(
                     let _ = tx.send(CtrlReq::SetHook(name, command));
                 }
             }
-            let _ = resp_tx.send(String::new());
+            let _ = resp_tx.send(ControlCommandResponse::empty());
             true
         }
         "show-hooks" => {
             let (rtx, rrx) = mpsc::channel::<String>();
             let _ = tx.send(CtrlReq::ShowHooks(rtx));
-            if let Ok(text) = rrx.recv_timeout(Duration::from_secs(5)) {
-                let _ = resp_tx.send(text);
-            }
+            forward_control_response(cmd, rrx, &resp_tx, Duration::from_secs(5));
             true
         }
         "server-info" | "info" => {
             let (rtx, rrx) = mpsc::channel::<String>();
             let _ = tx.send(CtrlReq::ServerInfo(rtx));
-            if let Ok(text) = rrx.recv_timeout(Duration::from_secs(5)) {
-                let _ = resp_tx.send(text);
-            }
+            forward_control_response(cmd, rrx, &resp_tx, Duration::from_secs(5));
             true
         }
         "list-commands" | "lscm" => {
             let (rtx, rrx) = mpsc::channel::<String>();
             let _ = tx.send(CtrlReq::ListCommands(rtx));
-            if let Ok(text) = rrx.recv_timeout(Duration::from_secs(5)) {
-                let _ = resp_tx.send(text);
-            }
+            forward_control_response(cmd, rrx, &resp_tx, Duration::from_secs(5));
             true
         }
         "dump-state" | "dump" => {
             let (rtx, rrx) = mpsc::channel::<String>();
             let _ = tx.send(CtrlReq::DumpState(rtx, false, client_id));
-            if let Ok(text) = rrx.recv_timeout(Duration::from_secs(5)) {
-                let _ = resp_tx.send(text);
-            }
+            forward_control_response(cmd, rrx, &resp_tx, Duration::from_secs(5));
             true
         }
         "zoom-pane" | "resizep -Z" => {
             let _ = tx.send(CtrlReq::ZoomPane);
-            let _ = resp_tx.send(String::new());
+            let _ = resp_tx.send(ControlCommandResponse::empty());
             true
         }
         "last-window" | "last" => {
             let _ = tx.send(CtrlReq::LastWindow);
-            let _ = resp_tx.send(String::new());
+            let _ = resp_tx.send(ControlCommandResponse::empty());
             true
         }
         "last-pane" | "lastp" => {
             let _ = tx.send(CtrlReq::LastPane);
-            let _ = resp_tx.send(String::new());
+            let _ = resp_tx.send(ControlCommandResponse::empty());
             true
         }
         "next-window" | "next" => {
             let _ = tx.send(CtrlReq::NextWindow);
-            let _ = resp_tx.send(String::new());
+            let _ = resp_tx.send(ControlCommandResponse::empty());
             true
         }
         "previous-window" | "prev" => {
             let _ = tx.send(CtrlReq::PrevWindow);
-            let _ = resp_tx.send(String::new());
+            let _ = resp_tx.send(ControlCommandResponse::empty());
             true
         }
         "rotate-window" | "rotatew" => {
             let upward = args.iter().any(|a| *a == "-U");
             let _ = tx.send(CtrlReq::RotateWindow(upward));
-            let _ = resp_tx.send(String::new());
+            let _ = resp_tx.send(ControlCommandResponse::empty());
             true
         }
         "break-pane" | "breakp" => {
             let _ = tx.send(CtrlReq::BreakPane);
-            let _ = resp_tx.send(String::new());
+            let _ = resp_tx.send(ControlCommandResponse::empty());
             true
         }
         "respawn-pane" | "respawnp" => {
@@ -4170,7 +4245,7 @@ fn dispatch_control_command(
                 .map(|s| s.trim().to_string())
                 .filter(|s| !s.is_empty());
             let _ = tx.send(CtrlReq::RespawnPane(workdir, kill, command, empty));
-            let _ = resp_tx.send(String::new());
+            let _ = resp_tx.send(ControlCommandResponse::empty());
             true
         }
         "wait-for" | "wait" => {
@@ -4181,7 +4256,7 @@ fn dispatch_control_command(
             if let Some(channel) = args.iter().find(|a| !a.starts_with('-')) {
                 let _ = tx.send(CtrlReq::WaitFor(channel.to_string(), op));
             }
-            let _ = resp_tx.send(String::new());
+            let _ = resp_tx.send(ControlCommandResponse::empty());
             true
         }
         "refresh-client" | "refresh" => {
@@ -4272,12 +4347,14 @@ fn dispatch_control_command(
                                 });
                             }
                             Err(error) => {
-                                let _ = resp_tx.send(format!("\u{0001}ERR\u{0001}{}", error));
+                                let _ = resp_tx.send(ControlCommandResponse::error(error));
                                 return true;
                             }
                         },
                         None => {
-                            let _ = resp_tx.send("\u{0001}ERR\u{0001}missing size argument".to_string());
+                            let _ = resp_tx.send(ControlCommandResponse::error(
+                                "missing size argument",
+                            ));
                             return true;
                         }
                     }
@@ -4286,32 +4363,28 @@ fn dispatch_control_command(
                 }
                 i += 1;
             }
-            let _ = resp_tx.send(String::new());
+            let _ = resp_tx.send(ControlCommandResponse::empty());
             true
         }
         "run-command" | "runcmd" => {
             let full_cmd = args.join(" ");
             let (rtx, rrx) = mpsc::channel::<String>();
             let _ = tx.send(CtrlReq::RunCommand(full_cmd, rtx));
-            if let Ok(resp) = rrx.recv_timeout(Duration::from_secs(15)) {
-                let _ = resp_tx.send(resp);
-            } else {
-                let _ = resp_tx.send("timeout".to_string());
-            }
+            forward_control_response(cmd, rrx, &resp_tx, Duration::from_secs(15));
             true
         }
         // iTerm2 sends "phony-command" as a tmux ping/keepalive on entering
         // gateway mode (see iTerm2 TmuxController.m kickOffTmuxForRestoration).
         // Real tmux returns success with no output; we mimic that.
         "phony-command" => {
-            let _ = resp_tx.send(String::new());
+            let _ = resp_tx.send(ControlCommandResponse::empty());
             true
         }
         // Copy mode in tmux control sessions is a no-op for iTerm2 — iTerm
         // implements its own copy mode locally on captured pane content.
         // Returning success keeps iTerm's command pipeline alive.
         "copy-mode" => {
-            let _ = resp_tx.send(String::new());
+            let _ = resp_tx.send(ControlCommandResponse::empty());
             true
         }
         "resize-window" | "resizew" => {
@@ -4330,19 +4403,19 @@ fn dispatch_control_command(
             };
             match response {
                 Ok(()) => {
-                    let _ = resp_tx.send(String::new());
+                    let _ = resp_tx.send(ControlCommandResponse::empty());
                 }
                 Err(error) => {
-                    let _ = resp_tx.send(format!("\u{0001}ERR\u{0001}{}", error));
+                    let _ = resp_tx.send(ControlCommandResponse::error(error));
                 }
             }
             true
         }
         _ => {
-            // Unknown command — emit %error like tmux does, not %end.
-            // The leading "\u{0001}ERR\u{0001}" sentinel tells the dispatch
-            // wrapper to use format_error instead of format_end.
-            let _ = resp_tx.send(format!("\u{0001}ERR\u{0001}unknown command: {}", cmd));
+            let _ = resp_tx.send(ControlCommandResponse::error(format!(
+                "unknown command: {}",
+                cmd
+            )));
             true
         }
     }
@@ -4355,3 +4428,7 @@ mod tests_issue476_bindkey_quoting;
 #[cfg(test)]
 #[path = "../../tests-rs/test_send_keys_literal_byte.rs"]
 mod tests_send_keys_literal_byte;
+
+#[cfg(test)]
+#[path = "../../tests-rs/test_control_mode_liveness.rs"]
+mod tests_control_mode_liveness;

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1262,25 +1262,30 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                                 );
                                 continue;
                             }
-                            // Send as extended-output with age
+                            // Send as extended-output with age. Chunked so a
+                            // large drain never becomes one oversized line.
                             let age_ms = age.as_millis() as u64;
-                            crate::control::try_send_notification(
-                                client,
-                                crate::types::ControlNotification::ExtendedOutput {
-                                    pane_id: *pane_id,
-                                    age_ms,
-                                    data: data.clone(),
-                                },
-                            );
+                            for chunk in crate::control::chunk_output(data) {
+                                crate::control::try_send_notification(
+                                    client,
+                                    crate::types::ControlNotification::ExtendedOutput {
+                                        pane_id: *pane_id,
+                                        age_ms,
+                                        data: chunk.to_string(),
+                                    },
+                                );
+                            }
                         } else {
-                            // No pause-after: send normal %output
-                            crate::control::try_send_notification(
-                                client,
-                                crate::types::ControlNotification::Output {
-                                    pane_id: *pane_id,
-                                    data: data.clone(),
-                                },
-                            );
+                            // No pause-after: send normal %output, chunked
+                            for chunk in crate::control::chunk_output(data) {
+                                crate::control::try_send_notification(
+                                    client,
+                                    crate::types::ControlNotification::Output {
+                                        pane_id: *pane_id,
+                                        data: chunk.to_string(),
+                                    },
+                                );
+                            }
                         }
                     }
                 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -5429,12 +5429,13 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                         state_dirty = true;
                     }
                 }
-                CtrlReq::ControlRegister { client_id, echo, output_tx } => {
+                CtrlReq::ControlRegister { client_id, echo, output_tx, backlog } => {
                     app.control_clients.insert(client_id, crate::types::ControlClient {
                         client_id,
                         cmd_counter: 0,
                         echo_enabled: echo,
                         output_tx,
+                        backlog,
                         paused_panes: std::collections::HashSet::new(),
                         subscriptions: std::collections::HashMap::new(),
                         subscription_values: std::collections::HashMap::new(),

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1200,21 +1200,15 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
     // FocusWindowTemp/FocusPaneByIndexTemp in one batch plus the actual
     // command (e.g. CapturePane) in the next batch still works correctly.
     let mut temp_focus_restore: Option<(usize, usize)> = None;
+    let mut warm_pane_spawner = crate::warm_pane_sync::WarmPaneSpawner::new();
 
     loop {
-        // Tier 3 — keep warm-pane spawning OFF the command path. A warm pane is a
-        // fresh shell + ConPTY; spawning one can block the single event loop for
-        // 100ms–seconds under load. Doing it inline after every new-window/split
-        // stalled *other* clients' commands, surfacing as the intermittent
-        // `os error 10060` timeouts. Instead replenish only during a quiet gap
-        // (no command processed in the last 20ms), so window-create bursts
-        // transplant the ready pane instantly and the blocking spawn lands in idle
-        // time. If no warm pane is ready when a new-window arrives, create_window
-        // still spawns one synchronously — correctness is unchanged.
+        warm_pane_spawner.poll(&mut app);
+        // Warm ConPTY creation runs on the spawner's sole worker. The quiet-gap
+        // gate avoids needless replenishment in a window-create burst without
+        // ever blocking unrelated control commands on the server thread.
         if app.warm_pane.is_none() && last_client_activity.elapsed() >= Duration::from_millis(20) {
-            if let Ok(wp) = spawn_warm_pane(&*pty_system, &mut app) {
-                app.warm_pane = Some(wp);
-            }
+            warm_pane_spawner.ensure(&mut app);
         }
         if last_registry_check.elapsed() >= Duration::from_secs(5) {
             last_registry_check = Instant::now();
@@ -1262,27 +1256,30 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                             if age.as_secs() >= pause_secs {
                                 // Client fell behind: pause this pane
                                 client.output_paused_panes.insert(*pane_id);
-                                let _ = client.notification_tx.try_send(
-                                    crate::types::ControlNotification::Pause { pane_id: *pane_id }
+                                crate::control::try_send_notification(
+                                    client,
+                                    crate::types::ControlNotification::Pause { pane_id: *pane_id },
                                 );
                                 continue;
                             }
                             // Send as extended-output with age
                             let age_ms = age.as_millis() as u64;
-                            let _ = client.notification_tx.try_send(
+                            crate::control::try_send_notification(
+                                client,
                                 crate::types::ControlNotification::ExtendedOutput {
                                     pane_id: *pane_id,
                                     age_ms,
                                     data: data.clone(),
-                                }
+                                },
                             );
                         } else {
                             // No pause-after: send normal %output
-                            let _ = client.notification_tx.try_send(
+                            crate::control::try_send_notification(
+                                client,
                                 crate::types::ControlNotification::Output {
                                     pane_id: *pane_id,
                                     data: data.clone(),
-                                }
+                                },
                             );
                         }
                     }
@@ -2285,6 +2282,7 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                     };
                 }
                 CtrlReq::ClientSize(cid, w, h) => { 
+                    let warm_sync = crate::warm_pane_sync::for_resize(&app, h, w);
                     app.client_sizes.insert(cid, (w, h));
                     app.latest_client_id = Some(cid);
                     app.latest_size_client_id = Some(cid);
@@ -2300,12 +2298,11 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                     // Reconcile warm pane dimensions through the central
                     // policy module so resize uses the same code path as
                     // every other warm-pane invalidation (#271).
-                    let sync = crate::warm_pane_sync::for_resize(
-                        &app,
-                        app.client_area.height,
-                        app.client_area.width,
+                    crate::warm_pane_sync::apply_runtime(
+                        &mut app,
+                        &mut warm_pane_spawner,
+                        warm_sync,
                     );
-                    crate::warm_pane_sync::apply(&mut app, &*pty_system, sync);
                     hook_event = Some("client-resized");
                 }
                 CtrlReq::HostColors(spec) => {
@@ -3791,7 +3788,11 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                     // All option-driven warm-pane lifecycle decisions
                     // route through this single module — see #271.
                     let sync = crate::warm_pane_sync::for_option_change(&option, &app);
-                    crate::warm_pane_sync::apply(&mut app, &*pty_system, sync);
+                    crate::warm_pane_sync::apply_runtime(
+                        &mut app,
+                        &mut warm_pane_spawner,
+                        sync,
+                    );
                     // Update shared aliases if command-alias changed
                     if option == "command-alias" {
                         if let Ok(mut map) = shared_aliases_main.write() {
@@ -3828,7 +3829,11 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                     // also covers history-limit (#271), allow-predictions,
                     // default-terminal, and claude-code-* options.
                     let sync = crate::warm_pane_sync::for_option_change(&option, &app);
-                    crate::warm_pane_sync::apply(&mut app, &*pty_system, sync);
+                    crate::warm_pane_sync::apply_runtime(
+                        &mut app,
+                        &mut warm_pane_spawner,
+                        sync,
+                    );
                     // Update shared aliases if command-alias changed
                     if option == "command-alias" {
                         if let Ok(mut map) = shared_aliases_main.write() {
@@ -3883,6 +3888,12 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                             _ => {}
                         }
                     }
+                    let sync = crate::warm_pane_sync::for_option_change(&option, &app);
+                    crate::warm_pane_sync::apply_runtime(
+                        &mut app,
+                        &mut warm_pane_spawner,
+                        sync,
+                    );
                 }
                 CtrlReq::SetOptionAppend(option, value) => {
                     // Append to existing option value
@@ -3924,6 +3935,12 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                     if !already_set {
                         apply_set_option(&mut app, &option, &value, false);
                         app.user_set_options.insert(option.clone());
+                        let sync = crate::warm_pane_sync::for_option_change(&option, &app);
+                        crate::warm_pane_sync::apply_runtime(
+                            &mut app,
+                            &mut warm_pane_spawner,
+                            sync,
+                        );
                         if option == "command-alias" {
                             if let Ok(mut map) = shared_aliases_main.write() {
                                 *map = app.command_aliases.clone();
@@ -4084,6 +4101,12 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                     // unreadable path); flush them like the startup load does
                     // or they never reach config-warnings.log.
                     write_config_warnings_log(&app.config_warnings);
+                    let sync = crate::warm_pane_sync::for_config_reload();
+                    crate::warm_pane_sync::apply_runtime(
+                        &mut app,
+                        &mut warm_pane_spawner,
+                        sync,
+                    );
                     // source-file may change pane-border-status which
                     // affects pane content height (#288)
                     resize_all_panes(&mut app);
@@ -4763,13 +4786,21 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                     // which can't be patched in place — must respawn.
                     // Centralised through warm_pane_sync (#137 / #271).
                     let sync = crate::warm_pane_sync::for_env_change();
-                    crate::warm_pane_sync::apply(&mut app, &*pty_system, sync);
+                    crate::warm_pane_sync::apply_runtime(
+                        &mut app,
+                        &mut warm_pane_spawner,
+                        sync,
+                    );
                 }
                 CtrlReq::UnsetEnvironment(key) => {
                     app.environment.remove(&key);
                     env::remove_var(&key);
                     let sync = crate::warm_pane_sync::for_env_change();
-                    crate::warm_pane_sync::apply(&mut app, &*pty_system, sync);
+                    crate::warm_pane_sync::apply_runtime(
+                        &mut app,
+                        &mut warm_pane_spawner,
+                        sync,
+                    );
                 }
                 CtrlReq::ShowEnvironment(resp) => {
                     let mut output = String::new();
@@ -5212,6 +5243,13 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                     }
                 }
                 CtrlReq::ControlClientResize { client_id, window_id, size } => {
+                    let warm_sync = if window_id.is_none() {
+                        size.map(|(width, height)| {
+                            crate::warm_pane_sync::for_resize(&app, height, width)
+                        })
+                    } else {
+                        None
+                    };
                     let old_areas: std::collections::HashMap<usize, Rect> = app
                         .windows
                         .iter()
@@ -5238,6 +5276,13 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                         let geometry_changed = crate::resize_window::refresh_dynamic_window_sizes(&mut app);
                         if geometry_changed {
                             resize_all_panes(&mut app);
+                        }
+                        if let Some(sync) = warm_sync {
+                            crate::warm_pane_sync::apply_runtime(
+                                &mut app,
+                                &mut warm_pane_spawner,
+                                sync,
+                            );
                         }
                         state_dirty = true;
                         meta_dirty = true;
@@ -5384,12 +5429,12 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                         state_dirty = true;
                     }
                 }
-                CtrlReq::ControlRegister { client_id, echo, notif_tx } => {
+                CtrlReq::ControlRegister { client_id, echo, output_tx } => {
                     app.control_clients.insert(client_id, crate::types::ControlClient {
                         client_id,
                         cmd_counter: 0,
                         echo_enabled: echo,
-                        notification_tx: notif_tx,
+                        output_tx,
                         paused_panes: std::collections::HashSet::new(),
                         subscriptions: std::collections::HashMap::new(),
                         subscription_values: std::collections::HashMap::new(),
@@ -5446,8 +5491,9 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                 CtrlReq::ControlContinuePane { client_id, pane_id } => {
                     if let Some(cc) = app.control_clients.get_mut(&client_id) {
                         if cc.output_paused_panes.remove(&pane_id) {
-                            let _ = cc.notification_tx.try_send(
-                                crate::types::ControlNotification::Continue { pane_id }
+                            crate::control::try_send_notification(
+                                cc,
+                                crate::types::ControlNotification::Continue { pane_id },
                             );
                         }
                     }
@@ -5531,6 +5577,12 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                             options[selected].1 = value.clone();
                             *editing = false;
                             options::apply_set_option(&mut app, &name, &value, true);
+                            let sync = crate::warm_pane_sync::for_option_change(&name, &app);
+                            crate::warm_pane_sync::apply_runtime(
+                                &mut app,
+                                &mut warm_pane_spawner,
+                                sync,
+                            );
                             state_dirty = true;
                         }
                     }
@@ -5552,6 +5604,12 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                                 let value = def.to_string();
                                 options[selected].1 = value.clone();
                                 options::apply_set_option(&mut app, &name, &value, true);
+                                let sync = crate::warm_pane_sync::for_option_change(&name, &app);
+                                crate::warm_pane_sync::apply_runtime(
+                                    &mut app,
+                                    &mut warm_pane_spawner,
+                                    sync,
+                                );
                                 state_dirty = true;
                             }
                         }
@@ -5973,7 +6031,7 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
             }
             for (cid, notif) in sub_notifs {
                 if let Some(cc) = app.control_clients.get(&cid) {
-                    let _ = cc.notification_tx.try_send(notif);
+                    crate::control::try_send_notification(cc, notif);
                 }
             }
         }
@@ -6034,9 +6092,8 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                 .unwrap_or(false);
             if warm_dead {
                 if let Some(mut dead) = app.warm_pane.take() { dead.child.kill().ok(); }
-                if let Ok(nw) = spawn_warm_pane(&*pty_system, &mut app) {
-                    app.warm_pane = Some(nw);
-                }
+                warm_pane_spawner.invalidate();
+                warm_pane_spawner.ensure(&mut app);
             }
             // #450 (opt-in `@heal-crashed-panes`): a shell can FailFast on its
             // very first ConPTY read right after a warm-pane transplant (pwsh
@@ -6159,7 +6216,7 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                         &app,
                         crate::types::ControlNotification::Exit { reason: None },
                     );
-                    // Give notification threads time to flush %exit through
+                    // Give control writers time to flush %exit through
                     // the DCS stream before we tear down the process.
                     std::thread::sleep(std::time::Duration::from_millis(80));
                 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -81,7 +81,12 @@ pub struct ControlClient {
     pub client_id: u64,
     pub cmd_counter: u64,
     pub echo_enabled: bool,
-    pub output_tx: mpsc::SyncSender<ControlOutput>,
+    pub output_tx: mpsc::Sender<ControlOutput>,
+    /// Bytes queued for this client but not yet written to its socket.
+    /// Used to shed `%output` frames for slow readers instead of letting
+    /// the queue grow without bound (tmux buffers slow control clients
+    /// rather than disconnecting them; capture-pane heals dropped frames).
+    pub backlog: Arc<std::sync::atomic::AtomicUsize>,
     pub paused_panes: HashSet<usize>,
     /// `refresh-client -B name:what:format` subscriptions.
     /// Key = subscription name, Value = (target, format_string).
@@ -1786,7 +1791,8 @@ pub enum CtrlReq {
     ControlRegister {
         client_id: u64,
         echo: bool,
-        output_tx: mpsc::SyncSender<ControlOutput>,
+        output_tx: mpsc::Sender<ControlOutput>,
+        backlog: Arc<std::sync::atomic::AtomicUsize>,
     },
     /// Deregister a control mode client.
     ControlDeregister {

--- a/src/types.rs
+++ b/src/types.rs
@@ -70,12 +70,18 @@ pub enum ControlNotification {
     Message { text: String },
 }
 
+#[derive(Debug)]
+pub enum ControlOutput {
+    Notification(ControlNotification),
+    CommandBlock(String),
+}
+
 /// Per-connection control mode client state.
 pub struct ControlClient {
     pub client_id: u64,
     pub cmd_counter: u64,
     pub echo_enabled: bool,
-    pub notification_tx: mpsc::SyncSender<ControlNotification>,
+    pub output_tx: mpsc::SyncSender<ControlOutput>,
     pub paused_panes: HashSet<usize>,
     /// `refresh-client -B name:what:format` subscriptions.
     /// Key = subscription name, Value = (target, format_string).
@@ -1780,7 +1786,7 @@ pub enum CtrlReq {
     ControlRegister {
         client_id: u64,
         echo: bool,
-        notif_tx: mpsc::SyncSender<ControlNotification>,
+        output_tx: mpsc::SyncSender<ControlOutput>,
     },
     /// Deregister a control mode client.
     ControlDeregister {

--- a/src/warm_pane_sync.rs
+++ b/src/warm_pane_sync.rs
@@ -32,9 +32,15 @@
 //! `apply` honours `app.warm_enabled`: if warm panes are disabled,
 //! `Respawn` degrades to a kill with no respawn.
 
-use crate::types::AppState;
+use std::io;
+use std::sync::mpsc;
+use std::time::{Duration, Instant};
 
-/// Decision returned by the `for_*` helpers.  Apply via [`apply`].
+use crate::types::{AppState, WarmPane};
+
+/// Decision returned by the `for_*` helpers. Apply it with [`apply`] during
+/// startup or [`apply_runtime`] once the server loop is running.
+#[derive(Debug)]
 pub enum WarmPaneSync {
     Noop,
     Patch(WarmPanePatch),
@@ -42,7 +48,7 @@ pub enum WarmPaneSync {
 }
 
 /// In-place mutations safe to perform on a running warm pane.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub enum WarmPanePatch {
     /// Resize the vt100 parser's scrollback cap.  Trims oldest rows
     /// if shrinking.  See `vt100::Screen::set_scrollback_len`.
@@ -77,6 +83,11 @@ pub fn for_option_change(name: &str, app: &AppState) -> WarmPaneSync {
 
         // The shell binary itself differs — must respawn.
         "default-shell" => WarmPaneSync::Respawn("default-shell changed"),
+
+        // These options change how the child is constructed, or whether a
+        // spare should exist at all.
+        "env-shim" => WarmPaneSync::Respawn("env-shim changed"),
+        "warm" => WarmPaneSync::Respawn("warm setting changed"),
 
         // We send a different PSReadLine init script depending on this
         // option (PSRL_FIX vs PSRL_CRASH_GUARD).  The script runs once
@@ -116,8 +127,16 @@ pub fn for_env_change() -> WarmPaneSync {
 pub fn for_resize(app: &AppState, new_rows: u16, new_cols: u16) -> WarmPaneSync {
     match app.warm_pane.as_ref() {
         Some(wp) if wp.rows == new_rows && wp.cols == new_cols => WarmPaneSync::Noop,
-        _ => WarmPaneSync::Respawn("client resized"),
+        Some(_) => WarmPaneSync::Respawn("client resized"),
+        None if app.client_area.height == new_rows && app.client_area.width == new_cols => {
+            WarmPaneSync::Noop
+        }
+        None => WarmPaneSync::Respawn("client resized"),
     }
+}
+
+pub fn for_config_reload() -> WarmPaneSync {
+    WarmPaneSync::Respawn("configuration reloaded")
 }
 
 /// After the user's config has been parsed at server boot, the
@@ -175,8 +194,8 @@ pub fn for_post_config(app: &AppState) -> WarmPaneSync {
     WarmPaneSync::Noop
 }
 
-/// The single mutation point for `app.warm_pane`.  Every other call
-/// site outside of pre-warm boot and consume paths goes through here.
+/// Synchronous startup reconciliation. Runtime call sites must use
+/// [`apply_runtime`] so ConPTY creation never blocks the server loop.
 pub fn apply(
     app: &mut AppState,
     pty_system: &dyn portable_pty::PtySystem,
@@ -186,6 +205,159 @@ pub fn apply(
         WarmPaneSync::Noop => {}
         WarmPaneSync::Patch(patch) => apply_patch(app, patch),
         WarmPaneSync::Respawn(_reason) => respawn(app, pty_system),
+    }
+}
+
+struct SpawnCompletion {
+    generation: u64,
+    result: io::Result<WarmPane>,
+}
+
+/// Owns the one permitted runtime warm-pane worker. A generation number
+/// rejects results built from stale size/config snapshots, while backoff
+/// prevents a broken PTY environment from spawning in a tight loop.
+pub struct WarmPaneSpawner {
+    generation: u64,
+    in_flight: bool,
+    completion_tx: mpsc::Sender<SpawnCompletion>,
+    completion_rx: mpsc::Receiver<SpawnCompletion>,
+    consecutive_failures: u32,
+    retry_not_before: Option<Instant>,
+}
+
+impl WarmPaneSpawner {
+    pub fn new() -> Self {
+        let (completion_tx, completion_rx) = mpsc::channel();
+        Self {
+            generation: 0,
+            in_flight: false,
+            completion_tx,
+            completion_rx,
+            consecutive_failures: 0,
+            retry_not_before: None,
+        }
+    }
+
+    pub fn invalidate(&mut self) {
+        self.generation = self.generation.wrapping_add(1);
+        self.retry_not_before = None;
+    }
+
+    pub fn poll(&mut self, app: &mut AppState) {
+        while let Ok(mut completion) = self.completion_rx.try_recv() {
+            self.in_flight = false;
+            let current = completion.generation == self.generation
+                && app.warm_enabled
+                && app.warm_pane.is_none();
+            if !current {
+                if let Ok(ref mut pane) = completion.result {
+                    pane.child.kill().ok();
+                }
+                continue;
+            }
+            match completion.result {
+                Ok(pane) => {
+                    app.warm_pane = Some(pane);
+                    self.consecutive_failures = 0;
+                    self.retry_not_before = None;
+                }
+                Err(_) => self.record_failure(),
+            }
+        }
+    }
+
+    pub fn ensure(&mut self, app: &mut AppState) {
+        if !app.warm_enabled || app.warm_pane.is_some() || self.in_flight {
+            return;
+        }
+        if self.retry_not_before.is_some_and(|deadline| Instant::now() < deadline) {
+            return;
+        }
+        let spec = match crate::pane::prepare_warm_pane_spawn(app) {
+            Ok(spec) => spec,
+            Err(_) => {
+                self.record_failure();
+                return;
+            }
+        };
+        let generation = self.generation;
+        let completion_tx = self.completion_tx.clone();
+        self.in_flight = true;
+        std::thread::spawn(move || {
+            #[cfg(debug_assertions)]
+            if let Ok(delay) = std::env::var("PSMUX_TEST_WARM_PANE_DELAY_MS") {
+                if let Ok(delay) = delay.parse::<u64>() {
+                    if let Ok(path) =
+                        std::env::var("PSMUX_TEST_WARM_PANE_DELAY_STARTED_FILE")
+                    {
+                        std::fs::write(path, b"started").ok();
+                    }
+                    std::thread::sleep(Duration::from_millis(delay));
+                }
+            }
+            let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                let pty_system = portable_pty::native_pty_system();
+                crate::pane::spawn_warm_pane_from_spec(&*pty_system, spec)
+            }))
+            .unwrap_or_else(|_| {
+                Err(io::Error::new(
+                    io::ErrorKind::Other,
+                    "warm pane worker panicked",
+                ))
+            });
+            let completion = SpawnCompletion { generation, result };
+            if let Err(mpsc::SendError(mut completion)) = completion_tx.send(completion) {
+                if let Ok(ref mut pane) = completion.result {
+                    pane.child.kill().ok();
+                }
+            }
+        });
+    }
+
+    fn record_failure(&mut self) {
+        self.consecutive_failures = self.consecutive_failures.saturating_add(1);
+        let delay = retry_delay(self.consecutive_failures);
+        self.retry_not_before = Some(Instant::now() + delay);
+    }
+}
+
+impl Default for WarmPaneSpawner {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+fn retry_delay(consecutive_failures: u32) -> Duration {
+    match consecutive_failures {
+        0 | 1 => Duration::from_millis(100),
+        2 => Duration::from_millis(500),
+        3 => Duration::from_secs(2),
+        _ => Duration::from_secs(5),
+    }
+}
+
+/// Apply runtime policy without performing PTY creation on the caller.
+pub fn apply_runtime(
+    app: &mut AppState,
+    spawner: &mut WarmPaneSpawner,
+    sync: WarmPaneSync,
+) {
+    match sync {
+        WarmPaneSync::Noop => {}
+        WarmPaneSync::Patch(patch) => {
+            apply_patch(app, patch);
+            if app.warm_pane.is_none() {
+                spawner.invalidate();
+                spawner.ensure(app);
+            }
+        }
+        WarmPaneSync::Respawn(_reason) => {
+            if let Some(mut old) = app.warm_pane.take() {
+                old.child.kill().ok();
+            }
+            spawner.invalidate();
+            spawner.ensure(app);
+        }
     }
 }
 

--- a/tests-rs/test_capture_pane_wait_bound.rs
+++ b/tests-rs/test_capture_pane_wait_bound.rs
@@ -1,0 +1,119 @@
+// Regression tests for the bounded one-shot capture-pane wait (47888d3).
+//
+// The CLI capture-pane path blocked forever on the server response channel
+// when the server loop was wedged, hanging the client process. The fix
+// bounds the wait (5 seconds, mirroring the control-mode capture path) and
+// reports "ERROR: capture-pane timed out" instead of blocking indefinitely.
+//
+// Two layers are locked here:
+//
+//   - `recv_control_response`, the named bounded-wait helper behind the
+//     control-mode capture path, directly: timeout and disconnect both
+//     produce errors within the bound instead of hanging.
+//   - `handle_connection`, the one-shot CLI connection handler, over real
+//     loopback sockets with a never-answered server request: the response
+//     arrives after the 5s bound with the exact error text.
+
+use super::*;
+
+use std::io::{Read, Write};
+use std::net::{Shutdown, TcpListener, TcpStream};
+use std::sync::{Arc, RwLock};
+use std::thread::JoinHandle;
+use std::time::{Duration, Instant};
+
+const TEST_KEY: &str = "unit-test-key";
+
+/// Serve one connection through the real one-shot handler. `tx` is the
+/// channel to the (absent) server loop; keep the receiving side alive but
+/// never service it to simulate a wedged server.
+fn spawn_handler(listener: TcpListener, tx: mpsc::Sender<CtrlReq>) -> JoinHandle<()> {
+    std::thread::spawn(move || {
+        let (stream, _) = listener.accept().expect("handler: accept");
+        handle_connection(
+            stream,
+            tx,
+            TEST_KEY,
+            Arc::new(RwLock::new(std::collections::HashMap::new())),
+        );
+    })
+}
+
+/// Connect like the one-shot CLI client: AUTH, expect OK, return the socket.
+fn connect_authenticated(addr: std::net::SocketAddr) -> TcpStream {
+    let mut client = TcpStream::connect(addr).expect("client connect");
+    client.set_read_timeout(Some(Duration::from_secs(20))).unwrap();
+    write!(client, "AUTH {TEST_KEY}\n").unwrap();
+    let mut reader = std::io::BufReader::new(client.try_clone().unwrap());
+    let mut ok = String::new();
+    reader.read_line(&mut ok).expect("read OK");
+    assert_eq!(ok, "OK\n", "handler must authenticate the client");
+    client
+}
+
+/// End-to-end: a wedged server (request never answered) must produce the
+/// timed-out error after the 5s bound — never an indefinite hang.
+#[test]
+fn one_shot_capture_pane_wait_is_bounded_by_five_seconds() {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+    let (tx, _rx) = mpsc::channel::<CtrlReq>(); // never serviced
+    let handler = spawn_handler(listener.try_clone().unwrap(), tx);
+
+    let mut client = connect_authenticated(listener.local_addr().unwrap());
+    let t0 = Instant::now();
+    write!(client, "capture-pane\n").unwrap();
+    client.shutdown(Shutdown::Write).unwrap();
+
+    let mut resp = String::new();
+    client.read_to_string(&mut resp).expect("read response");
+    let elapsed = t0.elapsed();
+    handler.join().expect("handler thread");
+
+    assert_eq!(
+        resp, "ERROR: capture-pane timed out\n",
+        "a wedged server must yield the explicit timeout error"
+    );
+    assert!(
+        elapsed >= Duration::from_secs(4),
+        "the wait must actually run the 5s bound, not fail instantly (took {elapsed:?})"
+    );
+    assert!(
+        elapsed < Duration::from_secs(12),
+        "the wait must be bounded (took {elapsed:?})"
+    );
+}
+
+/// The helper behind the bounded wait errors out within the given timeout
+/// instead of blocking forever.
+#[test]
+fn recv_control_response_times_out_with_the_command_error() {
+    let (_tx, rx) = mpsc::channel::<String>();
+    let t0 = Instant::now();
+    let result = recv_control_response("capture-pane", rx, Duration::from_millis(100));
+    assert_eq!(result, Err("capture-pane timed out".to_string()));
+    assert!(
+        t0.elapsed() < Duration::from_secs(2),
+        "the bounded wait must return, not hang"
+    );
+}
+
+/// A disconnected response channel reports an explicit error too.
+#[test]
+fn recv_control_response_reports_a_disconnected_channel() {
+    let (tx, rx) = mpsc::channel::<String>();
+    drop(tx);
+    let result = recv_control_response("display-message", rx, Duration::from_secs(1));
+    assert_eq!(
+        result,
+        Err("display-message response channel disconnected".to_string())
+    );
+}
+
+/// The bounded wait still delivers a real response when the server answers.
+#[test]
+fn recv_control_response_delivers_queued_value() {
+    let (tx, rx) = mpsc::channel::<String>();
+    tx.send("pane text".to_string()).unwrap();
+    let result = recv_control_response("capture-pane", rx, Duration::from_secs(1));
+    assert_eq!(result, Ok("pane text".to_string()));
+}

--- a/tests-rs/test_client_debug_log_truncation.rs
+++ b/tests-rs/test_client_debug_log_truncation.rs
@@ -1,0 +1,189 @@
+// Regression test for the client debug-log truncation fix (3240985).
+//
+// The control-mode reader logged each OUT line truncated to 200 bytes with
+// a raw byte slice. Any line whose 200th byte fell inside a multi-byte
+// character — routine for TUI box-drawing output — panicked the reader
+// thread and killed the whole control client, which the attached
+// integration saw as a command timeout followed by a reconnect loop. The
+// fix truncates on a char boundary instead.
+//
+// The truncation is inline inside `run_control_mode` (no callable seam),
+// so this test drives the REAL client function end-to-end: a child process
+// runs the test body in child mode with a temp data dir and a scripted
+// fake control server on a loopback socket; the server sends a line whose
+// 200th byte is mid-glyph. The parent then asserts the reader thread
+// survived (no panic on stderr, OUT line logged, full line still echoed)
+// and that the truncated log prefix ends exactly on the char boundary.
+// The child's stdin is held open by the parent until the exchange
+// completes, then closed so the client's input loop exits cleanly.
+
+use super::*;
+
+use std::io::Write;
+use std::net::TcpListener;
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+const CHILD_MODE_ENV: &str = "PSMUX_TRUNC_TEST_CHILD";
+
+/// A line of 199 ASCII bytes followed by a 3-byte CJK glyph: truncating at
+/// raw byte 200 lands inside the glyph.
+fn payload_line() -> String {
+    format!("{}{}", "a".repeat(199), "界")
+}
+
+fn temp_data_dir(tag: &str) -> String {
+    let dir = std::env::temp_dir().join(format!("psmux_rs_trunc_{}_{}", tag, std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    let _ = std::fs::create_dir_all(&dir);
+    dir.to_string_lossy().into_owned()
+}
+
+/// Removes every file the parent and child created, even when an assertion
+/// fails mid-test.
+struct Cleanup {
+    files: Vec<std::path::PathBuf>,
+    dir: std::path::PathBuf,
+}
+
+impl Drop for Cleanup {
+    fn drop(&mut self) {
+        for f in &self.files {
+            let _ = std::fs::remove_file(f);
+        }
+        let _ = std::fs::remove_dir_all(&self.dir);
+    }
+}
+
+/// Child side: run the real control-mode client against the parent's fake
+/// server, then return.
+fn child_run_client() {
+    let result = run_control_mode(1);
+    assert!(
+        result.is_ok(),
+        "run_control_mode must exit cleanly after the fake server closes: {result:?}"
+    );
+}
+
+#[test]
+fn multi_byte_out_line_does_not_panic_the_reader_thread() {
+    if std::env::var(CHILD_MODE_ENV).is_ok() {
+        child_run_client();
+        return;
+    }
+
+    let session = format!("trunc_{}", std::process::id());
+    let dir = temp_data_dir("main");
+    let key = "unit-test-key-1234";
+
+    // The child resolves its paths through its own PSMUX_DATA_DIR env; the
+    // parent spells out the same derived paths directly (the spelling is the
+    // contract locked by the PSMUX_DATA_DIR override tests) instead of
+    // mutating the process-global env, which would race with other tests in
+    // a full parallel run.
+    let port_path = format!("{dir}\\{session}.port");
+    let key_path = format!("{dir}\\{session}.key");
+    let log_path = format!("{dir}\\cc_debug.log");
+    let _cleanup = Cleanup {
+        files: vec![
+            std::path::PathBuf::from(&port_path),
+            std::path::PathBuf::from(&key_path),
+            std::path::PathBuf::from(&log_path),
+        ],
+        dir: std::path::PathBuf::from(&dir),
+    };
+
+    // Fake control server: auth, CONTROL handshake, then the adversarial
+    // payload line followed by a marker line, then close.
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind fake server");
+    let port = listener.local_addr().unwrap().port();
+    std::fs::write(&port_path, port.to_string()).unwrap();
+    std::fs::write(&key_path, key).unwrap();
+
+    let payload = format!("{}\n", payload_line());
+    let out_marker = format!("OUT ({} bytes):", payload.len());
+    let server = std::thread::spawn(move || {
+        let (mut sock, _) = listener.accept().expect("fake server accept");
+        let mut reader = std::io::BufReader::new(sock.try_clone().unwrap());
+        let mut line = String::new();
+        reader.read_line(&mut line).expect("read AUTH");
+        assert!(line.starts_with("AUTH "), "unexpected auth line: {line:?}");
+        sock.write_all(b"OK\n").unwrap();
+        sock.flush().unwrap();
+        line.clear();
+        reader.read_line(&mut line).expect("read mode");
+        assert_eq!(line.trim(), "CONTROL", "client must request CONTROL mode");
+        sock.write_all(payload.as_bytes()).unwrap();
+        sock.write_all(b"tail marker\n").unwrap();
+        sock.flush().unwrap();
+        // Keep the connection open long enough for the reader thread to
+        // log both lines, then close to end its read loop.
+        std::thread::sleep(Duration::from_millis(1500));
+    });
+
+    let exe = std::env::current_exe().expect("test binary path");
+    let test_name =
+        "tests_client_debug_log_truncation::multi_byte_out_line_does_not_panic_the_reader_thread";
+    let mut child = Command::new(exe)
+        .args(["--exact", test_name, "--nocapture", "--test-threads=1"])
+        .env(CHILD_MODE_ENV, "1")
+        .env("PSMUX_DATA_DIR", &dir)
+        .env("PSMUX_SESSION_NAME", &session)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn test child");
+
+    // Hold the child's stdin open so its input loop keeps running while
+    // the reader thread processes the payload.
+    let mut child_stdin = child.stdin.take().unwrap();
+
+    // Poll the client's debug log for the truncated OUT line.
+    let deadline = Instant::now() + Duration::from_secs(15);
+    let mut log_text = String::new();
+    let mut seen = false;
+    while Instant::now() < deadline {
+        if let Ok(text) = std::fs::read_to_string(&log_path) {
+            if text.contains(&out_marker) {
+                log_text = text;
+                seen = true;
+                break;
+            }
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    drop(child_stdin); // EOF: let the child's stdin loop finish.
+
+    let output = child.wait_with_output().expect("wait for test child");
+    let _ = server.join();
+    if !seen {
+        let final_log = std::fs::read_to_string(&log_path).unwrap_or_default();
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        panic!(
+            "the reader thread must log the OUT line\nlog {log_path:?}:\n{final_log}\nchild stderr:\n{stderr}"
+        );
+    }
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("panicked"),
+        "truncating mid-glyph must not panic the reader thread; stderr: {stderr}"
+    );
+    assert!(
+        output.status.success(),
+        "child must exit successfully: {:?}",
+        output.status
+    );
+    assert!(
+        log_text.contains("tail marker"),
+        "the reader thread must survive past the adversarial line and log the marker line"
+    );
+    // The truncation must stop exactly at the char boundary: 199 ASCII
+    // bytes then the closing quote of the {:?} debug repr — no partial
+    // glyph bytes, no over-truncation.
+    assert!(
+        log_text.contains(&format!("\"{}\"", "a".repeat(199))),
+        "truncation must end on the char boundary (199 bytes); log:\n{log_text}"
+    );
+}

--- a/tests-rs/test_control_mode_liveness.rs
+++ b/tests-rs/test_control_mode_liveness.rs
@@ -1,0 +1,92 @@
+use super::*;
+
+#[test]
+fn timed_out_control_handler_completes_with_explicit_error() {
+    let (_handler_tx, handler_rx) = mpsc::channel::<String>();
+    let (response_tx, response_rx) = mpsc::channel();
+
+    forward_control_response(
+        "capture-pane",
+        handler_rx,
+        &response_tx,
+        Duration::from_millis(1),
+    );
+
+    assert_eq!(
+        response_rx.recv().unwrap(),
+        ControlCommandResponse::error("capture-pane timed out")
+    );
+}
+
+#[test]
+fn disconnected_control_handler_completes_with_explicit_error() {
+    let (handler_tx, handler_rx) = mpsc::channel::<String>();
+    drop(handler_tx);
+    let (response_tx, response_rx) = mpsc::channel();
+
+    forward_control_response(
+        "display-message",
+        handler_rx,
+        &response_tx,
+        Duration::from_secs(1),
+    );
+
+    assert_eq!(
+        response_rx.recv().unwrap(),
+        ControlCommandResponse::error("display-message response channel disconnected")
+    );
+}
+
+#[test]
+fn command_block_has_one_atomic_begin_and_footer() {
+    let block = format_control_command_block(
+        true,
+        "capture-pane -p",
+        123,
+        7,
+        Some(Ok(ControlCommandResponse::success("pane text"))),
+    );
+
+    assert_eq!(block.matches("%begin 123 7 1").count(), 1);
+    assert_eq!(block.matches("%end 123 7 1").count(), 1);
+    assert_eq!(block.matches("%error").count(), 0);
+    assert_eq!(
+        block,
+        "capture-pane -p\n%begin 123 7 1\npane text\n%end 123 7 1\n"
+    );
+}
+
+#[test]
+fn command_error_block_has_one_error_footer() {
+    let block = format_control_command_block(
+        false,
+        "capture-pane -p",
+        123,
+        8,
+        Some(Ok(ControlCommandResponse::error("capture-pane timed out"))),
+    );
+
+    assert_eq!(block.matches("%begin 123 8 1").count(), 1);
+    assert_eq!(block.matches("%error 123 8 1").count(), 1);
+    assert_eq!(block.matches("%end").count(), 0);
+    assert_eq!(
+        block,
+        "%begin 123 8 1\ncapture-pane timed out\n%error 123 8 1\n"
+    );
+}
+
+#[test]
+fn successful_output_cannot_be_reinterpreted_as_an_error() {
+    let body = "\u{0001}ERR\u{0001}literal pane output";
+    let block = format_control_command_block(
+        false,
+        "capture-pane -p",
+        123,
+        9,
+        Some(Ok(ControlCommandResponse::success(body))),
+    );
+
+    assert!(block.contains(body));
+    assert!(block.contains("%end 123 9 1"));
+    assert!(!block.contains("%error 123 9 1"));
+}

--- a/tests-rs/test_control_output_chunking.rs
+++ b/tests-rs/test_control_output_chunking.rs
@@ -1,0 +1,132 @@
+// Regression tests for the bounded-notification-line fix (b85ecad).
+//
+// Draining a full pane output ring used to produce ONE %output line whose
+// escaped payload could reach ~256KB. tmux never does this: every PTY read
+// is bounded, so clients see a stream of moderate lines. `chunk_output`
+// splits drained output at 4096 bytes on UTF-8 boundaries so every chunk is
+// independently escapable and no single line explodes.
+//
+// `chunk_output` is a pure function; `format_notification` turns each chunk
+// into the actual wire line. Both are driven directly here — no server.
+
+use super::*;
+
+const MAX: usize = crate::control::OUTPUT_CHUNK_MAX;
+
+/// A short payload is passed through as one chunk; an empty payload yields
+/// no chunks at all.
+#[test]
+fn short_payload_is_a_single_chunk() {
+    assert_eq!(chunk_output("hello").collect::<Vec<_>>(), vec!["hello"]);
+    assert_eq!(chunk_output("").count(), 0);
+}
+
+/// An oversized payload is split into multiple chunks, each bounded by
+/// OUTPUT_CHUNK_MAX, and the concatenation reproduces the input exactly.
+#[test]
+fn oversized_payload_splits_into_bounded_chunks() {
+    let data = "x".repeat(MAX * 2 + 100);
+    let chunks: Vec<&str> = chunk_output(&data).collect();
+
+    assert_eq!(chunks.len(), 3, "expected 3 chunks for 2*MAX+100 bytes");
+    assert!(
+        chunks.iter().all(|c| !c.is_empty() && c.len() <= MAX),
+        "every chunk must be non-empty and bounded by OUTPUT_CHUNK_MAX"
+    );
+    assert_eq!(chunks.concat(), data, "chunks must reassemble the payload");
+}
+
+/// Splitting must never cut through a multi-byte UTF-8 sequence: every
+/// chunk must itself be valid UTF-8, even when a CJK glyph straddles the
+/// chunk boundary.
+#[test]
+fn chunking_never_splits_a_utf8_sequence() {
+    // Fill the first chunk so the 3-byte CJK glyph straddles the boundary.
+    let mut data = "a".repeat(MAX - 1);
+    data.push_str("终端输出");
+    data.push_str(&"b".repeat(MAX));
+
+    let chunks: Vec<&str> = chunk_output(&data).collect();
+    assert!(chunks.len() >= 3, "straddling glyph must still force a split");
+    for chunk in &chunks {
+        assert!(
+            std::str::from_utf8(chunk.as_bytes()).is_ok(),
+            "chunk must not contain a partial UTF-8 sequence"
+        );
+        assert!(!chunk.is_empty() && chunk.len() <= MAX);
+    }
+    assert_eq!(chunks.concat(), data);
+}
+
+/// A payload that is exactly one chunk long is not split.
+#[test]
+fn exact_chunk_size_is_a_single_chunk() {
+    let data = "x".repeat(MAX);
+    let chunks: Vec<&str> = chunk_output(&data).collect();
+    assert_eq!(chunks.len(), 1);
+    assert_eq!(chunks[0], data);
+}
+
+/// The wire-level contract: each chunk becomes its own %output line, the
+/// escaped payload of every line is bounded, and the notification stream
+/// carries the same bytes the single oversized frame would have.
+#[test]
+fn chunked_output_formats_as_multiple_bounded_output_lines() {
+    let data = "y".repeat(MAX + 100); // printable ASCII escapes 1:1
+    let chunks: Vec<&str> = chunk_output(&data).collect();
+    assert!(chunks.len() >= 2);
+
+    let mut reassembled = String::new();
+    for chunk in chunks {
+        let line = format_notification(&ControlNotification::Output {
+            pane_id: 7,
+            data: chunk.to_string(),
+        });
+        assert!(
+            line.starts_with("%output %7 "),
+            "each chunk must be its own %output line: {line:?}"
+        );
+        assert!(
+            line.len() <= "%output %7 ".len() + MAX,
+            "a single %output line must stay bounded by OUTPUT_CHUNK_MAX payload bytes"
+        );
+        reassembled.push_str(chunk);
+    }
+    assert_eq!(reassembled, data, "the chunk stream must carry the full payload");
+}
+
+/// The same boundedness applies to %extended-output frames (pause-after
+/// mode), which carry an age field before the payload.
+#[test]
+fn extended_output_chunks_keep_the_age_prefix() {
+    let data = "z".repeat(MAX + 1);
+    let chunks: Vec<&str> = chunk_output(&data).collect();
+    for chunk in chunks {
+        let line = format_notification(&ControlNotification::ExtendedOutput {
+            pane_id: 3,
+            age_ms: 42,
+            data: chunk.to_string(),
+        });
+        assert!(line.starts_with("%extended-output %3 42 : "));
+        assert!(line.len() <= "%extended-output %3 42 : ".len() + MAX);
+    }
+}
+
+/// Chunking is deterministic and allocation-free on the string itself:
+/// iterating twice yields identical splits.
+#[test]
+fn chunking_is_deterministic() {
+    let mut data = "a".repeat(MAX - 2);
+    data.push_str("你你你");
+    let first: Vec<&str> = chunk_output(&data).collect();
+    let second: Vec<&str> = chunk_output(&data).collect();
+    assert_eq!(first, second);
+}
+
+/// A payload of exactly N chunk sizes splits into exactly N chunks.
+#[test]
+fn chunk_count_for_moderate_payloads_is_sane() {
+    let data = "x".repeat(MAX * 10);
+    let chunks: Vec<&str> = chunk_output(&data).collect();
+    assert_eq!(chunks.len(), 10);
+}

--- a/tests-rs/test_control_slow_client_backlog.rs
+++ b/tests-rs/test_control_slow_client_backlog.rs
@@ -1,0 +1,215 @@
+// Regression tests for the slow-control-client buffering fix (99b2745).
+//
+// A control client that fell behind the output stream used to hit the
+// connection's 5s write timeout and get disconnected. The fix drops the
+// socket write timeout, switches the per-client queue to an unbounded
+// channel, and accounts queued bytes per client:
+//
+//   - below the soft backlog threshold every notification is queued
+//   - past the soft threshold, %output / %extended-output frames are shed
+//     (any client resynchronizes with capture-pane), while structural
+//     notifications such as %window-close always queue
+//   - past the hard threshold everything is shed
+//
+// `try_send_notification` is a pure function of (client backlog, channel),
+// so these tests drive it directly with no server and no real socket.
+
+use super::*;
+
+use std::collections::{HashMap, HashSet};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::mpsc;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+/// A control client whose backlog counter is preset, with a live unbounded
+/// queue. Returns the client and the receiving side of its queue.
+fn client_with_backlog(backlog: usize) -> (ControlClient, mpsc::Receiver<ControlOutput>) {
+    let (tx, rx) = mpsc::channel::<ControlOutput>();
+    let client = ControlClient {
+        client_id: 1,
+        cmd_counter: 0,
+        echo_enabled: false,
+        output_tx: tx,
+        backlog: Arc::new(AtomicUsize::new(backlog)),
+        paused_panes: HashSet::new(),
+        subscriptions: HashMap::new(),
+        subscription_values: HashMap::new(),
+        subscription_last_check: HashMap::new(),
+        pause_after_secs: None,
+        output_paused_panes: HashSet::new(),
+        pane_last_output: HashMap::new(),
+        size: None,
+        window_sizes: HashMap::new(),
+    };
+    (client, rx)
+}
+
+fn output_notif(data: &str) -> ControlNotification {
+    ControlNotification::Output { pane_id: 7, data: data.to_string() }
+}
+
+fn extended_output_notif(data: &str) -> ControlNotification {
+    ControlNotification::ExtendedOutput { pane_id: 7, age_ms: 123, data: data.to_string() }
+}
+
+fn structural_notif() -> ControlNotification {
+    ControlNotification::WindowClose { window_id: 5 }
+}
+
+/// A fresh client is not shedding anything: every notification type is
+/// queued and the backlog counter grows by the notification's wire cost.
+#[test]
+fn fresh_client_queues_output_and_accounts_backlog() {
+    let (client, rx) = client_with_backlog(0);
+    try_send_notification(&client, output_notif("abc"));
+
+    let queued = rx.recv_timeout(Duration::from_secs(1)).expect("output must be queued");
+    match queued {
+        ControlOutput::Notification(ControlNotification::Output { pane_id, data }) => {
+            assert_eq!(pane_id, 7);
+            assert_eq!(data, "abc", "queued output must be delivered intact");
+        }
+        other => panic!("expected an Output notification, got {other:?}"),
+    }
+    // Output cost = data.len() + 32.
+    assert_eq!(client.backlog.load(Ordering::Relaxed), 3 + 32);
+}
+
+/// Past the soft threshold, %output is shed: the frame must NOT reach the
+/// queue and the backlog must stay put. This is the exact contract that
+/// replaced the old disconnect-on-slow-reader behavior.
+#[test]
+fn output_is_shed_past_soft_backlog_threshold() {
+    let (client, rx) = client_with_backlog(crate::control::OUTPUT_BACKLOG_SOFT_MAX);
+    try_send_notification(&client, output_notif("abc"));
+
+    assert!(
+        rx.try_recv().is_err(),
+        "%output must be shed past the soft threshold"
+    );
+    assert_eq!(
+        client.backlog.load(Ordering::Relaxed),
+        crate::control::OUTPUT_BACKLOG_SOFT_MAX,
+        "shed frames must not add to the backlog"
+    );
+}
+
+/// %extended-output is a pane-output frame too and sheds past the soft
+/// threshold exactly like %output.
+#[test]
+fn extended_output_is_shed_past_soft_backlog_threshold() {
+    let (client, rx) = client_with_backlog(crate::control::OUTPUT_BACKLOG_SOFT_MAX);
+    try_send_notification(&client, extended_output_notif("abc"));
+
+    assert!(
+        rx.try_recv().is_err(),
+        "%extended-output must be shed past the soft threshold"
+    );
+}
+
+/// Structural notifications are never shed at the soft threshold: a slow
+/// reader must still learn about window teardown etc., so those frames
+/// always queue.
+#[test]
+fn structural_notifications_queue_past_soft_backlog_threshold() {
+    let (client, rx) = client_with_backlog(crate::control::OUTPUT_BACKLOG_SOFT_MAX);
+    try_send_notification(&client, structural_notif());
+
+    let queued = rx.recv_timeout(Duration::from_secs(1)).expect("structural notification must queue");
+    assert!(
+        matches!(queued, ControlOutput::Notification(ControlNotification::WindowClose { window_id: 5 })),
+        "structural notification must be delivered intact"
+    );
+    // Non-output notification cost is a flat 128.
+    assert_eq!(
+        client.backlog.load(Ordering::Relaxed),
+        crate::control::OUTPUT_BACKLOG_SOFT_MAX + 128
+    );
+}
+
+/// Past the hard threshold even structural notifications are shed: a reader
+/// that far behind is effectively gone and only TCP teardown will reap it.
+#[test]
+fn everything_is_shed_past_hard_backlog_threshold() {
+    let (client, rx) = client_with_backlog(crate::control::OUTPUT_BACKLOG_HARD_MAX);
+    try_send_notification(&client, output_notif("abc"));
+    try_send_notification(&client, structural_notif());
+
+    assert!(
+        rx.try_recv().is_err(),
+        "everything must be shed past the hard threshold"
+    );
+    assert_eq!(
+        client.backlog.load(Ordering::Relaxed),
+        crate::control::OUTPUT_BACKLOG_HARD_MAX
+    );
+}
+
+/// Backlog accounting is symmetric with the writer: `output_cost` is what
+/// the enqueue adds and what the writer subtracts after a successful write,
+/// so the two must agree exactly per variant.
+#[test]
+fn output_cost_matches_the_variants_that_can_be_queued() {
+    let output = ControlOutput::Notification(output_notif("abcd"));
+    assert_eq!(crate::control::output_cost(&output), 4 + 32);
+
+    let extended = ControlOutput::Notification(extended_output_notif("abcd"));
+    assert_eq!(crate::control::output_cost(&extended), 4 + 48);
+
+    let structural = ControlOutput::Notification(structural_notif());
+    assert_eq!(crate::control::output_cost(&structural), 128);
+
+    let block = ControlOutput::CommandBlock("%begin 1 2 1\nbody\n%end 1 2 1\n".to_string());
+    assert_eq!(
+        crate::control::output_cost(&block),
+        "%begin 1 2 1\nbody\n%end 1 2 1\n".len()
+    );
+}
+
+/// A disconnected client must never panic the server loop: the send result
+/// is deliberately ignored, and shedding must not even attempt the send.
+#[test]
+fn dead_client_queue_is_handled_silently() {
+    let (client, rx) = client_with_backlog(0);
+    drop(rx);
+    try_send_notification(&client, output_notif("abc"));
+    try_send_notification(&client, structural_notif());
+    // No panic above; the queue is unbounded so the send itself succeeds
+    // even with the receiver gone — teardown reaps the client later.
+    assert_eq!(client.backlog.load(Ordering::Relaxed), 3 + 32 + 128);
+}
+
+/// The soft/hard thresholds are real, ordered bounds — a regression in
+/// either constant changes the shedding decision.
+#[test]
+fn backlog_thresholds_are_ordered_and_nonzero() {
+    assert!(crate::control::OUTPUT_BACKLOG_SOFT_MAX > 0);
+    assert!(crate::control::OUTPUT_BACKLOG_HARD_MAX > crate::control::OUTPUT_BACKLOG_SOFT_MAX);
+}
+
+/// Queueing is non-blocking: `try_send_notification` must return
+/// immediately even when the reader never drains the queue. A large burst
+/// (multiple soft-thresholds worth of cost) still sheds per-frame instead
+/// of blocking the server loop.
+#[test]
+fn notification_burst_completes_immediately_without_a_reader() {
+    let (client, rx) = client_with_backlog(0);
+    let burst_start = Instant::now();
+    let mut expected_cost = 0;
+    for i in 0..1000 {
+        let data = format!("frame {i}");
+        expected_cost += data.len() + 32;
+        try_send_notification(&client, output_notif(&data));
+    }
+    assert!(
+        burst_start.elapsed() < Duration::from_secs(2),
+        "enqueue must never block"
+    );
+    assert_eq!(
+        client.backlog.load(Ordering::Relaxed),
+        expected_cost,
+        "every queued frame must be accounted at its exact wire cost"
+    );
+    drop(rx);
+}

--- a/tests-rs/test_resize_window_compat.rs
+++ b/tests-rs/test_resize_window_compat.rs
@@ -51,12 +51,12 @@ fn control_client(
     size: Option<(u16, u16)>,
     window_sizes: &[(usize, (u16, u16))],
 ) -> ControlClient {
-    let (notification_tx, _notification_rx) = std::sync::mpsc::sync_channel(1);
+    let (output_tx, _output_rx) = std::sync::mpsc::sync_channel(1);
     ControlClient {
         client_id,
         cmd_counter: 0,
         echo_enabled: false,
-        notification_tx,
+        output_tx,
         paused_panes: std::collections::HashSet::new(),
         subscriptions: std::collections::HashMap::new(),
         subscription_values: std::collections::HashMap::new(),

--- a/tests-rs/test_resize_window_compat.rs
+++ b/tests-rs/test_resize_window_compat.rs
@@ -51,12 +51,13 @@ fn control_client(
     size: Option<(u16, u16)>,
     window_sizes: &[(usize, (u16, u16))],
 ) -> ControlClient {
-    let (output_tx, _output_rx) = std::sync::mpsc::sync_channel(1);
+    let (output_tx, _output_rx) = std::sync::mpsc::channel();
     ControlClient {
         client_id,
         cmd_counter: 0,
         echo_enabled: false,
         output_tx,
+        backlog: std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0)),
         paused_panes: std::collections::HashSet::new(),
         subscriptions: std::collections::HashMap::new(),
         subscription_values: std::collections::HashMap::new(),

--- a/tests-rs/test_send_keys_literal_byte.rs
+++ b/tests-rs/test_send_keys_literal_byte.rs
@@ -1,12 +1,14 @@
 // `send-keys -H` is a byte channel: every operand is one hexadecimal byte value
 // that reaches the pty verbatim (tmux flags those keys KEYC_LITERAL and
-// input_key.c writes them as single bytes). psmux accepted the flag but never
-// implemented it, so the operands fell through to the key-name lookup and were
-// echoed into the pane as literal text -- typing `echo` produced "65 63 68 6f".
+// input_key.c writes them as single bytes). psmux already decoded the operands
+// and delivered the bytes, but its control dispatcher returned `handled`
+// without completing the response oneshot. The command reached the pane, but
+// dropping the sender was immediately misreported as a generic timeout error.
 //
-// These tests pin the two pure functions the fix rests on:
-//   * decode_send_command  -- per-command operand decoding
-//   * coalesce_send_commands -- merging consecutive sub-commands on one line
+// These tests keep the byte/codepoint contract separate from the completion
+// fix: decode_send_command handles per-command operands,
+// coalesce_send_commands merges consecutive sub-commands, and the dispatcher
+// must acknowledge the resulting byte write.
 //
 // They deliberately start no server (see AGENTS.md).
 
@@ -22,6 +24,34 @@ fn literal_byte_operands_decode_to_raw_bytes() {
     let (target, bytes) = decode("send-keys -H -t %1 65 63 68 6f").expect("must decode");
     assert_eq!(target, "%1");
     assert_eq!(bytes, b"echo");
+}
+
+#[test]
+fn control_dispatch_acknowledges_literal_byte_send() {
+    let (request_tx, request_rx) = mpsc::channel();
+    let (response_tx, response_rx) = mpsc::channel();
+    let args = ["-H", "-t", "%1", "41", "e4", "b8", "ad"];
+
+    assert!(dispatch_control_command(
+        "send-keys",
+        &args,
+        &request_tx,
+        response_tx,
+        Some(1),
+        true,
+        Some("%1"),
+        1,
+    ));
+    assert_eq!(
+        response_rx
+            .recv_timeout(Duration::from_millis(100))
+            .unwrap(),
+        ControlCommandResponse::empty()
+    );
+    match request_rx.recv_timeout(Duration::from_millis(100)).unwrap() {
+        CtrlReq::SendBytes(bytes) => assert_eq!(bytes, vec![0x41, 0xe4, 0xb8, 0xad]),
+        _ => panic!("literal-byte send dispatched the wrong request"),
+    }
 }
 
 #[test]

--- a/tests-rs/test_warm_pane_sync.rs
+++ b/tests-rs/test_warm_pane_sync.rs
@@ -13,6 +13,7 @@ use crate::types::AppState;
 
 fn fresh_app() -> AppState {
     let mut app = AppState::new("test".to_string());
+    app.warm_enabled = true;
     // Strip the implicit-PSMUX_TARGET_SESSION-style entries that
     // AppState::new may seed; for_post_config skips those by name,
     // but explicit cleanup keeps the test intent visible.
@@ -38,6 +39,19 @@ fn option_default_shell_requires_respawn() {
     let app = fresh_app();
     assert!(matches!(
         for_option_change("default-shell", &app),
+        WarmPaneSync::Respawn(_)
+    ));
+}
+
+#[test]
+fn option_process_construction_settings_require_respawn() {
+    let app = fresh_app();
+    assert!(matches!(
+        for_option_change("env-shim", &app),
+        WarmPaneSync::Respawn(_)
+    ));
+    assert!(matches!(
+        for_option_change("warm", &app),
         WarmPaneSync::Respawn(_)
     ));
 }
@@ -148,6 +162,68 @@ fn resize_with_no_warm_pane_returns_respawn() {
     // and possibly spawn a fresh warm pane at the new size.
     let app = fresh_app();
     assert!(matches!(for_resize(&app, 30, 80), WarmPaneSync::Respawn(_)));
+}
+
+#[test]
+fn repeated_resize_with_no_warm_pane_is_noop() {
+    let app = fresh_app();
+    assert!(matches!(
+        for_resize(&app, app.client_area.height, app.client_area.width),
+        WarmPaneSync::Noop
+    ));
+}
+
+#[test]
+fn warm_spawner_allows_only_one_worker() {
+    let mut app = fresh_app();
+    let mut spawner = WarmPaneSpawner::new();
+    spawner.in_flight = true;
+    let next_pane_id = app.next_pane_id;
+
+    spawner.ensure(&mut app);
+
+    assert!(spawner.in_flight);
+    assert_eq!(app.next_pane_id, next_pane_id);
+}
+
+#[test]
+fn stale_worker_failure_does_not_poison_current_generation() {
+    let mut app = fresh_app();
+    let mut spawner = WarmPaneSpawner::new();
+    let stale_generation = spawner.generation;
+    spawner.in_flight = true;
+    spawner.invalidate();
+    spawner.completion_tx.send(SpawnCompletion {
+        generation: stale_generation,
+        result: Err(std::io::Error::new(std::io::ErrorKind::Other, "stale")),
+    }).unwrap();
+
+    spawner.poll(&mut app);
+
+    assert!(!spawner.in_flight);
+    assert_eq!(spawner.consecutive_failures, 0);
+    assert!(spawner.retry_not_before.is_none());
+}
+
+#[test]
+fn current_worker_failure_uses_bounded_backoff() {
+    let mut app = fresh_app();
+    let mut spawner = WarmPaneSpawner::new();
+    spawner.in_flight = true;
+    spawner.completion_tx.send(SpawnCompletion {
+        generation: spawner.generation,
+        result: Err(std::io::Error::new(std::io::ErrorKind::Other, "failed")),
+    }).unwrap();
+
+    spawner.poll(&mut app);
+
+    assert!(!spawner.in_flight);
+    assert_eq!(spawner.consecutive_failures, 1);
+    assert!(spawner.retry_not_before.is_some());
+    assert_eq!(retry_delay(1), std::time::Duration::from_millis(100));
+    assert_eq!(retry_delay(2), std::time::Duration::from_millis(500));
+    assert_eq!(retry_delay(3), std::time::Duration::from_secs(2));
+    assert_eq!(retry_delay(99), std::time::Duration::from_secs(5));
 }
 
 // ── for_post_config: priority order ────────────────────────────────

--- a/tests/test_control_mode_liveness.ps1
+++ b/tests/test_control_mode_liveness.ps1
@@ -1,0 +1,354 @@
+# Regression coverage for control-mode liveness under the Windows lifecycle
+# failures that matter here:
+#   1. runtime warm-pane replenishment is deliberately delayed, while unrelated
+#      display-message and capture-pane commands must stay responsive;
+#   2. input EOF drains already-completed response blocks before socket close;
+#   3. a control client that stops reading is disconnected after the bounded
+#      socket write timeout, without stalling a second control client.
+#
+# The warm-pane delay hook is compiled only into debug builds. A release build
+# therefore skips this test rather than producing a false green.
+
+$ErrorActionPreference = 'Stop'
+. "$PSScriptRoot\psmux_test_helpers.ps1"
+
+$ctx = New-PsmuxTestEnv -Tag 'ctrl_live'
+$PSMUX = $ctx.PsmuxExe
+if ($PSMUX -notmatch '\\debug\\') {
+    Write-Host "[SKIP] control liveness fault injection requires a debug build: $PSMUX" -ForegroundColor Yellow
+    Remove-PsmuxTestEnv -Ctx $ctx
+    exit 0
+}
+
+$namespace = Register-PsmuxNamespace -Ctx $ctx -Namespace 'ctrl_live'
+$session = 'ctrl_live'
+$base = "${namespace}__${session}"
+$delayMs = 8000
+$commandLimitMs = 2500
+$delayStartedFile = Join-Path $ctx.Home 'warm-delay-started.txt'
+$pressureStartedFile = Join-Path $ctx.Home 'pressure-started.txt'
+$pass = 0
+$fail = 0
+
+function Write-Result([string]$Name, [bool]$Ok, [string]$Detail = '') {
+    if ($Ok) {
+        Write-Host "  [PASS] $Name" -ForegroundColor Green
+        $script:pass++
+    } else {
+        Write-Host "  [FAIL] $Name$(if ($Detail) { ": $Detail" })" -ForegroundColor Red
+        $script:fail++
+    }
+}
+
+function Read-ExactBytes {
+    param(
+        [Parameter(Mandatory)]$Stream,
+        [Parameter(Mandatory)][int]$Count
+    )
+    $buffer = New-Object byte[] $Count
+    $offset = 0
+    while ($offset -lt $Count) {
+        $read = $Stream.Read($buffer, $offset, $Count - $offset)
+        if ($read -le 0) { throw "control socket closed after $offset/$Count greeting bytes" }
+        $offset += $read
+    }
+    return ,$buffer
+}
+
+function Drain-ControlClient {
+    param(
+        [Parameter(Mandatory)]$Client,
+        [int]$TimeoutMs = 250
+    )
+    $Client.Stream.ReadTimeout = $TimeoutMs
+    try {
+        while ($null -ne $Client.Reader.ReadLine()) {}
+    } catch [System.IO.IOException] {}
+}
+
+function Open-ControlClient {
+    param(
+        [Parameter(Mandatory)]$Context,
+        [Parameter(Mandatory)][string]$SessionBase,
+        [switch]$SlowReceive
+    )
+    $port = [int](Get-Content (Join-Path $Context.PsmuxDir "$SessionBase.port") -Raw).Trim()
+    $key = (Get-Content (Join-Path $Context.PsmuxDir "$SessionBase.key") -Raw).Trim()
+    $tcp = [System.Net.Sockets.TcpClient]::new()
+    if ($SlowReceive) { $tcp.ReceiveBufferSize = 1024 }
+    $tcp.NoDelay = $true
+    $tcp.Connect('127.0.0.1', $port)
+    $stream = $tcp.GetStream()
+    $stream.ReadTimeout = 3000
+    $stream.WriteTimeout = 3000
+    $encoding = [System.Text.UTF8Encoding]::new($false)
+    $reader = [System.IO.StreamReader]::new($stream, $encoding, $false, 4096, $true)
+    $writer = [System.IO.StreamWriter]::new($stream, $encoding, 4096, $true)
+    $writer.NewLine = "`n"
+    $writer.AutoFlush = $true
+    $writer.WriteLine("AUTH $key")
+    $auth = $reader.ReadLine()
+    if ($auth -notmatch '^OK') { throw "control AUTH failed: $auth" }
+    $writer.WriteLine('CONTROL_NOECHO')
+    $reader.Dispose()
+    $greeting = Read-ExactBytes -Stream $stream -Count 7
+    $expected = [byte[]](0x1b, 0x50, 0x31, 0x30, 0x30, 0x30, 0x70)
+    if (Compare-Object $greeting $expected) {
+        throw 'control DCS greeting did not match ESC P 1000 p'
+    }
+    $reader = [System.IO.StreamReader]::new($stream, $encoding, $false, 4096, $true)
+    $client = [pscustomobject]@{
+        Tcp = $tcp
+        Stream = $stream
+        Reader = $reader
+        Writer = $writer
+    }
+    Drain-ControlClient -Client $client
+    return $client
+}
+
+function Close-ControlClient {
+    param($Client)
+    if ($null -eq $Client) { return }
+    try { $Client.Tcp.Close() } catch {}
+}
+
+function Invoke-ControlCommand {
+    param(
+        [Parameter(Mandatory)]$Client,
+        [Parameter(Mandatory)][string]$Command,
+        [int]$TimeoutMs = 5000
+    )
+    $Client.Stream.ReadTimeout = $TimeoutMs
+    $lines = [System.Collections.Generic.List[string]]::new()
+    $number = $null
+    $stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
+    $Client.Writer.WriteLine($Command)
+    try {
+        while ($true) {
+            $line = $Client.Reader.ReadLine()
+            if ($null -eq $line) { throw 'control socket closed before command footer' }
+            $lines.Add($line)
+            if ($line -match '^%begin \d+ (\d+) 1$') {
+                $number = $Matches[1]
+                continue
+            }
+            if ($null -ne $number -and $line -match "^%(end|error) \d+ $number 1$") {
+                break
+            }
+        }
+    } finally {
+        $stopwatch.Stop()
+    }
+    $text = $lines -join "`n"
+    return [pscustomobject]@{
+        Text = $text
+        ElapsedMs = [int]$stopwatch.ElapsedMilliseconds
+        BeginCount = ([regex]::Matches($text, '(?m)^%begin ')).Count
+        EndCount = ([regex]::Matches($text, '(?m)^%end ')).Count
+        ErrorCount = ([regex]::Matches($text, '(?m)^%error ')).Count
+    }
+}
+
+function Invoke-ControlBatchAndHalfClose {
+    param(
+        [Parameter(Mandatory)]$Client,
+        [Parameter(Mandatory)][string[]]$Commands,
+        [int]$TimeoutMs = 5000
+    )
+    $Client.Stream.ReadTimeout = $TimeoutMs
+    foreach ($command in $Commands) {
+        $Client.Writer.WriteLine($command)
+    }
+    $Client.Writer.Flush()
+    $Client.Tcp.Client.Shutdown([System.Net.Sockets.SocketShutdown]::Send)
+
+    $lines = [System.Collections.Generic.List[string]]::new()
+    $stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
+    try {
+        while ($true) {
+            $line = $Client.Reader.ReadLine()
+            if ($null -eq $line) { break }
+            $lines.Add($line)
+        }
+    } finally {
+        $stopwatch.Stop()
+    }
+    $text = $lines -join "`n"
+    return [pscustomobject]@{
+        Text = $text
+        ElapsedMs = [int]$stopwatch.ElapsedMilliseconds
+        BeginCount = ([regex]::Matches($text, '(?m)^%begin ')).Count
+        EndCount = ([regex]::Matches($text, '(?m)^%end ')).Count
+        ErrorCount = ([regex]::Matches($text, '(?m)^%error ')).Count
+    }
+}
+
+function Wait-ForFile {
+    param(
+        [Parameter(Mandatory)][string]$Path,
+        [int]$TimeoutMs = 5000
+    )
+    $deadline = [DateTime]::UtcNow.AddMilliseconds($TimeoutMs)
+    while ([DateTime]::UtcNow -lt $deadline) {
+        if (Test-Path $Path -PathType Leaf) { return $true }
+        Start-Sleep -Milliseconds 25
+    }
+    return $false
+}
+
+function Wait-ControlClientClosed {
+    param(
+        [Parameter(Mandatory)]$Client,
+        [int]$TimeoutMs = 5000
+    )
+    $Client.Stream.ReadTimeout = 250
+    $deadline = [DateTime]::UtcNow.AddMilliseconds($TimeoutMs)
+    $characters = 0L
+    while ([DateTime]::UtcNow -lt $deadline) {
+        try {
+            $line = $Client.Reader.ReadLine()
+            if ($null -eq $line) {
+                return [pscustomobject]@{ Closed = $true; Characters = $characters }
+            }
+            $characters += $line.Length
+        } catch [System.IO.IOException] {
+            $socket = $_.Exception.InnerException
+            if ($socket -is [System.Net.Sockets.SocketException] -and
+                $socket.SocketErrorCode -eq [System.Net.Sockets.SocketError]::TimedOut) {
+                continue
+            }
+            return [pscustomobject]@{ Closed = $true; Characters = $characters }
+        }
+    }
+    return [pscustomobject]@{ Closed = $false; Characters = $characters }
+}
+
+$control = $null
+$drainControl = $null
+$slowControl = $null
+$healthyControl = $null
+$savedConfig = $env:PSMUX_CONFIG_FILE
+$savedDelay = $env:PSMUX_TEST_WARM_PANE_DELAY_MS
+$savedMarker = $env:PSMUX_TEST_WARM_PANE_DELAY_STARTED_FILE
+try {
+    $env:PSMUX_CONFIG_FILE = 'NUL'
+    $env:PSMUX_TEST_WARM_PANE_DELAY_MS = "$delayMs"
+    $env:PSMUX_TEST_WARM_PANE_DELAY_STARTED_FILE = $delayStartedFile
+
+    & $PSMUX -L $namespace new-session -d -s $session -x 100 -y 30 2>&1 | Out-Null
+    if ($LASTEXITCODE -ne 0) { throw "new-session failed with exit code $LASTEXITCODE" }
+
+    Write-Host "`n=== Runtime warm-pane spawn does not block control commands ===" -ForegroundColor Cyan
+    $control = Open-ControlClient -Context $ctx -SessionBase $base
+    $trigger = Invoke-ControlCommand -Client $control `
+        -Command 'new-window -d -P -F "#{pane_id}" -n worker-trigger'
+    Write-Result 'new-window completed before the injected worker delay' `
+        ($trigger.EndCount -eq 1 -and $trigger.ErrorCount -eq 0) $trigger.Text
+
+    $injectionStarted = Wait-ForFile -Path $delayStartedFile -TimeoutMs 2500
+    Write-Result 'runtime warm-pane delay hook started' $injectionStarted `
+        "marker did not appear at $delayStartedFile"
+
+    $display = Invoke-ControlCommand -Client $control `
+        -Command 'display-message -p "control-alive"' `
+        -TimeoutMs $commandLimitMs
+    Write-Result 'display-message stays responsive during warm ConPTY creation' `
+        ($display.Text -match '(?m)^control-alive$' -and
+            $display.ElapsedMs -lt $commandLimitMs -and
+            $display.BeginCount -eq 1 -and
+            $display.EndCount -eq 1 -and
+            $display.ErrorCount -eq 0) `
+        "elapsed=$($display.ElapsedMs)ms output=$($display.Text)"
+
+    $capture = Invoke-ControlCommand -Client $control `
+        -Command 'capture-pane -p -e -J -N -t :0' `
+        -TimeoutMs $commandLimitMs
+    Write-Result 'capture-pane stays responsive during warm ConPTY creation' `
+        ($capture.ElapsedMs -lt $commandLimitMs -and
+            $capture.BeginCount -eq 1 -and
+            $capture.EndCount -eq 1 -and
+            $capture.ErrorCount -eq 0) `
+        "elapsed=$($capture.ElapsedMs)ms output=$($capture.Text)"
+
+    Write-Host "`n=== One failed command does not poison the control connection ===" -ForegroundColor Cyan
+    $bad = Invoke-ControlCommand -Client $control -Command 'definitely-not-a-real-command'
+    Write-Result 'unknown command has exactly one %begin/%error pair' `
+        ($bad.BeginCount -eq 1 -and $bad.EndCount -eq 0 -and $bad.ErrorCount -eq 1) `
+        $bad.Text
+    $afterError = Invoke-ControlCommand -Client $control -Command 'display-message -p "after-error"'
+    Write-Result 'next command succeeds on the same socket after %error' `
+        ($afterError.Text -match '(?m)^after-error$' -and
+            $afterError.BeginCount -eq 1 -and
+            $afterError.EndCount -eq 1 -and
+            $afterError.ErrorCount -eq 0) `
+        $afterError.Text
+    Close-ControlClient $control
+    $control = $null
+
+    Write-Host "`n=== Input EOF drains completed command blocks ===" -ForegroundColor Cyan
+    $drainControl = Open-ControlClient -Context $ctx -SessionBase $base
+    $drained = Invoke-ControlBatchAndHalfClose -Client $drainControl -Commands @(
+        'display-message -p "eof-drain-one"',
+        'display-message -p "eof-drain-two"'
+    )
+    Write-Result 'half-closed input preserves every response body' `
+        ($drained.Text -match '(?m)^eof-drain-one$' -and
+            $drained.Text -match '(?m)^eof-drain-two$') `
+        $drained.Text
+    Write-Result 'half-closed input drains every command guard before socket EOF' `
+        ($drained.BeginCount -eq 2 -and
+            $drained.EndCount -eq 2 -and
+            $drained.ErrorCount -eq 0 -and
+            $drained.ElapsedMs -lt 5000) `
+        "elapsed=$($drained.ElapsedMs)ms output=$($drained.Text)"
+    Close-ControlClient $drainControl
+    $drainControl = $null
+
+    Write-Host "`n=== A non-reading control client is bounded ===" -ForegroundColor Cyan
+    $slowControl = Open-ControlClient -Context $ctx -SessionBase $base -SlowReceive
+    $escapedStarted = $pressureStartedFile.Replace("'", "''")
+    $payload = "[IO.File]::WriteAllText('$escapedStarted','started');`$chunk='Z' * 65536;for(`$i=0;`$i -lt 512;`$i++){[Console]::Out.Write(`$chunk);[Console]::Out.Flush();[Threading.Thread]::Sleep(10)}"
+    $pressureWatch = [System.Diagnostics.Stopwatch]::StartNew()
+    & $PSMUX -L $namespace send-keys -t "${session}:0" -l $payload 2>&1 | Out-Null
+    & $PSMUX -L $namespace send-keys -t "${session}:0" Enter 2>&1 | Out-Null
+    $outputStarted = Wait-ForFile -Path $pressureStartedFile -TimeoutMs 5000
+    Write-Result 'pane started the socket-pressure payload' $outputStarted `
+        "start file did not appear at $pressureStartedFile"
+
+    $healthyControl = Open-ControlClient -Context $ctx -SessionBase $base
+    $healthy = Invoke-ControlCommand -Client $healthyControl `
+        -Command 'display-message -p "healthy-client"' `
+        -TimeoutMs $commandLimitMs
+    Write-Result 'a second control client remains responsive' `
+        ($healthy.Text -match '(?m)^healthy-client$' -and
+            $healthy.ElapsedMs -lt $commandLimitMs -and
+            $healthy.EndCount -eq 1) `
+        "elapsed=$($healthy.ElapsedMs)ms output=$($healthy.Text)"
+    Close-ControlClient $healthyControl
+    $healthyControl = $null
+
+    $remainingMs = 10000 - [int]$pressureWatch.ElapsedMilliseconds
+    if ($remainingMs -gt 0) { Start-Sleep -Milliseconds $remainingMs }
+    $closed = Wait-ControlClientClosed -Client $slowControl -TimeoutMs 5000
+    Write-Result 'non-reading client is disconnected after the write timeout' `
+        $closed.Closed "socket stayed open after draining $($closed.Characters) characters"
+} catch {
+    Write-Result 'test setup and protocol execution completed' $false $_.Exception.ToString()
+} finally {
+    Close-ControlClient $drainControl
+    Close-ControlClient $healthyControl
+    Close-ControlClient $slowControl
+    Close-ControlClient $control
+    if ($null -eq $savedConfig) { Remove-Item Env:\PSMUX_CONFIG_FILE -ErrorAction SilentlyContinue }
+    else { $env:PSMUX_CONFIG_FILE = $savedConfig }
+    if ($null -eq $savedDelay) { Remove-Item Env:\PSMUX_TEST_WARM_PANE_DELAY_MS -ErrorAction SilentlyContinue }
+    else { $env:PSMUX_TEST_WARM_PANE_DELAY_MS = $savedDelay }
+    if ($null -eq $savedMarker) { Remove-Item Env:\PSMUX_TEST_WARM_PANE_DELAY_STARTED_FILE -ErrorAction SilentlyContinue }
+    else { $env:PSMUX_TEST_WARM_PANE_DELAY_STARTED_FILE = $savedMarker }
+    Remove-PsmuxTestEnv -Ctx $ctx
+}
+
+Write-Host "`n=== Results: $pass passed, $fail failed ===" -ForegroundColor Cyan
+if ($fail -gt 0) { exit 1 }
+exit 0


### PR DESCRIPTION
## Context

[tmex](https://github.com/krhougs/tmex)'s Windows gateway (Vibe X is its commercial distribution) holds a long-lived control-mode connection to psmux and forwards pane output to remote web clients. The consumer side can stall for seconds at a time — network backpressure, a phone client on a weak link — which makes the control channel's robustness under a slow reader a production-critical property.

## Problems

1. **Slow readers were disconnected.** A control client that fell behind hit the connection's 5s write timeout and was dropped. For an integration this is catastrophic: the whole gateway loses every subscription and must resync from scratch — a stall became an outage.
2. **A command could stall the whole channel**, and error/success block framing wasn't atomic under concurrency (interleaved `%begin`/`%error` footers), so one late handler corrupted the line protocol for everything after it.
3. **Unbounded `%output` lines.** A single burst from a chatty pane produced one multi-hundred-KB notification line; real tmux emits one notification per PTY read. Line-based consumers allocate and parse per line, so these mega-lines caused latency spikes and buffer blowups.
4. **One-shot `capture-pane` could wait forever on the server response** — a wedged server hung the CLI and any script driving it, the one-shot flavor of the same stall class.
5. **The client's debug logger panicked on multi-byte output**: each OUT line was truncated to 200 raw bytes; any line whose 200th byte fell inside a multi-byte character — routine for TUI box-drawing — panicked the reader thread and killed the control client, observed as a command timeout followed by a reconnect loop.

## Fix

- Replace disconnect-on-slow with **bounded buffering + shedding**: below a soft backlog bound everything queues; past it, `%output`/`%extended-output` frames are shed (any client resynchronizes with `capture-pane`) while structural notifications (window/pane lifecycle) still queue; past a hard bound everything sheds. Queued bytes are accounted per client and drained symmetrically by the writer.
- Make each command handler complete with an explicit success/error response (`ControlCommandResponse`), keeping `%begin…%end/%error` blocks atomic and the channel responsive while a handler waits.
- **Split pane output into bounded notification lines** (4 KiB max, split on UTF-8 boundaries) matching tmux's one-notification-per-read shape.
- Bound the one-shot capture-pane wait; on expiry it reports `ERROR: capture-pane timed out` instead of hanging.
- Truncate the client debug log **on a char boundary** instead of a raw byte offset.

## Tests

`test_control_mode_liveness.rs` (handler timeout/error and block atomicity), `test_control_slow_client_backlog.rs` (9 tests: shed thresholds, structural-vs-output classes, cost accounting, non-blocking burst), `test_control_output_chunking.rs` (8 tests: bounds, UTF-8 boundary, reassembly, wire-level line bounds), `test_capture_pane_wait_bound.rs` (real connection handler over loopback: the 5s bound produces the timeout error), and a subprocess test driving the real client reader against a scripted control server with a mid-glyph 200th byte (`test_client_debug_log_truncation.rs`). All closed tests; no psmux server spawned. Verified on Windows.
