### PR TITLE
fix(split): honor -Z after splitting

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -10,7 +10,7 @@ use crate::pane::{create_window, split_active, kill_active_pane};
 use crate::copy_mode::{enter_copy_mode, scroll_copy_up, switch_with_copy_save, paste_latest,
     capture_active_pane, save_latest_buffer};
 use crate::session::{send_control_to_port, list_all_sessions_tree};
-use crate::window_ops::toggle_zoom;
+use crate::window_ops::{toggle_zoom, unzoom_if_zoomed};
 
 /// Parse a popup dimension spec: "80" (absolute) or "95%" (percentage of term_dim).
 pub(crate) fn parse_popup_dim_local(spec: &str, term_dim: u16, default: u16) -> u16 {
@@ -932,7 +932,14 @@ pub fn execute_command_prompt(app: &mut AppState) -> io::Result<()> {
         }
         "split-window" | "splitw" | "split-pane" | "splitp" => {
             let kind = if parts.iter().any(|p| *p == "-h") { LayoutKind::Horizontal } else { LayoutKind::Vertical };
+            let zoom_after_split = parts.iter().any(|p| *p == "-Z");
+            if zoom_after_split {
+                unzoom_if_zoomed(app);
+            }
             split_active(app, kind)?;
+            if zoom_after_split {
+                toggle_zoom(app);
+            }
         }
         "kill-pane" | "killp" => { kill_active_pane(app)?; }
         "capture-pane" | "capturep" => { capture_active_pane(app)?; }
@@ -977,6 +984,11 @@ fn execute_command_string_single(app: &mut AppState, cmd: &str) -> io::Result<()
             if let Some(port) = app.control_port {
                 // Forward the full command string to preserve -c, -d, -p etc. flags
                 let _ = send_control_to_port(port, &format!("{}\n", cmd), &app.session_key);
+            } else if parts.iter().any(|p| *p == "-Z") {
+                let kind = if parts.iter().any(|p| *p == "-h") { LayoutKind::Horizontal } else { LayoutKind::Vertical };
+                unzoom_if_zoomed(app);
+                split_active(app, kind)?;
+                toggle_zoom(app);
             }
         }
         "kill-pane" => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1750,6 +1750,7 @@ fn run_main() -> io::Result<()> {
                 let mut size_cells: Option<String> = None;
                 let mut title_arg: Option<String> = None;
                 let mut env_args: Vec<String> = Vec::new();
+                let mut zoom_after_split = false;
                 let mut sw_positional: Vec<String> = Vec::new();
                 {
                     let mut i = 1;
@@ -1770,7 +1771,8 @@ fn run_main() -> io::Result<()> {
                             "-v" => { flag = "-v"; }
                             "-d" => { detached = true; }
                             "-P" => { print_info = true; }
-                            "-b" | "-f" | "-I" | "-Z" => { /* ignored for compatibility */ }
+                            "-Z" => { zoom_after_split = true; }
+                            "-b" | "-f" | "-I" => { /* ignored for compatibility */ }
                             _ if a.starts_with('-') => { /* unknown flag, skip */ }
                             _ => { sw_positional.extend(cmd_args[i..].iter().map(|s| s.to_string())); break; }
                         }
@@ -1791,6 +1793,7 @@ fn run_main() -> io::Result<()> {
                 let mut cmd_line = format!("split-window {}", flag);
                 if detached { cmd_line.push_str(" -d"); }
                 if print_info { cmd_line.push_str(" -P"); }
+                if zoom_after_split { cmd_line.push_str(" -Z"); }
                 if let Some(ref fmt) = format_str {
                     cmd_line.push_str(&format!(" -F {}", crate::util::quote_arg(&fmt)));
                 }

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -1092,6 +1092,7 @@ match cmd {
     "split-window" | "splitw" | "split-pane" | "splitp" => {
         let kind = if args.iter().any(|a| *a == "-h") { LayoutKind::Horizontal } else { LayoutKind::Vertical };
         let detached = args.iter().any(|a| *a == "-d");
+        let zoom_after_split = args.iter().any(|a| *a == "-Z");
         let print_info = args.iter().any(|a| *a == "-P");
         let format_str: Option<String> = extract_flag_value(&args, "-F").map(|s| s.trim_matches('"').to_string());
         let title: Option<String> = extract_flag_value(&args, "-T").map(|s| s.trim_matches('"').to_string());
@@ -1119,7 +1120,7 @@ match cmd {
             .map(|s| s.trim_matches('"').to_string());
         if print_info {
             let (rtx, rrx) = mpsc::channel::<String>();
-            let _ = tx.send(CtrlReq::SplitWindowPrint(kind, cmd_str, detached, start_dir, split_size, format_str, rtx, title, env_sets));
+            let _ = tx.send(CtrlReq::SplitWindowPrint(kind, cmd_str, detached, start_dir, split_size, format_str, rtx, title, env_sets, zoom_after_split));
             if let Ok(text) = rrx.recv_timeout(Duration::from_millis(2000)) {
                 let _ = write!(write_stream, "{}\n", text);
                 let _ = write_stream.flush();
@@ -1127,7 +1128,7 @@ match cmd {
             if !persistent { break; }
         } else {
             let (rtx, rrx) = mpsc::channel::<String>();
-            let _ = tx.send(CtrlReq::SplitWindow(kind, cmd_str, detached, start_dir, split_size, rtx, title, env_sets));
+            let _ = tx.send(CtrlReq::SplitWindow(kind, cmd_str, detached, start_dir, split_size, rtx, title, env_sets, zoom_after_split));
             if let Ok(err_msg) = rrx.recv_timeout(Duration::from_millis(2000)) {
                 if !err_msg.is_empty() {
                     let _ = write!(write_stream, "{}\n", err_msg);
@@ -3801,6 +3802,7 @@ fn dispatch_control_command(
             let cmd_str = args.windows(2).find(|w| w[0] == "-c").map(|_| ()).and(None);
             let start_dir = args.windows(2).find(|w| w[0] == "-c").map(|w| w[1].trim_matches('"').to_string());
             let detached = crate::cli::has_short_flag(&args, 'd');
+            let zoom_after_split = crate::cli::has_short_flag(&args, 'Z');
             let print_info = crate::cli::has_short_flag(&args, 'P');
             let format_str = extract_flag_value(&args, "-F").map(|s| s.trim_matches('"').to_string());
             let title = extract_flag_value(&args, "-T").map(|s| s.trim_matches('"').to_string());
@@ -3821,9 +3823,9 @@ fn dispatch_control_command(
                 .collect();
             let (rtx, rrx) = mpsc::channel::<String>();
             if print_info {
-                let _ = tx.send(CtrlReq::SplitWindowPrint(kind, cmd_str, detached, start_dir, split_size, format_str, rtx, title, env_sets));
+                let _ = tx.send(CtrlReq::SplitWindowPrint(kind, cmd_str, detached, start_dir, split_size, format_str, rtx, title, env_sets, zoom_after_split));
             } else {
-                let _ = tx.send(CtrlReq::SplitWindow(kind, cmd_str, detached, start_dir, split_size, rtx, title, env_sets));
+                let _ = tx.send(CtrlReq::SplitWindow(kind, cmd_str, detached, start_dir, split_size, rtx, title, env_sets, zoom_after_split));
             }
             if let Ok(text) = rrx.recv_timeout(Duration::from_secs(5)) {
                 let _ = resp_tx.send(text);

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1589,7 +1589,7 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                     // other clients' commands.
                     resize_all_panes(&mut app); meta_dirty = true; hook_event = Some("after-new-window");
                 }
-                CtrlReq::SplitWindow(k, cmd, detached, start_dir, split_size, resp, title, env_sets) => {
+                CtrlReq::SplitWindow(k, cmd, detached, start_dir, split_size, resp, title, env_sets, zoom_after_split) => {
                     if let Some(cmds) = app.hooks.get("before-split-window") { let cmds = cmds.clone(); for cmd in &cmds { let _ = execute_command_string(&mut app, cmd); } }
                     // tmux: split-window without -Z permanently unzooms (#82)
                     unzoom_if_zoomed(&mut app);
@@ -1600,6 +1600,8 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                         win.floating_focus.and_then(|fi| win.floating.get(fi)).map(|fp| (fp.x, fp.y, fp.w, fp.h, fp.border.clone()))
                     };
                     if let Some((sx, sy, sw, sh, sborder)) = float_src {
+                        // Floating panes are overlays, so tiled-window zoom does
+                        // not apply to splits created from a floating pane.
                         let win_w = app.last_window_area.width.max(10);
                         let win_h = app.last_window_area.height.max(10);
                         let nx = (sx + 2).min(win_w.saturating_sub(sw));
@@ -1624,13 +1626,18 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                     let saved_dir = if start_dir.is_some() { env::current_dir().ok() } else { None };
                     if let Some(dir) = &start_dir { env::set_current_dir(dir).ok(); }
                     let prev_path = app.windows[app.active_idx].active_path.clone();
-                    if let Err(e) = split_active_with_env(&mut app, k, cmd.as_deref(), Some(&*pty_system), start_dir.as_deref(), &env_sets) {
-                        let msg = format!("split-window: {e}");
-                        app.status_message = Some((msg.clone(), std::time::Instant::now(), None));
-                        let _ = resp.send(format!("psmux: {msg}"));
-                    } else {
-                        let _ = resp.send(String::new());
-                    }
+                    let split_succeeded = match split_active_with_env(&mut app, k, cmd.as_deref(), Some(&*pty_system), start_dir.as_deref(), &env_sets) {
+                        Err(e) => {
+                            let msg = format!("split-window: {e}");
+                            app.status_message = Some((msg.clone(), std::time::Instant::now(), None));
+                            let _ = resp.send(format!("psmux: {msg}"));
+                            false
+                        }
+                        Ok(()) => {
+                            let _ = resp.send(String::new());
+                            true
+                        }
+                    };
                     // Apply size if specified: (value, true) = percentage, (value, false) = cell count
                     if let Some((val, is_pct)) = split_size {
                         let pct = if is_pct {
@@ -1682,6 +1689,9 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                         temp_focus_restore = None;
                         app.temp_focus_saved_active = None;
                     }
+                    if zoom_after_split && split_succeeded {
+                        toggle_zoom(&mut app);
+                    }
                     if let Some(prev) = saved_dir { env::set_current_dir(prev).ok(); }
                     // Replenish warm pane for the next new-window/split
                     // Warm-pane replenish is deferred OFF the command path — it
@@ -1691,17 +1701,21 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                     resize_all_panes(&mut app); meta_dirty = true; hook_event = Some("after-split-window");
                     }
                 }
-                CtrlReq::SplitWindowPrint(k, cmd, detached, start_dir, split_size, format_str, resp, title, env_sets) => {
+                CtrlReq::SplitWindowPrint(k, cmd, detached, start_dir, split_size, format_str, resp, title, env_sets, zoom_after_split) => {
                     if let Some(cmds) = app.hooks.get("before-split-window") { let cmds = cmds.clone(); for cmd in &cmds { let _ = execute_command_string(&mut app, cmd); } }
                     unzoom_if_zoomed(&mut app);
                     let start_dir = start_dir.map(|d| expand_format(&d, &app)).filter(|d| !d.is_empty());
                     let saved_dir = if start_dir.is_some() { env::current_dir().ok() } else { None };
                     if let Some(dir) = &start_dir { env::set_current_dir(dir).ok(); }
                     let prev_path = app.windows[app.active_idx].active_path.clone();
-                    if let Err(e) = split_active_with_env(&mut app, k, cmd.as_deref(), Some(&*pty_system), start_dir.as_deref(), &env_sets) {
-                        app.status_message = Some((format!("split-window: {e}"), std::time::Instant::now(), None));
-                        eprintln!("psmux: split-window error: {e}");
-                    }
+                    let split_succeeded = match split_active_with_env(&mut app, k, cmd.as_deref(), Some(&*pty_system), start_dir.as_deref(), &env_sets) {
+                        Err(e) => {
+                            app.status_message = Some((format!("split-window: {e}"), std::time::Instant::now(), None));
+                            eprintln!("psmux: split-window error: {e}");
+                            false
+                        }
+                        Ok(()) => true,
+                    };
                     // Apply size if specified: (value, true) = percentage, (value, false) = cell count
                     if let Some((val, is_pct)) = split_size {
                         let pct = if is_pct {
@@ -1745,6 +1759,9 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                     } else {
                         temp_focus_restore = None;
                         app.temp_focus_saved_active = None;
+                    }
+                    if zoom_after_split && split_succeeded {
+                        toggle_zoom(&mut app);
                     }
                     let _ = resp.send(pane_info);
                     if let Some(prev) = saved_dir { env::set_current_dir(prev).ok(); }

--- a/src/types.rs
+++ b/src/types.rs
@@ -1412,8 +1412,8 @@ pub struct Bind { pub key: (KeyCode, KeyModifiers), pub action: Action, pub repe
 pub enum CtrlReq {
     NewWindow(Option<String>, Option<String>, bool, Option<String>, Option<String>, bool, Vec<(String, String)>),  // cmd, name, detached, start_dir, title (-T), empty (-E), env (-e, #489)
     NewWindowPrint(Option<String>, Option<String>, bool, Option<String>, Option<String>, mpsc::Sender<String>, Option<String>, bool, Vec<(String, String)>),  // cmd, name, detached, start_dir, format, resp, title (-T), empty (-E), env (-e, #489)
-    SplitWindow(LayoutKind, Option<String>, bool, Option<String>, Option<(u16, bool)>, mpsc::Sender<String>, Option<String>, Vec<(String, String)>),  // kind, cmd, detached, start_dir, size (value, is_percent), error_resp, title (-T), env (-e, #489)
-    SplitWindowPrint(LayoutKind, Option<String>, bool, Option<String>, Option<(u16, bool)>, Option<String>, mpsc::Sender<String>, Option<String>, Vec<(String, String)>),  // kind, cmd, detached, start_dir, size (value, is_percent), format, resp, title (-T), env (-e, #489)
+    SplitWindow(LayoutKind, Option<String>, bool, Option<String>, Option<(u16, bool)>, mpsc::Sender<String>, Option<String>, Vec<(String, String)>, bool),  // kind, cmd, detached, start_dir, size (value, is_percent), error_resp, title (-T), env (-e, #489), zoom (-Z)
+    SplitWindowPrint(LayoutKind, Option<String>, bool, Option<String>, Option<(u16, bool)>, Option<String>, mpsc::Sender<String>, Option<String>, Vec<(String, String)>, bool),  // kind, cmd, detached, start_dir, size (value, is_percent), format, resp, title (-T), env (-e, #489), zoom (-Z)
     /// new-pane: create a floating pane over the active window's layout.
     /// Flags match tmux: `-X`/`-Y` position, `-x`/`-y` size, `-B` border,
     /// `-T` title, `-c` dir, `-d` detached, `-P` print (returns the pane id).

--- a/tests-rs/test_flag_parity.rs
+++ b/tests-rs/test_flag_parity.rs
@@ -911,8 +911,10 @@ fn split_window_flag_P_print() {
 #[test]
 fn split_window_flag_Z_zoom() {
     let mut app = mock_app_with_window();
+    assert!(app.windows[0].zoom_saved.is_none());
     execute_command_string(&mut app, "split-window -Z").unwrap();
-    // -Z should zoom the new pane after split
+    assert!(app.windows[0].zoom_saved.is_some(), "-Z should zoom the active pane after splitting");
+    assert_eq!(app.windows[0].active_path, vec![1], "-Z should leave the new pane active");
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- preserve `split-window -Z` through the CLI and both server command paths
- zoom the active pane after a successful tiled split, including detached and already-zoomed windows
- leave floating-pane splits as overlays instead of applying tiled-window zoom

## Testing
- `cargo test --all-targets -- --test-threads=4`
- isolated client/server checks for `split-window -Z` and `split-window -d -Z`