### PR TITLE
fix(layout): serialize the OSC 8 link in the fast dump path

### DIFF
--- a/src/layout.rs
+++ b/src/layout.rs
@@ -667,12 +667,21 @@ pub fn dump_layout_json_fast(app: &mut AppState) -> io::Result<String> {
     }
 
     /// Close the currently-open run: closing `"` for text, then fg/bg/flags/width, then `}`.
-    fn close_run(fg: vt100::Color, bg: vt100::Color, fl: u8, w: u16, out: &mut String) {
+    fn close_run(fg: vt100::Color, bg: vt100::Color, fl: u8, w: u16, link: Option<&str>, out: &mut String) {
         out.push_str("\",\"fg\":\"");
         push_color(fg, out);
         out.push_str("\",\"bg\":\"");
         push_color(bg, out);
-        let _ = std::fmt::Write::write_fmt(out, format_args!("\",\"flags\":{},\"width\":{}}}", fl, w));
+        let _ = std::fmt::Write::write_fmt(out, format_args!("\",\"flags\":{},\"width\":{}", fl, w));
+        // OSC 8 URI (#361).  The client re-emits hyperlinks only for runs that
+        // carry this field, and `CellRunJson::link` skips serialising when it is
+        // None, so omitting it here silently disabled hyperlinks in every pane.
+        if let Some(uri) = link {
+            out.push_str(",\"link\":\"");
+            json_esc(uri, out);
+            out.push('"');
+        }
+        out.push('}');
     }
 
     // ── recursive tree walker ────────────────────────────────────────
@@ -758,7 +767,7 @@ pub fn dump_layout_json_fast(app: &mut AppState) -> io::Result<String> {
                 // also holds p.term's mutex while processing ConPTY output).
                 // Without this, WSL echo gets starved because its output sits
                 // in the ConPTY pipe while we build the JSON string.
-                struct Run { text: String, fg: vt100::Color, bg: vt100::Color, flags: u8, width: u16 }
+                struct Run { text: String, fg: vt100::Color, bg: vt100::Color, flags: u8, width: u16, link: Option<String> }
                 struct RowSnap { runs: Vec<Run> }
                 struct CopyCell { text: String, fg: vt100::Color, bg: vt100::Color, bold: bool, italic: bool, underline: bool, inverse: bool, dim: bool, blink: bool, hidden: bool, strikethrough: bool, width: u16 }
                 struct LeafSnap {
@@ -800,6 +809,7 @@ pub fn dump_layout_json_fast(app: &mut AppState) -> io::Result<String> {
                         let mut prev_fg: Option<vt100::Color> = None;
                         let mut prev_bg: Option<vt100::Color> = None;
                         let mut prev_fl: u8 = 0;
+                        let mut prev_link: Option<u32> = None;
 
                         while c < p.last_cols {
                             if let Some(cell) = screen.cell(r, c) {
@@ -819,33 +829,45 @@ pub fn dump_layout_json_fast(app: &mut AppState) -> io::Result<String> {
                                 if cell.hidden()    { fl |= FLAG_HIDDEN; }
                                 if cell.strikethrough() { fl |= FLAG_STRIKETHROUGH; }
 
-                                if prev_fg == Some(cfg) && prev_bg == Some(cbg) && prev_fl == fl {
+                                // A hyperlink change must also break the run, so the
+                                // client wraps exactly the linked text in OSC 8 (#361).
+                                let clink = cell.hyperlink_id();
+                                if prev_fg == Some(cfg) && prev_bg == Some(cbg) && prev_fl == fl
+                                    && prev_link == Some(clink)
+                                {
                                     if let Some(last) = runs.last_mut() {
                                         last.text.push_str(t);
                                         last.width += w;
                                     }
                                 } else {
-                                    runs.push(Run { text: t.to_string(), fg: cfg, bg: cbg, flags: fl, width: w });
+                                    let link = if clink != 0 {
+                                        screen.hyperlink_uri(clink).map(|s| s.to_string())
+                                    } else { None };
+                                    runs.push(Run { text: t.to_string(), fg: cfg, bg: cbg, flags: fl, width: w, link });
                                 }
                                 prev_fg = Some(cfg);
                                 prev_bg = Some(cbg);
                                 prev_fl = fl;
+                                prev_link = Some(clink);
                                 c += w.max(1);
                             } else {
                                 let cfg = vt100::Color::Default;
                                 let cbg = vt100::Color::Default;
                                 let fl  = 0u8;
-                                if prev_fg == Some(cfg) && prev_bg == Some(cbg) && prev_fl == fl {
+                                if prev_fg == Some(cfg) && prev_bg == Some(cbg) && prev_fl == fl
+                                    && prev_link == Some(0)
+                                {
                                     if let Some(last) = runs.last_mut() {
                                         last.text.push(' ');
                                         last.width += 1;
                                     }
                                 } else {
-                                    runs.push(Run { text: " ".to_string(), fg: cfg, bg: cbg, flags: fl, width: 1 });
+                                    runs.push(Run { text: " ".to_string(), fg: cfg, bg: cbg, flags: fl, width: 1, link: None });
                                 }
                                 prev_fg = Some(cfg);
                                 prev_bg = Some(cbg);
                                 prev_fl = fl;
+                                prev_link = Some(0);
                                 c += 1;
                             }
                         }
@@ -1015,7 +1037,7 @@ pub fn dump_layout_json_fast(app: &mut AppState) -> io::Result<String> {
                         if i > 0 { out.push(','); }
                         out.push_str("{\"text\":\"");
                         json_esc(&run.text, out);
-                        close_run(run.fg, run.bg, run.flags, run.width, out);
+                        close_run(run.fg, run.bg, run.flags, run.width, run.link.as_deref(), out);
                     }
                     out.push_str("]}");
                 }
@@ -1373,3 +1395,7 @@ mod test_layout;
 #[cfg(test)]
 #[path = "../tests-rs/test_issue361_serialize_hyperlink.rs"]
 mod test_issue361_serialize_hyperlink;
+
+#[cfg(test)]
+#[path = "../tests-rs/test_issue361_fastdump_hyperlink.rs"]
+mod test_issue361_fastdump_hyperlink;

--- a/tests-rs/test_issue361_fastdump_hyperlink.rs
+++ b/tests-rs/test_issue361_fastdump_hyperlink.rs
@@ -1,0 +1,189 @@
+// Issue #361: the OSC 8 URI must survive the serializer the CLIENT actually
+// renders from.  `CtrlReq::DumpState` uses `dump_layout_json_fast`, which builds
+// its runs by hand — not through `CellRunJson` / `serialize_screen_rows`.  That
+// hand-rolled path had no `link` field, so every pane reached the client with
+// `run.link == None` and `build_osc8_overlay` never fired, even on hosts where
+// ConPTY passthrough delivers the OSC 8 to psmux.
+//
+// `test_issue361_serialize_hyperlink.rs` covers the serde path only, which is
+// why it stayed green while hyperlinks were dead end to end.
+//
+// Dummy PTY (no real spawn), so this stays hermetic and portable.
+
+use super::*;
+
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicU8};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use crate::types::{AppState, Node};
+
+const ROWS: u16 = 4;
+const COLS: u16 = 40;
+
+#[derive(Debug)]
+struct DummyChild;
+
+#[derive(Debug)]
+struct DummyWriter;
+
+struct DummyMaster;
+
+impl std::io::Write for DummyWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> { Ok(buf.len()) }
+    fn flush(&mut self) -> std::io::Result<()> { Ok(()) }
+}
+
+impl portable_pty::ChildKiller for DummyChild {
+    fn kill(&mut self) -> std::io::Result<()> { Ok(()) }
+    fn clone_killer(&self) -> Box<dyn portable_pty::ChildKiller + Send + Sync> {
+        Box::new(DummyChild)
+    }
+}
+
+impl portable_pty::Child for DummyChild {
+    fn try_wait(&mut self) -> std::io::Result<Option<portable_pty::ExitStatus>> {
+        Ok(Some(portable_pty::ExitStatus::with_exit_code(0)))
+    }
+    fn wait(&mut self) -> std::io::Result<portable_pty::ExitStatus> {
+        Ok(portable_pty::ExitStatus::with_exit_code(0))
+    }
+    fn process_id(&self) -> Option<u32> { None }
+    #[cfg(windows)]
+    fn as_raw_handle(&self) -> Option<std::os::windows::io::RawHandle> { None }
+}
+
+impl portable_pty::MasterPty for DummyMaster {
+    fn resize(&self, _size: portable_pty::PtySize) -> Result<(), anyhow::Error> { Ok(()) }
+    fn get_size(&self) -> Result<portable_pty::PtySize, anyhow::Error> {
+        Ok(portable_pty::PtySize { rows: ROWS, cols: COLS, pixel_width: 0, pixel_height: 0 })
+    }
+    fn try_clone_reader(&self) -> Result<Box<dyn std::io::Read + Send>, anyhow::Error> {
+        Ok(Box::new(std::io::empty()))
+    }
+    fn take_writer(&self) -> Result<Box<dyn std::io::Write + Send>, anyhow::Error> {
+        Ok(Box::new(DummyWriter))
+    }
+    #[cfg(unix)]
+    fn process_group_leader(&self) -> Option<i32> { None }
+    #[cfg(unix)]
+    fn as_raw_fd(&self) -> Option<std::os::unix::io::RawFd> { None }
+    #[cfg(unix)]
+    fn tty_name(&self) -> Option<std::path::PathBuf> { None }
+}
+
+fn make_pane(id: usize) -> crate::types::Pane {
+    let term = Arc::new(Mutex::new(vt100::Parser::new(ROWS, COLS, 0)));
+    let epoch = Instant::now() - Duration::from_secs(2);
+    crate::types::Pane {
+        master: Box::new(DummyMaster),
+        writer: Box::new(DummyWriter),
+        child: Box::new(DummyChild),
+        term,
+        last_rows: ROWS,
+        last_cols: COLS,
+        id,
+        title: String::new(),
+        title_locked: false,
+        child_pid: None,
+        data_version: Arc::new(AtomicU64::new(0)),
+        last_title_check: epoch,
+        last_infer_title: epoch,
+        dead: false,
+        last_text_input: None,
+        last_special_key: None,
+        vt_bridge_cache: None,
+        vti_mode_cache: None,
+        mouse_input_cache: None,
+        scroll_fg_cache: None,
+        cursor_shape: Arc::new(AtomicU8::new(0)),
+        bell_pending: Arc::new(AtomicBool::new(false)),
+        cpr_pending: Arc::new(AtomicBool::new(false)),
+        color_query_pending: Arc::new(std::sync::atomic::AtomicU32::new(0)),
+        copy_state: None,
+        pane_style: None,
+        squelch_until: None,
+        output_ring: Arc::new(Mutex::new(std::collections::VecDeque::new())),
+        spawned_at: None,
+    }
+}
+
+fn make_window() -> crate::types::Window {
+    crate::types::Window {
+        root: Node::Split { kind: crate::types::LayoutKind::Horizontal, sizes: vec![], children: vec![] },
+        active_path: vec![],
+        name: "w".to_string(),
+        id: 0,
+        area: ratatui::layout::Rect::new(0, 0, COLS, ROWS),
+        window_size: None,
+        activity_flag: false,
+        bell_flag: false,
+        silence_flag: false,
+        last_output_time: Instant::now(),
+        last_seen_version: 0,
+        manual_rename: false,
+        layout_index: 0,
+        pane_mru: vec![],
+        zoom_saved: None,
+        linked_from: None,
+        floating: Vec::new(),
+        floating_focus: None,
+    }
+}
+
+/// One window, one pane, with `bytes` already fed through the vt100 parser,
+/// dumped exactly the way `CtrlReq::DumpState` dumps it for the client.
+fn fast_dump_of(bytes: &[u8]) -> String {
+    let mut app = AppState::new("fastdump".to_string());
+    app.window_base_index = 0;
+    app.pane_base_index = 0;
+    app.copy_command = String::new();
+    app.set_clipboard = "off".to_string();
+    let pane = make_pane(0);
+    pane.term.lock().expect("parser lock").process(bytes);
+    let mut win = make_window();
+    win.root = Node::Leaf(pane);
+    win.active_path = vec![];
+    app.windows.push(win);
+    app.active_idx = 0;
+    app.last_window_area = ratatui::layout::Rect::new(0, 0, COLS, ROWS);
+    crate::layout::dump_layout_json_fast(&mut app).expect("fast dump")
+}
+
+#[test]
+fn fast_dump_run_carries_hyperlink_uri() {
+    let json = fast_dump_of(b"\x1b]8;;https://example.com\x1b\\Link\x1b]8;;\x1b\\ plain");
+    assert!(
+        json.contains("\"link\":\"https://example.com\""),
+        "fast dump must serialize the OSC 8 URI: {json}"
+    );
+}
+
+#[test]
+fn fast_dump_breaks_the_run_at_the_link_boundary() {
+    // Same style either side of the link, so only the hyperlink id can split it.
+    let json = fast_dump_of(b"\x1b]8;;https://example.com\x1b\\Link\x1b]8;;\x1b\\plain");
+    assert!(
+        json.contains("{\"text\":\"Link\""),
+        "linked text must be its own run, not merged with the plain tail: {json}"
+    );
+}
+
+#[test]
+fn fast_dump_omits_link_when_there_is_none() {
+    let json = fast_dump_of(b"just text");
+    assert!(
+        !json.contains("\"link\""),
+        "unlinked panes must not grow a link field: {json}"
+    );
+}
+
+#[test]
+fn fast_dump_escapes_the_uri() {
+    // A URI containing a quote must not break the JSON.
+    let json = fast_dump_of(b"\x1b]8;;https://example.com/a\"b\x1b\\Link\x1b]8;;\x1b\\");
+    assert!(
+        json.contains("\"link\":\"https://example.com/a\\\"b\""),
+        "URI must be JSON-escaped: {json}"
+    );
+}


### PR DESCRIPTION
`dump_layout_json_fast` builds its runs by hand rather than through `CellRunJson`, and that hand-rolled path never learned about OSC 8. Its private `struct Run` has no `link`, the merge condition ignores the hyperlink id, and `close_run()` emits no `"link"` key, so every pane reaches the client with `run.link == None`, `frame_hyperlinks_push` is never called, and `build_osc8_overlay` never runs. `CellRunJson::link` is `skip_serializing_if = "Option::is_none"`, so the missing key deserialises to `None` without a word.

This is the serialiser `CtrlReq::DumpState` uses (`src/server/mod.rs:2107`, `:5851`). `serialize_screen_rows`, the path `tests-rs/test_issue361_serialize_hyperlink.rs` covers, is reached only by the `dump-layout` introspection command, which is why #361's tests stay green while hyperlinks are dead end to end.

`src/layout.rs`:

- `Run` gains `link: Option<String>`, resolved via `screen.hyperlink_uri(cell.hyperlink_id())`.
- The merge condition gains `prev_link == Some(clink)`, so a hyperlink boundary breaks the run and the client wraps exactly the linked text. The blank-cell branch keeps `prev_link == Some(0)`, so trailing blanks cannot extend a link.
- `close_run()` takes `link: Option<&str>` and emits `,"link":"<uri>"` through `json_esc`. Nothing is emitted when there is no link, so the per-frame payload for normal output is byte-identical.

`tests-rs/test_issue361_fastdump_hyperlink.rs` covers the actual entry point: a one-pane `AppState` over a dummy PTY (no spawn), fed OSC 8, dumped through `dump_layout_json_fast`. It asserts the URI is serialised, that the run breaks at the link boundary with identical styling either side, that unlinked panes grow no `link` key, and that a URI containing `"` is JSON-escaped. The first assertion fails on master.

Fixes the psmux-side half of #361. The other half is the ConPTY `PSEUDOCONSOLE_PASSTHROUGH_MODE` fallback discussed in that issue: on builds where passthrough is rejected (26200 here), the URI is stripped before psmux sees it, so a link still will not become clickable there. Where passthrough works, this change is what lets the recorded URI reach the client. I am on 26200, so verification is at the serialiser rather than end to end.

Fixes #567.
