### PR TITLE
ci: enforce Clippy for portable-pty

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,21 @@ jobs:
       - name: Build
         run: cargo build --release --target ${{ matrix.target }}
 
+  clippy-portable-pty:
+    name: Clippy portable-pty
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+
+      - name: Run Clippy
+        run: cargo clippy -p portable-pty-psmux --all-targets --no-deps -- -D warnings
+
   test:
     name: Test Windows x64
     runs-on: windows-latest

--- a/crates/portable-pty-psmux/examples/narrow.rs
+++ b/crates/portable-pty-psmux/examples/narrow.rs
@@ -66,6 +66,7 @@ fn main() {
         // want to send data to the child, you'd set `to_write` to
         // that data and do it like this:
         let to_write = "";
+        #[allow(clippy::const_is_empty)]
         if !to_write.is_empty() {
             // To avoid deadlock, wrt. reading and waiting, we send
             // data to the stdin of the child in a different thread.

--- a/crates/portable-pty-psmux/examples/whoami.rs
+++ b/crates/portable-pty-psmux/examples/whoami.rs
@@ -63,6 +63,7 @@ fn main() {
         // want to send data to the child, you'd set `to_write` to
         // that data and do it like this:
         let to_write = "";
+        #[allow(clippy::const_is_empty)]
         if !to_write.is_empty() {
             // To avoid deadlock, wrt. reading and waiting, we send
             // data to the stdin of the child in a different thread.

--- a/crates/portable-pty-psmux/src/cmdbuilder.rs
+++ b/crates/portable-pty-psmux/src/cmdbuilder.rs
@@ -138,56 +138,51 @@ fn get_base_env() -> BTreeMap<OsString, EnvEntry> {
         if let Ok(sys_env) = RegKey::predef(HKEY_LOCAL_MACHINE)
             .open_subkey("System\\CurrentControlSet\\Control\\Session Manager\\Environment")
         {
-            for res in sys_env.enum_values() {
-                if let Ok((name, value)) = res {
-                    if name.eq_ignore_ascii_case("username") {
-                        continue;
-                    }
-                    if let Ok(value) = reg_value_to_string(&value) {
-                        log::trace!("adding SYS env: {:?} {:?}", name, value);
-                        env.insert(
-                            EnvEntry::map_key(name.clone().into()),
-                            EnvEntry {
-                                is_from_base_env: true,
-                                preferred_key: name.into(),
-                                value,
-                            },
-                        );
-                    }
+            for (name, value) in sys_env.enum_values().flatten() {
+                if name.eq_ignore_ascii_case("username") {
+                    continue;
+                }
+                if let Ok(value) = reg_value_to_string(&value) {
+                    log::trace!("adding SYS env: {:?} {:?}", name, value);
+                    env.insert(
+                        EnvEntry::map_key(name.clone().into()),
+                        EnvEntry {
+                            is_from_base_env: true,
+                            preferred_key: name.into(),
+                            value,
+                        },
+                    );
                 }
             }
         }
 
         if let Ok(sys_env) = RegKey::predef(HKEY_CURRENT_USER).open_subkey("Environment") {
-            for res in sys_env.enum_values() {
-                if let Ok((name, value)) = res {
-                    if let Ok(value) = reg_value_to_string(&value) {
-                        // Merge the system and user paths together
-                        let value = if name.eq_ignore_ascii_case("path") {
-                            match env.get(&EnvEntry::map_key(name.clone().into())) {
-                                Some(entry) => {
-                                    let mut result = OsString::new();
-                                    result.push(&entry.value);
-                                    result.push(";");
-                                    result.push(&value);
-                                    result
-                                }
-                                None => value,
+            for (name, value) in sys_env.enum_values().flatten() {
+                if let Ok(value) = reg_value_to_string(&value) {
+                    // Merge the system and user paths together
+                    let value = if name.eq_ignore_ascii_case("path") {
+                        match env.get(&EnvEntry::map_key(name.clone().into())) {
+                            Some(entry) => {
+                                let mut result = OsString::new();
+                                result.push(&entry.value);
+                                result.push(";");
+                                result.push(&value);
+                                result
                             }
-                        } else {
-                            value
-                        };
-
-                        log::trace!("adding USER env: {:?} {:?}", name, value);
-                        env.insert(
-                            EnvEntry::map_key(name.clone().into()),
-                            EnvEntry {
-                                is_from_base_env: true,
-                                preferred_key: name.into(),
-                                value,
-                            },
-                        );
-                    }
+                            None => value,
+                        }
+                    } else {
+                        value
+                    };
+                    log::trace!("adding USER env: {:?} {:?}", name, value);
+                    env.insert(
+                        EnvEntry::map_key(name.clone().into()),
+                        EnvEntry {
+                            is_from_base_env: true,
+                            preferred_key: name.into(),
+                            value,
+                        },
+                    );
                 }
             }
         }
@@ -308,7 +303,7 @@ impl CommandBuilder {
             EnvEntry {
                 is_from_base_env: false,
                 preferred_key: key,
-                value: value,
+                value,
             },
         );
     }
@@ -583,7 +578,7 @@ impl CommandBuilder {
             let extensions = self.get_env("PATHEXT").unwrap_or(OsStr::new(".EXE"));
             for path in std::env::split_paths(&path) {
                 // Check for exactly the user's string in this path dir
-                let candidate = path.join(&exe);
+                let candidate = path.join(exe);
                 if candidate.exists() {
                     return candidate.into_os_string();
                 }
@@ -595,7 +590,7 @@ impl CommandBuilder {
                     // PATHEXT includes the leading `.`, but `with_extension`
                     // doesn't want that
                     let ext = ext.to_str().expect("PATHEXT entries must be utf8");
-                    let path = path.join(&exe).with_extension(&ext[1..]);
+                    let path = path.join(exe).with_extension(&ext[1..]);
                     if path.exists() {
                         return path.into_os_string();
                     }

--- a/crates/portable-pty-psmux/src/lib.rs
+++ b/crates/portable-pty-psmux/src/lib.rs
@@ -292,10 +292,7 @@ impl_downcast!(PtySystem);
 
 impl Child for std::process::Child {
     fn try_wait(&mut self) -> IoResult<Option<ExitStatus>> {
-        std::process::Child::try_wait(self).map(|s| match s {
-            Some(s) => Some(s.into()),
-            None => None,
-        })
+        std::process::Child::try_wait(self).map(|status| status.map(Into::into))
     }
 
     fn wait(&mut self) -> IoResult<ExitStatus> {

--- a/crates/portable-pty-psmux/src/win/conpty.rs
+++ b/crates/portable-pty-psmux/src/win/conpty.rs
@@ -124,7 +124,7 @@ impl MasterPty for ConPtyMasterPty {
 
     fn get_size(&self) -> Result<PtySize, Error> {
         let inner = self.inner.lock().unwrap();
-        Ok(inner.size.clone())
+        Ok(inner.size)
     }
 
     fn try_clone_reader(&self) -> anyhow::Result<Box<dyn std::io::Read + Send>> {

--- a/crates/portable-pty-psmux/src/win/procthreadattr.rs
+++ b/crates/portable-pty-psmux/src/win/procthreadattr.rs
@@ -22,11 +22,7 @@ impl ProcThreadAttributeList {
                 &mut bytes_required,
             )
         };
-        let mut data = Vec::with_capacity(bytes_required);
-        // We have the right capacity, so force the vec to consider itself
-        // that length.  The contents of those bytes will be maintained
-        // by the win32 apis used in this impl.
-        unsafe { data.set_len(bytes_required) };
+        let mut data = vec![0; bytes_required];
 
         let attr_ptr = data.as_mut_slice().as_mut_ptr() as *mut _;
         let res = unsafe {

--- a/crates/portable-pty-psmux/src/win/psuedocon.rs
+++ b/crates/portable-pty-psmux/src/win/psuedocon.rs
@@ -22,6 +22,7 @@ use winapi::um::winbase::{
 use winapi::um::wincon::COORD;
 use winapi::um::winnt::HANDLE;
 
+#[allow(clippy::upper_case_acronyms)]
 pub type HPCON = HANDLE;
 
 /// Deliberately absent from base_flags() (see the doc comment there): only the


### PR DESCRIPTION
## Summary

- make all `portable-pty-psmux` Cargo targets Clippy-clean in the Windows CI job
- add a dedicated CI job that treats future warnings in that crate as errors
- replace the uninitialized attribute-list buffer and apply behavior-neutral lint cleanups

## Why

The repository installs Clippy and defines `cargo lint`, but CI does not run either.

A workspace-wide `-D warnings` gate is not reviewable yet: before this cleanup, a comprehensive workspace Clippy scan found 792 unique warning sites. This PR establishes a strict ratchet at the smaller `portable-pty-psmux` boundary instead:

```powershell
cargo clippy -p portable-pty-psmux --all-targets --no-deps -- -D warnings
```

## Attribute-list storage

`Vec::set_len` requires newly exposed elements to already be initialized. The old implementation reserved capacity, set the vector length, and created a `&mut [u8]` over bytes that Win32 had not initialized yet. The replacement allocates `vec![0; bytes_required]` before passing the same pointer and size to `InitializeProcThreadAttributeList`.

The uninitialized pattern originated in WezTerm's 2019 ConPTY spawner (`b387464`) and appears intended to avoid zero-filling before Win32 initializes the structure; the introducing commit records no measurement. A microbenchmark compared zeroed storage with valid uninitialized `Vec<MaybeUninit<u8>>` storage around the same Win32 initialize/delete calls. For the 48-byte buffer, five repeated runs measured a 3.45-4.19 ns cost per construction, about 0.000004 ms per ConPTY child spawn.

## Intentional lint decisions

- `HPCON` keeps the Windows SDK spelling under an item-scoped `upper_case_acronyms` allow.
- The two scoped `const_is_empty` allows preserve illustrative stdin-write branches: `whoami` does not consume stdin, and injecting input into `narrow` would alter an arbitrary command.
- Registry enumeration continues to ignore individual unreadable values; `.flatten()` expresses the existing nested `if let Ok(...)` behavior.