### PR TITLE
fix: make psmux faithful for programmatic control - pipe-pane file sinks, verbatim buffers, foreground pane_current_command

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,6 +80,7 @@ windows-sys = { version = "0.61", features = [
     "Win32_Foundation",
     "Win32_System_Memory",
     "Win32_System_DataExchange",
+    "Win32_Storage_FileSystem",
 ] }
 
 [[bin]]

--- a/docs/scripting.md
+++ b/docs/scripting.md
@@ -609,7 +609,8 @@ psmux next-layout
 psmux previous-layout
 psmux select-layout tiled         # Apply a specific layout
 psmux clear-history
-psmux pipe-pane -o "cat > pane.log"
+psmux pipe-pane -o "cat > pane.log"    # Direct file sink (see below)
+psmux pipe-pane                        # Stop piping
 
 # Hooks (event callbacks) - see Hooks section below for full reference
 psmux set-hook -g after-new-window "display-message created"
@@ -790,6 +791,57 @@ bind-key e run-shell -b "my-helper.ps1 -Pane '#{pane_id}' -Path '#{pane_current_
 > swallowing spawn errors, such a bind failed completely silently. If you are
 > targeting an older psmux, pass the values from the caller instead of relying
 > on expansion.
+
+## Piping Pane Output (pipe-pane)
+
+Stream a pane's raw output (ANSI escapes included) to a file or a command,
+like tmux's `pipe-pane` (one deviation: tmux expands format variables such
+as `#I` in the sink command; psmux does not):
+
+```powershell
+# Log the pane to a file (direct file sink - see below)
+psmux pipe-pane -o "cat > pane.log"
+psmux pipe-pane -o "cat >> pane.log"     # append instead of truncate
+psmux pipe-pane -t %2 -o "cat > out.log" # pipe a specific pane
+
+# Stop piping (or use -o again to toggle off)
+psmux pipe-pane
+```
+
+**Direct file sink.** The canonical tmux logging idiom `cat > <path>` /
+`cat >> <path>` (path may be quoted) is serviced by the psmux server itself:
+the pane's raw ConPTY bytes are written straight to the file, byte-for-byte,
+with no shell in between. This exists because arbitrary sink commands run
+under PowerShell, where `cat` is the `Get-Content` alias — it never reads
+stdin, so the idiom cannot work as a shell command on Windows.
+
+Prefer an **absolute path**: a relative path resolves against the psmux
+server's working directory (the session's start directory), not your
+shell's. The path must be a literal **local file** path — anything a shell
+would expand (`$var`, `` `...` ``, `%var%`, `#I`, leading `~`) falls
+through to the shell sink, and UNC paths, mapped network drives, and DOS
+device names (`CON`, `NUL`, ...) are refused loudly: an unreachable host
+would stall the whole server, and a device is not a log file. To log to a
+network location, use a sink command that reads stdin — it runs as a child
+process and stalls only itself.
+
+**Arbitrary command sinks.** Any other command runs under the sink shell
+(`pwsh`/`powershell -NoProfile -Command`, falling back to `cmd /c`) and
+**must actually read its stdin** — that is where the pane bytes arrive. In
+PowerShell, read `$input` or `[Console]::In`:
+
+```powershell
+# PowerShell sink: line-oriented processing of pane output
+psmux pipe-pane -o '$input | Out-File -Encoding utf8 pane.log'
+```
+
+A sink that never reads stdin (like the `cat` alias) exits immediately and
+captures nothing.
+
+**Errors are loud.** If a direct file sink cannot be opened (e.g. the log
+file's directory does not exist), `pipe-pane` prints `ERROR: ...` and exits
+non-zero instead of silently recording a dead pipe. A shell sink that fails
+to spawn is reported on the status bar and is likewise never recorded.
 
 ## Interactive Choosers
 

--- a/src/format.rs
+++ b/src/format.rs
@@ -1348,8 +1348,10 @@ fn expand_var_inner(var: &str, app: &AppState, win_idx: usize) -> String {
                     }
                 }
                 if let Some(pid) = p.child_pid {
-                    // Fallback: upstream process-tree heuristic, then shell binary name.
-                    crate::platform::process_info::get_foreground_process_name(pid)
+                    // Fallback: the deepest foreground descendant (what tmux
+                    // reports — `cat` running under a shell, not the shell),
+                    // then the pane's own process, then a generic label.
+                    crate::platform::process_info::get_deepest_foreground_process_name(pid)
                         .or_else(|| crate::platform::process_info::get_process_name(pid))
                         .unwrap_or_else(|| "shell".into())
                 } else if !p.title.is_empty() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -2695,7 +2695,10 @@ fn run_main() -> io::Result<()> {
                 }
                 let mut cmd = "set-buffer".to_string();
                 if let Some(b) = buffer_name { cmd.push_str(&format!(" -b {}", b)); }
-                if let Some(d) = data { cmd.push_str(&format!(" {}", d)); }
+                // Same byte-exact wire as load-buffer: `set-buffer "a  'b'"`
+                // reached the server as three bare words and came back out of
+                // paste-buffer as `a b`.
+                if let Some(d) = data { cmd.push_str(&format!(" -H {}", crate::util::hex_encode(d.as_bytes()))); }
                 cmd.push('\n');
                 send_control(cmd)?;
                 return Ok(());
@@ -3803,9 +3806,15 @@ fn run_main() -> io::Result<()> {
                     if let Some(b) = buffer_name {
                         cmd.push_str(&format!(" -b {}", b));
                     }
-                    // Escape the content for transmission
-                    let escaped = content.replace('\n', "\\n").replace('\r', "\\r");
-                    cmd.push_str(&format!(" {}", escaped));
+                    // Byte-exact transport (see `set-buffer -H` in the server).
+                    // The content used to travel as bare words with newlines
+                    // escaped to a literal `\n`, so the server's tokenizer ate
+                    // it: quote grouping was stripped, tabs and runs of spaces
+                    // collapsed to one space, a `;` split the line into two
+                    // commands, and the `\n` two-char escape was never undone.
+                    // `paste-buffer` then faithfully pasted the damaged text —
+                    // `printf '%s' 'ARG'` arrived as `printf %s ARG`.
+                    cmd.push_str(&format!(" -H {}", crate::util::hex_encode(content.as_bytes())));
                     cmd.push('\n');
                     send_control(cmd)?;
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3899,7 +3899,15 @@ fn run_main() -> io::Result<()> {
                     i += 1;
                 }
                 cmd.push('\n');
-                send_control(cmd)?;
+                // A direct file sink that could not be opened answers
+                // "ERROR: ..."; exiting 0 on it recorded nothing and looked
+                // identical to success (same shape as #559). Acceptance
+                // answers nothing.
+                let resp = send_control_with_response(cmd)?;
+                if resp.trim_start().starts_with("ERROR") {
+                    eprint!("{}", resp);
+                    std::process::exit(1);
+                }
                 return Ok(());
             }
             // find-window - Search for a window

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -3002,6 +3002,63 @@ pub mod process_info {
         None
     }
 
+    /// Name of the pane's DEEPEST foreground descendant, for
+    /// `#{pane_current_command}`.
+    ///
+    /// tmux answers that format with the program in front of the tty, so a
+    /// pane sitting at `pwsh -> bash -> cat` must report `cat`.
+    /// `get_foreground_process_name` cannot: it looks at the immediate child
+    /// and steps one further only for a known wrapper name, so the real
+    /// Windows shell chain (git bash alone is `bash.exe -> bash.exe`) already
+    /// exhausts its budget and the answer freezes at the shell. Control tools
+    /// that key off this format then mis-detect nesting and never see a command
+    /// finish.
+    ///
+    /// Resolution is on demand, off the shared render-path snapshot, and every
+    /// failure (snapshot unavailable, root has no descendants, the leaf's
+    /// executable path unreadable) degrades quietly so the caller can fall back
+    /// to the pane's own process name.
+    pub fn get_deepest_foreground_process_name(pid: u32) -> Option<String> {
+        let entries = process_table(RENDER_PATH_TTL)?;
+        let (leaf_pid, snapshot_name) = deepest_descendant(&entries, pid)?;
+        // The snapshot name is lowercased and carries `.exe`; the live query
+        // gives the real casing. Fall back to the snapshot when the leaf is
+        // gone or unopenable (an elevated process) rather than reporting the
+        // shell.
+        get_process_name(leaf_pid).or_else(|| {
+            Some(snapshot_name.strip_suffix(".exe").unwrap_or(&snapshot_name).to_string())
+        })
+    }
+
+    /// Follow the highest-PID non-system child at each level from `root_pid`
+    /// down to the deepest descendant, returning `(pid, snapshot_name)`.
+    /// `None` when the root has no descendants at all.
+    ///
+    /// Highest PID is this module's established "most recently created"
+    /// heuristic (Windows exposes no console foreground process group, and
+    /// Toolhelp32 carries no creation time). The iteration guard stops a
+    /// pathological loop from PID reuse inside one snapshot.
+    fn deepest_descendant(
+        entries: &[(u32, u32, String)],
+        root_pid: u32,
+    ) -> Option<(u32, String)> {
+        let mut cur = root_pid;
+        let mut leaf: Option<(u32, String)> = None;
+        for _ in 0..64 {
+            let next = entries.iter()
+                .filter(|(pid, ppid, name)| *ppid == cur && *pid != cur && !is_system_exe(name))
+                .max_by_key(|(pid, _, _)| *pid);
+            match next {
+                Some((pid, _, name)) => {
+                    cur = *pid;
+                    leaf = Some((*pid, name.clone()));
+                }
+                None => break,
+            }
+        }
+        leaf
+    }
+
     /// Get the CWD of the foreground process in the pane.
     pub fn get_foreground_cwd(pid: u32) -> Option<String> {
         if let Some(target) = find_foreground_child_pid(pid) {
@@ -3290,24 +3347,9 @@ pub mod process_info {
     fn foreground_leaf_name(root_pid: u32) -> Option<Option<String>> {
         let entries = process_table(std::time::Duration::ZERO)?;
 
-        // Descend to the deepest foreground leaf, skipping system
-        // processes, by following the highest-PID child at each level
-        // (a most-recently-created heuristic).  The iteration guard
-        // prevents pathological loops from PID-reuse cycles in the snapshot.
-        let mut cur = root_pid;
-        let mut leaf_name: Option<String> = None;
-        for _ in 0..64 {
-            let next = entries.iter()
-                .filter(|(pid, ppid, name)| *ppid == cur && *pid != cur && !is_system_exe(name))
-                .max_by_key(|(pid, _, _)| *pid);
-            match next {
-                Some((pid, _, name)) => {
-                    cur = *pid;
-                    leaf_name = Some(name.clone());
-                }
-                None => break,
-            }
-        }
+        // Descend to the deepest foreground leaf, skipping system processes
+        // (see `deepest_descendant`).
+        let leaf_name = deepest_descendant(&entries, root_pid).map(|(_, name)| name);
 
         // The process whose Ctrl+C behavior matters is the deepest
         // foreground leaf.  If the root has no children, classify the root
@@ -3367,6 +3409,7 @@ pub mod process_info {
     pub fn get_process_name(_pid: u32) -> Option<String> { None }
     pub fn get_process_cwd(_pid: u32) -> Option<String> { None }
     pub fn get_foreground_process_name(_pid: u32) -> Option<String> { None }
+    pub fn get_deepest_foreground_process_name(_pid: u32) -> Option<String> { None }
     pub fn get_foreground_cwd(_pid: u32) -> Option<String> { None }
     pub fn has_vt_bridge_descendant(_root_pid: u32) -> bool { false }
     pub fn foreground_is_shell(_root_pid: u32) -> Option<bool> { None }

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -2611,7 +2611,25 @@ match cmd {
         } else {
             (stdin_flag, stdout_flag)
         };
-        let _ = tx.send(CtrlReq::PipePane(cmd, stdin, stdout, toggle));
+        // Same reply shape as #559/#566: a direct file sink that cannot be
+        // opened must reach the caller as a non-zero exit, not a silent
+        // rc-0 no-op. The handler answers "" on acceptance; only an
+        // "ERROR: ..." reply is forwarded.
+        let (rtx, rrx) = mpsc::channel::<String>();
+        let _ = tx.send(CtrlReq::PipePane(cmd, stdin, stdout, toggle, Some(rtx)));
+        let resp = rrx.recv_timeout(Duration::from_millis(2000)).unwrap_or_default();
+        if !persistent {
+            if !resp.is_empty() {
+                let _ = write!(write_stream, "{}\n", resp);
+                let _ = write_stream.flush();
+            }
+            // pipe-pane can sit in the middle of a chained line
+            // (`pipe-pane -o ... \; display-message ...`); breaking with
+            // queued sub-commands would silently drop the rest of the
+            // chain. With no chain pending, the client's half-close ends
+            // the loop on the next read anyway.
+            if pending_chain.is_empty() { break; }
+        }
     }
     "select-layout" | "selectl" => {
         let layout = args.iter().find(|a| !a.starts_with('-')).unwrap_or(&"tiled").to_string();

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -1758,9 +1758,10 @@ match cmd {
         }
     }
     "set-buffer" => {
-        // Parse -b name, -w (clipboard propagation), and content
+        // Parse -b name, -w (clipboard propagation), -H hex content, and content
         let mut buf_name: Option<String> = None;
         let mut propagate_to_clipboard = false;
+        let mut hex_content: Option<&str> = None;
         let mut i = 0;
         let mut content_parts: Vec<&str> = Vec::new();
         while i < args.len() {
@@ -1772,6 +1773,16 @@ match cmd {
             } else if args[i] == "-w" {
                 propagate_to_clipboard = true;
                 i += 1;
+            } else if args[i] == "-H" {
+                // Byte-exact content, hex encoded. Bare words cannot carry a
+                // buffer: this line has already been split on `;`, tokenized
+                // with quote grouping stripped, and had runs of whitespace
+                // collapsed, so quotes, tabs, control bytes and newlines are
+                // gone before the handler runs. tmux's paste is verbatim, and
+                // for a buffer pasted at a shell prompt the lost quoting is a
+                // DIFFERENT command, not cosmetic damage.
+                hex_content = args.get(i + 1).copied();
+                i += 2;
             } else if args[i].starts_with('-') {
                 i += 1; // skip unknown flags
             } else {
@@ -1779,14 +1790,36 @@ match cmd {
                 break;
             }
         }
-        let content = content_parts.join(" ");
-        if propagate_to_clipboard {
-            crate::clipboard::copy_to_system_clipboard(&content);
-        }
-        if let Some(name) = buf_name {
-            let _ = tx.send(CtrlReq::SetNamedBuffer(name, content));
-        } else {
-            let _ = tx.send(CtrlReq::SetBuffer(content));
+        // A control-mode client is an external boundary, so a bad payload is
+        // refused loudly rather than stored half-decoded. psmux buffers are
+        // Rust `String`s, so non-UTF-8 bytes are rejected here too (the CLI
+        // never sends them: load-buffer reads the file as UTF-8 and errors on
+        // the file itself).
+        let content: Option<String> = match hex_content {
+            Some(hex) => crate::util::hex_decode(hex)
+                .and_then(|bytes| String::from_utf8(bytes).ok()),
+            None => Some(content_parts.join(" ")),
+        };
+        match content {
+            Some(content) => {
+                if propagate_to_clipboard {
+                    crate::clipboard::copy_to_system_clipboard(&content);
+                }
+                if let Some(name) = buf_name {
+                    let _ = tx.send(CtrlReq::SetNamedBuffer(name, content));
+                } else {
+                    let _ = tx.send(CtrlReq::SetBuffer(content));
+                }
+            }
+            None => {
+                let err = "set-buffer: -H requires hex-encoded UTF-8\n";
+                if persistent {
+                    let _ = tx.send(CtrlReq::ShowTextPopup("set-buffer".to_string(), format!("ERROR: {}", err.trim_end())));
+                } else {
+                    let _ = write!(write_stream, "ERROR: {}", err);
+                    let _ = write_stream.flush();
+                }
+            }
         }
     }
     "paste-buffer" | "pasteb" => {

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -44,6 +44,33 @@ use crate::control;
 use crate::format::{expand_format, format_list_windows, format_list_panes, set_buffer_idx_override, set_named_buffer_override};
 use crate::help;
 
+/// True when `path` sits on a mapped network drive (`DRIVE_REMOTE`): its
+/// CreateFile can stall like a UNC path when the host is unreachable, so the
+/// direct file sink refuses it and points the user at a shell sink (which
+/// runs as a child process and stalls only itself). `GetDriveTypeW` reads
+/// the local mount table and does not touch the network.
+#[cfg(windows)]
+fn file_sink_drive_is_remote(path: &str) -> bool {
+    // Judge `\\?\Z:\...` like `Z:\...`.
+    let p = path.strip_prefix("\\\\?\\").unwrap_or(path);
+    let bytes = p.as_bytes();
+    if bytes.len() < 2 || bytes[1] != b':' || !bytes[0].is_ascii_alphabetic() {
+        return false; // relative or non-drive path: resolved locally
+    }
+    let root: [u16; 4] = [bytes[0] as u16, b':' as u16, b'\\' as u16, 0];
+    // winbase.h GetDriveTypeW return value (windows-sys 0.61 does not
+    // re-export the DRIVE_* constants).
+    const DRIVE_REMOTE: u32 = 4;
+    unsafe {
+        windows_sys::Win32::Storage::FileSystem::GetDriveTypeW(root.as_ptr()) == DRIVE_REMOTE
+    }
+}
+
+#[cfg(not(windows))]
+fn file_sink_drive_is_remote(_path: &str) -> bool {
+    false
+}
+
 /// Build a JSON fragment with overlay state (popup, menu, confirm, display_panes).
 /// Delegates popup-specific serialization to the popup module.
 fn serialize_overlay_json(app: &AppState) -> String {
@@ -4272,7 +4299,7 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                     }
                     let _ = resp.send(output);
                 }
-                CtrlReq::PipePane(cmd, stdin, stdout, toggle) => {
+                CtrlReq::PipePane(cmd, stdin, stdout, toggle, mut reply) => {
                     // The `-t` target (if any) was temp-focused by the connection
                     // layer before this request ran, so the active pane here IS the
                     // requested target pane (issue #440 defect 2). The pipe binds to
@@ -4294,9 +4321,17 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                             if !alive { reaped.push(p.pane_id); }
                             alive
                         }
-                        // No handle to check: keep it, the explicit-close paths
-                        // below still remove it.
-                        None => true,
+                        // No child: a direct file sink. Its liveness IS the
+                        // registered writer — when the reader thread dropped
+                        // it on a failed write, keeping the entry would make
+                        // `-o` toggle OFF a dead sink again (the exact #564
+                        // shape). A pane_id match from another writer kind
+                        // (cross-session tunnel) errs on keeping the entry,
+                        // which is the pre-existing behavior.
+                        None => crate::types::PIPE_WRITERS
+                            .lock()
+                            .map(|w| w.iter().any(|(id, _)| *id == p.pane_id))
+                            .unwrap_or(true),
                     });
 
                     // Drop any writer this pane's reader thread was teeing to
@@ -4321,6 +4356,11 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                     // anything since leaves one registered.
                     for pid in reaped { unregister_writer(pid); }
                     let has_existing = app.pipe_panes.iter().any(|p| p.pane_id == pane_id);
+
+                    // Non-empty only when the sink could not be started; sent
+                    // to the reply channel at the end of the arm so the
+                    // one-shot CLI can exit non-zero (see CtrlReq::PipePane).
+                    let mut outcome = String::new();
 
                     if cmd.is_empty() {
                         // No command: close any existing pipe on this pane
@@ -4349,9 +4389,96 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                             }
                             app.pipe_panes.remove(idx);
                         }
-                        // Start new pipe
+                        // Direct file sink: the canonical tmux logging idiom
+                        // `cat > file` / `cat >> file` cannot work through the
+                        // Windows sink shell — PowerShell's `cat` is the
+                        // Get-Content alias, never reads stdin, and exits at
+                        // once, so the redirect left a 0-byte file with rc 0.
+                        // Service the idiom in-process instead: the reader
+                        // thread tees the pane's raw ConPTY bytes straight
+                        // into the file (byte-faithful, no shell, no child to
+                        // fail silently). Output direction only; `-I` and
+                        // every other command shape keep the shell sink.
+                        let file_sink = if stdout && !stdin {
+                            crate::util::parse_cat_file_sink(&cmd)
+                        } else {
+                            None
+                        };
+                        if let Some((path, append)) = file_sink {
+                            // The open runs on the server's single event loop,
+                            // so it must never be a call that can stall or hit
+                            // a device. A local CreateFile is microseconds;
+                            // UNC/remote-drive resolution against an
+                            // unreachable host blocks for tens of seconds and
+                            // would freeze every pane, and a DOS device name
+                            // opens the DEVICE (`cat > CON` would tee VT bytes
+                            // into the server's own console). All of those are
+                            // refused loudly; a sink command that reads stdin
+                            // runs as a child process and stalls only itself.
+                            // Known residual: a local directory junction that
+                            // resolves to an unreachable target can still
+                            // stall the open.
+                            if let Some(reason) = crate::util::refuse_file_sink_path(&path) {
+                                outcome = format!("ERROR: pipe-pane: {}: {}", reason, path);
+                            } else if file_sink_drive_is_remote(&path) {
+                                outcome = format!(
+                                    "ERROR: pipe-pane: remote drive not supported for the direct file sink (use a sink command that reads stdin): {}",
+                                    path
+                                );
+                            } else {
+                            let mut opts = std::fs::OpenOptions::new();
+                            opts.create(true).write(true);
+                            if append { opts.append(true); } else { opts.truncate(true); }
+                            match opts.open(&path) {
+                                Ok(file) => {
+                                    if let Ok(mut writers) = crate::types::PIPE_WRITERS.lock() {
+                                        writers.push((pane_id, Box::new(file)));
+                                        crate::types::PIPE_PANE_COUNT
+                                            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                                        app.pipe_panes.push(PipePaneState {
+                                            pane_id,
+                                            process: None,
+                                            stdin,
+                                            stdout,
+                                        });
+                                    } else {
+                                        // Poisoned registry: recording the pane as
+                                        // piped with no writer would be exactly the
+                                        // phantom pipe this change removes.
+                                        outcome =
+                                            "ERROR: pipe-pane: writer registry unavailable".to_string();
+                                    }
+                                }
+                                Err(e) => {
+                                    outcome = format!("ERROR: pipe-pane: can't open {}: {}", path, e);
+                                }
+                            }
+                            }
+                            // The reply channel only reaches the one-shot CLI;
+                            // a pipe-pane issued from a key binding or the
+                            // command prompt discards it, so mirror the
+                            // failure on the status bar (same surface the
+                            // shell-sink spawn failure below uses).
+                            if !outcome.is_empty() {
+                                app.status_message = Some((
+                                    outcome.trim_start_matches("ERROR: ").to_string(),
+                                    std::time::Instant::now(),
+                                    None,
+                                ));
+                            }
+                        } else {
+                        // Start new pipe. Answer "accepted" BEFORE spawning:
+                        // CreateProcess can stall for seconds on a cold
+                        // antivirus scan of the shell image, and holding the
+                        // reply hostage to it turns a successful pipe-pane
+                        // into a client-side timeout error. A spawn failure
+                        // is still not recorded (no phantom pipe) and is
+                        // surfaced on the status bar below.
+                        if let Some(tx) = reply.take() {
+                            let _ = tx.send(String::new());
+                        }
                         let (shell_prog, shell_args) = crate::commands::resolve_run_shell();
-                        let mut process = {
+                        let spawn_result = {
                             let mut c = std::process::Command::new(&shell_prog);
                             for a in &shell_args { c.arg(a); }
                             c.arg(&cmd);
@@ -4359,33 +4486,52 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                             c.stdout(if stdin { std::process::Stdio::piped() } else { std::process::Stdio::null() });
                             c.stderr(std::process::Stdio::null());
                             { use crate::platform::HideWindowCommandExt; c.hide_window(); }
-                            c.spawn().ok()
+                            c.spawn()
                         };
-
-                        // Issue #440: hand the child's stdin to this pane's reader
-                        // thread so pane output is actually fed to the pipe command.
-                        // Without this the child blocked on an empty pipe forever and
-                        // the sink stayed 0 bytes. Only the output direction (`-O` /
-                        // default) registers a writer; `-I` (child stdout -> pane
-                        // input) is unchanged.
-                        if stdout {
-                            if let Some(child) = process.as_mut() {
-                                if let Some(stdin_handle) = child.stdin.take() {
-                                    if let Ok(mut writers) = crate::types::PIPE_WRITERS.lock() {
-                                        writers.push((pane_id, Box::new(stdin_handle)));
-                                        crate::types::PIPE_PANE_COUNT
-                                            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                        match spawn_result {
+                            Ok(mut child) => {
+                                // Issue #440: hand the child's stdin to this pane's reader
+                                // thread so pane output is actually fed to the pipe command.
+                                // Without this the child blocked on an empty pipe forever and
+                                // the sink stayed 0 bytes. Only the output direction (`-O` /
+                                // default) registers a writer; `-I` (child stdout -> pane
+                                // input) is unchanged.
+                                if stdout {
+                                    if let Some(stdin_handle) = child.stdin.take() {
+                                        if let Ok(mut writers) = crate::types::PIPE_WRITERS.lock() {
+                                            writers.push((pane_id, Box::new(stdin_handle)));
+                                            crate::types::PIPE_PANE_COUNT
+                                                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                                        }
                                     }
                                 }
+
+                                app.pipe_panes.push(PipePaneState {
+                                    pane_id,
+                                    process: Some(child),
+                                    stdin,
+                                    stdout,
+                                });
+                            }
+                            Err(e) => {
+                                // A sink that never started must not be recorded:
+                                // the dead entry made a later `-o` toggle OFF a
+                                // nonexistent pipe and hid the failure behind rc 0
+                                // (`spawn().ok()` swallowed the error). The reply
+                                // was already sent, so report where run-shell -b
+                                // reports its spawn failures: the status bar.
+                                app.status_message = Some((
+                                    format!("pipe-pane: can't spawn sink: {}", e),
+                                    std::time::Instant::now(),
+                                    None,
+                                ));
                             }
                         }
+                        }
+                    }
 
-                        app.pipe_panes.push(PipePaneState {
-                            pane_id,
-                            process,
-                            stdin,
-                            stdout,
-                        });
+                    if let Some(reply) = reply {
+                        let _ = reply.send(outcome);
                     }
                 }
                 CtrlReq::SelectLayout(layout) => {

--- a/src/types.rs
+++ b/src/types.rs
@@ -1701,7 +1701,14 @@ pub enum CtrlReq {
     PaneForwardStatus(u64, mpsc::Sender<String>),
     /// Kill a forwarded pane's child process. Fields: forward_id.
     PaneForwardKill(u64),
-    PipePane(String, bool, bool, bool),
+    /// pipe-pane. Fields: command, -I (stdin), -O (stdout), -o (toggle),
+    /// optional response channel. The handler answers "" on acceptance and
+    /// "ERROR: ..." when a direct file sink cannot be opened, so the
+    /// one-shot CLI can exit non-zero instead of recording a dead pipe with
+    /// rc 0 (same shape as #559/#566). Shell-sink spawns are answered
+    /// BEFORE spawning (CreateProcess can stall on a cold AV scan); their
+    /// failures are reported on the status bar and never recorded.
+    PipePane(String, bool, bool, bool, Option<mpsc::Sender<String>>),
     SelectLayout(String),
     NextLayout,
     ListClients(mpsc::Sender<String>),

--- a/src/util.rs
+++ b/src/util.rs
@@ -525,10 +525,70 @@ pub fn collect_server_session_env_args(args: &[String]) -> Result<Vec<(String, S
     Ok(out)
 }
 
+/// Encode bytes as lowercase hex with no separators.
+///
+/// Used to carry a payload that must survive the control wire BYTE-EXACT.
+/// Every command line the server receives is tokenized before a handler sees
+/// it (`;` splits it into sub-commands, quote grouping is stripped, runs of
+/// whitespace collapse), so any operand that is data rather than a word has to
+/// be reduced to `[0-9a-f]` first.  `send -H` already does this for keystrokes;
+/// buffer contents use the same shape.
+pub fn hex_encode(bytes: &[u8]) -> String {
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        out.push_str(&format!("{:02x}", b));
+    }
+    out
+}
+
+/// Decode the output of [`hex_encode`].  `None` for an odd length or any
+/// non-hex character — a malformed payload is reported to the sender, never
+/// silently turned into partial data.
+pub fn hex_decode(s: &str) -> Option<Vec<u8>> {
+    if s.len() % 2 != 0 {
+        return None;
+    }
+    let bytes = s.as_bytes();
+    let mut out = Vec::with_capacity(s.len() / 2);
+    let mut i = 0;
+    while i < bytes.len() {
+        let hi = (bytes[i] as char).to_digit(16)?;
+        let lo = (bytes[i + 1] as char).to_digit(16)?;
+        out.push(((hi << 4) | lo) as u8);
+        i += 2;
+    }
+    Some(out)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::commands::parse_command_line;
+
+    /// The whole point of the hex wire: a buffer that the tokenizer would
+    /// otherwise destroy survives encode → tokenize → decode byte for byte.
+    #[test]
+    fn test_hex_buffer_wire_survives_tokenizer() {
+        let content = "printf '%s' 'QUOTED ARG'\tTAB\nline \"two\"; not-a-command\n\x1b[0m";
+        let line = format!("set-buffer -b pb -H {}", hex_encode(content.as_bytes()));
+        // What the server actually receives: the tokenized command line.
+        let toks = parse_command_line(&line);
+        assert_eq!(toks.len(), 5, "hex payload must stay a single token");
+        let decoded = hex_decode(&toks[4]).expect("valid hex");
+        assert_eq!(String::from_utf8(decoded).unwrap(), content);
+    }
+
+    #[test]
+    fn test_hex_encode_is_lowercase_pairs() {
+        assert_eq!(hex_encode(b"\x00\x0f\xff A"), "000fff2041");
+    }
+
+    #[test]
+    fn test_hex_decode_rejects_malformed() {
+        assert_eq!(hex_decode("abc"), None, "odd length");
+        assert_eq!(hex_decode("zz"), None, "non-hex digit");
+        assert_eq!(hex_decode(""), Some(Vec::new()));
+    }
 
     #[test]
     fn test_quote_arg_simple() {

--- a/src/util.rs
+++ b/src/util.rs
@@ -341,6 +341,125 @@ pub fn quote_arg_if_needed(s: &str) -> String {
     }
 }
 
+/// Parse the canonical tmux logging idiom `cat > <path>` / `cat >> <path>`
+/// so `pipe-pane` can service it in-process as a direct file sink.
+///
+/// On Windows the piped command runs under PowerShell (`resolve_run_shell`),
+/// where `cat` is the `Get-Content` alias: it never reads stdin, exits at
+/// once, and the redirection leaves a 0-byte file — so the single most
+/// common tmux sink, and the one this repo's own docs show, could not work
+/// through the shell at all. Recognizing the idiom here lets the server
+/// write the pane's raw ConPTY bytes to the file itself: byte-faithful (no
+/// PowerShell line decoding/re-encoding) and with no child process to fail
+/// silently.
+///
+/// Returns `(path, append)` — `append` is true for `>>`. The path may be
+/// single- or double-quoted (one level stripped; inner quote characters
+/// arrive intact through the #547/#563 wire round-trip). Anything that is
+/// not exactly this shape — options on `cat`, an unquoted path containing
+/// whitespace, trailing tokens after a quoted path, shell metacharacters,
+/// anything a shell would expand (`$var`, backticks, `%var%`, leading `~`)
+/// — returns `None` and falls through to the shell sink unchanged: the
+/// file sink must only ever intercept a path the user meant literally.
+pub fn parse_cat_file_sink(cmd: &str) -> Option<(String, bool)> {
+    let trimmed = cmd.trim();
+    // PowerShell aliases are case-insensitive, so `CAT`/`Cat` hit the same
+    // Get-Content trap as `cat` — match the word the same way.
+    if trimmed.len() < 3 || !trimmed[..3].eq_ignore_ascii_case("cat") {
+        return None;
+    }
+    let rest = &trimmed[3..];
+    // `cat` must end at a word boundary: whitespace or the redirection itself.
+    if !rest.is_empty() && !rest.starts_with('>') && !rest.starts_with(char::is_whitespace) {
+        return None;
+    }
+    let rest = rest.trim_start();
+    let (append, rest) = if let Some(r) = rest.strip_prefix(">>") {
+        (true, r)
+    } else if let Some(r) = rest.strip_prefix('>') {
+        (false, r)
+    } else {
+        return None;
+    };
+    let path_part = rest.trim();
+    if path_part.is_empty() {
+        return None;
+    }
+    let quoted = |q: char| {
+        path_part.len() >= 2 && path_part.starts_with(q) && path_part.ends_with(q)
+    };
+    let path = if quoted('"') || quoted('\'') {
+        let inner = &path_part[1..path_part.len() - 1];
+        // A quote character inside means this was not one plainly quoted
+        // path (e.g. `"a" "b"`, or nested quoting) — shell territory. `$`
+        // and backticks are what PowerShell would expand inside double
+        // quotes; `#` is what tmux would expand as a format (`#I`, `#{...}`).
+        // Intercepting any of them would silently take the LITERAL text as
+        // a filename, so they go to the shell too.
+        if inner.is_empty() || inner.contains(['"', '\'', '$', '`', '#']) {
+            return None;
+        }
+        inner.to_string()
+    } else {
+        // Unquoted: whitespace, further shell syntax, or anything a shell
+        // would expand means the command is more than a plain literal file
+        // redirect — leave it to the shell.
+        if path_part.chars().any(char::is_whitespace)
+            || path_part.contains(['>', '<', '|', '&', '"', '\'', ';', '$', '`', '%', '(', ')', '^', '#'])
+            || path_part.starts_with('~')
+        {
+            return None;
+        }
+        path_part.to_string()
+    };
+    Some((path, append))
+}
+
+/// Path-shape gate for the direct file sink. The open runs on the server's
+/// single event loop, so every path class whose CreateFile can stall or hit
+/// a device instead of a file must be refused BEFORE opening:
+///
+/// - UNC (`\\server\share`, `//server/share`, `\\?\UNC\...`): CreateFile
+///   against an unreachable host blocks for tens of seconds and would
+///   freeze every pane. `\\?\C:\...` (extended-length local) is allowed.
+/// - DOS reserved device names (`CON`, `PRN`, `AUX`, `NUL`, `COM1`-`COM9`,
+///   `LPT1`-`LPT9`, with or without an extension, in any directory):
+///   CreateFile opens the DEVICE — `cat > CON` would tee raw VT bytes into
+///   the server's own console while looking like a successful log.
+///
+/// Returns `Some(reason)` when the path must be refused. Remote-drive
+/// detection needs a live Win32 call and lives with the caller.
+pub fn refuse_file_sink_path(path: &str) -> Option<String> {
+    if path.starts_with("\\\\.\\") {
+        return Some("device namespace not supported for the direct file sink".to_string());
+    }
+    let is_unc_verbatim = path.to_ascii_lowercase().starts_with("\\\\?\\unc\\");
+    let is_verbatim_local = path.starts_with("\\\\?\\") && !is_unc_verbatim;
+    if !is_verbatim_local
+        && (path.starts_with("\\\\") || path.starts_with("//"))
+    {
+        return Some("UNC path not supported for the direct file sink".to_string());
+    }
+    let basename = path
+        .rsplit(['\\', '/'])
+        .next()
+        .unwrap_or(path);
+    let stem = basename.split('.').next().unwrap_or(basename);
+    let stem_upper = stem.trim().to_ascii_uppercase();
+    let reserved = matches!(stem_upper.as_str(), "CON" | "PRN" | "AUX" | "NUL")
+        || (stem_upper.len() == 4
+            && (stem_upper.starts_with("COM") || stem_upper.starts_with("LPT"))
+            && stem_upper.as_bytes()[3].is_ascii_digit()
+            && stem_upper.as_bytes()[3] != b'0');
+    if reserved {
+        return Some(format!(
+            "reserved device name '{}' not supported for the direct file sink",
+            stem_upper
+        ));
+    }
+    None
+}
+
 /// Parse `VARIABLE=value` for tmux `new-session -e` / internal `server -e`
 /// (split on the first `=` so values may contain `=`).
 pub fn parse_env_assignment(s: &str) -> Result<(String, String), &'static str> {
@@ -743,3 +862,7 @@ mod tests_deps_base64_parity;
 #[cfg(test)]
 #[path = "../tests-rs/test_issue560_quote_arg_control_bytes.rs"]
 mod tests_issue560_quote_arg_control_bytes;
+
+#[cfg(test)]
+#[path = "../tests-rs/test_pipe_pane_cat_file_sink.rs"]
+mod tests_pipe_pane_cat_file_sink;

--- a/tests-rs/test_pipe_pane_cat_file_sink.rs
+++ b/tests-rs/test_pipe_pane_cat_file_sink.rs
@@ -1,0 +1,138 @@
+// pipe-pane direct file sink: `cat > file` / `cat >> file` recognition.
+//
+// The canonical tmux logging idiom cannot work through the Windows sink
+// shell (PowerShell's `cat` is Get-Content and never reads stdin), so the
+// server services it in-process. These tests pin the parser's contract:
+// exactly the plain-redirect shape is recognized; everything else must
+// return None and fall through to the shell sink unchanged.
+
+use crate::util::{parse_cat_file_sink, refuse_file_sink_path};
+
+#[test]
+fn recognizes_truncate_and_append() {
+    assert_eq!(
+        parse_cat_file_sink("cat > pane.log"),
+        Some(("pane.log".to_string(), false))
+    );
+    assert_eq!(
+        parse_cat_file_sink("cat >> pane.log"),
+        Some(("pane.log".to_string(), true))
+    );
+}
+
+#[test]
+fn tolerates_spacing_variants() {
+    assert_eq!(
+        parse_cat_file_sink("  cat>pane.log  "),
+        Some(("pane.log".to_string(), false))
+    );
+    assert_eq!(
+        parse_cat_file_sink("cat>>pane.log"),
+        Some(("pane.log".to_string(), true))
+    );
+    assert_eq!(
+        parse_cat_file_sink("cat   >>   pane.log"),
+        Some(("pane.log".to_string(), true))
+    );
+}
+
+#[test]
+fn strips_one_level_of_quotes_preserving_spaces_and_backslashes() {
+    assert_eq!(
+        parse_cat_file_sink(r#"cat > "C:\my logs\pane.log""#),
+        Some((r"C:\my logs\pane.log".to_string(), false))
+    );
+    assert_eq!(
+        parse_cat_file_sink(r"cat >> 'C:\my logs\pane.log'"),
+        Some((r"C:\my logs\pane.log".to_string(), true))
+    );
+}
+
+#[test]
+fn rejects_non_cat_commands() {
+    assert_eq!(parse_cat_file_sink("catalog > f"), None);
+    assert_eq!(parse_cat_file_sink("category>f"), None);
+    assert_eq!(parse_cat_file_sink("cat"), None);
+    assert_eq!(parse_cat_file_sink("cat pane.log"), None);
+    assert_eq!(parse_cat_file_sink("tee pane.log"), None);
+    assert_eq!(parse_cat_file_sink(""), None);
+}
+
+#[test]
+fn rejects_shapes_that_need_a_real_shell() {
+    // Options on cat: not the plain idiom.
+    assert_eq!(parse_cat_file_sink("cat -A > f"), None);
+    // Unquoted path with whitespace: ambiguous under shell word splitting.
+    assert_eq!(parse_cat_file_sink("cat > my logs.txt"), None);
+    // Further redirection / piping / quoting inside the path.
+    assert_eq!(parse_cat_file_sink("cat > f > g"), None);
+    assert_eq!(parse_cat_file_sink("cat > f | sort"), None);
+    assert_eq!(parse_cat_file_sink("cat > f&"), None);
+    assert_eq!(parse_cat_file_sink(r#"cat > "a" "b""#), None);
+    assert_eq!(parse_cat_file_sink("cat > ''"), None);
+    assert_eq!(parse_cat_file_sink("cat > "), None);
+    assert_eq!(parse_cat_file_sink("cat >"), None);
+}
+
+#[test]
+fn matches_cat_case_insensitively_like_the_powershell_alias() {
+    assert_eq!(
+        parse_cat_file_sink("CAT > pane.log"),
+        Some(("pane.log".to_string(), false))
+    );
+    assert_eq!(
+        parse_cat_file_sink("Cat >> pane.log"),
+        Some(("pane.log".to_string(), true))
+    );
+    // Case-insensitivity must not loosen the word boundary.
+    assert_eq!(parse_cat_file_sink("CATALOG > f"), None);
+}
+
+#[test]
+fn refuses_paths_that_can_stall_or_hit_a_device() {
+    // UNC in every spelling; `\\?\C:\` (extended-length local) is fine.
+    assert!(refuse_file_sink_path(r"\\server\share\pane.log").is_some());
+    assert!(refuse_file_sink_path("//server/share/pane.log").is_some());
+    assert!(refuse_file_sink_path(r"\\?\UNC\server\share\pane.log").is_some());
+    assert!(refuse_file_sink_path(r"\\.\PhysicalDrive0").is_some());
+    assert!(refuse_file_sink_path(r"\\?\C:\logs\pane.log").is_none());
+    // DOS reserved device names, bare / with extension / in a directory /
+    // any case. `CON.log` still opens the console device on Windows.
+    assert!(refuse_file_sink_path("CON").is_some());
+    assert!(refuse_file_sink_path("con.log").is_some());
+    assert!(refuse_file_sink_path(r"C:\logs\CON").is_some());
+    assert!(refuse_file_sink_path(r"C:\logs\Nul.txt").is_some());
+    assert!(refuse_file_sink_path("COM1").is_some());
+    assert!(refuse_file_sink_path("lpt9.log").is_some());
+    // Near-misses are ordinary filenames.
+    assert!(refuse_file_sink_path("CONS.log").is_none());
+    assert!(refuse_file_sink_path("COM0").is_none());
+    assert!(refuse_file_sink_path("COM10").is_none());
+    assert!(refuse_file_sink_path(r"C:\logs\console.log").is_none());
+    assert!(refuse_file_sink_path(r"C:\logs\pane.log").is_none());
+}
+
+#[test]
+fn rejects_anything_a_shell_would_expand_or_chain() {
+    // Expansion: intercepting these would take the LITERAL text as a
+    // filename while the user meant the expanded value.
+    assert_eq!(parse_cat_file_sink("cat > $HOME/pane.log"), None);
+    assert_eq!(parse_cat_file_sink("cat > ~/pane.log"), None);
+    assert_eq!(parse_cat_file_sink("cat > $(date).log"), None);
+    assert_eq!(parse_cat_file_sink("cat > `date`.log"), None);
+    assert_eq!(parse_cat_file_sink("cat > %TEMP%.log"), None);
+    assert_eq!(parse_cat_file_sink("cat > a^b.log"), None);
+    assert_eq!(parse_cat_file_sink(r#"cat > "$LOG""#), None);
+    assert_eq!(parse_cat_file_sink("cat > '`x`.log'"), None);
+    // Chaining hidden in the "path".
+    assert_eq!(parse_cat_file_sink("cat > out.log;calc"), None);
+    // tmux format variables: tmux would expand these, we would not — so
+    // never intercept them as literal filenames.
+    assert_eq!(parse_cat_file_sink("cat >> output.#I-#P"), None);
+    assert_eq!(parse_cat_file_sink(r#"cat > "pane #{pane_id}.log""#), None);
+    // A tilde later in the name is a plain filename character.
+    assert_eq!(
+        parse_cat_file_sink("cat > pane~1.log"),
+        Some(("pane~1.log".to_string(), false))
+    );
+}

--- a/tests/test_pane_current_command_foreground.ps1
+++ b/tests/test_pane_current_command_foreground.ps1
@@ -1,0 +1,112 @@
+# `#{pane_current_command}` reports the pane's FOREGROUND program, not its shell.
+#
+# tmux answers that format with the program in front of the tty. psmux answered
+# it from a one-level walk (plus one extra level for a known wrapper name), so
+# any real Windows chain deeper than that froze at the shell: git bash alone is
+# `bash.exe -> bash.exe`, which spends the wrapper step before the user's
+# command is even reached. Control tools that key off this format then
+# mis-detect nesting and never see a command finish.
+#
+# The format now resolves the deepest non-system descendant on demand.
+#
+# Isolation (AGENTS.md): New-PsmuxTestEnv (throwaway USERPROFILE/HOME, scrubbed
+# PSMUX_*/TMUX vars) plus a dedicated -L namespace.
+
+$ErrorActionPreference = "Continue"
+
+$isDisposable = $env:PSMUX_ALLOW_DESTRUCTIVE_TESTS -or $env:CI -or $env:GITHUB_ACTIONS
+if (-not $isDisposable) {
+    Write-Host "[SKIP] test_pane_current_command_foreground: starts a real server." -ForegroundColor Yellow
+    Write-Host "       Set PSMUX_ALLOW_DESTRUCTIVE_TESTS=1 in a disposable environment to run it." -ForegroundColor Yellow
+    exit 0
+}
+
+. "$PSScriptRoot\psmux_test_helpers.ps1"
+
+$ctx = New-PsmuxTestEnv -Tag 'pcurcmd'
+$PSMUX = $ctx.PsmuxExe
+$ns = Register-PsmuxNamespace -Ctx $ctx -Namespace "pcurcmd"
+$S = "pcurcmd"
+$script:TestsPassed = 0
+$script:TestsFailed = 0
+
+function Write-Pass($msg) { Write-Host "  [PASS] $msg" -ForegroundColor Green; $script:TestsPassed++ }
+function Write-Fail($msg) { Write-Host "  [FAIL] $msg" -ForegroundColor Red; $script:TestsFailed++ }
+function Get-CurrentCommand {
+    (& $PSMUX -L $ns display-message -p -t $S '#{pane_current_command}' 2>&1 | Out-String).Trim()
+}
+
+Write-Host "`n=== pane_current_command follows the foreground process ===" -ForegroundColor Cyan
+Write-Host "  psmux: $PSMUX  namespace: $ns" -ForegroundColor DarkGray
+
+try {
+    & $PSMUX -L $ns new-session -d -s $S
+    Start-Sleep -Seconds 3
+
+    # -----------------------------------------------------------------------
+    # TEST 1: an idle pane reports its own shell
+    # -----------------------------------------------------------------------
+    Write-Host "`n[Test 1] idle pane reports the shell" -ForegroundColor Yellow
+    $idle = Get-CurrentCommand
+    if ($idle -match '^(pwsh|powershell|cmd|bash)$') { Write-Pass "idle pane reports '$idle'" }
+    else { Write-Fail "idle pane reported '$idle'" }
+
+    # -----------------------------------------------------------------------
+    # TEST 2: a command nested three levels down is reported, not the shell.
+    # `cmd /c "cmd /c ping"` is pwsh -> cmd -> cmd -> PING.EXE; the old walk
+    # stopped at the first wrapper's child and answered "cmd".
+    # -----------------------------------------------------------------------
+    Write-Host "`n[Test 2] deeply nested foreground command (pwsh -> cmd -> cmd -> ping)" -ForegroundColor Yellow
+    & $PSMUX -L $ns send-keys -t $S 'cmd /c "cmd /c ping -n 30 127.0.0.1"' Enter
+    Start-Sleep -Seconds 4
+    $running = Get-CurrentCommand
+    if ($running -ieq "PING") { Write-Pass "reports the foreground command ('$running')" }
+    elseif ($running -ieq "cmd" -or $running -ieq "pwsh") { Write-Fail "stopped short at '$running' instead of the ping" }
+    else { Write-Fail "reported '$running'" }
+
+    # -----------------------------------------------------------------------
+    # TEST 3: it goes back to the shell when the command ends
+    # -----------------------------------------------------------------------
+    Write-Host "`n[Test 3] returns to the shell after the command exits" -ForegroundColor Yellow
+    & $PSMUX -L $ns send-keys -t $S "C-c"
+    Start-Sleep -Seconds 3
+    $back = Get-CurrentCommand
+    if ($back -ieq $idle) { Write-Pass "back to '$back'" }
+    else { Write-Fail "expected '$idle', got '$back'" }
+
+    # -----------------------------------------------------------------------
+    # TEST 4: the reported repro shape — a command under a bash shell.
+    # Git bash is `bash.exe -> bash.exe -> <command>`, the chain that made the
+    # old walk answer "bash" for everything the user ran.
+    # -----------------------------------------------------------------------
+    Write-Host "`n[Test 4] command running under bash" -ForegroundColor Yellow
+    $gitBash = "C:\Program Files\Git\bin\bash.exe"
+    if (-not (Test-Path $gitBash)) {
+        Write-Host "  [SKIP] Git for Windows bash not installed at $gitBash" -ForegroundColor Yellow
+    } else {
+        & $PSMUX -L $ns send-keys -t $S ('& "' + $gitBash + '" -c "sleep 60"') Enter
+        Start-Sleep -Seconds 5
+        $under = Get-CurrentCommand
+        if ($under -ieq "sleep") { Write-Pass "reports 'sleep', not the bash wrapping it" }
+        elseif ($under -ieq "bash") { Write-Fail "reported the shell ('bash') while sleep was in front" }
+        else { Write-Fail "reported '$under'" }
+        & $PSMUX -L $ns send-keys -t $S "C-c"
+        Start-Sleep -Seconds 3
+    }
+
+    # -----------------------------------------------------------------------
+    # TEST 5: process enumeration failure must not be fatal — a pane whose
+    # child is gone still answers (the format never errors out).
+    # -----------------------------------------------------------------------
+    Write-Host "`n[Test 5] answer is always a non-empty name" -ForegroundColor Yellow
+    $final = Get-CurrentCommand
+    if ($final) { Write-Pass "still answers ('$final')" }
+    else { Write-Fail "empty answer" }
+} finally {
+    Remove-PsmuxTestEnv -Ctx $ctx
+}
+
+Write-Host "`n=== Results ===" -ForegroundColor Cyan
+Write-Host "  Passed: $($script:TestsPassed)" -ForegroundColor Green
+Write-Host "  Failed: $($script:TestsFailed)" -ForegroundColor $(if ($script:TestsFailed -gt 0) { "Red" } else { "Green" })
+exit $script:TestsFailed

--- a/tests/test_paste_buffer_verbatim.ps1
+++ b/tests/test_paste_buffer_verbatim.ps1
@@ -1,0 +1,109 @@
+# paste-buffer is byte-verbatim: quotes, tabs, control bytes and newlines that
+# went into a buffer come back out of it unchanged.
+#
+# tmux's paste is a byte copy. psmux's was not: `load-buffer` shipped the file
+# to the server as bare words on the control line, so before any handler saw it
+# the wire tokenizer had stripped quote grouping, collapsed tabs and runs of
+# spaces to one space, split the line at `;`, and left the client's `\n` escape
+# as two literal characters. `paste-buffer` then pasted that faithfully, which
+# for a buffer pasted at a shell prompt is not cosmetic damage but a DIFFERENT
+# command: `printf '%s' 'QUOTED ARG'` arrived as `printf %s QUOTED ARG`.
+#
+# Buffer content now travels hex-encoded (`set-buffer -H`), the same byte-exact
+# wire shape `send -H` already uses for keystrokes.
+#
+# Isolation (AGENTS.md): New-PsmuxTestEnv (throwaway USERPROFILE/HOME, scrubbed
+# PSMUX_*/TMUX vars) plus a dedicated -L namespace.
+
+$ErrorActionPreference = "Continue"
+
+$isDisposable = $env:PSMUX_ALLOW_DESTRUCTIVE_TESTS -or $env:CI -or $env:GITHUB_ACTIONS
+if (-not $isDisposable) {
+    Write-Host "[SKIP] test_paste_buffer_verbatim: starts a real server." -ForegroundColor Yellow
+    Write-Host "       Set PSMUX_ALLOW_DESTRUCTIVE_TESTS=1 in a disposable environment to run it." -ForegroundColor Yellow
+    Write-Host "       Server-free coverage: cargo test --bin psmux hex_buffer_wire" -ForegroundColor Yellow
+    exit 0
+}
+
+. "$PSScriptRoot\psmux_test_helpers.ps1"
+
+$ctx = New-PsmuxTestEnv -Tag 'pbverbatim'
+$PSMUX = $ctx.PsmuxExe
+$ns = Register-PsmuxNamespace -Ctx $ctx -Namespace "pbverbatim"
+$S = "pbverbatim"
+$script:TestsPassed = 0
+$script:TestsFailed = 0
+
+function Write-Pass($msg) { Write-Host "  [PASS] $msg" -ForegroundColor Green; $script:TestsPassed++ }
+function Write-Fail($msg) { Write-Host "  [FAIL] $msg" -ForegroundColor Red; $script:TestsFailed++ }
+
+Write-Host "`n=== paste-buffer verbatim bytes ===" -ForegroundColor Cyan
+Write-Host "  psmux: $PSMUX  namespace: $ns" -ForegroundColor DarkGray
+
+try {
+    & $PSMUX -L $ns new-session -d -s $S
+    Start-Sleep -Seconds 3
+
+    # -----------------------------------------------------------------------
+    # TEST 1: load-buffer -> show-buffer round-trips every hostile byte
+    # -----------------------------------------------------------------------
+    Write-Host "`n[Test 1] load-buffer round-trip keeps quotes, tab, ESC, ';', newlines" -ForegroundColor Yellow
+    $f = Join-Path $ctx.Home "verbatim.txt"
+    # Single quotes, double quotes, a TAB, a semicolon (the wire's command
+    # separator), an ESC control byte, a run of spaces, and two lines.
+    $content = "printf '%s' 'QUOTED ARG'`tTAB;NOTACOMMAND`nsecond `"dq`"  two-spaces`e[0m"
+    [System.IO.File]::WriteAllText($f, $content, [System.Text.UTF8Encoding]::new($false))
+    & $PSMUX -L $ns load-buffer -b pb $f
+    Start-Sleep -Milliseconds 500
+    # show-buffer appends a trailing newline of its own (protocol framing).
+    $shown = (& $PSMUX -L $ns show-buffer -b pb 2>&1 | Out-String) -replace "`r`n", "`n"
+    $expected = ($content -replace "`r`n", "`n")
+    if ($shown.TrimEnd("`n") -ceq $expected.TrimEnd("`n")) {
+        Write-Pass "buffer content is byte-identical to the file"
+    } else {
+        Write-Fail "buffer content differs"
+        Write-Host ("    expected: " + ($expected | ConvertTo-Json)) -ForegroundColor DarkGray
+        Write-Host ("    actual  : " + ($shown | ConvertTo-Json)) -ForegroundColor DarkGray
+    }
+
+    # -----------------------------------------------------------------------
+    # TEST 2: set-buffer content survives the same wire
+    # -----------------------------------------------------------------------
+    Write-Host "`n[Test 2] set-buffer keeps quoting and repeated spaces" -ForegroundColor Yellow
+    & $PSMUX -L $ns set-buffer -b sb "echo 'A  B'"
+    Start-Sleep -Milliseconds 300
+    $sb = (& $PSMUX -L $ns show-buffer -b sb 2>&1 | Out-String).TrimEnd("`r", "`n")
+    if ($sb -ceq "echo 'A  B'") { Write-Pass "set-buffer stored the literal text" }
+    else { Write-Fail "set-buffer stored '$sb'" }
+
+    # -----------------------------------------------------------------------
+    # TEST 3: what the pane RUNS is the command that was in the buffer.
+    # The single quotes are load-bearing, not decoration: with them the shell
+    # prints the literal text, without them it expands $novar_END to nothing.
+    # That is the whole point — a paste that drops quotes is a DIFFERENT
+    # command, and a buffer pasted at a prompt is program control, not display.
+    # -----------------------------------------------------------------------
+    Write-Host "`n[Test 3] pasted text executes as the original command" -ForegroundColor Yellow
+    $quoted = "Write-Output 'PBV_`$novar_END'"
+    & $PSMUX -L $ns set-buffer -b run $quoted
+    Start-Sleep -Milliseconds 300
+    & $PSMUX -L $ns paste-buffer -b run -t $S
+    Start-Sleep -Milliseconds 700
+    & $PSMUX -L $ns send-keys -t $S Enter
+    Start-Sleep -Seconds 2
+    $cap = & $PSMUX -L $ns capture-pane -p -t $S 2>&1 | Out-String
+    # Match the OUTPUT line, not the echoed input: the prompt line contains the
+    # marker either way, so only a line that is exactly the marker proves the
+    # shell received the quotes.
+    $lines = ($cap -split "`r?`n") | ForEach-Object { $_.Trim() }
+    if ($lines -contains 'PBV_$novar_END') { Write-Pass "quoted argument reached the shell intact" }
+    elseif ($lines -contains 'PBV_') { Write-Fail "quoting was lost: the shell ran a different command" }
+    else { Write-Fail "pasted command produced no recognizable output" }
+} finally {
+    Remove-PsmuxTestEnv -Ctx $ctx
+}
+
+Write-Host "`n=== Results ===" -ForegroundColor Cyan
+Write-Host "  Passed: $($script:TestsPassed)" -ForegroundColor Green
+Write-Host "  Failed: $($script:TestsFailed)" -ForegroundColor $(if ($script:TestsFailed -gt 0) { "Red" } else { "Green" })
+exit $script:TestsFailed

--- a/tests/test_pipe_pane_cat_file_sink.ps1
+++ b/tests/test_pipe_pane_cat_file_sink.ps1
@@ -1,0 +1,215 @@
+﻿# pipe-pane direct file sink: `cat > file` / `cat >> file` serviced in-process.
+#
+# The canonical tmux logging idiom could not work on Windows: sink commands run
+# under PowerShell, where `cat` is the Get-Content alias - it never reads stdin,
+# exits at once, and the redirect left a 0-byte file with rc 0. The server now
+# recognizes the idiom and writes the pane's raw ConPTY bytes to the file
+# itself. This test proves, end to end, that:
+#   1. the docs idiom `cat > file` captures pane output (was 0 bytes forever)
+#   2. `cat >> file` appends across re-pipes instead of truncating
+#   3. a quoted path with spaces works (quotes survive the #563 wire round-trip)
+#   4. toggle-off stops the file sink
+#   5. an unopenable path fails LOUD: non-zero exit + ERROR message, and the
+#      failed sink is NOT recorded (was: rc 0 and a phantom pipe that a later
+#      -o toggled off)
+#   6. a UNC path is refused loudly (opening one on the server's event loop
+#      could stall every pane on an unreachable host)
+#   7. an arbitrary PowerShell sink still runs via the shell (no misfire of the
+#      file-sink fast path)
+#   8. a DOS reserved device name is refused loudly (`cat > CON` would open
+#      the console DEVICE and tee raw VT bytes into the server's own TUI)
+#   9. `cat >` truncates an existing file, `cat >>` does not
+#
+# Isolation (AGENTS.md): runs under New-PsmuxTestEnv (throwaway USERPROFILE/
+# HOME, scrubbed PSMUX_*/TMUX vars) plus a dedicated -L namespace, so it cannot
+# see or disturb a psmux session the user is running for real.
+
+$ErrorActionPreference = "Continue"
+
+# Same safety gate as test_issue443_cuf_capture.ps1: starting real servers is
+# for CI or an explicitly disposable environment.
+$isDisposable = $env:PSMUX_ALLOW_DESTRUCTIVE_TESTS -or $env:CI -or $env:GITHUB_ACTIONS
+if (-not $isDisposable) {
+    Write-Host "[SKIP] test_pipe_pane_cat_file_sink: starts a real server." -ForegroundColor Yellow
+    Write-Host "       Set PSMUX_ALLOW_DESTRUCTIVE_TESTS=1 in a disposable environment to run it." -ForegroundColor Yellow
+    Write-Host "       Server-free coverage: cargo test --bin psmux tests_pipe_pane_cat_file_sink" -ForegroundColor Yellow
+    exit 0
+}
+
+. "$PSScriptRoot\psmux_test_helpers.ps1"
+
+$ctx = New-PsmuxTestEnv -Tag 'catsink'
+$PSMUX = $ctx.PsmuxExe
+$ns = Register-PsmuxNamespace -Ctx $ctx -Namespace "catsink"
+$S = "catsink"
+$script:TestsPassed = 0
+$script:TestsFailed = 0
+
+function Write-Pass($msg) { Write-Host "  [PASS] $msg" -ForegroundColor Green; $script:TestsPassed++ }
+function Write-Fail($msg) { Write-Host "  [FAIL] $msg" -ForegroundColor Red; $script:TestsFailed++ }
+
+function Count-Matches($file, $pattern) {
+    $c = Get-Content $file -Raw -EA SilentlyContinue
+    if ($null -eq $c) { return 0 }
+    return ([regex]::Matches($c, $pattern)).Count
+}
+
+$work = Join-Path $ctx.Home "sink"
+New-Item -ItemType Directory -Force $work | Out-Null
+
+Write-Host "`n=== pipe-pane direct file sink (cat > file) ===" -ForegroundColor Cyan
+Write-Host "  psmux: $PSMUX  namespace: $ns" -ForegroundColor DarkGray
+
+try {
+    & $PSMUX -L $ns new-session -d -s $S
+    Start-Sleep -Seconds 3
+
+    # -----------------------------------------------------------------------
+    # TEST 1: the docs idiom `cat > file` captures pane output
+    # -----------------------------------------------------------------------
+    Write-Host "`n[Test 1] docs idiom: cat > file captures output" -ForegroundColor Yellow
+    $log1 = Join-Path $work "t1.log"
+    & $PSMUX -L $ns pipe-pane -t $S -o "cat > `"$log1`""
+    if ($LASTEXITCODE -eq 0) { Write-Pass "pipe-pane returned exit 0" } else { Write-Fail "pipe-pane exit $LASTEXITCODE" }
+    & $PSMUX -L $ns send-keys -t $S "echo CATSINK_MARKER_1" Enter
+    Start-Sleep -Seconds 2
+    & $PSMUX -L $ns pipe-pane -t $S
+    Start-Sleep -Milliseconds 500
+    $n1 = Count-Matches $log1 "CATSINK_MARKER_1"
+    if ($n1 -gt 0) { Write-Pass "file sink captured $n1 marker match(es) (was 0 bytes before the fix)" }
+    else { Write-Fail "file sink captured nothing" }
+
+    # -----------------------------------------------------------------------
+    # TEST 2: `cat >> file` appends across re-pipes
+    # -----------------------------------------------------------------------
+    Write-Host "`n[Test 2] cat >> file appends instead of truncating" -ForegroundColor Yellow
+    $log2 = Join-Path $work "t2.log"
+    & $PSMUX -L $ns pipe-pane -t $S -o "cat >> `"$log2`""
+    & $PSMUX -L $ns send-keys -t $S "echo CATSINK_APPEND_A" Enter
+    Start-Sleep -Seconds 2
+    & $PSMUX -L $ns pipe-pane -t $S
+    Start-Sleep -Milliseconds 500
+    & $PSMUX -L $ns pipe-pane -t $S -o "cat >> `"$log2`""
+    & $PSMUX -L $ns send-keys -t $S "echo CATSINK_APPEND_B" Enter
+    Start-Sleep -Seconds 2
+    & $PSMUX -L $ns pipe-pane -t $S
+    Start-Sleep -Milliseconds 500
+    $a = Count-Matches $log2 "CATSINK_APPEND_A"
+    $b = Count-Matches $log2 "CATSINK_APPEND_B"
+    if ($a -gt 0 -and $b -gt 0) { Write-Pass "both markers survive re-pipe with >> (A=$a B=$b)" }
+    else { Write-Fail "append lost data across re-pipes (A=$a B=$b)" }
+
+    # -----------------------------------------------------------------------
+    # TEST 3: quoted path with spaces
+    # -----------------------------------------------------------------------
+    Write-Host "`n[Test 3] quoted path with spaces" -ForegroundColor Yellow
+    $dir3 = Join-Path $work "spaced dir"
+    New-Item -ItemType Directory -Force $dir3 | Out-Null
+    $log3 = Join-Path $dir3 "pane.log"
+    & $PSMUX -L $ns pipe-pane -t $S -o "cat > `"$log3`""
+    & $PSMUX -L $ns send-keys -t $S "echo CATSINK_QUOTED" Enter
+    Start-Sleep -Seconds 2
+    & $PSMUX -L $ns pipe-pane -t $S
+    Start-Sleep -Milliseconds 500
+    $q = Count-Matches $log3 "CATSINK_QUOTED"
+    if ($q -gt 0) { Write-Pass "quoted spaced path captured $q match(es)" }
+    else { Write-Fail "quoted spaced path captured nothing" }
+
+    # -----------------------------------------------------------------------
+    # TEST 4: toggle-off stops the file sink
+    # -----------------------------------------------------------------------
+    Write-Host "`n[Test 4] toggle-off stops the file sink" -ForegroundColor Yellow
+    $log4 = Join-Path $work "t4.log"
+    & $PSMUX -L $ns pipe-pane -t $S -o "cat > `"$log4`""
+    & $PSMUX -L $ns send-keys -t $S "echo CATSINK_BEFORE_OFF" Enter
+    Start-Sleep -Seconds 2
+    & $PSMUX -L $ns pipe-pane -t $S -o "cat > `"$log4`""   # toggle off
+    Start-Sleep -Milliseconds 500
+    & $PSMUX -L $ns send-keys -t $S "echo CATSINK_AFTER_OFF" Enter
+    Start-Sleep -Seconds 2
+    $before = Count-Matches $log4 "CATSINK_BEFORE_OFF"
+    $after = Count-Matches $log4 "CATSINK_AFTER_OFF"
+    if ($before -gt 0) { Write-Pass "captured before toggle-off ($before)" }
+    else { Write-Fail "nothing captured before toggle-off" }
+    if ($after -eq 0) { Write-Pass "nothing captured after toggle-off" }
+    else { Write-Fail "file sink kept running after toggle-off ($after)" }
+
+    # -----------------------------------------------------------------------
+    # TEST 5: unopenable path fails loud, and no phantom pipe is recorded
+    # -----------------------------------------------------------------------
+    Write-Host "`n[Test 5] unopenable path: non-zero exit + ERROR, no phantom pipe" -ForegroundColor Yellow
+    $badLog = Join-Path $work ("no_such_dir_" + (Get-Random)) | Join-Path -ChildPath "pane.log"
+    $err5 = & $PSMUX -L $ns pipe-pane -t $S -o "cat > `"$badLog`"" 2>&1 | Out-String
+    if ($LASTEXITCODE -ne 0) { Write-Pass "pipe-pane exited non-zero ($LASTEXITCODE)" }
+    else { Write-Fail "pipe-pane exited 0 for an unopenable path" }
+    if ($err5 -match "ERROR") { Write-Pass "ERROR message printed" }
+    else { Write-Fail "no ERROR message (got: $($err5.Trim()))" }
+    # The failed sink must NOT be recorded: a fresh -o on the same pane must
+    # start a pipe (not toggle a phantom one off).
+    $log5 = Join-Path $work "t5.log"
+    & $PSMUX -L $ns pipe-pane -t $S -o "cat > `"$log5`""
+    & $PSMUX -L $ns send-keys -t $S "echo CATSINK_AFTER_FAIL" Enter
+    Start-Sleep -Seconds 2
+    & $PSMUX -L $ns pipe-pane -t $S
+    Start-Sleep -Milliseconds 500
+    $n5 = Count-Matches $log5 "CATSINK_AFTER_FAIL"
+    if ($n5 -gt 0) { Write-Pass "failed sink was not recorded; next -o piped normally ($n5)" }
+    else { Write-Fail "phantom dead pipe: -o after failure captured nothing" }
+
+    # -----------------------------------------------------------------------
+    # TEST 6: UNC path is refused loudly
+    # -----------------------------------------------------------------------
+    Write-Host "`n[Test 6] UNC path refused (would stall the event loop)" -ForegroundColor Yellow
+    $err6 = & $PSMUX -L $ns pipe-pane -t $S -o "cat > `"\\no-such-host\share\pane.log`"" 2>&1 | Out-String
+    if ($LASTEXITCODE -ne 0 -and $err6 -match "UNC") { Write-Pass "UNC refused with non-zero exit + message" }
+    else { Write-Fail "UNC not refused (exit=$LASTEXITCODE, got: $($err6.Trim()))" }
+
+    # -----------------------------------------------------------------------
+    # TEST 7: arbitrary PowerShell sink still runs via the shell
+    # -----------------------------------------------------------------------
+    Write-Host "`n[Test 7] arbitrary shell sink unaffected by the fast path" -ForegroundColor Yellow
+    $log7 = Join-Path $work "t7.log"
+    & $PSMUX -L $ns pipe-pane -t $S -o "`$input | Out-File -Encoding utf8 `"$log7`""
+    & $PSMUX -L $ns send-keys -t $S "echo CATSINK_SHELL_SINK" Enter
+    Start-Sleep -Seconds 3
+    & $PSMUX -L $ns pipe-pane -t $S
+    Start-Sleep -Seconds 1
+    $n7 = Count-Matches $log7 "CATSINK_SHELL_SINK"
+    if ($n7 -gt 0) { Write-Pass "shell sink captured $n7 match(es)" }
+    else { Write-Fail "shell sink captured nothing" }
+
+    # -----------------------------------------------------------------------
+    # TEST 8: DOS reserved device name refused loudly
+    # -----------------------------------------------------------------------
+    Write-Host "`n[Test 8] reserved device name refused (cat > CON)" -ForegroundColor Yellow
+    $err8 = & $PSMUX -L $ns pipe-pane -t $S -o "cat > CON" 2>&1 | Out-String
+    if ($LASTEXITCODE -ne 0 -and $err8 -match "reserved device") { Write-Pass "CON refused with non-zero exit + message" }
+    else { Write-Fail "CON not refused (exit=$LASTEXITCODE, got: $($err8.Trim()))" }
+    $err8b = & $PSMUX -L $ns pipe-pane -t $S -o "cat > `"$(Join-Path $work 'CON.log')`"" 2>&1 | Out-String
+    if ($LASTEXITCODE -ne 0 -and $err8b -match "reserved device") { Write-Pass "CON.log in a directory refused too" }
+    else { Write-Fail "CON.log not refused (exit=$LASTEXITCODE, got: $($err8b.Trim()))" }
+
+    # -----------------------------------------------------------------------
+    # TEST 9: `>` truncates an existing file, `>>` appends
+    # -----------------------------------------------------------------------
+    Write-Host "`n[Test 9] > truncates, >> appends" -ForegroundColor Yellow
+    $log9 = Join-Path $work "t9.log"
+    Set-Content -Path $log9 -Value "CATSINK_STALE_CONTENT"
+    & $PSMUX -L $ns pipe-pane -t $S -o "cat > `"$log9`""
+    & $PSMUX -L $ns send-keys -t $S "echo CATSINK_FRESH" Enter
+    Start-Sleep -Seconds 2
+    & $PSMUX -L $ns pipe-pane -t $S
+    Start-Sleep -Milliseconds 500
+    $stale = Count-Matches $log9 "CATSINK_STALE_CONTENT"
+    $fresh = Count-Matches $log9 "CATSINK_FRESH"
+    if ($stale -eq 0 -and $fresh -gt 0) { Write-Pass "> truncated stale content and captured fresh ($fresh)" }
+    else { Write-Fail "> did not truncate (stale=$stale fresh=$fresh)" }
+} finally {
+    Remove-PsmuxTestEnv -Ctx $ctx
+}
+
+Write-Host "`n=== Results ===" -ForegroundColor Cyan
+Write-Host "  Passed: $($script:TestsPassed)" -ForegroundColor Green
+Write-Host "  Failed: $($script:TestsFailed)" -ForegroundColor $(if ($script:TestsFailed -gt 0) { "Red" } else { "Green" })
+exit $script:TestsFailed
+


### PR DESCRIPTION
Fixes #576.

## Why

I drive psmux programmatically (an MCP server that gives AI agents persistent Windows terminals — previously tmux-over-WSL, now native psmux). Porting it surfaced three fidelity gaps where psmux accepts the tmux command but silently does something different. All three break any tool that scripts psmux the way tmux is scripted; all three are fixed here, each with regression tests, and the whole set is validated end-to-end by the real consumer (details at the bottom).

## Commit 1 — `fix(pipe-pane)`: service `cat > file` sinks in-process; stop swallowing sink startup failures

`pipe-pane -o "cat > pane.log"` (the docs' own example) always produced a 0-byte file with rc 0: sinks run under PowerShell, where `cat` is the `Get-Content` alias — it never reads stdin. On top of that `spawn().ok()` swallowed startup failures *and* recorded the dead pipe, so a later `-o` toggled a phantom pipe off.

- The plain-redirect idiom (`cat > path` / `cat >> path`, case-insensitive, path optionally quoted) is now serviced in-process: the reader thread tees raw ConPTY bytes straight into the file via the existing `PIPE_WRITERS` mechanism. Byte-faithful, no shell, no child process.
- Strictly literal local paths only: shell/tmux expansions (`$var`, backticks, `%var%`, `#I`, leading `~`) fall through to the shell sink; UNC in every spelling, mapped network drives (`GetDriveTypeW`), the `\\.\` namespace, and DOS device names (`cat > CON` opens the console DEVICE) are refused loudly — the open runs on the server's single event loop and must never stall or hit a device. `\\?\C:\...` stays allowed.
- Failures are loud: unopenable path → `ERROR: ...`, non-zero CLI exit (reply shape of #559/#566) + status bar mirror; failed shell spawn → status bar, not recorded; acceptance is answered before spawning (a cold AV scan of the shell image stalls CreateProcess for seconds, and holding the reply hostage to it turned success into a client-side timeout); `pipe-pane` mid-chain keeps executing the rest of the chain.

## Commit 2 — `fix(paste)`: buffer contents survive the wire byte-exactly

`load-buffer` + `paste-buffer` delivered `printf %s QUOTED ARG` for a file containing `printf '%s' 'QUOTED ARG'` — quotes stripped, TAB collapsed. The paste path itself was innocent: the *buffer ingestion* line put file contents on the control wire as bare words, and the server re-tokenized and re-joined them. Buffer contents now travel as `set-buffer -H <hex>` (the same byte-exact wire the repo already uses for `send -H`); the plain-word form remains for config/bind-key/control-mode compatibility, and a malformed/non-UTF-8 `-H` payload is rejected with an ERROR instead of being lossily decoded. The CLI `set-buffer` path had the same defect and is fixed the same way.

## Commit 3 — `fix(format)`: `#{pane_current_command}` reports the foreground process, not the root shell

With `cat` running in a pane, `display-message -p '#{pane_current_command}'` returned the shell name. The existing Ctrl+C router already had a deepest-descendant process walker; the format now shares it (`deepest_descendant()`), with the render path's 250ms snapshot reuse and a quiet fallback to the pane's own name. `pwsh → cmd → PING.EXE` now reports `PING`; idle panes still report the shell. Known limit (pre-existing, documented in the commit): MSYS2/Git-Bash children re-parent to a dead intermediate PID, so processes under an *interactive* Git Bash cannot be attributed by PPID walk.

## Tests

- Rust: `cargo test --bin psmux` full — **2853 passed / 0 failed** (new units for the sink parser/path gate and the hex wire).
- New PowerShell suites under the repo's `New-PsmuxTestEnv` isolation + dedicated `-L` namespaces: `test_pipe_pane_cat_file_sink.ps1` (14 checks), `test_paste_buffer_verbatim.ps1` (3), `test_pane_current_command_foreground.ps1` (5).
- Non-regression, all green (`$env:PSMUX_EXE`, pwsh 7): `test_issue440` 8/8, `test_issue482` 2/2, `test_issue563` 2/2, `test_issue564` 2/2, `test_named_buffers` 12/12, `test_issue264_paste_buffer_proof` 5/5, `test_issue264_paste_buffer_repro` 8/8; chained `pipe-pane ; rename-window X` verified over a raw control connection.

## Validated by a real consumer

With these three fixes (and nothing else), the aiterm-mcp test suite — which drives every one of these surfaces hard (pipe-pane logging as its completion-detection substrate, buffer-based paste as its only text-input path, `#{pane_current_command}` for shell-state gates) — went from 8 hard failures to fully green on native Windows, including a live end-to-end run: launch Claude Code in a psmux pane, dispatch a prompt via bracketed paste, capture the response through the pipe-pane file sink, and recover the transcript.

Happy to split this into three PRs if you prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
