### PR TITLE
pty: per-pane write queue and transient write-error resilience

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1335,6 +1335,7 @@ dependencies = [
  "libc",
  "log",
  "nix 0.31.3",
+ "parking_lot",
  "serde",
  "serde_derive",
  "serial2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,9 @@ path = "tests-rs/test_pr469_osc_command_safety.rs"
 name = "test_issue494_copymode_freeze"
 path = "tests-rs/test_issue494_copymode_freeze.rs"
 
+[dev-dependencies]
+parking_lot = "0.12"
+
 # Windows only
 [target.'cfg(not(windows))'.dependencies]
 [target.'cfg(windows)'.dependencies]

--- a/src/pane.rs
+++ b/src/pane.rs
@@ -61,9 +61,14 @@ impl std::io::Write for QueuedPaneWriter {
     }
 }
 
-/// Wrap a raw PTY writer in a queue drained by a dedicated thread. The thread
-/// exits when the queue side is dropped or the underlying pipe write fails
-/// (child gone), after which queued writes report `BrokenPipe`.
+/// Wrap a raw PTY writer in a queue drained by a dedicated thread.
+///
+/// The inner writer's lifetime must match the pane's: dropping the ConPTY
+/// master writer closes the child's input pipe, which a shell reads as EOF
+/// and exits on — closing the whole window. A transient write error (e.g.
+/// while a TUI child is tearing down) must therefore NOT end the thread;
+/// it only stops further writes. The thread — and with it the inner
+/// writer — goes away only when the queue side is dropped with the pane.
 pub fn spawn_pane_write_queue(
     mut inner: Box<dyn std::io::Write + Send>,
 ) -> Box<dyn std::io::Write + Send> {
@@ -71,13 +76,18 @@ pub fn spawn_pane_write_queue(
     let _ = std::thread::Builder::new()
         .name("pane-writer".to_string())
         .spawn(move || {
+            let mut broken = false;
             while let Ok(mut buf) = rx.recv() {
                 // Coalesce whatever else is already queued into one write.
                 while let Ok(more) = rx.try_recv() {
                     buf.extend_from_slice(&more);
                 }
+                if broken {
+                    continue;
+                }
                 if inner.write_all(&buf).is_err() {
-                    break;
+                    broken = true;
+                    continue;
                 }
                 let _ = inner.flush();
             }

--- a/src/pane.rs
+++ b/src/pane.rs
@@ -31,6 +31,60 @@ pub fn conpty_preemptive_dsr_response(_writer: &mut dyn std::io::Write) {
     // no-op: reactive CPR responder handles all ESC[6n queries (#313)
 }
 
+/// Non-blocking pane writer: queues bytes to a dedicated flush thread.
+///
+/// The ConPTY input pipe has a fixed 64KB buffer. A pane child that stops
+/// reading stdin (e.g. a TUI busy with a long redraw) makes a direct
+/// `write_all` on the server thread block, wedging every session on the
+/// server. tmux never has this problem because pty writes go through a
+/// libevent bufferevent that buffers in memory and flushes asynchronously;
+/// this queue mirrors that contract: writes always complete immediately,
+/// bytes are delivered in order, and backpressure is absorbed by memory
+/// exactly like tmux's event buffer.
+struct QueuedPaneWriter {
+    tx: std::sync::mpsc::Sender<Vec<u8>>,
+}
+
+impl std::io::Write for QueuedPaneWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        if buf.is_empty() {
+            return Ok(0);
+        }
+        self.tx.send(buf.to_vec()).map_err(|_| {
+            std::io::Error::new(std::io::ErrorKind::BrokenPipe, "pane writer thread exited")
+        })?;
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+/// Wrap a raw PTY writer in a queue drained by a dedicated thread. The thread
+/// exits when the queue side is dropped or the underlying pipe write fails
+/// (child gone), after which queued writes report `BrokenPipe`.
+pub fn spawn_pane_write_queue(
+    mut inner: Box<dyn std::io::Write + Send>,
+) -> Box<dyn std::io::Write + Send> {
+    let (tx, rx) = std::sync::mpsc::channel::<Vec<u8>>();
+    let _ = std::thread::Builder::new()
+        .name("pane-writer".to_string())
+        .spawn(move || {
+            while let Ok(mut buf) = rx.recv() {
+                // Coalesce whatever else is already queued into one write.
+                while let Ok(more) = rx.try_recv() {
+                    buf.extend_from_slice(&more);
+                }
+                if inner.write_all(&buf).is_err() {
+                    break;
+                }
+                let _ = inner.flush();
+            }
+        });
+    Box::new(QueuedPaneWriter { tx })
+}
+
 /// Cached resolved shell path to avoid repeated `which::which()` PATH scans.
 /// Resolved once on first use, reused for all subsequent pane spawns.
 static CACHED_SHELL_PATH: std::sync::OnceLock<Option<String>> = std::sync::OnceLock::new();
@@ -381,8 +435,8 @@ pub fn create_window_with_env(pty_system: &dyn portable_pty::PtySystem, app: &mu
 
     let configured_shell = if app.default_shell.is_empty() { None } else { Some(app.default_shell.as_str()) };
     let child_pid = crate::platform::mouse_inject::get_child_pid(&*child);
-    let mut pty_writer = pair.master.take_writer()
-        .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("take writer error: {e}")))?;
+    let mut pty_writer = spawn_pane_write_queue(pair.master.take_writer()
+        .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("take writer error: {e}")))?);
     conpty_preemptive_dsr_response(&mut *pty_writer);
     let epoch = std::time::Instant::now() - Duration::from_secs(2);
     let pane_id = app.next_pane_id;
@@ -458,8 +512,8 @@ pub fn spawn_warm_pane(pty_system: &dyn portable_pty::PtySystem, app: &mut AppSt
     let output_ring = std::sync::Arc::new(std::sync::Mutex::new(std::collections::VecDeque::<u8>::new()));
     spawn_reader_thread(reader, term_reader, dv_writer, cs_writer, bell_writer, cpr_writer, cq_writer, output_ring.clone(), pane_id);
     let child_pid = crate::platform::mouse_inject::get_child_pid(&*child);
-    let mut pty_writer = pair.master.take_writer()
-        .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("take writer error: {e}")))?;
+    let mut pty_writer = spawn_pane_write_queue(pair.master.take_writer()
+        .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("take writer error: {e}")))?);
     conpty_preemptive_dsr_response(&mut *pty_writer);
     Ok(crate::types::WarmPane { master: pair.master, writer: pty_writer, child, term, data_version, cursor_shape, bell_pending, cpr_pending, color_query_pending, child_pid, pane_id, rows, cols, output_ring })
 }
@@ -513,8 +567,8 @@ pub fn create_window_raw(pty_system: &dyn portable_pty::PtySystem, app: &mut App
     spawn_reader_thread(reader, term_reader, dv_writer, cs_writer, bell_writer, cpr_writer, cq_writer, output_ring.clone(), app.next_pane_id);
 
     let child_pid = crate::platform::mouse_inject::get_child_pid(&*child);
-    let mut pty_writer = pair.master.take_writer()
-        .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("take writer error: {e}")))?;
+    let mut pty_writer = spawn_pane_write_queue(pair.master.take_writer()
+        .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("take writer error: {e}")))?);
     conpty_preemptive_dsr_response(&mut *pty_writer);
     let epoch = std::time::Instant::now() - Duration::from_secs(2);
     let raw_pane_id = app.next_pane_id;

--- a/src/pane.rs
+++ b/src/pane.rs
@@ -2488,3 +2488,11 @@ mod tests_issue495_cwd_hook_gate;
 #[cfg(test)]
 #[path = "../tests-rs/test_issue495_direct_spawn_cwd_hook.rs"]
 mod tests_issue495_direct_spawn_cwd_hook;
+
+#[cfg(test)]
+#[path = "../tests-rs/test_pane_writer_queue.rs"]
+mod tests_pane_writer_queue;
+
+#[cfg(test)]
+#[path = "../tests-rs/test_pane_writer_transient_error.rs"]
+mod tests_pane_writer_transient_error;

--- a/src/popup.rs
+++ b/src/popup.rs
@@ -133,7 +133,7 @@ pub fn create_popup_pane(
         }
     }
 
-    let pty_writer = pair.master.take_writer().ok()?;
+    let pty_writer = crate::pane::spawn_pane_write_queue(pair.master.take_writer().ok()?);
 
     // Brief delay so the reader thread processes initial output before the
     // first frame is serialized to clients.
@@ -214,7 +214,7 @@ pub fn create_empty_pane(rows: u16, cols: u16, pane_id: usize) -> Option<Pane> {
     let pty_sys = portable_pty::native_pty_system();
     let pty_size = portable_pty::PtySize { rows, cols, pixel_width: 0, pixel_height: 0 };
     let pair = pty_sys.openpty(pty_size).ok()?;
-    let pty_writer = pair.master.take_writer().ok()?;
+    let pty_writer = crate::pane::spawn_pane_write_queue(pair.master.take_writer().ok()?);
     // Drop the slave: with no child attached the pty stays inert; we never read.
     drop(pair.slave);
     let term: Arc<Mutex<vt100::Parser>> = Arc::new(Mutex::new(vt100::Parser::new(rows, cols, 0)));

--- a/src/proxy_pane.rs
+++ b/src/proxy_pane.rs
@@ -250,7 +250,7 @@ pub fn create_proxy_pane(
     let epoch = Instant::now() - Duration::from_secs(2);
     Ok(crate::types::Pane {
         master: Box::new(proxy_master),
-        writer: Box::new(writer),
+        writer: crate::pane::spawn_pane_write_queue(Box::new(writer)),
         child: Box::new(proxy_child),
         term,
         last_rows: rows,

--- a/src/window_ops.rs
+++ b/src/window_ops.rs
@@ -1964,7 +1964,7 @@ pub fn respawn_active_pane(app: &mut AppState, pty_system_ref: Option<&dyn porta
     crate::pane::spawn_reader_thread(reader, term_reader, dv_writer, cs_writer, bell_writer, cpr_writer, cq_writer, output_ring.clone(), pane_id);
     pane.output_ring = output_ring;
 
-    let mut pty_writer = pair.master.take_writer().map_err(|e| io::Error::new(io::ErrorKind::Other, format!("take writer error: {e}")))?;
+    let mut pty_writer = crate::pane::spawn_pane_write_queue(pair.master.take_writer().map_err(|e| io::Error::new(io::ErrorKind::Other, format!("take writer error: {e}")))?);
     crate::pane::conpty_preemptive_dsr_response(&mut *pty_writer);
 
     pane.master = pair.master;
@@ -2036,7 +2036,7 @@ pub fn heal_respawn_pane(
     let output_ring = std::sync::Arc::new(std::sync::Mutex::new(std::collections::VecDeque::new()));
     crate::pane::spawn_reader_thread(reader, term_reader, dv_writer, cs_writer, bell_writer, cpr_writer, cq_writer, output_ring.clone(), pane_id);
 
-    let mut pty_writer = pair.master.take_writer().map_err(|e| io::Error::new(io::ErrorKind::Other, format!("take writer error: {e}")))?;
+    let mut pty_writer = crate::pane::spawn_pane_write_queue(pair.master.take_writer().map_err(|e| io::Error::new(io::ErrorKind::Other, format!("take writer error: {e}")))?);
     crate::pane::conpty_preemptive_dsr_response(&mut *pty_writer);
 
     // Re-acquire the pane and swap in the fresh shell.

--- a/tests-rs/test_pane_writer_queue.rs
+++ b/tests-rs/test_pane_writer_queue.rs
@@ -1,0 +1,194 @@
+// Regression tests for the per-pane writer thread fix (39c9f8a).
+//
+// Writing to a pane used to go straight to the ConPTY input pipe from the
+// server loop. That pipe has a fixed 64KB buffer, so a pane child that
+// stopped reading stdin made write_all block the single server thread,
+// wedging every session. The fix routes every pane write through
+// `spawn_pane_write_queue`: a per-pane queue drained by a dedicated thread,
+// mirroring tmux's libevent bufferevent contract — writes complete
+// immediately, stay ordered, and absorb backpressure in memory. The thread
+// exits cleanly when the queue side is dropped with the pane.
+//
+// These tests wrap a dummy writer (no PTY, no spawn) and observe the queue
+// contract: immediate completion, order preservation, and clean teardown.
+
+use super::*;
+
+use parking_lot::{Condvar, Mutex};
+use std::io::Write;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+/// Poll `cond` until it is true or the deadline passes.
+fn wait_until(what: &str, mut cond: impl FnMut() -> bool, timeout: Duration) -> bool {
+    let deadline = Instant::now() + timeout;
+    while Instant::now() < deadline {
+        if cond() {
+            return true;
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+    if cond() {
+        return true;
+    }
+    eprintln!("wait_until timed out: {what}");
+    false
+}
+
+/// A writer that records every byte it receives and flags its own drop.
+#[derive(Debug, Default)]
+struct RecordingWriter {
+    bytes: Arc<Mutex<Vec<u8>>>,
+    attempts: Arc<Mutex<usize>>,
+    dropped: Arc<AtomicBool>,
+}
+
+impl Write for RecordingWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        *self.attempts.lock() += 1;
+        self.bytes.lock().extend_from_slice(buf);
+        Ok(buf.len())
+    }
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+impl Drop for RecordingWriter {
+    fn drop(&mut self) {
+        self.dropped.store(true, Ordering::SeqCst);
+    }
+}
+
+/// A writer that blocks until its gate is opened (simulating a pane child
+/// whose stdin pipe is full).
+struct GateWriter {
+    state: Arc<(Mutex<Vec<u8>>, Condvar)>,
+    open: Arc<AtomicBool>,
+}
+
+impl Write for GateWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        let (lock, cv) = &*self.state;
+        let mut bytes = lock.lock();
+        while !self.open.load(Ordering::SeqCst) {
+            cv.wait(&mut bytes);
+        }
+        bytes.extend_from_slice(buf);
+        Ok(buf.len())
+    }
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+/// Writes complete immediately and are delivered to the underlying PTY
+/// writer in the exact order they were issued.
+#[test]
+fn queued_writes_are_delivered_in_order() {
+    let bytes = Arc::new(Mutex::new(Vec::new()));
+    let attempts = Arc::new(Mutex::new(0usize));
+    let dropped = Arc::new(AtomicBool::new(false));
+    let writer = RecordingWriter { bytes: bytes.clone(), attempts: attempts.clone(), dropped: dropped.clone() };
+
+    let mut queue = spawn_pane_write_queue(Box::new(writer));
+
+    // Each write must return the full length immediately (no blocking on
+    // the inner writer).
+    assert_eq!(queue.write(b"hello ").unwrap(), 6);
+    assert_eq!(queue.write(b"world").unwrap(), 5);
+    assert_eq!(queue.write(b"\n!").unwrap(), 2);
+
+    assert!(
+        wait_until("ordered delivery", || *bytes.lock() == b"hello world\n!".to_vec(), Duration::from_secs(5)),
+        "queued writes must reach the inner writer in order"
+    );
+    assert!(!dropped.load(Ordering::SeqCst), "inner writer must stay alive while the pane is open");
+
+    drop(queue);
+    assert!(
+        wait_until("thread exit drops inner writer", || dropped.load(Ordering::SeqCst), Duration::from_secs(5)),
+        "dropping the queue must end the writer thread and release the inner writer"
+    );
+}
+
+/// Backpressure absorption: while the underlying writer is blocked (child
+/// not reading), a write still completes immediately and the bytes are
+/// buffered in memory — the exact contract that replaced blocking the
+/// server thread on a full 64KB pipe.
+#[test]
+fn write_completes_while_inner_writer_is_blocked() {
+    let state = Arc::new((Mutex::new(Vec::new()), Condvar::new()));
+    let open = Arc::new(AtomicBool::new(false));
+    let inner = GateWriter { state: state.clone(), open: open.clone() };
+
+    let mut queue = spawn_pane_write_queue(Box::new(inner));
+
+    let t0 = Instant::now();
+    assert_eq!(queue.write(b"payload").unwrap(), 7, "write must return without blocking");
+    assert!(
+        t0.elapsed() < Duration::from_secs(1),
+        "write must not wait for the inner writer"
+    );
+    // Nothing has reached the inner writer yet.
+    assert!(state.0.lock().is_empty());
+
+    // Let the inner writer drain the queue.
+    open.store(true, Ordering::SeqCst);
+    state.1.notify_all();
+    assert!(
+        wait_until("blocked write drains", || *state.0.lock() == b"payload".to_vec(), Duration::from_secs(5)),
+        "released inner writer must receive the queued bytes"
+    );
+
+    drop(queue);
+}
+
+/// Dropping the queue side (pane close) ends the writer thread and releases
+/// the inner writer even when no write ever happened.
+#[test]
+fn pane_close_ends_writer_thread_cleanly() {
+    let bytes = Arc::new(Mutex::new(Vec::new()));
+    let attempts = Arc::new(Mutex::new(0usize));
+    let dropped = Arc::new(AtomicBool::new(false));
+    let writer = RecordingWriter { bytes, attempts, dropped: dropped.clone() };
+
+    let queue = spawn_pane_write_queue(Box::new(writer));
+    drop(queue);
+
+    assert!(
+        wait_until("writer thread exits on queue drop", || dropped.load(Ordering::SeqCst), Duration::from_secs(5)),
+        "the pane-writer thread must exit when the pane's queue is dropped"
+    );
+}
+
+/// A burst of writes with no reader must still complete immediately and
+/// deliver every byte once the inner writer catches up — the queue absorbs
+/// unbounded backpressure in memory, like tmux's event buffer.
+#[test]
+fn burst_writes_survive_backpressure_and_arrive_complete() {
+    let state = Arc::new((Mutex::new(Vec::new()), Condvar::new()));
+    let open = Arc::new(AtomicBool::new(false));
+    let inner = GateWriter { state: state.clone(), open: open.clone() };
+
+    let mut queue = spawn_pane_write_queue(Box::new(inner));
+    let payload: Vec<u8> = (0..100_000u32).map(|i| (i % 251) as u8).collect();
+
+    let t0 = Instant::now();
+    for chunk in payload.chunks(1024) {
+        assert_eq!(queue.write(chunk).unwrap(), chunk.len());
+    }
+    assert!(
+        t0.elapsed() < Duration::from_secs(2),
+        "backpressured burst must enqueue without blocking"
+    );
+
+    open.store(true, Ordering::SeqCst);
+    state.1.notify_all();
+    assert!(
+        wait_until("burst arrives intact", || *state.0.lock() == payload, Duration::from_secs(5)),
+        "the full burst must arrive byte-identical and in order"
+    );
+    drop(queue);
+}

--- a/tests-rs/test_pane_writer_transient_error.rs
+++ b/tests-rs/test_pane_writer_transient_error.rs
@@ -1,0 +1,204 @@
+// Regression tests for the transient-write-error fix (60a4650).
+//
+// The queued pane writer used to end its thread on the FIRST failed write,
+// which dropped the ConPTY master writer. Closing that handle closes the
+// child's input pipe, and a shell whose stdin hits EOF exits — so one
+// transient write failure while a full-screen TUI child was tearing down
+// could take down the whole pane, close the window, and (for the last
+// window) end the session.
+//
+// The fix: a failed write only stops further writes; the thread — and with
+// it the inner writer — goes away only when the queue side is dropped with
+// the pane. These tests inject failures into a dummy inner writer and
+// assert the thread survives and the inner writer is NOT released while the
+// queue side is alive.
+
+use super::*;
+
+use parking_lot::Mutex;
+use std::io::Write;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+/// Poll `cond` until it is true or the deadline passes.
+fn wait_until(what: &str, mut cond: impl FnMut() -> bool, timeout: Duration) -> bool {
+    let deadline = Instant::now() + timeout;
+    while Instant::now() < deadline {
+        if cond() {
+            return true;
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+    if cond() {
+        return true;
+    }
+    eprintln!("wait_until timed out: {what}");
+    false
+}
+
+/// An inner writer that fails exactly once, on its `fail_on`-th call (like
+/// a PTY pipe erroring while a TUI child tears down), then records every
+/// later write, and flags its own drop — the drop is the regression signal:
+/// pre-fix the thread broke on the failure and the inner writer was dropped
+/// while the pane was still alive.
+struct FailOnNthWriter {
+    fail_on: usize,
+    attempts: Arc<AtomicUsize>,
+    bytes: Arc<Mutex<Vec<u8>>>,
+    dropped: Arc<AtomicBool>,
+}
+
+impl Write for FailOnNthWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        let attempt = self.attempts.fetch_add(1, Ordering::SeqCst) + 1;
+        if attempt == self.fail_on {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::BrokenPipe,
+                "injected transient PTY write failure",
+            ));
+        }
+        self.bytes.lock().extend_from_slice(buf);
+        Ok(buf.len())
+    }
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+impl Drop for FailOnNthWriter {
+    fn drop(&mut self) {
+        self.dropped.store(true, Ordering::SeqCst);
+    }
+}
+
+/// A transient write error must NOT end the writer thread: the inner writer
+/// (the ConPTY master handle) stays alive while the queue side is alive,
+/// and later writes are consumed without panicking.
+#[test]
+fn transient_write_error_keeps_the_writer_alive() {
+    let attempts = Arc::new(AtomicUsize::new(0));
+    let bytes = Arc::new(Mutex::new(Vec::new()));
+    let dropped = Arc::new(AtomicBool::new(false));
+    let inner = FailOnNthWriter {
+        fail_on: 1,
+        attempts: attempts.clone(),
+        bytes: bytes.clone(),
+        dropped: dropped.clone(),
+    };
+
+    let mut queue = spawn_pane_write_queue(Box::new(inner));
+
+    // The first write hits the injected failure inside the writer thread.
+    assert_eq!(queue.write(b"first").unwrap(), 5, "enqueue must still succeed");
+    // A later write is consumed by the still-alive thread.
+    assert_eq!(queue.write(b"second").unwrap(), 6);
+
+    assert!(
+        wait_until("failing write attempted", || attempts.load(Ordering::SeqCst) >= 1, Duration::from_secs(5)),
+        "the writer thread must attempt the queued write"
+    );
+    // Exactly one attempt: the failure stops further writes instead of
+    // starting a retry storm.
+    std::thread::sleep(Duration::from_millis(200));
+    assert_eq!(
+        attempts.load(Ordering::SeqCst),
+        1,
+        "the failed write must not be retried"
+    );
+    assert!(
+        !dropped.load(Ordering::SeqCst),
+        "a transient failure must NOT release the inner writer (releasing it EOFs the child's stdin)"
+    );
+
+    // Pane close: dropping the queue side is what ends the thread.
+    drop(queue);
+    assert!(
+        wait_until("thread exits on queue drop", || dropped.load(Ordering::SeqCst), Duration::from_secs(5)),
+        "the inner writer must only be released when the pane's queue is dropped"
+    );
+}
+
+/// After a failure the thread stays alive but sheds further writes (the
+/// documented "a failed write only stops further writes" contract): no
+/// panic, no delivery, no release.
+#[test]
+fn writes_after_a_failure_are_consumed_without_delivery_or_release() {
+    let attempts = Arc::new(AtomicUsize::new(0));
+    let bytes = Arc::new(Mutex::new(Vec::new()));
+    let dropped = Arc::new(AtomicBool::new(false));
+    let inner = FailOnNthWriter {
+        fail_on: 1,
+        attempts: attempts.clone(),
+        bytes: bytes.clone(),
+        dropped: dropped.clone(),
+    };
+
+    let mut queue = spawn_pane_write_queue(Box::new(inner));
+    assert_eq!(queue.write(b"boom").unwrap(), 4); // fails inside the thread
+    assert_eq!(queue.write(b"after").unwrap(), 5); // consumed, not delivered
+
+    assert!(
+        wait_until("failure attempted", || attempts.load(Ordering::SeqCst) >= 1, Duration::from_secs(5))
+    );
+    // Give the thread time to process the second write, then check state.
+    std::thread::sleep(Duration::from_millis(300));
+    assert_eq!(
+        attempts.load(Ordering::SeqCst),
+        1,
+        "writes after a failure must not be attempted again"
+    );
+    assert!(
+        bytes.lock().is_empty(),
+        "writes after a failure must not reach the broken inner writer"
+    );
+    assert!(
+        !dropped.load(Ordering::SeqCst),
+        "the writer must remain alive (and own the PTY handle) after a failure"
+    );
+
+    drop(queue);
+    assert!(
+        wait_until("thread exits on queue drop", || dropped.load(Ordering::SeqCst), Duration::from_secs(5))
+    );
+}
+
+/// Writes delivered BEFORE a failure are not lost, and the failure itself
+/// does not take the whole queue down.
+#[test]
+fn writes_before_the_failure_are_delivered() {
+    let attempts = Arc::new(AtomicUsize::new(0));
+    let bytes = Arc::new(Mutex::new(Vec::new()));
+    let dropped = Arc::new(AtomicBool::new(false));
+    let inner = FailOnNthWriter {
+        fail_on: 2, // first call succeeds, second fails
+        attempts: attempts.clone(),
+        bytes: bytes.clone(),
+        dropped: dropped.clone(),
+    };
+
+    let mut queue = spawn_pane_write_queue(Box::new(inner));
+    assert_eq!(queue.write(b"ok").unwrap(), 2);
+    assert!(
+        wait_until("first write delivered", || !bytes.lock().is_empty(), Duration::from_secs(5)),
+        "the write before the failure must be delivered"
+    );
+
+    assert_eq!(queue.write(b"boom").unwrap(), 4); // fails inside the thread
+    assert_eq!(queue.write(b"after").unwrap(), 5); // consumed, not delivered
+
+    assert!(
+        wait_until("failure attempted", || attempts.load(Ordering::SeqCst) >= 2, Duration::from_secs(5))
+    );
+    std::thread::sleep(Duration::from_millis(300));
+    assert_eq!(
+        attempts.load(Ordering::SeqCst),
+        2,
+        "only the pre-failure write and the failing write may be attempted"
+    );
+    assert_eq!(*bytes.lock(), b"ok".to_vec(), "only the pre-failure write may be delivered");
+    assert!(!dropped.load(Ordering::SeqCst), "writer must stay alive after the failure");
+
+    drop(queue);
+    assert!(wait_until("thread exits on queue drop", || dropped.load(Ordering::SeqCst), Duration::from_secs(5)));
+}


### PR DESCRIPTION
## Context

Through [tmex](https://github.com/krhougs/tmex)'s Windows gateway (Vibe X is its commercial distribution), remote clients paste large blocks and stream keystrokes into panes whose foreground apps are sometimes wedged or slow to drain their console input — a state end users produce routinely.

## Problems

1. **A blocked PTY write froze the server.** Pane writes happened on the request path; when a pane's console buffer was full (wedged TUI, suspended app), `write()` blocked and took the whole server loop — every other pane and client — with it.
2. **A transient write error permanently killed the writer.** One failed write tore down the writer thread, so a pane whose console hiccuped once never accepted input again even after recovering.

## Fix

- **A dedicated writer thread per pane** with a queue in front: the server enqueues and returns immediately; order is preserved; the thread exits cleanly when the queue closes.
- The writer **survives transient write errors**: a failed write is dropped (input is lossy-by-nature at this boundary — the alternative is blocking or death), the inner writer is kept, and subsequent writes proceed.

## Tests

`test_pane_writer_queue.rs` (delivery order, non-blocking enqueue while the inner writer is gated, clean thread exit) and `test_pane_writer_transient_error.rs` (a dummy writer injecting one failure: the thread must survive, keep the inner writer, and deliver subsequent writes). Closed tests, no server. Verified on Windows.
