### PR TITLE
Add opt-in drag-to-copy inside mouse-aware applications

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -130,6 +130,7 @@ Details worth knowing:
 | `status-interval` | Int | `15` | Status refresh (seconds) |
 | `mouse` | Bool | `on` | Mouse support |
 | `mouse-selection` | Bool | `on` | psmux's client-side drag selection. Set `off` to let in-pane TUI apps (opencode, nvim, etc.) handle their own mouse selection without psmux drawing on top |
+| `mouse-selection-force` | Bool | `off` | Keep psmux drag selection active in apps that request mouse tracking. Plain clicks are replayed to the app; drags are copied by psmux |
 | `scroll-enter-copy-mode` | Bool | `on` | Enter copy mode on mouse scroll (set `off` to disable) |
 | `pwsh-mouse-selection` | Bool | `off` | tmux-like release-copy selection with word/line multi-click and pane-clipped extraction |
 | `paste-detection` | Bool | `on` | Detect Ctrl+V paste from console host and send as bracketed paste (set `off` to let Ctrl+V reach child apps like neovim) |

--- a/src/client.rs
+++ b/src/client.rs
@@ -498,6 +498,14 @@ fn pane_wants_mouse_json(layout: &LayoutJson, pane_id: usize) -> bool {
     }
 }
 
+fn client_selection_owns_drag(
+    mouse_selection: bool,
+    mouse_selection_force: bool,
+    pane_handles_mouse: bool,
+) -> bool {
+    mouse_selection && (mouse_selection_force || !pane_handles_mouse)
+}
+
 /// Check if the active pane is in server-side copy mode.
 /// When true, the client should NOT start its own text selection —
 /// the server handles cursor positioning and selection in copy mode.
@@ -1878,6 +1886,10 @@ pub fn run_remote(terminal: &mut Terminal<crate::platform::PsmuxBackend>, input:
         /// in-pane apps (opencode, etc.) can do their own mouse selection.
         #[serde(default = "default_mouse_selection")]
         mouse_selection: bool,
+        /// mouse-selection-force option. When true, client-side drag
+        /// selection overrides an application's mouse tracking.
+        #[serde(default)]
+        mouse_selection_force: bool,
         /// paste-detection option (mirror of server-side AppState field)
         #[serde(default = "default_paste_detection")]
         paste_detection: bool,
@@ -2040,6 +2052,9 @@ pub fn run_remote(terminal: &mut Terminal<crate::platform::PsmuxBackend>, input:
     let mut rsel_end: Option<(u16, u16)> = None;
     let mut rsel_pane_rect: Option<Rect> = None;    // clip bounds of the originating pane
     let mut rsel_dragged = false;
+    // A click withheld from a mouse-aware pane while psmux determines whether
+    // the gesture is a click or a selection drag: (pane_id, col, row).
+    let mut deferred_left_click: Option<(usize, i16, i16)> = None;
     // Multi-click tracking for word/line selection.
     let mut last_click: Option<(Instant, (u16, u16))> = None;
     let mut click_count: u32 = 0;
@@ -2062,6 +2077,7 @@ pub fn run_remote(terminal: &mut Terminal<crate::platform::PsmuxBackend>, input:
     let mut client_copy_mode: bool = false;
     let mut client_pwsh_selection: bool = false;
     let mut client_mouse_selection: bool = true;
+    let mut client_mouse_selection_force: bool = false;
     let mut client_zoomed: bool = false;
     let mut client_drag: Option<ClientDragState> = None;
     // Border hover highlight: (position, kind, area) of the border under the cursor.
@@ -4226,6 +4242,7 @@ pub fn run_remote(terminal: &mut Terminal<crate::platform::PsmuxBackend>, input:
                                             let rel_row = (me.row as i16 - pane_content_inner(pane_rect, &client_border_status, &client_border_format).y as i16).max(0);
 
                                             if client_copy_mode {
+                                                deferred_left_click = None;
                                                 cmd_batch.push(format!("pane-mouse {} 0 {} {} M\n",
                                                     pane_id, rel_col, rel_row));
                                                 rsel_start = None;
@@ -4234,8 +4251,6 @@ pub fn run_remote(terminal: &mut Terminal<crate::platform::PsmuxBackend>, input:
                                                 rsel_block = false;
                                                 selection_changed = true;
                                             } else {
-                                                cmd_batch.push(format!("pane-mouse {} 0 {} {} M\n",
-                                                    pane_id, rel_col, rel_row));
                                                 border_drag = false;
 
                                                 // mouse-selection off: do not start any client-side
@@ -4243,17 +4258,33 @@ pub fn run_remote(terminal: &mut Terminal<crate::platform::PsmuxBackend>, input:
                                                 // can implement their own mouse selection without
                                                 // psmux drawing on top.  (issue #245)
                                                 //
-                                                // Per-pane: even with mouse-selection on, yield to a
-                                                // pane whose app explicitly enabled a mouse protocol
-                                                // — it handles its own selection, and the press was
-                                                // already forwarded above; with no client selection
-                                                // active, the Drag/Up arms forward mouse-drag /
-                                                // mouse-up so the app sees the full gesture.
+                                                // Per-pane: even with mouse-selection on, normally
+                                                // yield to an app that enabled a mouse protocol. The
+                                                // force option instead withholds the press until
+                                                // release, so clicks can be replayed while drags stay
+                                                // available for psmux selection.
                                                 let pane_handles_mouse =
                                                     serde_json::from_str::<DumpState>(&prev_dump_buf)
                                                         .map(|s| pane_wants_mouse_json(&s.layout, pane_id))
                                                         .unwrap_or(false);
-                                                if !client_mouse_selection || pane_handles_mouse {
+                                                let force_client_selection =
+                                                    client_selection_owns_drag(
+                                                        client_mouse_selection,
+                                                        client_mouse_selection_force,
+                                                        pane_handles_mouse,
+                                                    ) && pane_handles_mouse;
+                                                if force_client_selection {
+                                                    deferred_left_click = Some((pane_id, rel_col, rel_row));
+                                                } else {
+                                                    deferred_left_click = None;
+                                                    cmd_batch.push(format!("pane-mouse {} 0 {} {} M\n",
+                                                        pane_id, rel_col, rel_row));
+                                                }
+                                                if !client_selection_owns_drag(
+                                                    client_mouse_selection,
+                                                    client_mouse_selection_force,
+                                                    pane_handles_mouse,
+                                                ) {
                                                     rsel_start = None;
                                                     rsel_end = None;
                                                     rsel_pane_rect = None;
@@ -4332,6 +4363,7 @@ pub fn run_remote(terminal: &mut Terminal<crate::platform::PsmuxBackend>, input:
                                                 } // end client-side selection gate (mouse-selection + per-pane wants_mouse)
                                             }
                                         } else {
+                                            deferred_left_click = None;
                                             cmd_batch.push(format!("mouse-down {} {}\n", me.column, me.row));
                                         }
                                     }
@@ -4475,6 +4507,7 @@ pub fn run_remote(terminal: &mut Terminal<crate::platform::PsmuxBackend>, input:
                             MouseEventKind::Drag(MouseButton::Right) => {}
                             MouseEventKind::Up(MouseButton::Left) => {
                                 if border_drag {
+                                    deferred_left_click = None;
                                     cmd_batch.push(format!("split-resize-done\n"));
                                     border_drag = false;
                                     client_drag = None;
@@ -4533,13 +4566,37 @@ pub fn run_remote(terminal: &mut Terminal<crate::platform::PsmuxBackend>, input:
                                         rsel_dragged = false;
                                         selection_changed = true;
                                     }
+                                    deferred_left_click = None;
                                 } else {
                                     rsel_start = None;
                                     rsel_end = None;
                                     rsel_pane_rect = None;
                                     rsel_block = false;
                                     selection_changed = true;
-                                    if client_copy_mode {
+                                    if let Some((pane_id, down_col, down_row)) = deferred_left_click.take() {
+                                        let (up_col, up_row) = client_pane_rects.iter()
+                                            .find(|(id, _)| *id == pane_id)
+                                            .map(|(_, pane_rect)| {
+                                                let inner = pane_content_inner(
+                                                    *pane_rect,
+                                                    &client_border_status,
+                                                    &client_border_format,
+                                                );
+                                                (
+                                                    (me.column as i16 - pane_rect.x as i16)
+                                                        .max(0)
+                                                        .min(pane_rect.width.saturating_sub(1) as i16),
+                                                    (me.row as i16 - inner.y as i16)
+                                                        .max(0)
+                                                        .min(inner.height.saturating_sub(1) as i16),
+                                                )
+                                            })
+                                            .unwrap_or((down_col, down_row));
+                                        cmd_batch.push(format!("pane-mouse {} 0 {} {} M\n",
+                                            pane_id, down_col, down_row));
+                                        cmd_batch.push(format!("pane-mouse {} 0 {} {} m\n",
+                                            pane_id, up_col, up_row));
+                                    } else if client_copy_mode {
                                         if let Some(&(pane_id, pane_rect)) = client_pane_rects.iter().find(|(_, r)| {
                                             r.contains(ratatui::layout::Position { x: me.column, y: me.row })
                                         }) {
@@ -4857,6 +4914,7 @@ pub fn run_remote(terminal: &mut Terminal<crate::platform::PsmuxBackend>, input:
         client_copy_mode = active_pane_in_copy_mode(&root);
         client_pwsh_selection = state.pwsh_mouse_selection;
         client_mouse_selection = state.mouse_selection;
+        client_mouse_selection_force = state.mouse_selection_force;
         #[cfg(windows)]
         { paste_detection_enabled = state.paste_detection; }
         choose_tree_preview_default = state.choose_tree_preview;

--- a/src/config.rs
+++ b/src/config.rs
@@ -1024,6 +1024,7 @@ pub fn parse_option_value(app: &mut AppState, key: &str, value: &str, _is_global
         "scroll-enter-copy-mode" => app.scroll_enter_copy_mode = matches!(value, "on" | "true" | "1" | "yes"),
         "pwsh-mouse-selection" => app.pwsh_mouse_selection = matches!(value, "on" | "true" | "1" | "yes"),
         "mouse-selection" => app.mouse_selection = matches!(value, "on" | "true" | "1" | "yes"),
+        "mouse-selection-force" => app.mouse_selection_force = matches!(value, "on" | "true" | "1" | "yes"),
         "paste-detection" => app.paste_detection = matches!(value, "on" | "true" | "1" | "yes"),
         "choose-tree-preview" => app.choose_tree_preview = matches!(value, "on" | "true" | "1" | "yes"),
         "bold-is-bright" => {

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -2139,7 +2139,7 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                     let status_format_json = &sf.status_format_json;
                     let cursor_style_code = crate::rendering::configured_cursor_code();
                     let _ = std::fmt::Write::write_fmt(&mut combined_buf, format_args!(
-                        "{{\"layout\":{},\"windows\":{},\"prefix\":\"{}\",\"prefix2\":\"{}\",\"tree\":{},\"base_index\":{},\"pane_base_index\":{},\"prediction_dimming\":{},\"status_style\":\"{}\",\"status_left\":\"{}\",\"status_right\":\"{}\",\"pane_border_style\":\"{}\",\"pane_active_border_style\":\"{}\",\"pane_border_hover_style\":\"{}\",\"wsf\":\"{}\",\"wscf\":\"{}\",\"wss\":\"{}\",\"ws_style\":\"{}\",\"wsc_style\":\"{}\",\"clock_mode\":{},\"bindings\":{},\"status_left_length\":{},\"status_right_length\":{},\"status_lines\":{},\"status_format\":{},\"mode_style\":\"{}\",\"message_style\":\"{}\",\"status_position\":\"{}\",\"status_justify\":\"{}\",\"cursor_style_code\":{},\"status_visible\":{},\"repeat_time\":{},\"zoomed\":{},\"defaults_suppressed\":{},\"pwsh_mouse_selection\":{},\"mouse_selection\":{},\"paste_detection\":{},\"choose_tree_preview\":{},\"scroll_enter_copy_mode\":{},\"bold_is_bright\":{}}}",
+                        "{{\"layout\":{},\"windows\":{},\"prefix\":\"{}\",\"prefix2\":\"{}\",\"tree\":{},\"base_index\":{},\"pane_base_index\":{},\"prediction_dimming\":{},\"status_style\":\"{}\",\"status_left\":\"{}\",\"status_right\":\"{}\",\"pane_border_style\":\"{}\",\"pane_active_border_style\":\"{}\",\"pane_border_hover_style\":\"{}\",\"wsf\":\"{}\",\"wscf\":\"{}\",\"wss\":\"{}\",\"ws_style\":\"{}\",\"wsc_style\":\"{}\",\"clock_mode\":{},\"bindings\":{},\"status_left_length\":{},\"status_right_length\":{},\"status_lines\":{},\"status_format\":{},\"mode_style\":\"{}\",\"message_style\":\"{}\",\"status_position\":\"{}\",\"status_justify\":\"{}\",\"cursor_style_code\":{},\"status_visible\":{},\"repeat_time\":{},\"zoomed\":{},\"defaults_suppressed\":{},\"pwsh_mouse_selection\":{},\"mouse_selection\":{},\"mouse_selection_force\":{},\"paste_detection\":{},\"choose_tree_preview\":{},\"scroll_enter_copy_mode\":{},\"bold_is_bright\":{}}}",
                         layout_json, cached_windows_json, cached_prefix_str, cached_prefix2_str, cached_tree_json, cached_base_index, app.pane_base_index, cached_pred_dim, ss_escaped, sl_expanded, sr_expanded, pbs_escaped, pabs_escaped, pbhs_escaped, wsf_escaped, wscf_escaped, wss_escaped, ws_style_escaped, wsc_style_escaped,
                         matches!(app.mode, Mode::ClockMode), cached_bindings_json,
                         app.status_left_length, app.status_right_length, app.status_lines, status_format_json,
@@ -2149,6 +2149,7 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                         app.defaults_suppressed,
                         app.pwsh_mouse_selection,
                         app.mouse_selection,
+                        app.mouse_selection_force,
                         app.paste_detection,
                         app.choose_tree_preview,
                         app.scroll_enter_copy_mode,
@@ -3919,6 +3920,7 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                             "scroll-enter-copy-mode" => { app.scroll_enter_copy_mode = true; }
                             "pwsh-mouse-selection" => { app.pwsh_mouse_selection = false; }
                             "mouse-selection" => { app.mouse_selection = true; }
+                            "mouse-selection-force" => { app.mouse_selection_force = false; }
                             "paste-detection" => { app.paste_detection = true; }
                             "choose-tree-preview" => { app.choose_tree_preview = false; }
                             "escape-time" => { app.escape_time_ms = 500; }
@@ -4008,6 +4010,7 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                     output.push_str(&format!("scroll-enter-copy-mode {}\n", if app.scroll_enter_copy_mode { "on" } else { "off" }));
                     output.push_str(&format!("pwsh-mouse-selection {}\n", if app.pwsh_mouse_selection { "on" } else { "off" }));
                     output.push_str(&format!("mouse-selection {}\n", if app.mouse_selection { "on" } else { "off" }));
+                    output.push_str(&format!("mouse-selection-force {}\n", if app.mouse_selection_force { "on" } else { "off" }));
                     output.push_str(&format!("paste-detection {}\n", if app.paste_detection { "on" } else { "off" }));
                     output.push_str(&format!("choose-tree-preview {}\n", if app.choose_tree_preview { "on" } else { "off" }));
                     output.push_str(&format!("status {}\n", if app.status_visible { "on" } else { "off" }));
@@ -5932,7 +5935,7 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
             let status_format_json = &sf.status_format_json;
             let cursor_style_code = crate::rendering::configured_cursor_code();
             let _ = std::fmt::Write::write_fmt(&mut combined_buf, format_args!(
-                "{{\"layout\":{},\"windows\":{},\"prefix\":\"{}\",\"prefix2\":\"{}\",\"tree\":{},\"base_index\":{},\"pane_base_index\":{},\"prediction_dimming\":{},\"status_style\":\"{}\",\"status_left\":\"{}\",\"status_right\":\"{}\",\"pane_border_style\":\"{}\",\"pane_active_border_style\":\"{}\",\"pane_border_hover_style\":\"{}\",\"wsf\":\"{}\",\"wscf\":\"{}\",\"wss\":\"{}\",\"ws_style\":\"{}\",\"wsc_style\":\"{}\",\"clock_mode\":{},\"bindings\":{},\"status_left_length\":{},\"status_right_length\":{},\"status_lines\":{},\"status_format\":{},\"mode_style\":\"{}\",\"message_style\":\"{}\",\"status_position\":\"{}\",\"status_justify\":\"{}\",\"cursor_style_code\":{},\"status_visible\":{},\"repeat_time\":{},\"zoomed\":{},\"pwsh_mouse_selection\":{},\"mouse_selection\":{},\"paste_detection\":{},\"choose_tree_preview\":{},\"scroll_enter_copy_mode\":{},\"bold_is_bright\":{}}}",
+                "{{\"layout\":{},\"windows\":{},\"prefix\":\"{}\",\"prefix2\":\"{}\",\"tree\":{},\"base_index\":{},\"pane_base_index\":{},\"prediction_dimming\":{},\"status_style\":\"{}\",\"status_left\":\"{}\",\"status_right\":\"{}\",\"pane_border_style\":\"{}\",\"pane_active_border_style\":\"{}\",\"pane_border_hover_style\":\"{}\",\"wsf\":\"{}\",\"wscf\":\"{}\",\"wss\":\"{}\",\"ws_style\":\"{}\",\"wsc_style\":\"{}\",\"clock_mode\":{},\"bindings\":{},\"status_left_length\":{},\"status_right_length\":{},\"status_lines\":{},\"status_format\":{},\"mode_style\":\"{}\",\"message_style\":\"{}\",\"status_position\":\"{}\",\"status_justify\":\"{}\",\"cursor_style_code\":{},\"status_visible\":{},\"repeat_time\":{},\"zoomed\":{},\"pwsh_mouse_selection\":{},\"mouse_selection\":{},\"mouse_selection_force\":{},\"paste_detection\":{},\"choose_tree_preview\":{},\"scroll_enter_copy_mode\":{},\"bold_is_bright\":{}}}",
                 layout_json, cached_windows_json, cached_prefix_str, cached_prefix2_str, cached_tree_json, cached_base_index, app.pane_base_index, cached_pred_dim, ss_escaped, sl_expanded, sr_expanded, pbs_escaped, pabs_escaped, pbhs_escaped, wsf_escaped, wscf_escaped, wss_escaped, ws_style_escaped, wsc_style_escaped,
                 matches!(app.mode, Mode::ClockMode), cached_bindings_json,
                 app.status_left_length, app.status_right_length, app.status_lines, status_format_json,
@@ -5941,6 +5944,7 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                 app.windows.get(app.active_idx).map_or(false, |w| w.zoom_saved.is_some()),
                 app.pwsh_mouse_selection,
                 app.mouse_selection,
+                app.mouse_selection_force,
                 app.paste_detection,
                 app.choose_tree_preview,
                 app.scroll_enter_copy_mode,

--- a/src/server/option_catalog.rs
+++ b/src/server/option_catalog.rs
@@ -32,6 +32,7 @@ pub static OPTION_CATALOG: &[OptionDef] = &[
     OptionDef { name: "scroll-enter-copy-mode", scope: "session", option_type: "boolean", default: "on", description: "Enter copy mode on mouse scroll up at shell prompt" },
     OptionDef { name: "pwsh-mouse-selection", scope: "session", option_type: "boolean", default: "off", description: "Windows 11 PowerShell-style drag selection (pane-aware, right-click to copy, word/line multi-click)" },
     OptionDef { name: "mouse-selection", scope: "session", option_type: "boolean", default: "on", description: "Enable psmux's client-side drag-selection overlay. Set to off so apps inside a pane (opencode, etc.) can implement their own mouse selection without psmux drawing on top." },
+    OptionDef { name: "mouse-selection-force", scope: "session", option_type: "boolean", default: "off", description: "Keep psmux drag selection active in mouse-aware apps; replay plain clicks while consuming drags" },
     OptionDef { name: "paste-detection", scope: "session", option_type: "boolean", default: "on", description: "Detect Ctrl+V paste from console host and send as bracketed paste (disable to let Ctrl+V reach child apps)" },
     OptionDef { name: "mode-keys", scope: "session", option_type: "choice", default: "emacs", description: "Key bindings in copy mode (vi/emacs)" },
     OptionDef { name: "copy-mode-line-numbers", scope: "window", option_type: "choice", default: "off", description: "Line number mode in copy mode (off/default/absolute/relative/hybrid)" },

--- a/src/server/options.rs
+++ b/src/server/options.rs
@@ -66,6 +66,7 @@ pub(crate) fn get_option_value(app: &AppState, name: &str) -> String {
         "scroll-enter-copy-mode" => if app.scroll_enter_copy_mode { "on".into() } else { "off".into() },
         "pwsh-mouse-selection" => if app.pwsh_mouse_selection { "on".into() } else { "off".into() },
         "mouse-selection" => if app.mouse_selection { "on".into() } else { "off".into() },
+        "mouse-selection-force" => if app.mouse_selection_force { "on".into() } else { "off".into() },
         "paste-detection" => if app.paste_detection { "on".into() } else { "off".into() },
         "choose-tree-preview" => if app.choose_tree_preview { "on".into() } else { "off".into() },
         "status" => {
@@ -264,6 +265,7 @@ pub(crate) fn is_boolean_option(name: &str) -> bool {
             | "scroll-enter-copy-mode"
             | "pwsh-mouse-selection"
             | "mouse-selection"
+            | "mouse-selection-force"
             | "paste-detection"
             | "choose-tree-preview"
             | "focus-events"
@@ -349,6 +351,7 @@ pub(crate) fn apply_set_option(app: &mut AppState, option: &str, value: &str, _q
         "scroll-enter-copy-mode" => { app.scroll_enter_copy_mode = matches!(value, "on" | "true" | "1" | "yes"); }
         "pwsh-mouse-selection" => { app.pwsh_mouse_selection = matches!(value, "on" | "true" | "1" | "yes"); }
         "mouse-selection" => { app.mouse_selection = matches!(value, "on" | "true" | "1" | "yes"); }
+        "mouse-selection-force" => { app.mouse_selection_force = matches!(value, "on" | "true" | "1" | "yes"); }
         "paste-detection" => { app.paste_detection = matches!(value, "on" | "true" | "1" | "yes"); }
         "choose-tree-preview" => { app.choose_tree_preview = matches!(value, "on" | "true" | "1" | "yes"); }
         "prefix" => {

--- a/src/types.rs
+++ b/src/types.rs
@@ -543,6 +543,11 @@ pub struct AppState {
     /// forwarded to the application (click-to-focus, scroll, app-level
     /// mouse tracking continue to work).  Default: on.  (issue #245)
     pub mouse_selection: bool,
+    /// mouse-selection-force: when on, psmux keeps client-side drag selection
+    /// even when the pane application enabled mouse tracking. Plain clicks are
+    /// deferred until release and replayed to the application; drags are
+    /// consumed by psmux. Default: off.
+    pub mouse_selection_force: bool,
     /// paste-detection: when on (default), Ctrl+V Press is suppressed and the
     /// Windows paste detection mechanism intercepts clipboard content injected
     /// by the console host.  When off, Ctrl+V is forwarded as send-key C-v so
@@ -1174,6 +1179,7 @@ impl AppState {
             scroll_enter_copy_mode: true,
             pwsh_mouse_selection: false,
             mouse_selection: true,
+            mouse_selection_force: false,
             paste_detection: true,
             choose_tree_preview: false,
             paste_buffers: Vec::new(),

--- a/tests-rs/test_config_exhaustive.rs
+++ b/tests-rs/test_config_exhaustive.rs
@@ -259,6 +259,12 @@ fn default_pwsh_mouse_selection() {
 }
 
 #[test]
+fn default_mouse_selection_force() {
+    let app = mock_app();
+    assert!(!app.mouse_selection_force);
+}
+
+#[test]
 fn default_sync_input() {
     let app = mock_app();
     assert!(!app.sync_input);

--- a/tests-rs/test_issue245_mouse_selection.rs
+++ b/tests-rs/test_issue245_mouse_selection.rs
@@ -52,6 +52,42 @@ fn default_mouse_selection_is_on() {
 }
 
 #[test]
+fn default_mouse_selection_force_is_off() {
+    let app = mock_app();
+    assert!(!app.mouse_selection_force);
+}
+
+#[test]
+fn config_and_server_options_support_mouse_selection_force() {
+    let mut app = mock_app_with_window();
+    crate::config::parse_config_content(&mut app, "set -g mouse-selection-force on\n");
+    assert!(app.mouse_selection_force);
+    assert_eq!(
+        crate::server::options::get_option_value(&app, "mouse-selection-force"),
+        "on"
+    );
+
+    crate::server::options::apply_set_option(
+        &mut app,
+        "mouse-selection-force",
+        "off",
+        false,
+    );
+    assert!(!app.mouse_selection_force);
+}
+
+#[test]
+fn option_catalog_registers_mouse_selection_force() {
+    let entry = crate::server::option_catalog::OPTION_CATALOG
+        .iter()
+        .find(|o| o.name == "mouse-selection-force")
+        .expect("mouse-selection-force must be in catalog");
+    assert_eq!(entry.default, "off");
+    assert_eq!(entry.option_type, "boolean");
+    assert_eq!(entry.scope, "session");
+}
+
+#[test]
 fn config_parses_mouse_selection_off() {
     let mut app = mock_app_with_window();
     crate::config::parse_config_content(&mut app, "set -g mouse-selection off\n");

--- a/tests-rs/test_issue278_toggle_bool_option.rs
+++ b/tests-rs/test_issue278_toggle_bool_option.rs
@@ -219,7 +219,7 @@ fn issue278_bind_m_set_mouse_simulated() {
 fn all_boolean_options_recognized() {
     let booleans = [
         "mouse", "scroll-enter-copy-mode", "pwsh-mouse-selection",
-        "mouse-selection", "paste-detection", "choose-tree-preview",
+        "mouse-selection", "mouse-selection-force", "paste-detection", "choose-tree-preview",
         "focus-events", "renumber-windows", "automatic-rename",
         "allow-rename", "allow-set-title", "monitor-activity",
         "visual-activity", "synchronize-panes", "remain-on-exit",

--- a/tests-rs/test_pane_wants_mouse_selection.rs
+++ b/tests-rs/test_pane_wants_mouse_selection.rs
@@ -75,3 +75,23 @@ fn pane_wants_mouse_json_matches_only_the_flagged_pane() {
         "unknown pane id must default to false (keep client selection)"
     );
 }
+
+#[test]
+fn mouse_aware_pane_yields_selection_by_default() {
+    assert!(!client_selection_owns_drag(true, false, true));
+}
+
+#[test]
+fn force_option_keeps_psmux_selection_in_mouse_aware_pane() {
+    assert!(client_selection_owns_drag(true, true, true));
+}
+
+#[test]
+fn force_option_does_not_enable_globally_disabled_selection() {
+    assert!(!client_selection_owns_drag(false, true, true));
+}
+
+#[test]
+fn shell_pane_keeps_selection_without_force() {
+    assert!(client_selection_owns_drag(true, false, false));
+}

--- a/tests/test_config_exhaustive_cli.ps1
+++ b/tests/test_config_exhaustive_cli.ps1
@@ -102,7 +102,7 @@ $bools = @(
     'allow-rename', 'monitor-activity',
     'remain-on-exit', 'destroy-unattached', 'exit-empty',
     'set-titles',
-    'scroll-enter-copy-mode', 'pwsh-mouse-selection',
+    'scroll-enter-copy-mode', 'pwsh-mouse-selection', 'mouse-selection-force',
     'synchronize-panes', 'warm',
     'allow-predictions', 'claude-code-fix-tty', 'claude-code-force-interactive'
 )

--- a/tests/test_config_exhaustive_tcp.ps1
+++ b/tests/test_config_exhaustive_tcp.ps1
@@ -98,7 +98,7 @@ $bools = @(
     'allow-rename', 'monitor-activity',
     'remain-on-exit', 'destroy-unattached', 'exit-empty',
     'set-titles',
-    'scroll-enter-copy-mode', 'pwsh-mouse-selection',
+    'scroll-enter-copy-mode', 'pwsh-mouse-selection', 'mouse-selection-force',
     'synchronize-panes', 'warm',
     'allow-predictions', 'claude-code-fix-tty', 'claude-code-force-interactive'
 )

--- a/tests/test_config_exhaustive_tui.ps1
+++ b/tests/test_config_exhaustive_tui.ps1
@@ -317,7 +317,7 @@ $bools = @(
     'allow-rename', 'monitor-activity', 'visual-activity',
     'remain-on-exit', 'destroy-unattached', 'exit-empty',
     'aggressive-resize', 'set-titles', 'visual-bell',
-    'scroll-enter-copy-mode', 'pwsh-mouse-selection',
+    'scroll-enter-copy-mode', 'pwsh-mouse-selection', 'mouse-selection-force',
     'synchronize-panes', 'env-shim', 'warm',
     'allow-predictions', 'claude-code-fix-tty', 'claude-code-force-interactive'
 )
@@ -854,6 +854,7 @@ Test-TuiOption "set-option -g allow-predictions on" "allow-predictions" '\bon\b'
 Test-TuiOption "set-option -g warm on" "warm" '\bon\b' "TUI psmux: warm"
 Test-TuiOption "set-option -g env-shim on" "env-shim" '\bon\b' "TUI psmux: env-shim"
 Test-TuiOption "set-option -g pwsh-mouse-selection on" "pwsh-mouse-selection" '\bon\b' "TUI psmux: pwsh-mouse-selection"
+Test-TuiOption "set-option -g mouse-selection-force on" "mouse-selection-force" '\bon\b' "TUI psmux: mouse-selection-force"
 Test-TuiOption "set-option -g scroll-enter-copy-mode on" "scroll-enter-copy-mode" '\bon\b' "TUI psmux: scroll-enter-copy-mode"
 
 # =============================================================================


### PR DESCRIPTION
## Summary

Add a new session option:

```tmux
set -g mouse-selection-force on
```

This allows psmux drag-to-copy to remain active inside applications that enable terminal mouse tracking, while preserving application scrolling, hovering, and ordinary clicks.

The option defaults to `off`, so existing behavior is unchanged.

## Motivation

psmux currently yields the complete mouse gesture to any pane whose application enables DEC mouse tracking. This is appropriate for applications that implement their own selection, but prevents users from combining:

- application-controlled wheel scrolling
- psmux client-side drag selection
- copy-on-release behavior

GitHub Copilot CLI is one example: it enables DECSET 1002/1003 for mouse tracking. Users must currently choose between Copilot scrolling and psmux drag-to-copy.

## Behavior

With `mouse-selection-force on`:

- Mouse wheel and hover events continue reaching the application.
- A left-button press is temporarily buffered.
- If the pointer moves, psmux owns the gesture and copies the selected text.
- If the pointer does not move, the press and release are replayed to the application as an ordinary click.
- Right and middle mouse behavior is unchanged.

## Compatibility

- Default: `off`
- Existing per-pane mouse-yield behavior remains unchanged unless explicitly enabled.
- `mouse-selection off` still disables psmux selection globally.
- `pwsh-mouse-selection` remains independent.

## Testing

- `cargo check`
- Targeted client-selection and option-plumbing unit tests
- Boolean-option and configuration parity tests
- ARM64 Windows release build
- Isolated namespace option round-trip validation
- Manually verified with Copilot CLI inside psmux:
  - wheel scrolling works
  - ordinary clicks work
  - drag selection copies on release

---

Developed and tested with assistance from GitHub Copilot CLI.