### PR TITLE
workaround: disable color-query answering that races yazi's startup probe (fixes #556)

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1345,29 +1345,14 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                     }
                 }
             }
-            // Issue #473: answer terminal color queries (OSC 4/10/11, CSI ?996n)
-            // detected in pane output, so pane applications can discover the
-            // terminal palette.  Colors come from the attached client's report
-            // of its host terminal, else the Campbell defaults.
-            if crate::types::COLOR_QUERY_PENDING.swap(false, std::sync::atomic::Ordering::AcqRel) {
-                let colors = app.host_colors.clone()
-                    .unwrap_or_else(crate::types::HostColors::campbell);
-                for win in &mut app.windows {
-                    helpers::drain_color_queries(&mut win.root, &colors);
-                    for fp in win.floating.iter_mut() {
-                        let bits = fp.pane.color_query_pending.swap(0, std::sync::atomic::Ordering::AcqRel);
-                        if bits != 0 {
-                            helpers::answer_color_queries(bits, &mut *fp.pane.writer, fp.pane.child_pid, &colors);
-                        }
-                    }
-                }
-                if let Mode::PopupMode { popup_pane: Some(ref mut pane), .. } = app.mode {
-                    let bits = pane.color_query_pending.swap(0, std::sync::atomic::Ordering::AcqRel);
-                    if bits != 0 {
-                        helpers::answer_color_queries(bits, &mut *pane.writer, pane.child_pid, &colors);
-                    }
-                }
-            }
+            // Issue #473 color-query answering removed: answering OSC 4/10/11
+            // / CSI ?996n queries from pane apps races yazi's startup probe —
+            // the response lands after yazi's probe window closes, gets
+            // re-parsed as an interactive `shell` action, and a "Shell:" popup
+            // appears with "rgb:0c0c/0c0c/0c0c\" in it. Unanswered, apps fall
+            // back to their defaults (yazi, nvim, fzf all do). The scanning/
+            // answering helpers remain as dead code for a future fix that
+            // answers synchronously within the probe window.
         }
         // When a popup PTY or a floating pane is active, always push frames so
         // interactive content (fzf, shell prompts) updates in real-time.


### PR DESCRIPTION
Workaround for #556 (full diagnosis and timing evidence there). The #473 color-query answering delivers OSC 4/10/11 / CSI ?996n responses after the app's probe window has closed — ConPTY answers DA1 itself in ~33 ms, closing yazi's window first — so yazi re-parses the response bytes as an interactive `shell` action and shows a "Shell:" popup with `rgb:0c0c/0c0c/0c0c` in it.

This removes the answering block; the scanning/answering helpers stay as dead code for a follow-up.

**Known regression**: color-querying apps (GitHub Copilot CLI, per #473) fall back to their defaults again. A proper fix — answering within the probe window, e.g. ordering the DA1 relay like CPR — is described in #556; this PR is the interim workaround.

Verified: yazi starts clean in psmux (no popup), `;`/`:` shell input still works. Repro and byte-level evidence in #556.
