### PR TITLE
tmux parity batch: warm-claim sizing, refresh-client flag rejection, PSMUX_DATA_DIR override

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,9 @@ path = "tests-rs/test_pr469_osc_command_safety.rs"
 name = "test_issue494_copymode_freeze"
 path = "tests-rs/test_issue494_copymode_freeze.rs"
 
+[dev-dependencies]
+parking_lot = "0.12"
+
 # Windows only
 [target.'cfg(not(windows))'.dependencies]
 [target.'cfg(windows)'.dependencies]

--- a/src/debug_log.rs
+++ b/src/debug_log.rs
@@ -29,10 +29,7 @@ use std::sync::atomic::{AtomicU32, Ordering};
 
 /// Resolve the psmux data directory (`~/.psmux/`).
 fn psmux_dir() -> String {
-    let home = std::env::var("USERPROFILE")
-        .or_else(|_| std::env::var("HOME"))
-        .unwrap_or_default();
-    format!("{}/.psmux", home)
+    crate::paths::psmux_dir()
 }
 
 /// Open a log file in the psmux data directory, creating the directory if needed.

--- a/src/format.rs
+++ b/src/format.rs
@@ -1793,8 +1793,7 @@ fn expand_var_inner(var: &str, app: &AppState, win_idx: usize) -> String {
         "version" => VERSION.to_string(),
         "start_time" => app.created_at.timestamp().to_string(),
         "socket_path" => {
-            let home = env::var("USERPROFILE").or_else(|_| env::var("HOME")).unwrap_or_default();
-            format!("{}/.psmux/default", home)
+            format!("{}/default", crate::paths::psmux_dir())
         }
 
         // ── Options as format variables ──

--- a/src/main.rs
+++ b/src/main.rs
@@ -1032,10 +1032,13 @@ fn run_main() -> io::Result<()> {
                 // Skipped when PSMUX_NO_WARM=1 is set or config has 'set -g warm off'.
                 // Also skipped when a custom config file is specified (-f or PSMUX_CONFIG_FILE)
                 // because the warm server loaded the default config, not the custom one.
+                // Also skipped when -x/-y request an explicit size: the warm server
+                // was spawned with the default geometry, and tmux guarantees that
+                // `new-session -d -x W -y H` yields a session of exactly that size.
                 let warm_disabled = std::env::var("PSMUX_NO_WARM").map(|v| v == "1" || v == "true").unwrap_or(false)
                     || crate::config::is_warm_disabled_by_config();
                 let has_custom_config = f_config_file.is_some() || std::env::var("PSMUX_CONFIG_FILE").is_ok();
-                let claimed_warm = if !warm_disabled && !has_custom_config && initial_cmd.is_none() && raw_cmd_args.is_none() && start_dir.is_none() && env_vars.is_empty() {
+                let claimed_warm = if !warm_disabled && !has_custom_config && initial_cmd.is_none() && raw_cmd_args.is_none() && start_dir.is_none() && env_vars.is_empty() && init_width.is_none() && init_height.is_none() {
                     let warm_base = if let Some(ref l) = l_socket_name {
                         format!("{}____warm__", l)
                     } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -3804,10 +3804,15 @@ fn run_main() -> io::Result<()> {
                     match cmd_args[i].as_str() {
                         "-S" => { cmd.push_str(" -S"); }
                         "-l" => { cmd.push_str(" -l"); }
-                        "-C" => {
+                        // Control-only flags are forwarded so the server can
+                        // reject them with tmux's "not a control client" error
+                        // instead of the client silently dropping them.
+                        "-C" | "-B" | "-A" | "-f" => {
                             if let Some(t) = cmd_args.get(i + 1) {
-                                cmd.push_str(&format!(" -C {}", t));
+                                cmd.push_str(&format!(" {} {}", cmd_args[i], t));
                                 i += 1;
+                            } else {
+                                cmd.push_str(&format!(" {}", cmd_args[i]));
                             }
                         }
                         "-t" => {
@@ -3821,7 +3826,15 @@ fn run_main() -> io::Result<()> {
                     i += 1;
                 }
                 cmd.push('\n');
-                send_control(cmd)?;
+                let resp = send_control_with_response(cmd)?;
+                let trimmed = resp.trim();
+                if let Some(reason) = trimmed.strip_prefix("ERROR:") {
+                    eprintln!("psmux: {}", reason.trim());
+                    std::process::exit(1);
+                }
+                if !trimmed.is_empty() {
+                    print!("{}", resp);
+                }
                 return Ok(());
             }
             // send-prefix - Send the prefix key to the active pane

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -233,3 +233,7 @@ mod tests {
 #[cfg(test)]
 #[path = "../tests-rs/test_issue474_home_resolution.rs"]
 mod tests_issue474_home_resolution;
+
+#[cfg(test)]
+#[path = "../tests-rs/test_data_dir_override.rs"]
+mod tests_data_dir_override;

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -76,6 +76,14 @@ fn windows_profile_dir() -> Option<String> {
 /// call sites that early-exit when home is missing (`.ok()?` /
 /// `Err(_) => return …`). `None` when no home directory is available.
 pub fn psmux_dir_opt() -> Option<String> {
+    if let Some(raw) = std::env::var_os("PSMUX_DATA_DIR") {
+        let path = std::path::PathBuf::from(raw);
+        assert!(
+            path.is_absolute() && !path.as_os_str().is_empty(),
+            "PSMUX_DATA_DIR must be an absolute non-empty path"
+        );
+        return Some(path.to_string_lossy().trim_end_matches(['/', '\\']).to_string());
+    }
     let home = home_dir();
     if home.is_empty() {
         None

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -891,8 +891,7 @@ pub mod mouse_inject {
         }
         if !ENABLED.load(Ordering::Relaxed) { return; }
 
-        let home = std::env::var("USERPROFILE").or_else(|_| std::env::var("HOME")).unwrap_or_default();
-        let path = format!("{}/.psmux/mouse_debug.log", home);
+        let path = format!("{}/mouse_debug.log", crate::paths::psmux_dir());
         if let Ok(mut f) = std::fs::OpenOptions::new().create(true).append(true).open(&path) {
             use std::io::Write;
             let _ = writeln!(f, "[platform] {}", msg);
@@ -2952,8 +2951,7 @@ pub mod process_info {
         // writes (n = 0..=99); `> 100` allowed 101. This cap predates the branch;
         // aligned with the "first 100 entries" doc while touching the function.
         if n >= 100 { return; }
-        let home = std::env::var("USERPROFILE").or_else(|_| std::env::var("HOME")).unwrap_or_default();
-        let path = format!("{}/.psmux/autorename.log", home);
+        let path = format!("{}/autorename.log", crate::paths::psmux_dir());
         if let Ok(mut f) = std::fs::OpenOptions::new().create(true).append(true).open(&path) {
             use std::io::Write;
             let _ = writeln!(f, "[{}] {}", chrono::Local::now().format("%H:%M:%S%.3f"), msg);

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -4365,3 +4365,7 @@ mod tests_issue476_bindkey_quoting;
 #[cfg(test)]
 #[path = "../../tests-rs/test_send_keys_literal_byte.rs"]
 mod tests_send_keys_literal_byte;
+
+#[cfg(test)]
+#[path = "../../tests-rs/test_refresh_client_flags.rs"]
+mod tests_refresh_client_flags;

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -2513,7 +2513,17 @@ match cmd {
         let _ = tx.send(CtrlReq::LockClient);
     }
     "refresh-client" | "refresh" => {
-        let _ = tx.send(CtrlReq::RefreshClient);
+        // tmux restricts -C/-B/-A/-f to control-mode clients. A one-shot CLI
+        // client is not one, so reject the flag instead of silently ignoring
+        // it and letting the caller believe the size/subscription was applied.
+        if let Some(flag) = args.iter().find(|a| matches!(**a, "-C" | "-B" | "-A" | "-f")) {
+            if !persistent {
+                let _ = writeln!(write_stream, "ERROR: refresh-client {}: not a control client", flag);
+                let _ = write_stream.flush();
+            }
+        } else {
+            let _ = tx.send(CtrlReq::RefreshClient);
+        }
     }
     "suspend-client" | "suspendc" => {
         let _ = tx.send(CtrlReq::SuspendClient);

--- a/src/ssh_input.rs
+++ b/src/ssh_input.rs
@@ -1378,10 +1378,7 @@ fn vk_modifiers(state: u32) -> KeyModifiers {
 #[cfg(windows)]
 static SSH_LOG: std::sync::LazyLock<std::sync::Mutex<Option<std::fs::File>>> =
     std::sync::LazyLock::new(|| {
-        let home = std::env::var("USERPROFILE")
-            .or_else(|_| std::env::var("HOME"))
-            .unwrap_or_default();
-        let dir = format!("{}/.psmux", home);
+        let dir = crate::paths::psmux_dir();
         let _ = std::fs::create_dir_all(&dir);
         let f = std::fs::OpenOptions::new()
             .create(true)

--- a/src/window_ops.rs
+++ b/src/window_ops.rs
@@ -25,8 +25,7 @@ fn mouse_log(msg: &str) {
     let n = COUNT.fetch_add(1, Ordering::Relaxed);
     if n > 2000 { return; }
 
-    let home = std::env::var("USERPROFILE").or_else(|_| std::env::var("HOME")).unwrap_or_default();
-    let path = format!("{}/.psmux/mouse_debug.log", home);
+    let path = format!("{}/mouse_debug.log", crate::paths::psmux_dir());
     if let Ok(mut f) = std::fs::OpenOptions::new().create(true).append(true).open(&path) {
         let _ = writeln!(f, "[{}] {}", chrono::Local::now().format("%H:%M:%S%.3f"), msg);
     }

--- a/tests-rs/test_data_dir_override.rs
+++ b/tests-rs/test_data_dir_override.rs
@@ -1,0 +1,136 @@
+// Regression tests for the PSMUX_DATA_DIR override (a41720f).
+//
+// Every data-directory consumer used to resolve the root on its own,
+// mixing USERPROFILE/HOME; the fix routes them all through
+// `paths::psmux_dir()` and lets an absolute PSMUX_DATA_DIR take precedence.
+//
+// Contracts locked here:
+//
+//   - with PSMUX_DATA_DIR set, every derived path (.port/.key/.sid/.pid/
+//     .spawnlock, fixed-name files, server markers) lands under the
+//     override root
+//   - trailing separators are trimmed
+//   - a relative or empty value is rejected (assertion panic)
+//   - with the variable unset, the default home-based root is restored
+//
+// Env is process-global, so every test in this file serializes on
+// ENV_LOCK and restores the previous value via a Drop guard.
+
+use super::*;
+
+use parking_lot::Mutex;
+
+static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+/// An absolute path for this platform (is_absolute() semantics differ).
+#[cfg(windows)]
+fn abs_root() -> &'static str {
+    "C:\\psmux\\data\\root"
+}
+
+#[cfg(not(windows))]
+fn abs_root() -> &'static str {
+    "/psmux/data/root"
+}
+
+/// Restores a mutated env var on drop, so a failure mid-test cannot leak
+/// the value into other tests.
+struct EnvGuard {
+    var: &'static str,
+    prev: Option<std::ffi::OsString>,
+}
+
+impl EnvGuard {
+    fn set(var: &'static str, value: &str) -> EnvGuard {
+        let prev = std::env::var_os(var);
+        std::env::set_var(var, value);
+        EnvGuard { var, prev }
+    }
+
+    fn remove(var: &'static str) -> EnvGuard {
+        let prev = std::env::var_os(var);
+        std::env::remove_var(var);
+        EnvGuard { var, prev }
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        match &self.prev {
+            Some(value) => std::env::set_var(self.var, value),
+            None => std::env::remove_var(self.var),
+        }
+    }
+}
+
+/// With PSMUX_DATA_DIR set, every derived path must live under the override
+/// root; removing the variable restores the default root.
+#[test]
+fn data_dir_env_reroutes_every_derived_path() {
+    let _lock = ENV_LOCK.lock();
+    let _clean = EnvGuard::remove("PSMUX_DATA_DIR");
+    let default_dir = psmux_dir();
+
+    let _override = EnvGuard::set("PSMUX_DATA_DIR", abs_root());
+    assert_eq!(psmux_dir(), abs_root());
+    assert_eq!(psmux_dir_opt(), Some(abs_root().to_string()));
+    assert_eq!(port_file("sess"), format!("{}\\sess.port", abs_root()));
+    assert_eq!(key_file("sess"), format!("{}\\sess.key", abs_root()));
+    assert_eq!(sid_file("sess"), format!("{}\\sess.sid", abs_root()));
+    assert_eq!(pid_file("sess"), format!("{}\\sess.pid", abs_root()));
+    assert_eq!(spawnlock_file("sess"), format!("{}\\sess.spawnlock", abs_root()));
+    assert_eq!(port_file_opt("sess"), Some(format!("{}\\sess.port", abs_root())));
+    assert_eq!(psmux_dir_file("latency.log"), format!("{}\\latency.log", abs_root()));
+    assert_eq!(server_marker_dir(), format!("{}\\servers", abs_root()));
+    assert_eq!(server_marker_file(42), format!("{}\\servers\\42", abs_root()));
+
+    drop(_override);
+    assert_eq!(
+        psmux_dir(),
+        default_dir,
+        "removing PSMUX_DATA_DIR must restore the home-based root"
+    );
+}
+
+/// Trailing '/' and '\\' are trimmed from the override root.
+#[test]
+fn data_dir_env_trims_trailing_separators() {
+    let _lock = ENV_LOCK.lock();
+    for raw in [format!("{}/", abs_root()), format!("{}\\", abs_root())] {
+        let _g = EnvGuard::set("PSMUX_DATA_DIR", &raw);
+        assert_eq!(psmux_dir(), abs_root(), "raw value {raw:?}");
+    }
+}
+
+/// A relative or empty PSMUX_DATA_DIR is a configuration error and must be
+/// rejected loudly, never silently resolved relative to the CWD.
+#[test]
+fn relative_or_empty_data_dir_is_rejected() {
+    let _lock = ENV_LOCK.lock();
+    for bad in ["", ".", "relative/path", "C:relative"] {
+        let _g = EnvGuard::set("PSMUX_DATA_DIR", bad);
+        let result = std::panic::catch_unwind(psmux_dir_opt);
+        assert!(
+            result.is_err(),
+            "PSMUX_DATA_DIR={bad:?} must panic instead of resolving"
+        );
+    }
+}
+
+/// Without PSMUX_DATA_DIR the data root falls back to the home directory,
+/// and the fallback is unaffected by the override code path.
+#[test]
+fn unset_data_dir_falls_back_to_home_root() {
+    let _lock = ENV_LOCK.lock();
+    let _clean = EnvGuard::remove("PSMUX_DATA_DIR");
+    // Pin USERPROFILE so the fallback is deterministic on every platform
+    // (home_dir() prefers USERPROFILE over HOME).
+    let _profile = EnvGuard::set("USERPROFILE", "/unit/test_home");
+    let _home = EnvGuard::remove("HOME");
+    let _drive = EnvGuard::remove("HOMEDRIVE");
+    let _path = EnvGuard::remove("HOMEPATH");
+
+    assert_eq!(psmux_dir(), "/unit/test_home\\.psmux");
+    assert_eq!(psmux_dir_opt(), Some("/unit/test_home\\.psmux".to_string()));
+    assert_eq!(port_file("sess"), "/unit/test_home\\.psmux\\sess.port");
+}

--- a/tests-rs/test_refresh_client_flags.rs
+++ b/tests-rs/test_refresh_client_flags.rs
@@ -1,0 +1,122 @@
+// Regression tests for the refresh-client control-only flag rejection
+// (f62b3cb + d80093a).
+//
+// refresh-client -C/-B/-A/-f only make sense for a control-mode client;
+// tmux rejects them with "not a control client" for anyone else. The
+// one-shot CLI path used to silently drop every flag, letting callers
+// believe a size or subscription was applied when nothing happened. The
+// fix rejects the flags server-side with tmux's error text, which the CLI
+// then surfaces (error to stderr, non-zero exit).
+//
+// The server-side rejection lives in `handle_connection`, the one-shot CLI
+// connection handler. These tests drive it over real loopback sockets and
+// assert the exact wire text for every control-only flag, plus that a
+// flag-free refresh-client is still forwarded to the server loop.
+
+use super::*;
+
+use std::io::{Read, Write};
+use std::net::{Shutdown, TcpListener, TcpStream};
+use std::sync::{Arc, RwLock};
+use std::thread::JoinHandle;
+use std::time::Duration;
+
+const TEST_KEY: &str = "unit-test-key";
+
+/// Serve one connection through the real one-shot handler.
+fn spawn_handler(listener: TcpListener, tx: mpsc::Sender<CtrlReq>) -> JoinHandle<()> {
+    std::thread::spawn(move || {
+        let (stream, _) = listener.accept().expect("handler: accept");
+        handle_connection(
+            stream,
+            tx,
+            TEST_KEY,
+            Arc::new(RwLock::new(std::collections::HashMap::new())),
+        );
+    })
+}
+
+/// Connect like the one-shot CLI client: AUTH, expect OK, return the socket.
+fn connect_authenticated(addr: std::net::SocketAddr) -> TcpStream {
+    let mut client = TcpStream::connect(addr).expect("client connect");
+    client.set_read_timeout(Some(Duration::from_secs(20))).unwrap();
+    write!(client, "AUTH {TEST_KEY}\n").unwrap();
+    let mut reader = std::io::BufReader::new(client.try_clone().unwrap());
+    let mut ok = String::new();
+    reader.read_line(&mut ok).expect("read OK");
+    assert_eq!(ok, "OK\n", "handler must authenticate the client");
+    client
+}
+
+/// Every control-only refresh-client flag is rejected on the one-shot CLI
+/// path with tmux's "not a control client" error carrying the flag name —
+/// the text the CLI propagates to its exit path.
+#[test]
+fn control_only_flags_are_rejected_with_the_tmux_error_text() {
+    for flag in ["-C", "-B", "-A", "-f"] {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+        let (tx, _rx) = mpsc::channel::<CtrlReq>();
+        let handler = spawn_handler(listener.try_clone().unwrap(), tx);
+
+        let mut client = connect_authenticated(listener.local_addr().unwrap());
+        write!(client, "refresh-client {flag}\n").unwrap();
+        client.shutdown(Shutdown::Write).unwrap();
+
+        let mut resp = String::new();
+        client.read_to_string(&mut resp).expect("read response");
+        handler.join().expect("handler thread");
+
+        assert_eq!(
+            resp,
+            format!("ERROR: refresh-client {flag}: not a control client\n"),
+            "the one-shot CLI path must reject {flag} instead of silently dropping it"
+        );
+    }
+}
+
+/// A refresh-client without control-only flags is still forwarded to the
+/// server loop (the rejection must not break the flag-free path).
+#[test]
+fn flag_free_refresh_client_is_forwarded_to_the_server() {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+    let (tx, rx) = mpsc::channel::<CtrlReq>();
+    let handler = spawn_handler(listener.try_clone().unwrap(), tx);
+
+    let mut client = connect_authenticated(listener.local_addr().unwrap());
+    write!(client, "refresh-client\n").unwrap();
+    client.shutdown(Shutdown::Write).unwrap();
+
+    let mut resp = String::new();
+    client.read_to_string(&mut resp).expect("read response");
+    handler.join().expect("handler thread");
+
+    assert_eq!(resp, "", "flag-free refresh-client must produce no error");
+    let request = rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("the request must reach the server loop");
+    assert!(
+        matches!(request, CtrlReq::RefreshClient),
+        "flag-free refresh-client must be forwarded unchanged"
+    );
+}
+
+/// Unknown flags are not control-only and must not be rejected: the
+/// rejection must key off exactly -C/-B/-A/-f.
+#[test]
+fn non_control_flags_are_not_rejected() {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+    let (tx, rx) = mpsc::channel::<CtrlReq>();
+    let handler = spawn_handler(listener.try_clone().unwrap(), tx);
+
+    let mut client = connect_authenticated(listener.local_addr().unwrap());
+    write!(client, "refresh-client -S\n").unwrap();
+    client.shutdown(Shutdown::Write).unwrap();
+
+    let mut resp = String::new();
+    client.read_to_string(&mut resp).expect("read response");
+    handler.join().expect("handler thread");
+
+    assert_eq!(resp, "", "-S must not be rejected as control-only");
+    let request = rx.recv_timeout(Duration::from_secs(2)).expect("request forwarded");
+    assert!(matches!(request, CtrlReq::RefreshClient));
+}


### PR DESCRIPTION
## Context

A batch of small tmux-parity and hygiene fixes found while running psmux under [tmex](https://github.com/krhougs/tmex)'s Windows gateway (Vibe X is its commercial distribution), which drives psmux the way iTerm2 drives tmux: control mode plus one-shot CLI commands.

## Problems and fixes

1. **`new-session -x/-y` sizes were discarded when a warm server claimed the session** — the pre-spawned warm server kept its default size, so the first window came up 120x30 regardless of what the caller asked. The claim path now applies the requested size.
2. **Control-only `refresh-client` flags (`-C`/`-B`/`-A`/`-f`) were silently accepted on the CLI path** — tmux errors on these outside control mode. They are now rejected with the tmux error text, and the server's error actually reaches the CLI user on stderr with a non-zero exit (previously it was swallowed).
3. **`PSMUX_DATA_DIR`**: every data-directory consumer resolved the root on its own, mixing `USERPROFILE`/`HOME` and hardcoded separators. All consumers now route through `paths::psmux_dir()`, and an absolute `PSMUX_DATA_DIR` takes precedence — analogous to tmux's `TMUX_TMPDIR`, and what lets an embedding application keep server state, logs and session files inside its own root instead of the user profile. Relative/empty values are rejected.

## Tests

`test_refresh_client_flags.rs` drives the real connection handler over loopback sockets (each control-only flag is rejected with tmux wording; flag-free and `-S` still forward). `test_data_dir_override.rs` locks every derived path under the override root, separator trimming, rejection of relative/empty values, and the home fallback (env access serialized with a lock + drop-guard restore). Verified on Windows.
