### PR TITLE
fix(commands): preserve deferred command targets

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -153,6 +153,42 @@ pub fn normalize_attached_target_flag(args: Vec<String>) -> Vec<String> {
     out
 }
 
+pub fn deferred_command_start<S: AsRef<str>>(command: &str, args: &[S]) -> Option<usize> {
+    let value_options: &[&str] = match command {
+        "bind-key" | "bind" => &["-T"],
+        "set-hook" => &["-t"],
+        "confirm-before" | "confirm" => &["-p", "-t"],
+        _ => return None,
+    };
+
+    let mut i = 0;
+    while i < args.len() {
+        let token = args[i].as_ref();
+        if token == "--" {
+            i += 1;
+            break;
+        }
+        if !token.starts_with('-') || token == "-" {
+            break;
+        }
+        i += if value_options.contains(&token) { 2 } else { 1 };
+    }
+
+    match command {
+        "bind-key" | "bind" | "set-hook" => (i < args.len()).then_some(i + 1),
+        "confirm-before" | "confirm" => (i < args.len()).then_some(i),
+        _ => None,
+    }
+}
+
+pub fn outer_target_scan_end<S: AsRef<str>>(command: &str, args: &[S]) -> usize {
+    deferred_command_start(command, args)
+        .into_iter()
+        .chain(args.iter().position(|arg| arg.as_ref() == "--"))
+        .min()
+        .unwrap_or(args.len())
+}
+
 /// Same as [`normalize_flag_equals`] but operates on `Vec<&str>`, returning
 /// owned strings (needed where the caller already has borrowed slices).
 pub fn normalize_flag_equals_borrowed(args: &[&str]) -> Vec<String> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -462,6 +462,75 @@ fn main() {
     }
 }
 
+fn process_command_index(args: &[String]) -> Option<usize> {
+    let mut i = 1;
+    while i < args.len() {
+        if matches!(args[i].as_str(), "-t" | "-L" | "-f" | "-S") && i + 1 < args.len() {
+            i += 2;
+        } else if matches!(args[i].as_str(), "-h" | "--help" | "-V" | "-v" | "--version") {
+            return Some(i);
+        } else if args[i].starts_with('-') {
+            i += 1;
+        } else {
+            return Some(i);
+        }
+    }
+    None
+}
+
+fn process_target_position(args: &[String], command_index: usize) -> Option<usize> {
+    if let Some(position) = args[1..command_index].iter().position(|arg| arg == "-t") {
+        return Some(position + 1);
+    }
+
+    let command = &args[command_index];
+    let command_args = &args[command_index + 1..];
+    let scan_end = crate::cli::outer_target_scan_end(command, command_args);
+    command_args[..scan_end]
+        .iter()
+        .position(|arg| arg == "-t")
+        .map(|position| command_index + 1 + position)
+}
+
+#[cfg(test)]
+mod process_command_arg_tests {
+    use super::*;
+
+    fn strings(args: &[&str]) -> Vec<String> {
+        args.iter().map(|arg| (*arg).to_string()).collect()
+    }
+
+    #[test]
+    fn child_target_after_separator_does_not_route_client() {
+        let args = strings(&[
+            "psmux",
+            "new-window",
+            "-t",
+            "outer",
+            "--",
+            "program",
+            "-t",
+            "child",
+        ]);
+        let command = process_command_index(&args).unwrap();
+        assert_eq!(process_target_position(&args, command), Some(2));
+    }
+
+    #[test]
+    fn deferred_target_does_not_route_client() {
+        let args = strings(&["psmux", "bind-key", "x", "kill-window", "-t", "child"]);
+        let command = process_command_index(&args).unwrap();
+        assert_eq!(process_target_position(&args, command), None);
+    }
+
+    #[test]
+    fn global_target_before_command_routes_client() {
+        let args = strings(&["psmux", "-t", "outer", "new-window"]);
+        let command = process_command_index(&args).unwrap();
+        assert_eq!(process_target_position(&args, command), Some(1));
+    }
+}
+
 fn run_main() -> io::Result<()> {
     // `-L=foo` first (flag_equals), then `-Lfoo` (attached globals), then
     // command-level `-tname` (attached target): running attached passes
@@ -540,8 +609,13 @@ fn run_main() -> io::Result<()> {
     // $TMUX-based resolution below so a stale PSMUX_TARGET_SESSION inherited from
     // the pane environment (e.g. a warm-pool shell frozen at `__warm__`) can never
     // hijack the current session. See issue #485.
+    let command_index = process_command_index(&args);
+    let target_position = command_index.and_then(|index| process_target_position(&args, index));
+    let strip_target_position = command_index
+        .filter(|index| !matches!(args[*index].as_str(), "detach-client" | "detach"))
+        .and(target_position);
     let mut explicit_session_target = false;
-    if let Some(pos) = args.iter().position(|a| a == "-t") {
+    if let Some(pos) = target_position {
         if let Some(target) = args.get(pos + 1) {
             // move-window/swap-window: a bare numeric -t is a WINDOW index (tmux
             // target-window semantics), not a session. Coerce "N" -> ":N" so the
@@ -620,49 +694,22 @@ fn run_main() -> io::Result<()> {
         }
     }
     
-    // Find the actual command by skipping global -t/-L and their arguments.
-    // -t is stripped everywhere (the global handler already set PSMUX_TARGET_SESSION).
-    // -L is only stripped BEFORE the subcommand (global socket namespace flag);
-    // after the subcommand, -L is kept (e.g. select-pane -L, resize-pane -L).
-    let cmd_args: Vec<&String> = {
-        let mut result = Vec::new();
-        let mut i = 1; // skip binary name
-        let mut found_subcommand = false;
-        while i < args.len() {
-            if !found_subcommand {
-                // Before subcommand: skip global flags with values
-                if (args[i] == "-t" || args[i] == "-L" || args[i] == "-f" || args[i] == "-S") && i + 1 < args.len() {
-                    i += 2; // skip flag and its value
-                    continue;
-                } else if args[i] == "-h" || args[i] == "--help"
-                       || args[i] == "-V" || args[i] == "-v" || args[i] == "--version" {
-                    // Treat help/version flags as the subcommand itself
-                    found_subcommand = true;
-                    // fall through to push
-                } else if args[i].starts_with('-') {
-                    i += 1; // skip single global flags (e.g. -v)
-                    continue;
-                } else {
-                    found_subcommand = true;
-                    // fall through to push the subcommand name
-                }
-            } else {
-                // After subcommand: strip only -t (and its value). Exception:
-                // detach-client's -t is a client spec (tty or %id) that the
-                // handler itself must read, so leave it in place. Stripping it
-                // made the handler see no target and widen to detach-all
-                // (issue #565).
-                let is_detach = result.first().map_or(false, |s| *s == "detach-client" || *s == "detach");
-                if args[i] == "-t" && i + 1 < args.len() && !is_detach {
-                    i += 2;
-                    continue;
-                }
-            }
-            result.push(&args[i]);
-            i += 1;
-        }
-        result
-    };
+    // Keep command tails verbatim. Only the outer target consumed for routing
+    // is removed; nested commands and argv after `--` retain their own `-t`.
+    let cmd_args: Vec<&String> = command_index
+        .map(|index| {
+            args[index..]
+                .iter()
+                .enumerate()
+                .filter(|(offset, _)| {
+                    let absolute = index + *offset;
+                    strip_target_position
+                        .map_or(true, |target| absolute != target && absolute != target + 1)
+                })
+                .map(|(_, arg)| arg)
+                .collect()
+        })
+        .unwrap_or_default();
     
     let cmd = cmd_args.first().map(|s| s.as_str()).unwrap_or("");
 

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -203,6 +203,21 @@ fn requote_command_tail(args: &[&str]) -> String {
     }).collect::<Vec<String>>().join(" ")
 }
 
+fn without_outer_target<'a>(cmd: &str, args: &[&'a str]) -> Vec<&'a str> {
+    let scan_end = crate::cli::outer_target_scan_end(cmd, args);
+    let mut filtered = Vec::with_capacity(args.len());
+    let mut i = 0;
+    while i < args.len() {
+        if i < scan_end && args[i] == "-t" {
+            i += 2;
+        } else {
+            filtered.push(args[i]);
+            i += 1;
+        }
+    }
+    filtered
+}
+
 /// Walk the sub-commands produced by `split_top_level_semicolons` and merge
 /// any consecutive run of `send`/`send-keys` commands targeting the same
 /// pane into a single synthesized `send -lt <target> <bytes>` command.
@@ -705,8 +720,9 @@ if control_echo || control_noecho {
         let mut ctrl_pane_is_id = false;
         let mut ctrl_raw_target: Option<String> = None;
         {
+            let target_scan_end = crate::cli::outer_target_scan_end(cmd_name, &cmd_args);
             let mut i = 0;
-            while i < cmd_args.len() {
+            while i < target_scan_end {
                 if cmd_args[i] == "-t" {
                     if let Some(v) = cmd_args.get(i+1) {
                         // Issue #558: drop the '=' exact-match marker (see TARGET capture).
@@ -725,17 +741,7 @@ if control_echo || control_noecho {
             }
         }
 
-        // Build filtered args (without -t)
-        let filtered_args: Vec<&str> = {
-            let mut filtered = Vec::new();
-            let mut i = 0;
-            while i < cmd_args.len() {
-                if cmd_args[i] == "-t" { i += 2; continue; }
-                filtered.push(cmd_args[i]);
-                i += 1;
-            }
-            filtered
-        };
+        let filtered_args = without_outer_target(cmd_name, &cmd_args);
 
         // Apply target focus
         let is_focus_cmd = matches!(cmd_name, "select-window" | "selectw" | "select-pane" | "selectp");
@@ -968,11 +974,9 @@ let mut pane_is_id = global_pane_is_id;
 // Save raw -t value for relative pane targets like :.+ or :.-
 // Falls back to global_raw_target from TARGET protocol line
 let mut raw_target: Option<String> = global_raw_target.clone();
+let target_scan_end = crate::cli::outer_target_scan_end(cmd, &args);
 let mut i = 0;
-while i < args.len() {
-    // `--` ends option parsing: a `-t` after it is command/value data, not a
-    // target flag (#583).
-    if args[i] == "--" { break; }
+while i < target_scan_end {
     if args[i] == "-t" {
         if let Some(v) = args.get(i+1) {
             // Issue #558: drop the '=' exact-match marker (see TARGET capture).
@@ -990,31 +994,8 @@ while i < args.len() {
     }
     i += 1;
 }
-// Build args without -t and its value so command handlers get clean positional args
-let args: Vec<&str> = {
-    let mut filtered = Vec::new();
-    let mut i = 0;
-    let mut end_of_opts = false;
-    while i < args.len() {
-        if !end_of_opts {
-            if args[i] == "--" {
-                // Keep the `--` itself (arms that understand it use it as the
-                // end-of-options marker) but stop eating -t pairs after it.
-                end_of_opts = true;
-                filtered.push(args[i]);
-                i += 1;
-                continue;
-            }
-            if args[i] == "-t" {
-                i += 2; // skip -t and its value
-                continue;
-            }
-        }
-        filtered.push(args[i]);
-        i += 1;
-    }
-    filtered
-};
+// Remove this command's target while retaining targets in deferred commands.
+let args = without_outer_target(cmd, &args);
 // Commands that should permanently change focus when used with -t
 let is_focus_cmd = matches!(cmd, "select-window" | "selectw" | "select-pane" | "selectp");
 // Commands that handle -t internally and should NOT get FocusWindowTemp.
@@ -3105,8 +3086,9 @@ match cmd {
             }
             i += 1;
         }
-        let non_flag: Vec<&str> = args.iter().filter(|a| !a.starts_with('-') && Some(&a.to_string()) != prompt.as_ref()).copied().collect();
-        let command = non_flag.join(" ");
+        let command = crate::cli::deferred_command_start(cmd, &args)
+            .map(|i| requote_command_tail(&args[i..]))
+            .unwrap_or_default();
         let prompt_str = prompt.unwrap_or_else(|| format!("Run '{}'", command));
         let _ = tx.send(CtrlReq::ConfirmBefore(prompt_str, command));
     }
@@ -4529,21 +4511,19 @@ fn dispatch_control_command(
             true
         }
         "set-hook" => {
-            let positional: Vec<&str> = args.iter().filter(|a| !a.starts_with('-')).copied().collect();
-            if positional.len() >= 2 {
-                let name = positional[0].to_string();
-                // Re-quote tokens that contain spaces to preserve paths like "Psmux Plugins"
-                let command = positional[1..].iter().map(|s| {
-                    if s.contains(' ') { format!("'{}'", s) } else { s.to_string() }
-                }).collect::<Vec<_>>().join(" ");
-                let has_append = args.iter().any(|a| {
-                    if *a == "-a" { return true; }
-                    a.starts_with('-') && a.len() > 2 && a.chars().skip(1).all(|c| c.is_ascii_alphabetic()) && a.contains('a')
-                });
-                if has_append {
-                    let _ = tx.send(CtrlReq::AppendHook(name, command));
-                } else {
-                    let _ = tx.send(CtrlReq::SetHook(name, command));
+            if let Some(command_start) = crate::cli::deferred_command_start(cmd, args) {
+                if command_start < args.len() {
+                    let name = args[command_start - 1].to_string();
+                    let command = requote_command_tail(&args[command_start..]);
+                    let has_append = args.iter().any(|a| {
+                        if *a == "-a" { return true; }
+                        a.starts_with('-') && a.len() > 2 && a.chars().skip(1).all(|c| c.is_ascii_alphabetic()) && a.contains('a')
+                    });
+                    if has_append {
+                        let _ = tx.send(CtrlReq::AppendHook(name, command));
+                    } else {
+                        let _ = tx.send(CtrlReq::SetHook(name, command));
+                    }
                 }
             }
             let _ = resp_tx.send(String::new());

--- a/tests-rs/test_issue476_bindkey_quoting.rs
+++ b/tests-rs/test_issue476_bindkey_quoting.rs
@@ -77,3 +77,25 @@ fn format_condition_token_stays_bare() {
     assert_eq!(out[3], "send-keys C-h");
     assert_eq!(out[4], "select-pane -L");
 }
+
+#[test]
+fn target_filter_stops_at_deferred_command_boundaries() {
+    let cases: &[(&str, &[&str], &[&str])] = &[
+        ("bind-key", &["-n", "x", "kill-window", "-t"], &["-n", "x", "kill-window", "-t"]),
+        (
+            "set-hook",
+            &["-g", "-t", "0", "after-split-window", "kill-window", "-t"],
+            &["-g", "after-split-window", "kill-window", "-t"],
+        ),
+        (
+            "confirm-before",
+            &["-p", "Kill?", "-t", "0", "kill-window", "-t"],
+            &["-p", "Kill?", "kill-window", "-t"],
+        ),
+        ("kill-window", &["-t", "0", "-a"], &["-a"]),
+    ];
+
+    for (command, args, expected) in cases {
+        assert_eq!(without_outer_target(command, args), *expected, "{command}");
+    }
+}


### PR DESCRIPTION
## Summary
- stop generic `-t` extraction at `bind-key`, `set-hook`, and `confirm-before` deferred-command boundaries
- route and remove only the process CLI's outer target, preserving nested targets and child `-t` arguments after `--`
- share the same boundary calculation across process, one-shot TCP, and control-mode ingress

## Why
psmux currently treats every `-t` token as its own target, even when it belongs to a stored command or spawned program. This can rewrite a binding or hook to target the wrong window, and `new-window -t dev -- tool -t worker` can route on or remove the child's `-t worker` instead of passing it through.

This complements the direct-exec and `--` handling added for #582/#583; it does not introduce another command parser.

## Testing
- focused Rust tests for wrapper and process target boundaries
- `cargo check --all-targets`
- isolated native-recorder smoke proving child `-t child` survives `new-window ... --`