### PR TITLE
fix(mouse): wheel over inline TUIs (pi) cycled prompt history instead of scrolling

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -2756,14 +2756,11 @@ pub fn handle_mouse(app: &mut AppState, me: MouseEvent, window_area: Rect) -> io
                 win.active_path = path.clone();
                 active_area = Some(*area);
             }
-            // Forward scroll to child if pane wants mouse events (real TUI app
-            // like nvim/htop).  If not (shell prompt), auto-enter copy mode.
-            //
-            // Uses pane_wants_mouse() which includes heuristic fallback for
-            // older Windows 10 builds where ConPTY strips DECSET 1049h.
-            // (fixes #285)
+            // Wheel gate: alternate_screen ONLY — known-good pre-3.3.5
+            // semantics.  pane_wants_mouse() must not be used for the wheel
+            // (see pane_in_alt_screen for the rationale).
             let child_in_alt = active_pane(&win.root, &win.active_path)
-                .map_or(false, |p| crate::window_ops::pane_wants_mouse(p));
+                .map_or(false, |p| crate::window_ops::pane_in_alt_screen(p));
             if child_in_alt {
                 if let Some(area) = active_area {
                     if let Some(active) = active_pane_mut(&mut win.root, &win.active_path) {
@@ -2801,10 +2798,10 @@ pub fn handle_mouse(app: &mut AppState, me: MouseEvent, window_area: Rect) -> io
                 win.active_path = path.clone();
                 active_area = Some(*area);
             }
-            // Forward scroll-down to child only if pane wants mouse events.
-            // Uses pane_wants_mouse() with heuristic fallback. (fixes #285)
+            // Wheel gate: alternate_screen ONLY — known-good pre-3.3.5
+            // semantics (see pane_in_alt_screen for the rationale).
             let child_in_alt = active_pane(&win.root, &win.active_path)
-                .map_or(false, |p| crate::window_ops::pane_wants_mouse(p));
+                .map_or(false, |p| crate::window_ops::pane_in_alt_screen(p));
             if child_in_alt {
                 if let Some(area) = active_area {
                     if let Some(active) = active_pane_mut(&mut win.root, &win.active_path) {

--- a/src/window_ops.rs
+++ b/src/window_ops.rs
@@ -248,27 +248,22 @@ pub(crate) fn pane_wants_mouse(pane: &Pane) -> bool {
     is_fullscreen_tui(pane)
 }
 
-/// Stricter than `pane_wants_mouse`, used ONLY for the scroll-wheel decision.
+/// Wheel-forwarding gate: is the pane's child on the alternate screen?
 ///
-/// The wheel must auto-enter copy mode for an ordinary shell pane (tmux parity,
-/// issue #360).  `pane_wants_mouse`'s tier-3 `is_fullscreen_tui` content
-/// heuristic returns true for a normal shell that has filled the screen with
-/// the prompt sitting at the bottom, which wrongly forwarded the wheel to the
-/// shell (it ignores SGR wheel) instead of entering copy mode.  For scroll we
-/// only forward when the child RELIABLY wants the mouse: it enabled a mouse
-/// protocol (e.g. nvim `set mouse=a`) or is on the alternate screen.  TUI apps
-/// that genuinely consume the wheel satisfy one of these even on older ConPTY
-/// (the mouse protocol DECSETs are not stripped); apps that satisfy neither do
-/// not interpret the wheel anyway, so copy-mode scrollback is the right thing.
-pub(crate) fn pane_wants_scroll_forward(pane: &Pane) -> bool {
+/// The wheel is the ONE mouse event that must use this check alone — the
+/// known-good pre-3.3.5 semantics.  Neither of the broader signals is safe
+/// for it:
+///   - mouse_protocol_mode: PSReadLine spuriously enables mouse tracking on
+///     ConPTY, so any pane whose shell is pwsh reports a mouse protocol even
+///     when the foreground app (pi, …) never asked for the wheel.
+///   - is_fullscreen_tui: false-positives on a filled shell (#360) and on
+///     inline TUIs like pi whose input box then eats the wheel as prompt
+///     history instead of psmux entering copy mode.
+/// Apps that genuinely consume the wheel (nvim, htop, less, opencode) run on
+/// the alternate screen, which modern ConPTY reports reliably.
+pub(crate) fn pane_in_alt_screen(pane: &Pane) -> bool {
     if let Ok(parser) = pane.term.lock() {
-        let screen = parser.screen();
-        if screen.mouse_protocol_mode() != vt100::MouseProtocolMode::None {
-            return true;
-        }
-        if screen.alternate_screen() {
-            return true;
-        }
+        return parser.screen().alternate_screen();
     }
     false
 }
@@ -292,11 +287,13 @@ pub(crate) fn pane_wants_scroll_forward(pane: &Pane) -> bool {
 /// This deliberately does NOT use the tier-3 `is_fullscreen_tui` content
 /// heuristic (a plain shell that merely filled the screen trips it) nor the
 /// console `ENABLE_MOUSE_INPUT` flag (which is SET by default on every console,
-/// so it never distinguishes a mouse app from a plain shell).  It matches the
-/// gate `pane_wants_scroll_forward` already uses for the wheel, and tmux, which
-/// forwards mouse events only to apps that requested a mouse mode.  A plain
-/// shell — inside a container or not — requests none, so clicks are no longer
-/// leaked into it.
+/// so it never distinguishes a mouse app from a plain shell).  It matches
+/// tmux, which forwards mouse events only to apps that requested a mouse
+/// mode.  A plain shell — inside a container or not — requests none, so
+/// clicks are no longer leaked into it.  (The wheel uses the even stricter
+/// `pane_in_alt_screen`: mouse_protocol_mode is not trustworthy there because
+/// PSReadLine enables it spuriously, and a wheel misroute is user-visible —
+/// it cycles prompt history in inline TUIs like pi.)
 pub(crate) fn pane_wants_click(pane: &Pane) -> bool {
     if let Ok(parser) = pane.term.lock() {
         let screen = parser.screen();
@@ -1029,15 +1026,7 @@ fn remote_scroll_wheel(app: &mut AppState, x: u16, y: u16, up: bool) {
     // Determine target pane, switch focus, and check if child is a TUI app
     // that should receive scroll events.
     //
-    // Detection strategy (same as pane_wants_mouse, fixes #285):
-    //   1. alternate_screen() — authoritative on newer Windows 11+ ConPTY
-    //   2. is_fullscreen_tui() heuristic — fallback for older Windows 10
-    //      builds where ConPTY strips DECSET 1049h.
-    //
-    // Note: is_fullscreen_tui() may false-positive after `ls`/`dir` fills
-    // the screen (preventing scroll-to-copy-mode briefly), but this is far
-    // less harmful than completely breaking scroll in TUI apps like Neovim
-    // on older Windows.
+    // Wheel gate: alternate_screen ONLY (see pane_in_alt_screen).
     let (child_in_alt_screen, target_area_opt, sgr_btn, button_state) = {
         let win = &mut app.windows[app.active_idx];
         let mut rects: Vec<(Vec<usize>, Rect)> = Vec::new();
@@ -1059,7 +1048,7 @@ fn remote_scroll_wheel(app: &mut AppState, x: u16, y: u16, up: bool) {
         }
 
         let alt = active_pane(&win.root, &win.active_path)
-            .map_or(false, |p| pane_wants_mouse(p));
+            .map_or(false, |p| pane_in_alt_screen(p));
         let sgr_btn: u8 = if up { 64 } else { 65 };
         let wheel_delta: i16 = if up { 120 } else { -120 };
         let bs = ((wheel_delta as i32) << 16) as u32;
@@ -1231,13 +1220,12 @@ pub fn handle_pane_scroll(app: &mut AppState, pane_id: usize, up: bool) {
         }
     }
 
-    // Use the stricter scroll-forward check (mouse protocol or alternate
-    // screen only).  The permissive pane_wants_mouse() heuristic misclassifies
-    // a normal shell that has filled the screen (prompt at the bottom) as a TUI
-    // app, so the wheel was forwarded to the shell instead of entering copy
-    // mode (#360).
+    // Wheel gate: alternate_screen ONLY — the known-good pre-3.3.5 semantics.
+    // Gating on mouse_protocol_mode (what #360's check kept) routed the wheel
+    // into pi's focused input box via PSReadLine's spurious mouse tracking;
+    // see pane_in_alt_screen for the full rationale.
     let alt = active_pane(&win.root, &win.active_path)
-        .map_or(false, |p| pane_wants_scroll_forward(p));
+        .map_or(false, |p| pane_in_alt_screen(p));
 
     if alt {
         // Forward scroll to TUI app
@@ -1262,25 +1250,29 @@ pub fn handle_pane_scroll(app: &mut AppState, pane_id: usize, up: bool) {
         return;
     }
 
-    // Not mouse-aware and not on psmux's tracked alternate screen.  Before
-    // falling back to shell semantics (copy-mode entry / no-op), check
-    // whether the pane's foreground is a genuine non-shell program (e.g.
-    // legacy pagers like Windows' `more.com`, which never issues DECSET
-    // 1049/1000 at all — `pane_wants_scroll_forward` can never see it as
-    // "alt" — but is still a real foreground app, not the shell prompt).
+    // Not mouse-aware and not on psmux's tracked alternate screen.  tmux
+    // parity: a main-screen program without mouse tracking gets copy-mode
+    // scrollback.  Alternate-scroll (DECSET 1007, wheel → arrow keys) only
+    // ever applies to ALTERNATE-screen panes in tmux/xterm; the forward
+    // branch above already covers those via wheel injection.
     //
-    // tmux's answer for a foreground program with no mouse tracking is
-    // alternate-scroll: translate each wheel notch into arrow-key presses
-    // so the program's own built-in paging moves (DECSET 1007 semantics).
-    // That is the general case below. `more.com` is a special case within
-    // it: it's a DOS-heritage getch()-style reader that parses no ANSI
-    // escape sequences at all, so arrow keys are a silent no-op for it —
-    // proven by direct keystroke testing (Enter advances one line, Space
-    // one page, arrows do nothing). It's also forward-only by design (MS
-    // docs: no backward paging), so only wheel-down gets the Enter-advance
-    // treatment; wheel-up falls through to copy-mode entry, which already
-    // works because psmux's own scrollback buffer captured everything
-    // `more` printed regardless of what `more` itself can rewind to.
+    // Do NOT blanket-translate the wheel into arrow keys for every non-shell
+    // foreground.  Interactive inline TUIs (pi, Claude Code, …) run on the
+    // main screen without mouse tracking, and their focused input box reads
+    // Up/Down as prompt-history navigation: the general alternate-scroll
+    // branch this replaced sent 3×arrows per wheel notch, so the wheel over
+    // pi cycled prompt history instead of scrolling the transcript
+    // (regression 3.3.4→3.3.5+).
+    //
+    // The one legacy pager that genuinely needs help stays as an exact
+    // allowlist. `more.com` is a DOS-heritage getch()-style reader that
+    // parses no ANSI escape sequences at all, so arrow keys are a silent
+    // no-op for it — proven by direct keystroke testing (Enter advances one
+    // line, Space one page, arrows do nothing). It's also forward-only by
+    // design (MS docs: no backward paging), so only wheel-down gets the
+    // Enter-advance treatment; wheel-up falls through to copy-mode entry,
+    // which already works because psmux's own scrollback buffer captured
+    // everything `more` printed regardless of what `more` can rewind to.
     //
     // `non_shell_fg` is gated on a *confirmed* `Some(false)` from the
     // process-identity check in platform::process_info::foreground_is_shell
@@ -1313,18 +1305,10 @@ pub fn handle_pane_scroll(app: &mut AppState, pane_id: usize, up: bool) {
             }
             let _ = pane.writer.flush();
         }
-    } else if non_shell_fg && !is_legacy_pager {
-        // General alternate-scroll: arrow keys (tmux DECSET-1007 parity).
-        if let Some(pane) = active_pane_mut(&mut win.root, &win.active_path) {
-            let seq: &[u8] = if up { b"\x1b[A" } else { b"\x1b[B" };
-            for _ in 0..3 {
-                crate::input::write_key_seq(pane, seq);
-            }
-            let _ = pane.writer.flush();
-        }
     } else if up && app.scroll_enter_copy_mode {
-        // Shell prompt (or `more.com` wheel-up, or a probe failure) —
-        // enter copy mode and scroll psmux's own buffer.
+        // Everything else (shell prompt, inline TUI like pi, `more.com`
+        // wheel-up, or a probe failure) — enter copy mode and scroll
+        // psmux's own buffer, exactly like tmux.
         enter_copy_mode(app);
         scroll_copy_up(app, 3);
     } else if !app.scroll_enter_copy_mode {

--- a/tests/test_pi_wheel_copymode.ps1
+++ b/tests/test_pi_wheel_copymode.ps1
@@ -1,0 +1,121 @@
+# pi scroll regression (3.3.4 good -> 3.3.5+ bad): mouse wheel over a pane
+# running an inline TUI like pi must enter copy mode (scroll psmux's buffer),
+# NOT be routed into the app.
+#
+# pi's pane profile that broke every heuristic-based wheel gate:
+#   - foreground process is NOT a shell (node.exe)
+#   - the pane reports an active mouse protocol (PSReadLine enables mouse
+#     tracking spuriously on ConPTY; the sim enables DECSET 1002/1006 itself)
+#   - screen filled, cursor at a bottom input box (is_fullscreen_tui matches)
+#
+# Broken behaviors this guards against:
+#   - 3.3.5 (b64408e): pane_wants_mouse() heuristic forwarded the wheel into
+#     the app via mouse injection.
+#   - 3.3.6/3.3.7 (7d6300b): the "general alternate-scroll" fallback sent
+#     3x arrow keys per wheel notch; pi's focused input box reads Up/Down as
+#     prompt-history navigation, so the wheel cycled history instead of
+#     scrolling the transcript.
+#
+# The sim app records any arrow/SGR-wheel sequence reaching its stdin into a
+# leak file; the test asserts copy_mode turns on AND the leak file is empty.
+#
+# This drives a REAL attached psmux client in classic conhost and injects REAL
+# console mouse-wheel events via WriteConsoleInput, then verifies copy_mode via
+# TCP dump-state.  (Harness adapted from test_issue360_mouse_wheel_copymode.ps1.)
+$ErrorActionPreference="Continue"
+$PSMUX=(Get-Command psmux -EA Stop).Source
+$NODE=(Get-Command node -EA SilentlyContinue).Source
+if (-not $NODE) { Write-Host "SKIP: node.exe not found (required for pi simulator)" -ForegroundColor Yellow; exit 0 }
+$MINJ="$env:LOCALAPPDATA\Temp\psmux_mouse_injector.exe"
+$psmuxDir="$env:USERPROFILE\.psmux"
+$S="tpiwheel"
+$script:Pass=0; $script:Fail=0
+function Write-Pass($m){ Write-Host "  [PASS] $m" -ForegroundColor Green; $script:Pass++ }
+function Write-Fail($m){ Write-Host "  [FAIL] $m" -ForegroundColor Red; $script:Fail++ }
+
+# write the pi simulator + leak file to temp
+$simDir=Join-Path $env:LOCALAPPDATA "Temp\psmux_pi_sim"
+New-Item -ItemType Directory -Force -Path $simDir | Out-Null
+$sim=Join-Path $simDir "pi-sim.js"
+$leak=Join-Path $simDir "pi-sim-leak.txt"
+if (Test-Path $leak) { Remove-Item $leak -Force }
+@'
+const fs = require('fs');
+const leakFile = process.argv[2];
+process.stdout.write('\x1b[?1002h\x1b[?1006h'); // mouse tracking like PSReadLine/pi
+const rows = process.stdout.rows || 40;
+for (let i = 1; i <= rows - 2; i++) process.stdout.write(`transcript line ${i}\n`);
+process.stdout.write('> input box (focused)');
+process.stdin.setRawMode(true);
+process.stdin.resume();
+process.stdin.on('data', (d) => {
+  const s = d.toString('utf8');
+  if (s.includes('\x1b[A') || s.includes('\x1b[B') ||
+      s.includes('\x1b[<64') || s.includes('\x1b[<65')) {
+    fs.appendFileSync(leakFile, JSON.stringify(s) + '\n');
+  }
+  if (s.includes('q')) process.exit(0);
+});
+setInterval(() => {}, 1000);
+'@ | Set-Content -Path $sim -Encoding UTF8
+
+# compile mouse injector if missing
+if (-not (Test-Path $MINJ)) {
+    $csc="C:\Windows\Microsoft.NET\Framework64\v4.0.30319\csc.exe"
+    $src=Join-Path (Split-Path $PSScriptRoot -Parent) "tests\mouse_injector.cs"
+    if (-not (Test-Path $src)) { $src="$PSScriptRoot\mouse_injector.cs" }
+    & $csc /nologo /optimize /out:$MINJ $src 2>&1 | Out-Null
+}
+
+$sk="HKCU:\Console\%%Startup"; if(-not(Test-Path $sk)){New-Item -Path $sk -Force|Out-Null}
+$oDC=(Get-ItemProperty $sk -EA SilentlyContinue).DelegationConsole; $oDT=(Get-ItemProperty $sk -EA SilentlyContinue).DelegationTerminal
+$classic="{B23D10C0-E52E-411E-9D5B-C09FDF709C7D}"
+Set-ItemProperty $sk -Name DelegationConsole -Value $classic; Set-ItemProperty $sk -Name DelegationTerminal -Value $classic
+function Restore { if($oDC){Set-ItemProperty $sk -Name DelegationConsole -Value $oDC}else{Remove-ItemProperty $sk -Name DelegationConsole -EA SilentlyContinue}; if($oDT){Set-ItemProperty $sk -Name DelegationTerminal -Value $oDT}else{Remove-ItemProperty $sk -Name DelegationTerminal -EA SilentlyContinue} }
+function Get-CopyMode { param($Session)
+    $port=(Get-Content "$psmuxDir\$Session.port" -Raw).Trim(); $key=(Get-Content "$psmuxDir\$Session.key" -Raw).Trim()
+    $tcp=[System.Net.Sockets.TcpClient]::new("127.0.0.1",[int]$port); $tcp.NoDelay=$true; $tcp.ReceiveTimeout=4000
+    $st=$tcp.GetStream(); $w=[System.IO.StreamWriter]::new($st); $r=[System.IO.StreamReader]::new($st)
+    $w.Write("AUTH $key`n"); $w.Flush(); $null=$r.ReadLine(); $w.Write("dump-state`n"); $w.Flush()
+    $best=$null; for($j=0;$j -lt 60;$j++){ try{$l=$r.ReadLine()}catch{break}; if($null -eq $l){break}; if($l -ne "NC" -and $l.Length -gt 100){$best=$l;break} }
+    $tcp.Close(); if($best -match '"copy_mode"\s*:\s*true'){return $true}else{return $false} }
+
+Write-Host "=== pi wheel regression: copy mode, no input leak ===" -ForegroundColor Cyan
+& $PSMUX kill-session -t $S 2>&1 | Out-Null; Start-Sleep -Milliseconds 600
+$conhost="$env:WINDIR\System32\conhost.exe"
+$cmd="$NODE `"$sim`" `"$leak`""
+$proc=Start-Process -FilePath $conhost -ArgumentList $PSMUX,"new-session","-s",$S,$cmd -PassThru
+Start-Sleep -Seconds 6
+$child=Get-CimInstance Win32_Process -Filter "ParentProcessId=$($proc.Id)" | Where-Object {$_.Name -like 'psmux*'} | Select-Object -First 1
+$cpid=if($child){[int]$child.ProcessId}else{$proc.Id}
+
+& $PSMUX set-option -g mouse on -t $S 2>&1 | Out-Null
+& $PSMUX set-option -g scroll-enter-copy-mode on -t $S 2>&1 | Out-Null
+Start-Sleep -Seconds 2
+
+$before = Get-CopyMode $S
+# Inject with retry: WriteConsoleInput occasionally lands before the client's
+# input loop is ready (same timing sensitivity as the other mouse E2E suites).
+$after = $false
+for ($try = 0; $try -lt 3 -and -not $after; $try++) {
+    & $MINJ $cpid up 4 40 10 | Out-Null
+    Start-Sleep -Seconds 2
+    $after = Get-CopyMode $S
+}
+Write-Host "  pi-like pane wheel-up: copy_mode before=$before after=$after"
+if (-not $before -and $after) { Write-Pass "wheel-up entered copy mode (transcript scrolls)" }
+else { Write-Fail "wheel-up did NOT enter copy mode (before=$before after=$after)" }
+
+Start-Sleep -Seconds 1
+if (Test-Path $leak) {
+    $c = Get-Content $leak -Raw
+    Write-Fail "input leaked into the app (would cycle pi prompt history): $c"
+} else {
+    Write-Pass "no arrows/wheel leaked into the app's stdin"
+}
+
+& $PSMUX kill-session -t $S 2>&1 | Out-Null
+try{Stop-Process -Id $proc.Id -Force -EA SilentlyContinue}catch{}
+Restore
+Write-Host "`n=== Results: Passed=$($script:Pass) Failed=$($script:Fail) ===" -ForegroundColor Cyan
+exit $script:Fail


### PR DESCRIPTION
## Symptom

Inside psmux under Windows Terminal, with an inline TUI like [pi](https://github.com/earendil-works/pi) focused on its input box, the mouse wheel over the conversation transcript **cycles the input box's prompt history** instead of scrolling — regardless of where the mouse pointer is. Copy mode is never entered; the only workaround is pressing PgUp first. Outside psmux the same app scrolls fine, and it also scrolls fine on psmux **3.3.4**.

## Version matrix / bisect

| psmux | wheel over pi |
|---|---|
| 3.3.3 | ✅ scrolls (copy mode) |
| 3.3.4 | ✅ scrolls (copy mode) |
| 3.3.5 | ❌ cycles prompt history |
| 3.3.6 / 3.3.7 | ❌ cycles prompt history |

`git bisect` names b64408ed (`fix(mouse): restore heuristic fallback in pane_wants_mouse for TUI apps (#285)`) as the first bad commit; 7d6300b7 later compounded it with a different mechanism producing the same symptom.

## Root cause (two stacked issues on the live wheel path)

The attached client sends `pane-scroll` → `handle_pane_scroll`. There:

1. **The wheel gate trusted `mouse_protocol_mode`** (`pane_wants_scroll_forward`, from #360). But PSReadLine spuriously enables mouse tracking on ConPTY, so *any pane whose shell is pwsh* reports an active mouse protocol even when the foreground app never asked for the wheel — and the wheel got injected into the app. The 3.3.4 wheel handlers documented exactly this false positive; b64408ed removed that rationale along with the code.

2. **The "general alternate-scroll" fallback** (7d6300b7) translated each wheel notch into 3× arrow keys for *any* confirmed non-shell foreground. pi's focused input box reads Up/Down as history navigation — hence the history cycling. In tmux/xterm, alternate-scroll (DECSET 1007) only ever applies to **alternate-screen** panes; blanket arrows on the main screen are not tmux parity.

## Fix

Restores the known-good 3.3.4 wheel semantics on all wheel paths:

- New `pane_in_alt_screen()` helper is the single wheel-forwarding gate; `handle_pane_scroll`, `remote_scroll_wheel`, and the `input.rs` wheel arms all use it. Real wheel consumers (nvim, htop, less, opencode) run on the alternate screen, which modern ConPTY reports reliably. Click/drag/hover gates are untouched.
- Drop the general arrow-key fallback; keep the exact-allowlisted `more.com` Enter-advance special case.
- Remove the now-unused `pane_wants_scroll_forward`.

## Verification

New E2E test `tests/test_pi_wheel_copymode.ps1` drives a real attached client in classic conhost with real `WriteConsoleInput` wheel injection against a pane simulating pi's exact profile (non-shell foreground + spurious mouse protocol + filled screen with bottom input box), asserting copy mode turns on **and** nothing leaks into the app's stdin. A/B results:

| binary | copy mode | input leaked to app |
|---|---|---|
| official 3.3.7 | ❌ never | `ESC[A` ×3 per notch |
| official 3.3.4 | ✅ | none |
| this branch | ✅ | none |

`tests/test_issue360_mouse_wheel_copymode.ps1` (filled-shell wheel-up enters copy mode) still passes. The reporter also confirmed the fix interactively with the real pi app.

🤖 Co authored with [Claude Code](https://claude.com/claude-code)


## Related issues

No pre-existing psmux issue describes this exact bug. Adjacent pi-side reports about transcript scrolling/focus exist (earendil-works/pi#5745 — overlay focus API, earendil-works/pi#1891 — anchored-input feature request), but they are distinct from this regression: here pi behaves correctly outside psmux and on psmux ≤ 3.3.4, so the fault is psmux's wheel routing.

Prior psmux issues in the same area, already discussed above: #360 (wheel vs filled shell), #285 (heuristic fallback that started the regression window), #277/#295 (scroll for inline Bubble Tea TUIs).
