### PR TITLE
docs(status-format): the multi-line example produces an unclickable window list

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -228,12 +228,20 @@ psmux supports a multi-line status bar using the `status-format[]` array. Set th
 # Enable a 2-line status bar
 set -g status 2
 
-# Configure each line (0-indexed)
-set -g status-format[0] "#[align=left]#S #[align=right]%H:%M"
-set -g status-format[1] "#[align=left]#{W:#I:#W }"
+# Line 0 carries the window list. #[range=window|N] is what makes each tab a
+# click target -- see "Clickable window tabs" below.
+set -g status-format[0] "#[align=left]#{W:#[range=window|#{e|-:#{window_index}#,1}]  #I #W  #[norange]}"
+set -g status-format[1] "#[align=left]#S #[align=right]%H:%M"
 ```
 
 The first line (`status-format[0]`) replaces the default status bar content. Additional lines stack below (or above, depending on `status-position`).
+
+**Clickable window tabs.** With a custom `status-format[0]`, tab click targets come from that line's `#[range=window|N]` markers and nothing else. A window list written without them renders correctly but cannot be clicked, with no warning. Two things to get right:
+
+- **`N` is zero-based.** `base-index` is added back when the click is resolved, so with the default `base-index 1` the marker needs `#{window_index}` minus one: `#[range=window|#{e|-:#{window_index}#,1}]`.
+- **Escape commas inside `#{W:...}`.** A comma separates the `inactive,current` arguments of the loop, so any other comma within it must be written `#,` — including the one in `#{e|-:a,b}`. For the same reason write styles as `#[fg=green]#[bold]` rather than `#[fg=green,bold]`.
+
+Today only line 0's ranges are collected, and only the first status row is hit-tested, so a window list on line 1 or later cannot be clicked at all — put it on line 0. See [#593](https://github.com/psmux/psmux/issues/593).
 
 ### Pane Border Labels
 


### PR DESCRIPTION
Refs #593.

The multi-line status bar example in `docs/configuration.md` gives a window list that cannot be clicked. Following it verbatim is how I hit #593.

```tmux
set -g status-format[0] "#[align=left]#S #[align=right]%H:%M"
set -g status-format[1] "#[align=left]#{W:#I:#W }"
```

Two independent reasons it cannot work:

- No `#[range=window|N]` markers. With a custom `status-format[0]`, hit-boxes come from that line's parsed ranges and nothing else (`client.rs:6000`), so the list is empty and no tab is a click target.
- The list is on line 1. Ranges are only collected inside the `use_status_format_0` branch, and only the first status row is hit-tested (`client_status_row = status_chunk.y`, `client.rs:5964`/`4173`).

It renders perfectly, which is what makes it confusing — there is no warning, the tabs just do nothing.

## What this changes

Docs only. The example moves the window list to line 0 and carries the markers, so it works as written. Plus a short note on the two traps in hand-writing them:

- `N` is zero-based — `base_index` is added back on resolve (`client.rs:6003`), so with the default `base-index 1` the marker needs `#{window_index}` − 1.
- Commas split `#{W:inactive,current}`, so a comma inside the loop must be escaped `#,` — including the one in `#{e|-:a,b}`. Styles are easier written `#[fg=green]#[bold]` than `#[fg=green,bold]`.

The final paragraph documents the line-0 restriction as current behaviour. If #593 is fixed so ranges are collected from every status line and all status rows are hit-tested, that paragraph should go.

Verified against 3.3.7 and the 3.3.8 release binary: the example's window list is unclickable, and the config in this diff is clickable.