### PR TITLE
Add configurable active-pane border indicators

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -207,6 +207,7 @@ Details worth knowing:
 | `pane-border-style` | Str | | Inactive border style |
 | `pane-active-border-style` | Str | `fg=green` | Active border style |
 | `pane-border-hover-style` | Str | `fg=yellow` | Border style while the mouse hovers a draggable pane border |
+| `pane-border-indicators` | Str | `colour` | Active pane cues: `off`, `colour`, `arrows`, `both`. See [Pane Border Indicators](#pane-border-indicators) |
 | `pane-border-lines` | Str | `single` | Border glyph set: `single`, `double`, `heavy`, `simple`, `number`, `spaces`, `none`. See [Pane Border Lines](#pane-border-lines) |
 | `pane-border-format` | Str | | Pane border format string (e.g. `#{pane_index}: #{pane_title}`) |
 | `pane-border-status` | Str | | Pane border status position (`top`/`bottom`/`off`) |
@@ -289,6 +290,23 @@ set -g pane-border-lines none
 ```
 
 `number` is accepted for tmux compatibility and renders the same as `single`. Any unrecognised value also falls back to `single`.
+
+### Pane Border Indicators
+
+`pane-border-indicators` controls the extra cues that identify the focused pane.
+The default `colour` mode splits a two-pane divider between the active and
+inactive border colours. `arrows` places inward-pointing markers on internal
+dividers adjacent to the active tiled pane and on the focused floating pane's
+border. `both` combines the colour and arrow cues. `off` disables both extra
+cues. `pane-active-border-style` applies to the focused pane's border in every
+mode. When a floating pane owns focus, tiled active cues are suppressed.
+
+```tmux
+set -g pane-border-indicators arrows
+```
+
+`pane-border-indicators` is a global/default setting; per-window values are
+unsupported.
 
 ### Copy Mode Line Numbers
 

--- a/docs/preview.md
+++ b/docs/preview.md
@@ -52,22 +52,17 @@ Inside the chooser, `p` always toggles the preview for the current session regar
 
 ## How the Preview Renders
 
-The preview pane uses the tiled-pane renderer from the main viewport. Each open chooser fetches a JSON layout dump of the target window using the internal `window-dump` TCP command. The dump includes per-cell text, foreground and background colours, and style flags for every visible tiled pane.
+The preview pane uses the tiled-pane renderer from the main viewport. Preview state travels over the internal `window-dump <id> state` TCP command. The response includes the tiled layout, pane border settings, floating-focus state, and per-cell text, colours, and style flags for every visible tiled pane.
 
-That dump is then drawn into the preview area using `render_layout_json`, the same function that draws the live psmux viewport. The result is a styled miniature of the serialized pane content, including:
+That state is drawn into the preview area using `render_layout_json`. The result is a styled miniature of the target's tiled layout, including:
 
-* Internal pane dividers.
+* Internal pane dividers, including their colours and active-pane indicators.
 * Foreground and background colours from any TUI program running in the pane.
 * Bold, italic, underline, reversed, dim, blink, and strikethrough attributes.
 * True-colour (24-bit) and 256-colour palettes.
 * Wide characters (CJK).
 
-Persistent floating panes and pane title bars are not drawn. All previews use
-single border lines and `colour` indicators. Border colours come from the
-chooser and can differ in a cross-session preview because `window-dump`
-carries layout only.
-
-The preview is updated on a short cache window (about 1.5 seconds) so navigating quickly through a long session list does not flood the network with dump requests, but content still appears live for a steady selection.
+Persistent floating panes and pane title bars are not drawn. When a floating pane owns focus, the preview suppresses active indicators on the tiled layout to avoid highlighting the wrong pane.
 
 ## How psmux Handles Size Differences
 
@@ -101,25 +96,26 @@ psmux aims to keep the preview feature on par with tmux, with a few intentional 
 * **`choose-tree-preview` option.** Standard tmux does not have an option to make the preview visible by default. You must press `p` every time. psmux adds the `choose-tree-preview` option (default `off`, matching tmux behaviour) so you can opt in to a preview that is always visible.
 * **Render fidelity.** psmux uses its own `window-dump` snapshot pipeline rather than tmux's `capture-pane` text. This carries per-cell colours and supported attributes into the preview, so a preview of a Powerline prompt or a syntax-highlighted file remains styled rather than becoming plain text.
 * **Resize behaviour.** tmux scales / squeezes the preview content when the pane is wider than the preview slot, which can produce visually surprising results for column aligned output. psmux clips at one to one as described above. The result is that long lines or wide TUIs are cropped on the right edge in psmux but stay perfectly aligned, while in tmux they may be scaled but mis aligned.
-* **Cache window.** psmux caches the preview dump for about 1.5 seconds. tmux re-renders on every selection change. The psmux behaviour reduces network traffic when scrolling through many sessions but a very recent change to a target may take up to 1.5 seconds to appear in the preview.
+* **Cache window.** tmux re-renders on every selection change. See [Performance](#performance) for psmux's cache policy.
 * **Movable popup.** The chooser popup itself can be dragged with the mouse in psmux. Standard tmux choosers are fixed in place. The preview pane moves with the popup.
 
 ### Compatibility notes
 
 * The option name `choose-tree-preview` is psmux specific. tmux does not recognise it. Adding it to a shared configuration file is safe because tmux's set-option command will warn but not fail; if you want to be strict, guard the line with `if-shell` or split your config.
 * The option key in `show-options` output and in the JSON sent to the client uses kebab-case (`choose-tree-preview`) and snake_case (`choose_tree_preview`) respectively, matching the existing psmux convention.
-* The preview uses the target's serialized cell styles and the chooser's pane-border styles. The `window-dump` response does not include target `window-style` or `window-active-style` options.
+* The preview uses the target's pane-border settings and serialized cell styles. The `window-dump` response does not include target `window-style` or `window-active-style` options.
+* `window-dump <id> state` is optional on the wire. Clients accept a layout-only response and use chooser border colours with single lines and `colour` indicators. The layout-only request and response remain compatible with state-aware servers and clients.
 
 ## Performance
 
-The preview path has a dedicated layout cache, so an open chooser sends at most one `window-dump` request per target during each cached interval. Rendering is done client side using the tiled-pane renderer, so there is no extra server work for each frame after the dump is fetched.
+The preview path caches successful responses for about 1.5 seconds. Unreachable targets are retried while selected. Rendering is done client side using the existing tiled-pane renderer, so there is no extra server work for each frame after state is fetched.
 
 If you have very many sessions and the chooser feels slow, that is almost always due to scanning many session port files in `~/.psmux/`, not the preview itself. The preview only fetches the dump for the currently highlighted target.
 
 ## Troubleshooting
 
 **The preview shows an empty box.**
-The target window may not have responded yet. Move the selection away and back, or wait about 1.5 seconds for the cache to expire.
+The target window may not have responded yet. Verify that its session is reachable, or move the selection away and back to retry.
 
 **Long lines are cut off on the right.**
 This is by design. See "How psmux Handles Size Differences" above. If you want to see the full content, switch to the target with Enter.
@@ -130,6 +126,8 @@ The option is read when the chooser opens, not while it is open. Close the choos
 ## Related Options and Commands
 
 * `mode-style`: controls how the selected entry in the chooser list is highlighted.
+* `pane-border-style` and `pane-active-border-style`: control the inactive and active border colours copied from the target window.
+* `pane-border-indicators` and `pane-border-lines`: control the active cues and border glyphs copied from the target window.
 * `mouse on`: enables clicking entries in the chooser list and dragging the popup.
 
 ## See Also

--- a/docs/preview.md
+++ b/docs/preview.md
@@ -52,16 +52,20 @@ Inside the chooser, `p` always toggles the preview for the current session regar
 
 ## How the Preview Renders
 
-The preview pane is fed by the same renderer that draws the main viewport. Each open chooser fetches a JSON dump of the target window using the internal `window-dump` TCP command. The dump includes per-cell text, foreground and background colours, and style flags (bold, underline, italic, reversed, etc.) for every visible row of every pane in that window.
+The preview pane uses the tiled-pane renderer from the main viewport. Each open chooser fetches a JSON layout dump of the target window using the internal `window-dump` TCP command. The dump includes per-cell text, foreground and background colours, and style flags for every visible tiled pane.
 
 That dump is then drawn into the preview area using `render_layout_json`, the same function that draws the live psmux viewport. The result is a styled miniature of the serialized pane content, including:
 
-* Pane borders, including their colours and the active pane highlight.
-* Pane title bars and status indicators.
+* Internal pane dividers.
 * Foreground and background colours from any TUI program running in the pane.
 * Bold, italic, underline, reversed, dim, blink, and strikethrough attributes.
 * True-colour (24-bit) and 256-colour palettes.
 * Wide characters (CJK).
+
+Persistent floating panes and pane title bars are not drawn. All previews use
+single border lines and `colour` indicators. Border colours come from the
+chooser and can differ in a cross-session preview because `window-dump`
+carries layout only.
 
 The preview is updated on a short cache window (about 1.5 seconds) so navigating quickly through a long session list does not flood the network with dump requests, but content still appears live for a steady selection.
 
@@ -72,7 +76,7 @@ Real panes are usually much larger than the preview area. For example, a 200x50 
 Instead, the preview shows the pane at one to one with two simple rules:
 
 1. **Bottom rows win.** Any trailing fully blank rows are trimmed first so that a shell prompt or the bottom edge of a TUI sits at the bottom of the preview rather than being scrolled off by empty viewport space. The bottom rows of what remains are then shown.
-2. **Columns clip naturally.** Cells that fall outside the preview width are not drawn. The grid stays pixel accurate, so column aligned output (process tables, file listings, source code) keeps its alignment.
+2. **Columns clip naturally.** Cells that fall outside the preview width are not drawn. The grid stays one to one, so column aligned output (process tables, file listings, source code) keeps its alignment.
 
 The trade off is that very wide content is cut on the right edge instead of being squeezed in. In practice this matches what tmux itself does in `choose-tree` previews and is much more useful than a scrambled "scaled" view.
 
@@ -95,7 +99,7 @@ psmux aims to keep the preview feature on par with tmux, with a few intentional 
 ### Things that differ
 
 * **`choose-tree-preview` option.** Standard tmux does not have an option to make the preview visible by default. You must press `p` every time. psmux adds the `choose-tree-preview` option (default `off`, matching tmux behaviour) so you can opt in to a preview that is always visible.
-* **Render fidelity.** psmux uses its own `window-dump` snapshot pipeline rather than tmux's `capture-pane` text. This carries full per-cell styling (24-bit colour, all SGR attributes) into the preview, so a preview of a Powerline prompt or a syntax-highlighted file looks right rather than being plain text.
+* **Render fidelity.** psmux uses its own `window-dump` snapshot pipeline rather than tmux's `capture-pane` text. This carries per-cell colours and supported attributes into the preview, so a preview of a Powerline prompt or a syntax-highlighted file remains styled rather than becoming plain text.
 * **Resize behaviour.** tmux scales / squeezes the preview content when the pane is wider than the preview slot, which can produce visually surprising results for column aligned output. psmux clips at one to one as described above. The result is that long lines or wide TUIs are cropped on the right edge in psmux but stay perfectly aligned, while in tmux they may be scaled but mis aligned.
 * **Cache window.** psmux caches the preview dump for about 1.5 seconds. tmux re-renders on every selection change. The psmux behaviour reduces network traffic when scrolling through many sessions but a very recent change to a target may take up to 1.5 seconds to appear in the preview.
 * **Movable popup.** The chooser popup itself can be dragged with the mouse in psmux. Standard tmux choosers are fixed in place. The preview pane moves with the popup.
@@ -108,7 +112,7 @@ psmux aims to keep the preview feature on par with tmux, with a few intentional 
 
 ## Performance
 
-The preview path is cheap: it shares the same dump cache between the main viewport and the chooser, so opening the preview adds at most one extra `window-dump` request per cached interval (about 1.5 seconds). Rendering is done client side using the existing renderer, so there is no extra server work for each frame after the dump is fetched.
+The preview path has a dedicated layout cache, so an open chooser sends at most one `window-dump` request per target during each cached interval. Rendering is done client side using the tiled-pane renderer, so there is no extra server work for each frame after the dump is fetched.
 
 If you have very many sessions and the chooser feels slow, that is almost always due to scanning many session port files in `~/.psmux/`, not the preview itself. The preview only fetches the dump for the currently highlighted target.
 
@@ -120,15 +124,11 @@ The target window may not have responded yet. Move the selection away and back, 
 **Long lines are cut off on the right.**
 This is by design. See "How psmux Handles Size Differences" above. If you want to see the full content, switch to the target with Enter.
 
-**The preview text looks fine but the borders are missing.**
-Check that `pane-border-style` is set to a non empty value. Empty styles render as transparent which can hide borders against the popup background.
-
 **Setting `choose-tree-preview on` does not seem to take effect.**
 The option is read when the chooser opens, not while it is open. Close the chooser with Esc and reopen it. Verify the option is set with `psmux show-options -g | Select-String choose-tree-preview`.
 
 ## Related Options and Commands
 
-* `pane-border-style`, `pane-active-border-style`: control how borders look in both the main view and the preview.
 * `mode-style`: controls how the selected entry in the chooser list is highlighted.
 * `mouse on`: enables clicking entries in the chooser list and dragging the popup.
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -471,6 +471,7 @@ SET OPTIONS (use with: set -g <option> <value>):
     pane-border-style   Str  Inactive pane border style
     pane-active-border-style Str Active pane border style
     pane-border-hover-style Str Border hover highlight style
+    pane-border-indicators Str Active pane indicator (off/colour/arrows/both)
     window-status-format        Str  Inactive window tab format
     window-status-current-format Str  Active window tab format
     window-status-separator     Str  Separator between tabs

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -842,6 +842,119 @@ pub fn extract_session_from_target(target: &str) -> String {
     parsed.session.unwrap_or_else(|| "default".to_string())
 }
 
+/// Split set-option flags from operands. Ordinary flags end at the option
+/// name; `-t <target>` remains recognized until `--`.
+pub(crate) struct ParsedSetOptionArgs<'a> {
+    pub flag_chars: String,
+    pub target: Option<&'a str>,
+    pub missing_target: bool,
+    pub positionals: Vec<&'a str>,
+}
+
+impl ParsedSetOptionArgs<'_> {
+    pub fn validate(&self, window_command: bool) -> Result<(), String> {
+        if let Some(flag) = invalid_set_option_flag(&self.flag_chars) {
+            return Err(format!("unknown flag -{}", flag));
+        }
+        if self.missing_target {
+            return Err("target required after -t".to_string());
+        }
+        let unset = self.flag_chars.contains('u') || self.flag_chars.contains('U');
+        let append = self.flag_chars.contains('a');
+        let pane_scope = self.flag_chars.contains('p');
+        let local_window = (window_command || self.flag_chars.contains('w'))
+            && !self.flag_chars.contains('g')
+            && !self.flag_chars.contains('s');
+        let Some(option) = self.positionals.first().copied() else {
+            return Err("too few arguments (need at least 1)".to_string());
+        };
+        crate::server::option_catalog::validate_local_window_override(option, local_window)?;
+        if pane_scope {
+            if unset || self.positionals.len() >= 2 {
+                return Ok(());
+            }
+            return Err("set-option -p: option and value required".to_string());
+        }
+        if unset {
+            return Ok(());
+        }
+        if self.positionals.get(1).is_none() {
+            if !append && crate::server::options::missing_value_toggles(option) {
+                return Ok(());
+            }
+            return Err(format!("empty value for '{}'", option));
+        }
+        if append {
+            crate::server::option_catalog::validate_option_append(option)?;
+        }
+        crate::server::option_catalog::validate_option_value(
+            option,
+            &self.positionals[1..].join(" "),
+        )
+    }
+}
+
+pub(crate) fn parse_set_option_args<'a>(args: &[&'a str]) -> ParsedSetOptionArgs<'a> {
+    let mut flag_chars = String::new();
+    let mut target = None;
+    let mut missing_target = false;
+    let mut positionals = Vec::new();
+    let mut i = 0;
+    let mut parsing_flags = true;
+    let mut literal_values = false;
+    while i < args.len() {
+        let arg = args[i];
+        if parsing_flags {
+            if arg == "--" {
+                parsing_flags = false;
+                literal_values = true;
+                i += 1;
+                continue;
+            }
+            if arg.starts_with('-') && arg.len() > 1 {
+                flag_chars.push_str(&arg[1..]);
+                if arg.contains('t') {
+                    match args.get(i + 1).copied() {
+                        Some(value) => target = Some(value),
+                        None => missing_target = true,
+                    }
+                    i += 2;
+                } else {
+                    i += 1;
+                }
+                continue;
+            }
+            parsing_flags = false;
+        } else if !literal_values && arg == "--" {
+            literal_values = true;
+            i += 1;
+            continue;
+        } else if !literal_values && arg == "-t" {
+            flag_chars.push('t');
+            match args.get(i + 1).copied() {
+                Some(value) => target = Some(value),
+                None => missing_target = true,
+            }
+            i += 2;
+            continue;
+        }
+        positionals.push(arg);
+        i += 1;
+    }
+    ParsedSetOptionArgs {
+        flag_chars,
+        target,
+        missing_target,
+        positionals,
+    }
+}
+
+fn invalid_set_option_flag(flag_chars: &str) -> Option<char> {
+    flag_chars
+        .chars()
+        .find(|flag| !crate::SET_OPTION_CLI_FLAGS.contains(*flag))
+}
+
 /// Extract a flag value from args, supporting tmux short-flag CLI forms:
 ///   * Two-token form: `-F value`
 ///   * Concatenated form: `-Fvalue`

--- a/src/client.rs
+++ b/src/client.rs
@@ -1196,7 +1196,7 @@ fn complete_pane_border_colors(style: Style) -> Style {
         .bg(style.bg.unwrap_or(Color::Reset))
 }
 
-fn parse_pane_border_colors(raw: Option<&str>, default: Style) -> Style {
+pub(crate) fn parse_pane_border_colors(raw: Option<&str>, default: Style) -> Style {
     let Some(raw) = raw.filter(|style| !style.is_empty()) else {
         return complete_pane_border_colors(default);
     };
@@ -2045,12 +2045,9 @@ pub fn run_remote(terminal: &mut Terminal<crate::platform::PsmuxBackend>, input:
     // Live preview cache for choose-tree / choose-session pickers (issue #257).
     // Keyed by "session\twin_id\tpane_id"; pane_id == usize::MAX => active pane.
     let mut preview_cache: crate::preview::PreviewCache = std::collections::HashMap::new();
-    // Full-styled dump cache: every pane in a window with its own
-    // `rows_v2` content, fetched in one round trip via `window-dump`.
-    // This is the primary preview source — it sidesteps the per-pane
-    // `capture-pane -t` round trips that mis-targeted the active pane,
-    // and lets the client reuse the same renderer the main view uses.
-    let mut dump_cache: crate::preview::DumpCache = std::collections::HashMap::new();
+    // Target-window preview state keyed by session and window.
+    let mut preview_state_cache: crate::preview::PreviewWindowStateCache =
+        std::collections::HashMap::new();
     // Whether the right-side preview pane is shown. Toggled by `p`
     // while a chooser is open. Persisted across reopens.
     let mut preview_enabled: bool = false;
@@ -6162,16 +6159,23 @@ pub fn run_remote(terminal: &mut Terminal<crate::platform::PsmuxBackend>, input:
                         });
 
                         if let Some(wid) = win_id {
-                            if let Some(layout) = crate::preview::get_or_fetch_dump(
-                                &mut dump_cache, sname, wid,
+                            if let Some(preview_state) = crate::preview::get_or_fetch_preview_window_state(
+                                &mut preview_state_cache, sname, wid,
                             ) {
-                                crate::preview::render_dump_tree(
+                                let (preview_border_style, preview_active_border_style) =
+                                    preview_state.pane_border_styles(
+                                        pane_border_style,
+                                        pane_active_border_style,
+                                    );
+                                crate::preview::render_preview_layout(
                                     f,
-                                    &layout,
+                                    &preview_state.layout,
                                     parea,
-                                    pane_border_style,
-                                    pane_active_border_style,
-                                    None,
+                                    preview_border_style,
+                                    preview_active_border_style,
+                                    crate::border_lines::border_chars(&preview_state.border_lines),
+                                    preview_state.border_indicators,
+                                    preview_state.floating_pane_focused,
                                 );
                                 rendered = true;
                             }
@@ -6349,20 +6353,23 @@ pub fn run_remote(terminal: &mut Terminal<crate::platform::PsmuxBackend>, input:
                         };
 
                         if let Some(twid) = target_win {
-                            if let Some(layout) = crate::preview::get_or_fetch_dump(
-                                &mut dump_cache, &sess, twid,
+                            if let Some(preview_state) = crate::preview::get_or_fetch_preview_window_state(
+                                &mut preview_state_cache, &sess, twid,
                             ) {
-                                // Highlight which pane the user is hovering on
-                                // (for pane-level entries). Active pane gets a
-                                // brighter separator anyway.
-                                let highlight_pid = if !is_win { Some(pid) } else { None };
-                                crate::preview::render_dump_tree(
+                                let (preview_border_style, preview_active_border_style) =
+                                    preview_state.pane_border_styles(
+                                        pane_border_style,
+                                        pane_active_border_style,
+                                    );
+                                crate::preview::render_preview_layout(
                                     f,
-                                    &layout,
+                                    &preview_state.layout,
                                     parea,
-                                    pane_border_style,
-                                    pane_active_border_style,
-                                    highlight_pid,
+                                    preview_border_style,
+                                    preview_active_border_style,
+                                    crate::border_lines::border_chars(&preview_state.border_lines),
+                                    preview_state.border_indicators,
+                                    preview_state.floating_pane_focused,
                                 );
                                 rendered = true;
                             }

--- a/src/client.rs
+++ b/src/client.rs
@@ -21,6 +21,7 @@ use crate::clipboard::{copy_to_system_clipboard, read_from_system_clipboard};
 use crate::debug_log::{client_log, client_log_enabled, input_log, input_log_enabled};
 use crate::layout::RowRunsJson;
 use crate::tree::split_with_gaps;
+use crate::pane_border::PaneBorderIndicators;
 
 /// A floating pane (tmux new-pane) as shipped from the server: position, size,
 /// border style, focus, title, and the pane's rendered rows.
@@ -924,6 +925,7 @@ pub(crate) fn render_float_overlays(
     window_styles: WindowContentStyles,
     border_style: Style,
     active_border_style: Style,
+    indicators: PaneBorderIndicators,
 ) {
     let border_style = complete_pane_border_colors(border_style);
     let active_border_style = complete_pane_border_colors(active_border_style);
@@ -1001,6 +1003,37 @@ pub(crate) fn render_float_overlays(
                     .title(fl.title.clone());
                 let inner = block.inner(area);
                 f.render_widget(block, area);
+                if fl.focused && indicators.uses_arrows() && area.width >= 3 && area.height >= 3 {
+                    let buffer = f.buffer_mut();
+                    let title_width =
+                        unicode_width::UnicodeWidthStr::width(fl.title.as_str());
+                    let midpoint_x = area.x + area.width / 2;
+                    let midpoint_y = area.y + area.height / 2;
+                    let mut arrows = vec![
+                        (midpoint_x, area.y + area.height - 1, "↑"),
+                        (area.x, midpoint_y, "→"),
+                        (area.x + area.width - 1, midpoint_y, "←"),
+                    ];
+                    let top_x = if title_width == 0 {
+                        Some(midpoint_x)
+                    } else {
+                        let offset = title_width.saturating_add(2);
+                        (offset < area.width.saturating_sub(1) as usize)
+                            .then(|| area.x + offset as u16)
+                    };
+                    if let Some(top_x) = top_x {
+                        arrows.push((top_x, area.y, "↓"));
+                    }
+                    for (x, y, symbol) in arrows {
+                        if x >= buffer.area.x
+                            && x < buffer.area.x + buffer.area.width
+                            && y >= buffer.area.y
+                            && y < buffer.area.y + buffer.area.height
+                        {
+                            buffer[(x, y)].set_symbol(symbol);
+                        }
+                    }
+                }
                 f.render_widget(
                     Paragraph::new(Text::from(lines))
                         .style(window_content_fill_style(window_fill)),
@@ -1177,6 +1210,20 @@ fn parse_pane_border_hover_style(raw: Option<&str>) -> Style {
         .unwrap_or_else(|| Style::default().fg(Color::Yellow))
 }
 
+/// A focused floating pane owns the active cue, so the tiled layout draws none.
+pub(crate) fn tiled_border_focus(
+    active_rect: Option<Rect>,
+    border_style: Style,
+    active_border_style: Style,
+    floating_pane_focused: bool,
+) -> (Option<Rect>, Style) {
+    if floating_pane_focused {
+        (None, border_style)
+    } else {
+        (active_rect, active_border_style)
+    }
+}
+
 /// Recolor only junctions so straight separators keep their per-cell styles.
 pub(crate) fn recolor_border_junctions(
     buffer: &mut ratatui::buffer::Buffer,
@@ -1223,6 +1270,48 @@ fn border_cell_touches_rect(x: u16, y: u16, rect: Rect) -> bool {
     touches_vertical || touches_horizontal || touches_corner
 }
 
+pub(crate) fn draw_pane_border_arrows(
+    buffer: &mut ratatui::buffer::Buffer,
+    borders: &crate::rendering::BorderGeometry,
+    border_chars: Option<crate::border_lines::BorderChars>,
+    active_rect: Option<Rect>,
+    indicators: PaneBorderIndicators,
+) {
+    if border_chars.is_none() || !indicators.uses_arrows() { return; }
+    let Some(active_rect) = active_rect else { return; };
+    if active_rect.width == 0 || active_rect.height == 0 { return; }
+    let width = buffer.area.width as usize;
+    let mut draw = |x: i32, y: i32, symbol: &str, vertical: bool| {
+        let rel_x = x - buffer.area.x as i32;
+        let rel_y = y - buffer.area.y as i32;
+        if rel_x < 0 || rel_y < 0
+            || rel_x >= buffer.area.width as i32
+            || rel_y >= buffer.area.height as i32
+        {
+            return;
+        }
+        let idx = rel_y as usize * width + rel_x as usize;
+        let matches_orientation = if vertical {
+            borders.contains_vertical(idx)
+        } else {
+            borders.contains_horizontal(idx)
+        };
+        if !matches_orientation { return; }
+        buffer.content[idx].set_symbol(symbol);
+    };
+
+    let x = active_rect.x as i32;
+    let y = active_rect.y as i32;
+    let right = (active_rect.x + active_rect.width) as i32;
+    let bottom = (active_rect.y + active_rect.height) as i32;
+    let side_y = y + i32::from(active_rect.height.saturating_sub(1).min(1));
+    let side_x = x + i32::from(active_rect.width.saturating_sub(1).min(1));
+    draw(x - 1, side_y, "→", true);
+    draw(right, side_y, "←", true);
+    draw(side_x, y - 1, "↓", false);
+    draw(side_x, bottom, "↑", false);
+}
+
 pub fn render_layout_json(
     f: &mut Frame,
     node: &LayoutJson,
@@ -1241,6 +1330,7 @@ pub fn render_layout_json(
     bchars: Option<crate::border_lines::BorderChars>,
     copy_ln: Option<CopyLnRender>,
     window_styles: WindowContentStyles,
+    border_indicators: PaneBorderIndicators,
 ) {
     let border_style = complete_pane_border_colors(border_style);
     let active_border_style = complete_pane_border_colors(active_border_style);
@@ -1566,7 +1656,7 @@ pub fn render_layout_json(
             if zoomed {
                 if let Some(i) = effective_sizes.iter().position(|&s| s != 0) {
                     if let Some(child) = children.get(i) {
-                        render_layout_json(f, child, area, dim_preds, border_style, active_border_style, clock_mode, clock_colour, active_rect, mode_style_str, zoomed, border_status, border_format, total_panes, bchars, copy_ln, window_styles);
+                        render_layout_json(f, child, area, dim_preds, border_style, active_border_style, clock_mode, clock_colour, active_rect, mode_style_str, zoomed, border_status, border_format, total_panes, bchars, copy_ln, window_styles, border_indicators);
                     }
                 }
                 return;
@@ -1576,7 +1666,7 @@ pub fn render_layout_json(
 
             for (i, child) in children.iter().enumerate() {
                 if i < rects.len() {
-                    render_layout_json(f, child, rects[i], dim_preds, border_style, active_border_style, clock_mode, clock_colour, active_rect, mode_style_str, zoomed, border_status, border_format, total_panes, bchars, copy_ln, window_styles);
+                    render_layout_json(f, child, rects[i], dim_preds, border_style, active_border_style, clock_mode, clock_colour, active_rect, mode_style_str, zoomed, border_status, border_format, total_panes, bchars, copy_ln, window_styles, border_indicators);
                 }
             }
             // pane-border-lines none: children are drawn, but no separators.
@@ -1592,7 +1682,7 @@ pub fn render_layout_json(
                 if is_horizontal {
                     let sep_x = rects[i].x + rects[i].width;
                     if sep_x < buf.area.x + buf.area.width {
-                        if both_leaves && total_panes == 2 {
+                        if both_leaves && total_panes == 2 && border_indicators.uses_colour() {
                             let left_active = matches!(&children[i], LayoutJson::Leaf { active, .. } if *active);
                             let right_active = matches!(children.get(i + 1), Some(LayoutJson::Leaf { active, .. }) if *active);
                             let left_sty = if left_active { active_border_style } else { border_style };
@@ -1626,7 +1716,7 @@ pub fn render_layout_json(
                 } else {
                     let sep_y = rects[i].y + rects[i].height;
                     if sep_y < buf.area.y + buf.area.height {
-                        if both_leaves && total_panes == 2 {
+                        if both_leaves && total_panes == 2 && border_indicators.uses_colour() {
                             let top_active = matches!(&children[i], LayoutJson::Leaf { active, .. } if *active);
                             let bot_active = matches!(children.get(i + 1), Some(LayoutJson::Leaf { active, .. }) if *active);
                             let top_sty = if top_active { active_border_style } else { border_style };
@@ -2193,6 +2283,8 @@ pub fn run_remote(terminal: &mut Terminal<crate::platform::PsmuxBackend>, input:
         pane_active_border_style: Option<String>,
         #[serde(default)]
         pane_border_hover_style: Option<String>,
+        #[serde(default)]
+        pane_border_indicators: Option<PaneBorderIndicators>,
         #[serde(default)]
         window_style: Option<String>,
         #[serde(default)]
@@ -5808,12 +5900,21 @@ pub fn run_remote(terminal: &mut Terminal<crate::platform::PsmuxBackend>, input:
             };
             let floating_pane_focused =
                 srv_floats.iter().any(|float| float.focused);
+            let border_indicators = state.pane_border_indicators.unwrap_or_default();
+            let (tiled_active_rect, tiled_active_border_style) =
+                tiled_border_focus(
+                    active_rect,
+                    pane_border_style,
+                    pane_active_border_style,
+                    floating_pane_focused,
+                );
             render_layout_json(
                 f, &root, content_chunk, dim_preds, pane_border_style,
-                pane_active_border_style, clock_active, clock_col, active_rect,
+                tiled_active_border_style, clock_active, clock_col, tiled_active_rect,
                 &mode_style_str, state.zoomed, border_status, border_format,
                 total_panes, bchars, copy_ln,
                 window_styles.for_tiled_panes(floating_pane_focused),
+                border_indicators,
             );
             let borders = border_geometry_from_layout(
                 &root,
@@ -5826,9 +5927,16 @@ pub fn run_remote(terminal: &mut Terminal<crate::platform::PsmuxBackend>, input:
             recolor_border_junctions(
                 f.buffer_mut(),
                 &junctions,
-                active_rect,
+                tiled_active_rect,
                 pane_border_style,
-                pane_active_border_style,
+                tiled_active_border_style,
+            );
+            draw_pane_border_arrows(
+                f.buffer_mut(),
+                &borders,
+                bchars,
+                tiled_active_rect,
+                border_indicators,
             );
 
             // Highlight the border under the cursor to preview what a drag would move.
@@ -6749,6 +6857,7 @@ pub fn run_remote(terminal: &mut Terminal<crate::platform::PsmuxBackend>, input:
                     window_styles,
                     pane_border_style,
                     pane_active_border_style,
+                    border_indicators,
                 );
             }
             if srv_popup_active {
@@ -7403,3 +7512,7 @@ mod test_issue619_window_style_fallback;
 #[cfg(test)]
 #[path = "../tests-rs/test_pane_border_backgrounds.rs"]
 mod test_pane_border_backgrounds;
+
+#[cfg(test)]
+#[path = "../tests-rs/test_pane_border_indicators.rs"]
+mod test_pane_border_indicators;

--- a/src/config.rs
+++ b/src/config.rs
@@ -1346,7 +1346,7 @@ pub fn parse_option_value(app: &mut AppState, key: &str, value: &str, _is_global
         "status-left-style" => { app.status_left_style = value.to_string(); }
         "status-right-style" => { app.status_right_style = value.to_string(); }
         "clock-mode-colour" | "clock-mode-style" => { app.user_options.insert(key.to_string(), value.to_string()); }
-        "pane-border-format" | "pane-border-status" => { app.user_options.insert(key.to_string(), value.to_string()); }
+        "pane-border-format" | "pane-border-status" | "pane-border-indicators" => { app.user_options.insert(key.to_string(), value.to_string()); }
         "popup-style" | "popup-border-style" | "popup-border-lines" => { app.user_options.insert(key.to_string(), value.to_string()); }
         "window-style" | "window-active-style" => { app.user_options.insert(key.to_string(), value.to_string()); }
         "wrap-search" => { app.user_options.insert(key.to_string(), value.to_string()); }

--- a/src/config.rs
+++ b/src/config.rs
@@ -705,11 +705,10 @@ pub fn parse_config_line(app: &mut AppState, line: &str) {
     };
     
     if l.starts_with("set-option ") || l.starts_with("set ") {
-        parse_set_option(app, l);
+        parse_set_option(app, l, false);
     }
     else if l.starts_with("setw ") || l.starts_with("set-window-option ") {
-        // setw maps to the same option parser (tmux window options overlap)
-        parse_set_option(app, l);
+        parse_set_option(app, l, true);
     }
     else if l.starts_with("bind-key ") || l.starts_with("bind ") {
         parse_bind_key(app, l);
@@ -915,7 +914,7 @@ fn extract_option_value(rest: &str) -> String {
     strip_wrapping_quotes(rest).to_string()
 }
 
-fn parse_set_option(app: &mut AppState, line: &str) {
+fn parse_set_option(app: &mut AppState, line: &str, window_command: bool) {
     let toks = tokens_with_offsets(line);
     if toks.len() < 2 { warn_config(app, "set-option requires an option name"); return; }
 
@@ -926,6 +925,7 @@ fn parse_set_option(app: &mut AppState, line: &str) {
     let mut append_mode = false;    // -a: append to current value
     let mut unset_mode = false;     // -u: unset (reset to default)
     let mut quiet = false;          // -q: suppress the "already set" error
+    let mut window_scope = window_command;
 
     while i < toks.len() {
         let p = toks[i].1.as_str();
@@ -940,6 +940,7 @@ fn parse_set_option(app: &mut AppState, line: &str) {
             if p.contains('F') { format_expand = true; }
             if p.contains('o') { only_if_unset = true; }
             if p.contains('a') { append_mode = true; }
+            if p.contains('w') { window_scope = true; }
             // -U is an unset alias of -u (tmux parity, #553); the contains
             // check is case-sensitive so both must be tested.
             if p.contains('u') || p.contains('U') { unset_mode = true; }
@@ -948,7 +949,6 @@ fn parse_set_option(app: &mut AppState, line: &str) {
             // exit 0 (`if (args_has(args, 'q')) goto out;`). Unknown options
             // are still reported.
             if p.contains('q') { quiet = true; }
-            // -w: window option — treat same as global for our single-server model
             i += 1;
             if p.contains('t') && i < toks.len() { i += 1; }
         } else {
@@ -966,6 +966,15 @@ fn parse_set_option(app: &mut AppState, line: &str) {
         Some((off, _)) => extract_option_value(&line[*off..]),
         None => String::new(),
     };
+    if let Err(error) =
+        crate::server::option_catalog::validate_local_window_override(
+            key,
+            window_scope && !is_global,
+        )
+    {
+        warn_config(app, error);
+        return;
+    }
 
     // Handle -u (unset): restore the option's table default.
     //
@@ -1019,16 +1028,44 @@ fn parse_set_option(app: &mut AppState, line: &str) {
     // it reaches ~/.psmux/config-warnings.log and the attach-time summary; the
     // in-TUI command prompt runs through this same parser, so it also gets a
     // status message the way a failed command should.
+    // Expand format strings in the value if -F flag is set. No quote trimming
+    // here any more: extract_option_value already resolved the quoting, so a
+    // value whose content legitimately begins and ends with a quote keeps it.
+    let value = if format_expand && !raw_value.is_empty() {
+        crate::format::expand_format(&raw_value, app)
+    } else {
+        raw_value
+    };
+
+    if append_mode {
+        if let Err(error) = crate::server::option_catalog::validate_option_append(key) {
+            warn_config(app, error);
+            return;
+        }
+    }
+
+    // Handle -a (append to current value)
+    let final_value = if append_mode {
+        let current = crate::format::lookup_option_pub(key, app).unwrap_or_default();
+        format!("{}{}", current, value)
+    } else {
+        value
+    };
+
+    // -o still validates the requested assignment before deciding that the
+    // existing value wins.
     if only_if_unset {
-        // For @-prefixed user options, check if key exists
-        // For built-in options, check the user_set_options tracker
         let already_set = if key.starts_with('@') {
             app.user_options.contains_key(key)
         } else {
             app.user_set_options.contains(key)
         };
         if already_set {
-            if !quiet {
+            if let Err(error) =
+                crate::server::option_catalog::validate_option_value(key, &final_value)
+            {
+                warn_config(app, error);
+            } else if !quiet {
                 warn_config(app, format!("already set: {}", key));
                 if !in_startup_load() {
                     app.status_message = Some((
@@ -1042,29 +1079,13 @@ fn parse_set_option(app: &mut AppState, line: &str) {
         }
     }
 
-    // Expand format strings in the value if -F flag is set. No quote trimming
-    // here any more: extract_option_value already resolved the quoting, so a
-    // value whose content legitimately begins and ends with a quote keeps it.
-    let value = if format_expand && !raw_value.is_empty() {
-        crate::format::expand_format(&raw_value, app)
-    } else {
-        raw_value
-    };
-
-    // Handle -a (append to current value)
-    let final_value = if append_mode {
-        let current = crate::format::lookup_option_pub(key, app).unwrap_or_default();
-        format!("{}{}", current, value)
-    } else {
-        value
-    };
-
     // Pass key and value separately. Rejoining them into one string could not
     // represent a value with leading or trailing spaces, which the receiver
     // then trimmed back off (#536).
-    parse_option_value(app, key, &final_value, is_global);
-    // Track that this option was explicitly set (for -o only-if-unset checks)
-    app.user_set_options.insert(key.to_string());
+    if parse_option_value(app, key, &final_value, is_global) {
+        // Track that this option was explicitly set (for -o only-if-unset checks)
+        app.user_set_options.insert(key.to_string());
+    }
 }
 
 /// Apply one option, given its name and its **exact** value.
@@ -1074,12 +1095,17 @@ fn parse_set_option(app: &mut AppState, line: &str) {
 /// config value, survives to here. This used to take a single `"key value"`
 /// string and re-split it, which could not represent those runs at all and
 /// trimmed the ends back off (#536).
-pub fn parse_option_value(app: &mut AppState, key: &str, value: &str, _is_global: bool) {
+///
+/// Returns false when validation rejects the value.
+pub fn parse_option_value(app: &mut AppState, key: &str, value: &str, _is_global: bool) -> bool {
     let key = key.trim();
+    if let Err(error) = crate::server::option_catalog::validate_option_value(key, value) {
+        warn_config(app, error);
+        return false;
+    }
 
-    // Validate the value against the option's declared type from the catalog
-    // (issue #370 follow-up). Only options that exist in the catalog are
-    // checked, so unmodeled/user options never produce a false warning.
+    // Keep the existing boolean diagnostics. Numeric assignments are validated
+    // once above against the destination type declared by the option catalog.
     if !value.is_empty() {
         if let Some(def) = crate::server::option_catalog::OPTION_CATALOG
             .iter()
@@ -1087,13 +1113,7 @@ pub fn parse_option_value(app: &mut AppState, key: &str, value: &str, _is_global
         {
             let v = value.trim();
             match def.option_type {
-                "number" => {
-                    if v.parse::<i64>().is_err() {
-                        warn_config(app, format!(
-                            "invalid value '{}' for option '{}' (expected a number)", v, key));
-                    }
-                }
-                "boolean" => {
+                crate::server::option_catalog::OptionType::Boolean => {
                     // Accept the usual boolean tokens, and also any integer:
                     // a few "boolean" options (e.g. `status`) also take counts.
                     let lv = v.to_ascii_lowercase();
@@ -1382,7 +1402,7 @@ pub fn parse_option_value(app: &mut AppState, key: &str, value: &str, _is_global
                         app.status_format.push(String::new());
                     }
                     app.status_format[idx] = value.to_string();
-                    return;
+                    return true;
                 }
             }
             // Store @-prefixed user/plugin options separately from environment
@@ -1487,6 +1507,7 @@ pub fn parse_option_value(app: &mut AppState, key: &str, value: &str, _is_global
             }
         }
     }
+    true
 }
 
 /// Split a string into tokens respecting single and double quotes.

--- a/src/help.rs
+++ b/src/help.rs
@@ -425,6 +425,7 @@ const OPTIONS_REF: &[(&str, &str)] = &[
     ("pane-border-style",          "\"\""),
     ("pane-active-border-style",   "fg=green"),
     ("pane-border-hover-style",     "fg=yellow"),
+    ("pane-border-indicators",     crate::pane_border::INDICATORS_DEFAULT),
     // Messages / Modes
     ("message-style",              "bg=yellow,fg=black"),
     ("message-command-style",      "bg=black,fg=yellow"),

--- a/src/input.rs
+++ b/src/input.rs
@@ -1278,13 +1278,36 @@ pub fn handle_key(app: &mut AppState, key: KeyEvent) -> io::Result<bool> {
                         }
                     }
                     KeyCode::Enter => {
-                        if let Mode::CustomizeMode { ref mut editing, ref options, selected, ref edit_buffer, .. } = app.mode {
-                            let name = options[selected].0.clone();
-                            let value = edit_buffer.clone();
-                            *editing = false;
-                            crate::server::options::apply_set_option(app, &name, &value, true);
-                            if let Mode::CustomizeMode { ref mut options, selected, .. } = app.mode {
-                                options[selected].1 = value;
+                        let pending = match &app.mode {
+                            Mode::CustomizeMode { options, selected, edit_buffer, .. } => {
+                                Some((options[*selected].0.clone(), edit_buffer.clone()))
+                            }
+                            _ => None,
+                        };
+                        if let Some((name, value)) = pending {
+                            match crate::server::options::apply_set_option(
+                                app, &name, &value, true,
+                            ) {
+                                Ok(()) => {
+                                    app.user_set_options.insert(name.clone());
+                                    if let Mode::CustomizeMode {
+                                        ref mut options,
+                                        selected,
+                                        ref mut editing,
+                                        ..
+                                    } = app.mode
+                                    {
+                                        options[selected].1 = value;
+                                        *editing = false;
+                                    }
+                                }
+                                Err(error) => {
+                                    app.status_message = Some((
+                                        format!("set-option: {}", error),
+                                        Instant::now(),
+                                        None,
+                                    ));
+                                }
                             }
                         }
                     }
@@ -1362,12 +1385,39 @@ pub fn handle_key(app: &mut AppState, key: KeyEvent) -> io::Result<bool> {
                         }
                     }
                     KeyCode::Char('d') => {
-                        if let Mode::CustomizeMode { ref mut options, selected, .. } = app.mode {
-                            if let Some(def) = crate::server::option_catalog::default_for(&options[selected].0) {
-                                let name = options[selected].0.clone();
-                                let value = def.to_string();
-                                options[selected].1 = value.clone();
-                                crate::server::options::apply_set_option(app, &name, &value, true);
+                        let pending = match &app.mode {
+                            Mode::CustomizeMode { options, selected, .. } => {
+                                crate::server::option_catalog::default_for(
+                                    &options[*selected].0,
+                                )
+                                .map(|value| {
+                                    (options[*selected].0.clone(), value.to_string())
+                                })
+                            }
+                            _ => None,
+                        };
+                        if let Some((name, value)) = pending {
+                            match crate::server::options::apply_set_option(
+                                app, &name, &value, true,
+                            ) {
+                                Ok(()) => {
+                                    app.user_set_options.remove(&name);
+                                    if let Mode::CustomizeMode {
+                                        ref mut options,
+                                        selected,
+                                        ..
+                                    } = app.mode
+                                    {
+                                        options[selected].1 = value;
+                                    }
+                                }
+                                Err(error) => {
+                                    app.status_message = Some((
+                                        format!("set-option: {}", error),
+                                        Instant::now(),
+                                        None,
+                                    ));
+                                }
                             }
                         }
                     }

--- a/src/input.rs
+++ b/src/input.rs
@@ -1390,34 +1390,20 @@ pub fn handle_key(app: &mut AppState, key: KeyEvent) -> io::Result<bool> {
                                 crate::server::option_catalog::default_for(
                                     &options[*selected].0,
                                 )
-                                .map(|value| {
-                                    (options[*selected].0.clone(), value.to_string())
-                                })
+                                .map(|_| options[*selected].0.clone())
                             }
                             _ => None,
                         };
-                        if let Some((name, value)) = pending {
-                            match crate::server::options::apply_set_option(
-                                app, &name, &value, true,
-                            ) {
-                                Ok(()) => {
-                                    app.user_set_options.remove(&name);
-                                    if let Mode::CustomizeMode {
-                                        ref mut options,
-                                        selected,
-                                        ..
-                                    } = app.mode
-                                    {
-                                        options[selected].1 = value;
-                                    }
-                                }
-                                Err(error) => {
-                                    app.status_message = Some((
-                                        format!("set-option: {}", error),
-                                        Instant::now(),
-                                        None,
-                                    ));
-                                }
+                        if let Some(name) = pending {
+                            crate::server::options::reset_option_to_default(app, &name);
+                            let value = crate::server::options::get_option_value(app, &name);
+                            if let Mode::CustomizeMode {
+                                ref mut options,
+                                selected,
+                                ..
+                            } = app.mode
+                            {
+                                options[selected].1 = value;
                             }
                         }
                     }

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -228,7 +228,7 @@ impl LayoutJson {
 }
 
 pub fn dump_layout_json(app: &mut AppState) -> io::Result<String> {
-    dump_layout_json_inner(app, None)
+    serialize_layout(&dump_layout_inner(app, None)?)
 }
 
 /// Same as `dump_layout_json` but for a specific window id, regardless of
@@ -238,7 +238,16 @@ pub fn dump_layout_json(app: &mut AppState) -> io::Result<String> {
 /// transient focus and was returning the active pane's content for every
 /// requested pane id).
 pub fn dump_window_layout_json(app: &mut AppState, win_id: usize) -> io::Result<String> {
-    dump_layout_json_inner(app, Some(win_id))
+    serialize_layout(&dump_window_layout(app, win_id)?)
+}
+
+pub fn dump_window_layout(app: &mut AppState, win_id: usize) -> io::Result<LayoutJson> {
+    dump_layout_inner(app, Some(win_id))
+}
+
+fn serialize_layout(layout: &LayoutJson) -> io::Result<String> {
+    serde_json::to_string(layout)
+        .map_err(|error| io::Error::new(io::ErrorKind::Other, format!("json error: {error}")))
 }
 
 /// Copy-mode screen freeze (issue #494, tmux parity): while the session is in
@@ -304,7 +313,7 @@ fn sync_copy_freeze(app: &mut AppState, in_copy_mode: bool) {
     if let Some(v) = new_offset { app.copy_scroll_offset = v; }
 }
 
-fn dump_layout_json_inner(app: &mut AppState, win_id_override: Option<usize>) -> io::Result<String> {
+fn dump_layout_inner(app: &mut AppState, win_id_override: Option<usize>) -> io::Result<LayoutJson> {
     let in_copy_mode = matches!(app.mode, Mode::CopyMode | Mode::CopySearch { .. });
     if win_id_override.is_none() {
         sync_copy_freeze(app, in_copy_mode);
@@ -659,8 +668,7 @@ fn dump_layout_json_inner(app: &mut AppState, win_id_override: Option<usize>) ->
         if win_id_override.is_none() { app.copy_anchor } else { None },
         if win_id_override.is_none() { app.copy_pos } else { None },
     );
-    let s = serde_json::to_string(&root).map_err(|e| io::Error::new(io::ErrorKind::Other, format!("json error: {e}")))?;
-    Ok(s)
+    Ok(root)
 }
 
 /// Direct JSON serialisation of the layout tree – writes JSON straight into

--- a/src/main.rs
+++ b/src/main.rs
@@ -900,10 +900,22 @@ fn run_main() -> io::Result<()> {
             let win_id: usize = cmd_args[2].parse().expect("win_id must be a number");
             let w: u16 = cmd_args[3].parse().expect("width must be a number");
             let h: u16 = cmd_args[4].parse().expect("height must be a number");
-            let layout = match crate::preview::fetch_window_dump(&sess, win_id) {
-                Some(l) => l,
+            let preview_state = match crate::preview::fetch_preview_window_state(&sess, win_id) {
+                Some(state) => state,
                 None => { eprintln!("failed to fetch window-dump for {}:@{}", sess, win_id); std::process::exit(3); }
             };
+            let (border_style, active_border_style) = preview_state.pane_border_styles(
+                ratatui::style::Style::default().fg(ratatui::style::Color::DarkGray),
+                ratatui::style::Style::default().fg(ratatui::style::Color::Green),
+            );
+            let crate::types::PreviewWindowState {
+                layout,
+                border_lines,
+                border_indicators,
+                pane_border_style: _,
+                pane_active_border_style: _,
+                floating_pane_focused,
+            } = preview_state;
             use ratatui::Terminal;
             use ratatui::backend::TestBackend;
             use ratatui::layout::Rect;
@@ -912,42 +924,15 @@ fn run_main() -> io::Result<()> {
             let mut term = Terminal::new(backend).unwrap();
             term.draw(|f| {
                 let area = Rect::new(0, 0, w, h);
-                let active_rect = crate::client::compute_active_rect_json(&layout, area);
-                let total_panes = layout.count_leaves();
-                let border_style = ratatui::style::Style::default().fg(Color::DarkGray);
-                let active_border_style = ratatui::style::Style::default().fg(Color::Green);
-                let border_chars = crate::border_lines::border_chars(crate::border_lines::DEFAULT);
-                crate::client::render_layout_json(
-                    f, &layout, area,
-                    false,
-                    border_style,
-                    active_border_style,
-                    false, Color::Reset,
-                    active_rect,
-                    "", false, "off", "",
-                    total_panes,
-                    border_chars,
-                    None,
-                    crate::client::WindowContentStyles::default(),
-                    crate::pane_border::PaneBorderIndicators::Colour,
-                );
-                let borders = crate::client::border_geometry_from_layout(
+                crate::preview::render_preview_layout(
+                    f,
                     &layout,
                     area,
-                    f.buffer_mut().area,
-                    false,
-                );
-                let junctions = crate::rendering::fix_border_intersections(
-                    f.buffer_mut(),
-                    border_chars,
-                    &borders,
-                );
-                crate::client::recolor_border_junctions(
-                    f.buffer_mut(),
-                    &junctions,
-                    active_rect,
                     border_style,
                     active_border_style,
+                    crate::border_lines::border_chars(&border_lines),
+                    border_indicators,
+                    floating_pane_focused,
                 );
             }).unwrap();
             // Dump the buffer as ANSI escape sequences so colors are visible.

--- a/src/main.rs
+++ b/src/main.rs
@@ -656,6 +656,7 @@ fn run_main() -> io::Result<()> {
     // This avoids conflict with subcommand flags (e.g. select-pane -L, resize-pane -L).
     let mut l_socket_name: Option<String> = None;
     let mut f_config_file: Option<String> = None;
+    let mut precommand_target: Option<String> = None;
     let mut control_mode: u8 = 0; // 0=off, 1=-C (echo), 2=-CC (no echo)
     {
         let mut i = 1; // skip binary name
@@ -673,7 +674,10 @@ fn run_main() -> io::Result<()> {
             } else if arg == "-f" && i + 1 < args.len() {
                 f_config_file = Some(args[i + 1].clone());
                 i += 2;
-            } else if (arg == "-S" || arg == "-t") && i + 1 < args.len() {
+            } else if arg == "-t" && i + 1 < args.len() {
+                precommand_target = Some(args[i + 1].clone());
+                i += 2;
+            } else if arg == "-S" && i + 1 < args.len() {
                 i += 2; // skip other global flag-value pairs
             } else if arg.starts_with('-') {
                 i += 1; // skip single global flags (e.g. -v, -V)
@@ -704,9 +708,33 @@ fn run_main() -> io::Result<()> {
     let strip_target_position = command_index
         .filter(|index| !matches!(args[*index].as_str(), "detach-client" | "detach"))
         .and(target_position);
+    let is_set_option_command = command_index
+        .and_then(|index| args.get(index))
+        .is_some_and(|command| {
+            matches!(
+                command.as_str(),
+                "set-option" | "set" | "set-window-option" | "setw"
+            )
+        });
+    let set_option_target = if is_set_option_command {
+        let index = command_index.expect("set-option command has an index");
+        let command_args: Vec<&str> = args[index + 1..]
+            .iter()
+            .map(String::as_str)
+            .collect();
+        crate::cli::parse_set_option_args(&command_args)
+            .target
+            .map(str::to_string)
+    } else {
+        None
+    };
+    let explicit_target = if is_set_option_command {
+        set_option_target.as_ref().or(precommand_target.as_ref())
+    } else {
+        target_position.and_then(|position| args.get(position + 1))
+    };
     let mut explicit_session_target = false;
-    if let Some(pos) = target_position {
-        if let Some(target) = args.get(pos + 1) {
+    if let Some(target) = explicit_target {
             // move-window/swap-window: a bare -t that names a WINDOW (tmux
             // target-window semantics), not a session. Coerce "N" -> ":N" so the
             // generic parser treats it as a window and routing stays on the current
@@ -780,7 +808,6 @@ fn run_main() -> io::Result<()> {
                 env::set_var("PSMUX_TARGET_SESSION", &port_file_base);
                 explicit_session_target = true;
             }
-        }
     }
     if !explicit_session_target {
         // No explicit `-t session` on this command line: `$TMUX` (set inside
@@ -812,7 +839,7 @@ fn run_main() -> io::Result<()> {
                 .enumerate()
                 .filter(|(offset, _)| {
                     let absolute = index + *offset;
-                    strip_target_position
+                    is_set_option_command || strip_target_position
                         .map_or(true, |target| absolute != target && absolute != target + 1)
                 })
                 .map(|(_, arg)| arg)
@@ -3585,156 +3612,20 @@ fn run_main() -> io::Result<()> {
             }
             // set-option / set / set-window-option / setw - Set an option
             "set-option" | "set" | "set-window-option" | "setw" => {
-                // Validate that known integer-valued options receive a numeric value,
-                // erroring (nonzero exit) like tmux instead of silently accepting junk.
-                let (cli_pane_scope, cli_only_if_unset) = {
-                    // NOTE: "lock-after-time" is intentionally excluded. Unlike the
-                    // options below, psmux has no real numeric business logic for it
-                    // anywhere server-side -- config.rs stores it as an opaque
-                    // user_options passthrough (locking isn't implemented), so gating
-                    // it here just made the CLI reject values the server itself
-                    // accepts unchecked, breaking round-trip (task #7 batch A bug 1).
-                    const INT_OPTS: &[&str] = &[
-                        "history-limit", "escape-time", "display-time", "display-panes-time",
-                        "repeat-time", "message-limit", "status-interval", "base-index",
-                        "pane-base-index", "status-left-length", "status-right-length",
-                        "history-file-limit",
-                    ];
-                    // Collect positional (non-flag) args, skipping -t/-p values.
-                    // `@user-options` start with '@', not '-', so they are
-                    // positionals; an explicit empty string ("") is a real
-                    // value and must stay in the list (tmux accepts
-                    // `set -g @foo ""`).
-                    let mut positionals: Vec<&str> = Vec::new();
-                    let mut flags = String::new();
-                    let mut j = 1;
-                    while j < cmd_args.len() {
-                        let a = cmd_args[j].as_str();
-                        // Flags parse only BEFORE the first positional, and
-                        // `--` ends option parsing entirely (#583, the
-                        // set-option sibling of the #562 send-keys fix). tmux
-                        // (getopt) stops scanning at the option name, so a
-                        // dash-leading VALUE is data, never a flag: `set @k
-                        // -u` stores the literal "-u" instead of consuming it
-                        // as the unset flag and deleting the key at rc 0.
-                        if positionals.is_empty() {
-                            if a == "--" {
-                                positionals.extend(cmd_args[j + 1..].iter().map(|s| s.as_str()));
-                                break;
-                            }
-                            // Only -t consumes a value. `-p` is a bare pane-scope
-                            // flag (tmux parity, #580); treating it as a target
-                            // flag ate the option name, so `set -p -t %3
-                            // remain-on-exit failed` misparsed as an empty-value
-                            // set of 'failed'.
-                            if a == "-t" { j += 2; continue; }
-                            if a.starts_with('-') && a.len() > 1 {
-                                flags.push_str(&a[1..]);
-                                j += 1;
-                                continue;
-                            }
-                        }
-                        positionals.push(a);
-                        j += 1;
-                    }
-                    // Issue #553: reject flags psmux does not implement
-                    // instead of silently accepting them and letting the
-                    // write land under different semantics than requested
-                    // (tmux: "unknown flag -Z", rc 1, nothing written). Same
-                    // principle as dd84b97 for refresh-client. -t/-p never
-                    // reach `flags` (skipped with their values above); -U is
-                    // the unset alias, -w a scope flag.
-                    //
-                    // Issue #618: -s is the SERVER scope flag. tmux 3.2 moved
-                    // default-terminal, extended-keys and friends onto the
-                    // server option table and tools write them the documented
-                    // way (`set-option -s default-terminal xterm-256color`).
-                    // Rejecting it turned every such bootstrap into a hard
-                    // failure. psmux runs one server per session and keeps a
-                    // single option store, so -s selects the same store as -g
-                    // rather than a genuinely cross-session one; the write
-                    // lands where the caller expects it, but it is not true
-                    // cross-session server-option storage.
-                    for ch in flags.chars() {
-                        if !SET_OPTION_CLI_FLAGS.contains(ch) {
-                            eprintln!("psmux: set-option: unknown flag -{}", ch);
-                            std::process::exit(1);
-                        }
-                    }
-                    let has_unset = flags.contains('u') || flags.contains('U');
-                    let has_append = flags.contains('a');
-                    // Issue #535: a set-option carrying no value used to be
-                    // dropped in silence: nothing set, empty stderr, exit 0.
-                    // That turned a one-character mistake (PowerShell eats a
-                    // bare `@name` as the splatting operator, so `set -g
-                    // @pill $undefined` arrives as `set -g <text>`) into an
-                    // undebuggable no-op. tmux fails these loudly, so we do
-                    // too. `-q` is NOT consulted: both tmux's manual and our
-                    // own -q help text scope it to unknown/ambiguous options,
-                    // and tmux 3.4 still errors on `set -gq @foo`.
-                    if positionals.is_empty() {
-                        eprintln!("psmux: set-option: too few arguments (need at least 1)");
-                        std::process::exit(1);
-                    }
-                    if positionals.len() == 1 && !has_unset {
-                        let name = positionals[0];
-                        // Boolean flags legitimately take no value: they
-                        // toggle (tmux parity, #278). Everything else is an
-                        // error. `-a` appends, so it always needs a value.
-                        if has_append || !crate::server::options::missing_value_toggles(name) {
-                            eprintln!("psmux: set-option: empty value for '{}'", name);
-                            std::process::exit(1);
-                        }
-                    }
-                    if let (Some(name), Some(val)) = (positionals.first(), positionals.get(1)) {
-                        if INT_OPTS.contains(name) && val.parse::<i64>().is_err() {
-                            eprintln!("psmux: set-option: value for '{}' must be a number, got '{}'", name, val);
-                            std::process::exit(1);
-                        }
-                        // Issue #606: repeat-time is bounded in tmux
-                        // (options-table.c: 0..=2000000 ms). Without this the
-                        // number check above waved through 2000001 and -5
-                        // alike: the first installed a 33 minute repeat
-                        // window, the second was dropped server-side at exit
-                        // 0 so a typo looked like it had been applied.
-                        // #608: `priority` takes a fixed set of three values.
-                        // The generic catalog check only validates numbers and
-                        // booleans, so without this a typo returned 0 and was
-                        // dropped server-side, leaving the class unchanged and
-                        // the mistake invisible.
-                        if *name == "priority"
-                            && crate::platform::normalize_priority(val).is_none()
-                        {
-                            eprintln!(
-                                "psmux: set-option: value for 'priority' must be one of {}, got '{}'",
-                                crate::platform::PRIORITY_VALUES.join(", "),
-                                val
-                            );
-                            std::process::exit(1);
-                        }
-                        if *name == "repeat-time" {
-                            if let Ok(ms) = val.parse::<i64>() {
-                                if ms < 0 {
-                                    eprintln!("psmux: set-option: value is too small: {}", val);
-                                    std::process::exit(1);
-                                }
-                                if ms > crate::server::options::REPEAT_TIME_MAX_MS {
-                                    eprintln!("psmux: set-option: value is too large: {}", val);
-                                    std::process::exit(1);
-                                }
-                            }
-                        }
-                    }
-                    // `-o` on an option that is already set is an error in tmux
-                    // (`already set: <name>`, exit 1) and silent at exit 0 only
-                    // under `-q`, so the no-q case has to read the server's
-                    // answer instead of firing and forgetting (#619 follow up).
-                    // `-u` disarms the guard entirely: tmux skips it whenever
-                    // `-u` is present, so that stays a plain unset.
-                    let only_if_unset =
-                        flags.contains('o') && !has_unset && !flags.contains('q');
-                    (flags.contains('p'), only_if_unset)
-                };
+                let set_args: Vec<&str> =
+                    cmd_args[1..].iter().map(|arg| arg.as_str()).collect();
+                let parsed_set = crate::cli::parse_set_option_args(&set_args);
+                let window_command = matches!(cmd, "set-window-option" | "setw");
+                if let Err(error) = parsed_set.validate(window_command) {
+                    eprintln!("psmux: set-option: {}", error);
+                    std::process::exit(1);
+                }
+                let unset =
+                    parsed_set.flag_chars.contains('u') || parsed_set.flag_chars.contains('U');
+                let cli_pane_scope = parsed_set.flag_chars.contains('p');
+                let cli_only_if_unset = parsed_set.flag_chars.contains('o')
+                    && !unset
+                    && !parsed_set.flag_chars.contains('q');
                 let cmd_str: String = cmd_args.iter().map(|s| {
                     let s = s.as_str();
                     // An explicitly empty argument must be re-quoted, or it
@@ -3802,11 +3693,22 @@ fn run_main() -> io::Result<()> {
                     }
                     return Ok(());
                 }
-                match send_control(format!("{}\n", cmd_str)) {
-                    Ok(()) => {},
-                    Err(e) if e.to_string().contains("no session") => {
+                // `session-info` is an event-loop barrier: its response proves
+                // the preceding mutation has been applied before this CLI exits.
+                match send_control_with_response(format!("{}\nsession-info\n", cmd_str)) {
+                    Ok(resp) => {
+                        if resp.trim_start().starts_with("ERROR") {
+                            eprintln!(
+                                "psmux: {}",
+                                resp.trim_start().trim_start_matches("ERROR:").trim(),
+                            );
+                            std::process::exit(1);
+                        }
+                    }
+                    Err(e) if e.to_string().contains("no session")
+                        || e.to_string().contains("no server running") => {
                         eprintln!("warning: no active session; option will take effect when set inside a session or via config file");
-                    },
+                    }
                     Err(e) => return Err(e),
                 }
                 return Ok(());

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,7 @@ mod commands;
 mod pane;
 mod warm_pane_sync;
 mod popup;
+mod pane_border;
 mod clipboard;
 mod copy_mode;
 mod input;
@@ -928,6 +929,7 @@ fn run_main() -> io::Result<()> {
                     border_chars,
                     None,
                     crate::client::WindowContentStyles::default(),
+                    crate::pane_border::PaneBorderIndicators::Colour,
                 );
                 let borders = crate::client::border_geometry_from_layout(
                     &layout,

--- a/src/pane_border.rs
+++ b/src/pane_border.rs
@@ -1,0 +1,48 @@
+//! Policy for marking the active pane at tiled and floating pane borders.
+//!
+//! Line glyph selection remains in `border_lines`; this module owns whether
+//! active-pane colour cues, arrow cues, both, or neither are drawn.
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum PaneBorderIndicators {
+    Off,
+    #[default]
+    Colour,
+    Arrows,
+    Both,
+}
+
+impl PaneBorderIndicators {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Off => "off",
+            Self::Colour => "colour",
+            Self::Arrows => "arrows",
+            Self::Both => "both",
+        }
+    }
+
+    pub fn parse(value: &str) -> Result<Self, String> {
+        match value {
+            "off" => Ok(Self::Off),
+            "colour" => Ok(Self::Colour),
+            "arrows" => Ok(Self::Arrows),
+            "both" => Ok(Self::Both),
+            _ => Err(format!(
+                "invalid value '{}' for pane-border-indicators (expected off, colour, arrows, or both)",
+                value,
+            )),
+        }
+    }
+
+    pub(crate) fn uses_colour(self) -> bool {
+        matches!(self, Self::Colour | Self::Both)
+    }
+
+    pub(crate) fn uses_arrows(self) -> bool {
+        matches!(self, Self::Arrows | Self::Both)
+    }
+}
+
+pub const INDICATORS_DEFAULT: &str = PaneBorderIndicators::Colour.as_str();

--- a/src/preview.rs
+++ b/src/preview.rs
@@ -684,7 +684,8 @@ pub fn dump_separators(
 
 /// Render the target's pane contents and separators into the preview area.
 /// Target window styles are not part of `window-dump`, so cross-session
-/// previews use only the colours serialized in the dump.
+/// previews use the colours serialized in the dump, the caller's border
+/// styles, and the default colour indicator mode.
 pub fn render_dump_tree(
     f: &mut ratatui::Frame,
     layout: &crate::layout::LayoutJson,
@@ -711,6 +712,7 @@ pub fn render_dump_tree(
         crate::border_lines::border_chars(crate::border_lines::DEFAULT),
         None,
         crate::client::WindowContentStyles::default(),
+        crate::pane_border::PaneBorderIndicators::Colour,
     );
     let borders = crate::client::border_geometry_from_layout(
         layout,

--- a/src/preview.rs
+++ b/src/preview.rs
@@ -438,60 +438,75 @@ pub fn layout_separators(
     out
 }
 
-// ---------------------------------------------------------------------
-// Full styled preview (issue #257 follow-up): reuse the same rich
-// `LayoutJson` (with `rows_v2` cell runs) the main viewport renders,
-// instead of replaying `capture-pane -e` per pane and parsing ANSI.
-// This fixes two problems at once:
-//   1. `capture-pane -t :@W.%P` resolved through transient -t focus and
-//      could return the active pane's content for every pane id, so all
-//      preview cells showed the same buffer.
-//   2. The hand-rolled ANSI pipeline duplicated rendering logic that
-//      already exists in the main viewport (border, color, attribute
-//      handling). Sharing the structured `LayoutJson` keeps previews
-//      visually identical to the real window.
-// ---------------------------------------------------------------------
+impl crate::types::PreviewWindowState {
+    /// Empty state styles use target defaults; missing fields use chooser fallbacks.
+    pub fn pane_border_styles(
+        &self,
+        border_fallback: Style,
+        active_fallback: Style,
+    ) -> (Style, Style) {
+        let border_default = Style::default().fg(Color::DarkGray);
+        let active_default = Style::default().fg(Color::Green);
+        (
+            match self.pane_border_style.as_deref() {
+                Some(style) => {
+                    crate::client::parse_pane_border_colors(Some(style), border_default)
+                }
+                None => crate::client::parse_pane_border_colors(None, border_fallback),
+            },
+            match self.pane_active_border_style.as_deref() {
+                Some(style) => {
+                    crate::client::parse_pane_border_colors(Some(style), active_default)
+                }
+                None => crate::client::parse_pane_border_colors(None, active_fallback),
+            },
+        )
+    }
+}
 
-/// Cache for full layout dumps keyed by "sess\twin_id".
-pub type DumpCache = HashMap<String, (crate::layout::LayoutJson, Instant)>;
+/// Cache for preview state keyed by "sess\twin_id".
+pub type PreviewWindowStateCache =
+    HashMap<String, (crate::types::PreviewWindowState, Instant)>;
 
-pub const DUMP_TTL: Duration = Duration::from_millis(1500);
-
-/// Fetch the full styled layout (rows_v2) for a window in any session
-/// via TCP using the new `window-dump` command.
-pub fn fetch_window_dump(sess: &str, win_id: usize) -> Option<crate::layout::LayoutJson> {
+/// Fetch the layout, border options, and floating-focus state required to
+/// preview a window in any session.
+pub fn fetch_preview_window_state(
+    sess: &str,
+    win_id: usize,
+) -> Option<crate::types::PreviewWindowState> {
     let port_path = crate::paths::port_file(sess);
     let port: u16 = std::fs::read_to_string(&port_path).ok()?.trim().parse().ok()?;
     let key = read_session_key(sess).ok()?;
-    let cmd = format!("window-dump {}\n", win_id);
-    let resp = fetch_authed_response_multi(
-        &format!("127.0.0.1:{}", port),
+    let addr = format!("127.0.0.1:{}", port);
+    let cmd = format!("window-dump {} state\n", win_id);
+    let response = fetch_authed_response_multi(
+        &addr,
         &key,
         cmd.as_bytes(),
         CONNECT_TIMEOUT,
         READ_TIMEOUT,
     )?;
-    let trimmed = resp.trim();
+    let trimmed = response.trim();
     if trimmed.is_empty() || trimmed == "{}" {
         return None;
     }
-    serde_json::from_str::<crate::layout::LayoutJson>(trimmed).ok()
+    crate::types::parse_preview_window_state(trimmed)
 }
 
-pub fn get_or_fetch_dump(
-    cache: &mut DumpCache,
+pub fn get_or_fetch_preview_window_state(
+    cache: &mut PreviewWindowStateCache,
     sess: &str,
     win_id: usize,
-) -> Option<crate::layout::LayoutJson> {
+) -> Option<crate::types::PreviewWindowState> {
     let key = format!("{}\t{}", sess, win_id);
-    if let Some((layout, ts)) = cache.get(&key) {
-        if ts.elapsed() < DUMP_TTL {
-            return Some(layout.clone());
+    if let Some((state, ts)) = cache.get(&key) {
+        if ts.elapsed() < PREVIEW_TTL {
+            return Some(state.clone());
         }
     }
-    let layout = fetch_window_dump(sess, win_id)?;
-    cache.insert(key, (layout.clone(), Instant::now()));
-    Some(layout)
+    let state = fetch_preview_window_state(sess, win_id)?;
+    cache.insert(key, (state.clone(), Instant::now()));
+    Some(state)
 }
 
 /// Map a vt100-style color name (as emitted by `crate::util::color_to_name`)
@@ -682,20 +697,26 @@ pub fn dump_separators(
     out
 }
 
-/// Render the target's pane contents and separators into the preview area.
-/// Target window styles are not part of `window-dump`, so cross-session
-/// previews use the colours serialized in the dump, the caller's border
-/// styles, and the default colour indicator mode.
-pub fn render_dump_tree(
+/// Render a clipped view of a target's tiled layout. Floating panes, pane title
+/// bars, and zoom are deliberately omitted.
+pub fn render_preview_layout(
     f: &mut ratatui::Frame,
     layout: &crate::layout::LayoutJson,
     area: ratatui::layout::Rect,
     border_style: ratatui::style::Style,
     active_border_style: ratatui::style::Style,
-    _highlight_pid: Option<usize>,
+    border_chars: Option<crate::border_lines::BorderChars>,
+    border_indicators: crate::pane_border::PaneBorderIndicators,
+    floating_pane_focused: bool,
 ) {
     if area.width == 0 || area.height == 0 { return; }
     let active_rect = crate::client::compute_active_rect_json(layout, area);
+    let (active_rect, active_border_style) = crate::client::tiled_border_focus(
+        active_rect,
+        border_style,
+        active_border_style,
+        floating_pane_focused,
+    );
     let total_panes = layout.count_leaves();
     crate::client::render_layout_json(
         f, layout, area,
@@ -709,10 +730,10 @@ pub fn render_dump_tree(
         "off",            // border_status off (no per-pane title bar)
         "",               // border_format irrelevant
         total_panes,
-        crate::border_lines::border_chars(crate::border_lines::DEFAULT),
+        border_chars,
         None,
         crate::client::WindowContentStyles::default(),
-        crate::pane_border::PaneBorderIndicators::Colour,
+        border_indicators,
     );
     let borders = crate::client::border_geometry_from_layout(
         layout,
@@ -722,7 +743,7 @@ pub fn render_dump_tree(
     );
     let junctions = crate::rendering::fix_border_intersections(
         f.buffer_mut(),
-        crate::border_lines::border_chars(crate::border_lines::DEFAULT),
+        border_chars,
         &borders,
     );
     crate::client::recolor_border_junctions(
@@ -731,6 +752,13 @@ pub fn render_dump_tree(
         active_rect,
         border_style,
         active_border_style,
+    );
+    crate::client::draw_pane_border_arrows(
+        f.buffer_mut(),
+        &borders,
+        border_chars,
+        active_rect,
+        border_indicators,
     );
 }
 

--- a/src/rendering.rs
+++ b/src/rendering.rs
@@ -230,6 +230,14 @@ impl BorderGeometry {
         self.cells.contains_key(idx)
     }
 
+    pub(crate) fn contains_vertical(&self, idx: usize) -> bool {
+        self.has_orientation(idx, BorderOrientation::Vertical)
+    }
+
+    pub(crate) fn contains_horizontal(&self, idx: usize) -> bool {
+        self.has_orientation(idx, BorderOrientation::Horizontal)
+    }
+
     fn has_orientation(&self, idx: usize, orientation: BorderOrientation) -> bool {
         self.cells.get(&idx) == Some(&orientation)
     }

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -5002,3 +5002,7 @@ mod tests_refresh_client_flags;
 #[cfg(test)]
 #[path = "../../tests-rs/test_set_option_control.rs"]
 mod tests_set_option_control;
+
+#[cfg(test)]
+#[path = "../../tests-rs/test_pane_border_indicator_control.rs"]
+mod tests_pane_border_indicator_control;

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -3,7 +3,9 @@ use std::sync::mpsc;
 use std::time::Duration;
 use std::net::TcpStream;
 
-use crate::types::{CtrlReq, LayoutKind, WaitForOp, ControlNotification};
+use crate::types::{
+    ControlNotification, CtrlReq, LayoutKind, WaitForOp, WindowDumpFormat,
+};
 
 /// Clear HANDLE_FLAG_INHERIT on a connection socket (see the comment at the
 /// clone sites in `handle_connection`). No-op off Windows.
@@ -1547,15 +1549,18 @@ match cmd {
         if !persistent { break; }
     }
     "window-dump" => {
-        // Issue #257: return full styled `LayoutJson` (with rows_v2 cell
-        // runs, titles, sizes) for a specific window id. The client uses
-        // this for cross-session previews so every pane is rendered with
-        // its own content via the same code path as the main viewport.
-        // Usage: window-dump <window_id>
+        // Return a fully styled LayoutJson, or the layout plus preview styles
+        // and focus metadata when `state` is requested.
+        // Usage: window-dump <window_id> [state]
         let wid: Option<usize> = args.get(0).and_then(|a| a.trim_start_matches('@').parse::<usize>().ok());
         if let Some(wid) = wid {
             let (rtx, rrx) = mpsc::channel::<String>();
-            let _ = tx.send(CtrlReq::WindowDump(wid, rtx));
+            let format = if args.get(1) == Some(&"state") {
+                WindowDumpFormat::PreviewState
+            } else {
+                WindowDumpFormat::Layout
+            };
+            let _ = tx.send(CtrlReq::WindowDump(wid, format, rtx));
             if let Ok(text) = rrx.recv() {
                 let _ = write!(write_stream, "{}\n", text);
                 let _ = write_stream.flush();

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -21,7 +21,7 @@ fn clear_inherit(s: &TcpStream) {
 }
 #[cfg(not(windows))]
 fn clear_inherit(_s: &TcpStream) {}
-use crate::cli::{parse_target, extract_flag_value};
+use crate::cli::{extract_flag_value, parse_set_option_args, parse_target};
 use crate::util::base64_decode;
 use crate::control;
 
@@ -726,7 +726,34 @@ if control_echo || control_noecho {
         let mut ctrl_target_pane: Option<usize> = None;
         let mut ctrl_pane_is_id = false;
         let mut ctrl_raw_target: Option<String> = None;
-        {
+        let ctrl_set_option = matches!(
+            cmd_name,
+            "set-option" | "set" | "set-window-option" | "setw"
+        );
+        let ctrl_set_window_option =
+            matches!(cmd_name, "set-window-option" | "setw");
+        let ctrl_set_args = ctrl_set_option
+            .then(|| parse_set_option_args(&cmd_args));
+        if let Some(parsed_set) = ctrl_set_args.as_ref() {
+            if let Some(value) = parsed_set.target {
+                ctrl_raw_target =
+                    Some(crate::cli::strip_exact_match_prefix(value).to_string());
+                let parsed_target = parse_target(value);
+                if parsed_target.window.is_some() {
+                    ctrl_target_win = parsed_target.window;
+                    ctrl_target_win_is_id = parsed_target.window_is_id;
+                    ctrl_target_win_name = None;
+                } else if parsed_target.window_name.is_some() {
+                    ctrl_target_win_name = parsed_target.window_name;
+                    ctrl_target_win = None;
+                    ctrl_target_win_is_id = false;
+                }
+                if parsed_target.pane.is_some() {
+                    ctrl_target_pane = parsed_target.pane;
+                    ctrl_pane_is_id = parsed_target.pane_is_id;
+                }
+            }
+        } else {
             let target_scan_end = crate::cli::outer_target_scan_end(cmd_name, &cmd_args);
             let mut i = 0;
             while i < target_scan_end {
@@ -748,7 +775,11 @@ if control_echo || control_noecho {
             }
         }
 
-        let filtered_args = without_outer_target(cmd_name, &cmd_args);
+        let filtered_args = if ctrl_set_option {
+            cmd_args.clone()
+        } else {
+            without_outer_target(cmd_name, &cmd_args)
+        };
 
         // Apply target focus
         // tmux parity (#592): select-pane -T/-P is title/style-only (see the
@@ -774,42 +805,48 @@ if control_echo || control_noecho {
         // and turn the swap into a no-op).
         let ctrl_capture_by_id = matches!(cmd_name, "capture-pane" | "capturep") && ctrl_pane_is_id && ctrl_target_pane.is_some();
         let skip_pane_focus = matches!(cmd_name, "display-message" | "display" | "swap-pane" | "swapp") || skip_target_focus || ctrl_capture_by_id;
-        let mut focus_err: Option<String> = None;
-        if is_focus_cmd {
-            if let Some(wid) = ctrl_target_win {
-                if ctrl_target_win_is_id {
-                    let _ = tx_ctrl.send(CtrlReq::FocusWindowById(wid));
-                } else {
-                    let _ = tx_ctrl.send(CtrlReq::FocusWindow(wid));
+        let mut focus_err = ctrl_set_args.as_ref().and_then(|parsed_set| {
+            parsed_set.validate(ctrl_set_window_option).err()
+        });
+        if focus_err.is_none() {
+            if is_focus_cmd {
+                if let Some(wid) = ctrl_target_win {
+                    if ctrl_target_win_is_id {
+                        let _ = tx_ctrl.send(CtrlReq::FocusWindowById(wid));
+                    } else {
+                        let _ = tx_ctrl.send(CtrlReq::FocusWindow(wid));
+                    }
+                } else if let Some(ref wname) = ctrl_target_win_name {
+                    let _ = tx_ctrl.send(CtrlReq::FocusWindowByName(wname.clone()));
                 }
-            } else if let Some(ref wname) = ctrl_target_win_name {
-                let _ = tx_ctrl.send(CtrlReq::FocusWindowByName(wname.clone()));
-            }
-            if let Some(pid) = ctrl_target_pane {
-                if ctrl_pane_is_id {
-                    let _ = tx_ctrl.send(CtrlReq::FocusPane(pid));
-                } else {
-                    let _ = tx_ctrl.send(CtrlReq::FocusPaneByIndex(pid));
+                if let Some(pid) = ctrl_target_pane {
+                    if ctrl_pane_is_id {
+                        let _ = tx_ctrl.send(CtrlReq::FocusPane(pid));
+                    } else {
+                        let _ = tx_ctrl.send(CtrlReq::FocusPaneByIndex(pid));
+                    }
                 }
-            }
-        } else {
-            // Validated temporary focus (issue #545): on an unresolvable
-            // window/pane target the command must not run — reply %error
-            // instead of silently executing against the active window.
-            let want_win = (ctrl_target_win.is_some() || ctrl_target_win_name.is_some()) && !skip_target_focus;
-            let want_pane = ctrl_target_pane.is_some() && !skip_pane_focus;
-            if want_win || want_pane {
-                let (focus_s, focus_r) = mpsc::channel::<Result<(), String>>();
-                let _ = tx_ctrl.send(CtrlReq::FocusTargetTemp {
-                    win: if want_win { ctrl_target_win } else { None },
-                    win_is_id: ctrl_target_win_is_id,
-                    win_name: if want_win { ctrl_target_win_name.clone() } else { None },
-                    pane: if want_pane { ctrl_target_pane } else { None },
-                    pane_is_id: ctrl_pane_is_id,
-                    resp: focus_s,
-                });
-                if let Ok(Err(e)) = focus_r.recv_timeout(Duration::from_secs(5)) {
-                    focus_err = Some(e);
+            } else {
+                // Validated temporary focus (issue #545): on an unresolvable
+                // window/pane target the command must not run — reply %error
+                // instead of silently executing against the active window.
+                let want_win = (ctrl_target_win.is_some()
+                    || ctrl_target_win_name.is_some())
+                    && !skip_target_focus;
+                let want_pane = ctrl_target_pane.is_some() && !skip_pane_focus;
+                if want_win || want_pane {
+                    let (focus_s, focus_r) = mpsc::channel::<Result<(), String>>();
+                    let _ = tx_ctrl.send(CtrlReq::FocusTargetTemp {
+                        win: if want_win { ctrl_target_win } else { None },
+                        win_is_id: ctrl_target_win_is_id,
+                        win_name: if want_win { ctrl_target_win_name.clone() } else { None },
+                        pane: if want_pane { ctrl_target_pane } else { None },
+                        pane_is_id: ctrl_pane_is_id,
+                        resp: focus_s,
+                    });
+                    if let Ok(Err(e)) = focus_r.recv_timeout(Duration::from_secs(5)) {
+                        focus_err = Some(e);
+                    }
                 }
             }
         }
@@ -987,28 +1024,66 @@ let mut pane_is_id = global_pane_is_id;
 // Save raw -t value for relative pane targets like :.+ or :.-
 // Falls back to global_raw_target from TARGET protocol line
 let mut raw_target: Option<String> = global_raw_target.clone();
-let target_scan_end = crate::cli::outer_target_scan_end(cmd, &args);
-let mut i = 0;
-while i < target_scan_end {
-    if args[i] == "-t" {
-        if let Some(v) = args.get(i+1) {
-            // Issue #558: drop the '=' exact-match marker (see TARGET capture).
-            raw_target = Some(crate::cli::strip_exact_match_prefix(v).to_string());
-            // Parse the -t value using parse_target for consistent handling
-            let pt = parse_target(v);
-            if pt.window.is_some() { target_win = pt.window; target_win_is_id = pt.window_is_id; target_win_name = None; }
-            else if pt.window_name.is_some() { target_win_name = pt.window_name; target_win = None; target_win_is_id = false; }
-            if pt.pane.is_some() {
-                target_pane = pt.pane;
-                pane_is_id = pt.pane_is_id;
-            }
+let set_option_command = matches!(
+    cmd,
+    "set-option" | "set" | "set-window-option" | "setw"
+);
+if set_option_command {
+    if let Some(value) = parse_set_option_args(&args).target {
+        raw_target = Some(crate::cli::strip_exact_match_prefix(value).to_string());
+        let parsed_target = parse_target(value);
+        if parsed_target.window.is_some() {
+            target_win = parsed_target.window;
+            target_win_is_id = parsed_target.window_is_id;
+            target_win_name = None;
+        } else if parsed_target.window_name.is_some() {
+            target_win_name = parsed_target.window_name;
+            target_win = None;
+            target_win_is_id = false;
         }
-        i += 2; continue;
+        if parsed_target.pane.is_some() {
+            target_pane = parsed_target.pane;
+            pane_is_id = parsed_target.pane_is_id;
+        }
     }
-    i += 1;
+} else {
+    let target_scan_end = crate::cli::outer_target_scan_end(cmd, &args);
+    let mut i = 0;
+    while i < target_scan_end {
+        if args[i] == "-t" {
+            if let Some(v) = args.get(i+1) {
+            // Issue #558: drop the '=' exact-match marker (see TARGET capture).
+                raw_target = Some(crate::cli::strip_exact_match_prefix(v).to_string());
+                // Parse the -t value using parse_target for consistent handling
+                let pt = parse_target(v);
+                if pt.window.is_some() { target_win = pt.window; target_win_is_id = pt.window_is_id; target_win_name = None; }
+                else if pt.window_name.is_some() { target_win_name = pt.window_name; target_win = None; target_win_is_id = false; }
+                if pt.pane.is_some() {
+                    target_pane = pt.pane;
+                    pane_is_id = pt.pane_is_id;
+                }
+            }
+            i += 2; continue;
+        }
+        i += 1;
+    }
 }
-// Remove this command's target while retaining targets in deferred commands.
-let args = without_outer_target(cmd, &args);
+let args = if set_option_command {
+    args
+} else {
+    without_outer_target(cmd, &args)
+};
+if set_option_command {
+    let parsed_set = parse_set_option_args(&args);
+    let window_command = matches!(cmd, "set-window-option" | "setw");
+    if let Err(error) = parsed_set.validate(window_command) {
+        let _ = writeln!(write_stream, "ERROR: {}", error);
+        let _ = write_stream.flush();
+        if !persistent { break; }
+        line.clear();
+        continue;
+    }
+}
 // tmux parity (#592): `select-pane -T`/`-P` is a title/style-only
 // operation — tmux's cmd-select-pane.c sets the title and returns
 // before any activation. Classify it as a NON-focus command so it takes
@@ -2446,36 +2521,18 @@ match cmd {
         // so a dash-leading VALUE is data, never a flag: `set @k -u` must
         // store the literal "-u", not route the command to the unset path
         // (that was a silent rc-0 key deletion). Combined tokens like -ga,
-        // -gu, -gq still work in the flag region. -t and its value never
-        // reach this match (stripped by the generic -t filter above).
+        // -gu, and -gt still work; the shared parser separates any -t target
+        // from the option operands.
         //
         // -U is an unset alias (tmux parity, #553). It was only recognized
         // CLIENT-side, so `set -U @x V` cleared the CLI's empty-value guard,
         // arrived here unrecognized, and fell through to the plain SET path:
         // the option was written where the caller asked for an unset, rc 0.
-        let mut flag_chars = String::new();
-        let mut non_flag_args: Vec<&str> = Vec::new();
-        {
-            let mut i = 0;
-            while i < args.len() {
-                let a = args[i];
-                if non_flag_args.is_empty() {
-                    if a == "--" {
-                        non_flag_args.extend(args[i + 1..].iter().copied());
-                        break;
-                    }
-                    if a.starts_with('-') && a.len() > 1
-                        && a.chars().skip(1).all(|c| c.is_ascii_alphabetic())
-                    {
-                        flag_chars.push_str(&a[1..]);
-                        i += 1;
-                        continue;
-                    }
-                }
-                non_flag_args.push(a);
-                i += 1;
-            }
-        }
+        let crate::cli::ParsedSetOptionArgs {
+            flag_chars,
+            positionals: non_flag_args,
+            ..
+        } = parse_set_option_args(&args);
         let has_u = flag_chars.contains('u') || flag_chars.contains('U');
         let has_a = flag_chars.contains('a');
         let has_q = flag_chars.contains('q');
@@ -2493,22 +2550,21 @@ match cmd {
                 .map(|s| s.trim_matches('"').to_string())
                 .unwrap_or_default();
             let reply = if has_u {
-                match non_flag_args.first() {
-                    Some(option) => {
-                        let (rtx, rrx) = mpsc::channel::<String>();
-                        let _ = tx.send(CtrlReq::SetPaneOption(raw_target, option.to_string(), String::new(), rtx));
-                        rrx.recv_timeout(Duration::from_millis(2000)).unwrap_or_default()
-                    }
-                    None => "ERROR: set-option -pu: option name required".to_string(),
-                }
-            } else if non_flag_args.len() >= 2 {
+                let option = non_flag_args[0];
+                let (rtx, rrx) = mpsc::channel::<String>();
+                let _ = tx.send(CtrlReq::SetPaneOption(
+                    raw_target,
+                    option.to_string(),
+                    String::new(),
+                    rtx,
+                ));
+                rrx.recv_timeout(Duration::from_millis(2000)).unwrap_or_default()
+            } else {
                 let option = non_flag_args[0].to_string();
                 let value = non_flag_args[1..].join(" ").trim_matches('"').to_string();
                 let (rtx, rrx) = mpsc::channel::<String>();
                 let _ = tx.send(CtrlReq::SetPaneOption(raw_target, option, value, rtx));
                 rrx.recv_timeout(Duration::from_millis(2000)).unwrap_or_default()
-            } else {
-                "ERROR: set-option -p: option and value required".to_string()
             };
             if !reply.is_empty() {
                 let _ = write!(write_stream, "{}\n", reply);
@@ -4203,32 +4259,29 @@ fn dispatch_control_command(
             true
         }
         "set-option" | "set" | "set-window-option" | "setw" => {
-            // Support combined flag tokens like -ga, -gu, -gq (tmux compat)
-            let combined_has_set2 = |ch: char| -> bool {
-                args.iter().any(|a| {
-                    if *a == format!("-{}", ch) { return true; }
-                    a.starts_with('-') && a.len() > 2 && a.chars().skip(1).all(|c| c.is_ascii_alphabetic()) && a.contains(ch)
-                })
-            };
-            let quiet = combined_has_set2('q');
+            let parsed_set = parse_set_option_args(args);
+            let window_command = matches!(cmd, "set-window-option" | "setw");
+            if let Err(error) = parsed_set.validate(window_command) {
+                let _ = resp_tx.send(format!("\u{0001}ERR\u{0001}{}", error));
+                return true;
+            }
+            let crate::cli::ParsedSetOptionArgs {
+                flag_chars,
+                positionals: positional,
+                ..
+            } = parsed_set;
+            let quiet = flag_chars.contains('q');
             // -U is an unset alias (tmux parity, #553) — same fix as the
             // one-shot handler above.
-            let unset = combined_has_set2('u') || combined_has_set2('U');
-            let append = combined_has_set2('a');
-            // -s (server scope, #618) resolves to the same single option store
-            // as -g here; see the one-shot handler above.
-            let global = combined_has_set2('g') || combined_has_set2('s');
-            let only_if_unset = combined_has_set2('o');
+            let unset = flag_chars.contains('u') || flag_chars.contains('U');
+            let append = flag_chars.contains('a');
+            // -s resolves to the same single option store as -g.
+            let global = flag_chars.contains('g') || flag_chars.contains('s');
+            let only_if_unset = flag_chars.contains('o');
             // `-p` is a bare pane-scope flag (#580), like `-w`: it never
             // consumes the next argument. Only -t carries a value here.
-            let pane_scope2 = combined_has_set2('p');
-            let t_vals2: std::collections::HashSet<&str> = args.windows(2)
-                .filter(|w| w[0] == "-t")
-                .map(|w| w[1]).collect();
-            let positional: Vec<&str> = args.iter()
-                .filter(|a| (!a.starts_with('-') || a.starts_with('@')) && !t_vals2.contains(*a))
-                .copied().collect();
-            if pane_scope2 {
+            let pane_scope = flag_chars.contains('p');
+            if pane_scope {
                 let raw = extract_flag_value(&args, "-t")
                     .map(|s| s.trim_matches('"').to_string())
                     .unwrap_or_default();
@@ -4254,7 +4307,7 @@ fn dispatch_control_command(
                 }
             } else if positional.len() >= 2 {
                 let key = positional[0].to_string();
-                let val = positional[1].trim_matches('"').to_string();
+                let val = positional[1..].join(" ").trim_matches('"').to_string();
                 if key == "window-size" && !global {
                     let _ = tx.send(CtrlReq::SetWindowSize(Some(val)));
                 } else if append {
@@ -4945,3 +4998,7 @@ mod tests_send_keys_literal_byte;
 #[cfg(test)]
 #[path = "../../tests-rs/test_refresh_client_flags.rs"]
 mod tests_refresh_client_flags;
+
+#[cfg(test)]
+#[path = "../../tests-rs/test_set_option_control.rs"]
+mod tests_set_option_control;

--- a/src/server/helpers.rs
+++ b/src/server/helpers.rs
@@ -207,6 +207,10 @@ pub(crate) fn append_extra_style_json(buf: &mut String, app: &AppState) {
         .get("window-active-style")
         .map(String::as_str)
         .unwrap_or("");
+    let pane_border_indicators = app.user_options
+        .get("pane-border-indicators")
+        .map(String::as_str)
+        .unwrap_or(crate::pane_border::INDICATORS_DEFAULT);
     for (key, raw) in [
         ("status_left_style", app.status_left_style.as_str()),
         ("status_right_style", app.status_right_style.as_str()),
@@ -215,6 +219,7 @@ pub(crate) fn append_extra_style_json(buf: &mut String, app: &AppState) {
         ("wsl_style", app.window_status_last_style.as_str()),
         ("window_style", window_style),
         ("window_active_style", window_active_style),
+        ("pane_border_indicators", pane_border_indicators),
     ] {
         buf.push_str(",\"");
         buf.push_str(key);

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -413,34 +413,36 @@ fn drain_plugin_req(
 ) {
     match req {
         CtrlReq::SetOption(option, value) => {
-            apply_set_option(app, &option, &value, false);
-            app.user_set_options.insert(option.clone());
-            if option == "command-alias" {
-                if let Ok(mut map) = shared_aliases.write() {
-                    *map = app.command_aliases.clone();
+            if apply_set_option(app, &option, &value, false).is_ok() {
+                app.user_set_options.insert(option.clone());
+                if option == "command-alias" {
+                    if let Ok(mut map) = shared_aliases.write() {
+                        *map = app.command_aliases.clone();
+                    }
                 }
-            }
-            // pane-border-status changes the effective content height (#288)
-            if option == "pane-border-status" {
-                resize_all_panes(app);
-            }
-            if option == "window-size" && crate::resize_window::refresh_dynamic_window_sizes(app) {
-                resize_all_panes(app);
+                // pane-border-status changes the effective content height (#288)
+                if option == "pane-border-status" {
+                    resize_all_panes(app);
+                }
+                if option == "window-size" && crate::resize_window::refresh_dynamic_window_sizes(app) {
+                    resize_all_panes(app);
+                }
             }
         }
         CtrlReq::SetOptionQuiet(option, value, quiet) => {
-            apply_set_option(app, &option, &value, quiet);
-            app.user_set_options.insert(option.clone());
-            if option == "command-alias" {
-                if let Ok(mut map) = shared_aliases.write() {
-                    *map = app.command_aliases.clone();
+            if apply_set_option(app, &option, &value, quiet).is_ok() {
+                app.user_set_options.insert(option.clone());
+                if option == "command-alias" {
+                    if let Ok(mut map) = shared_aliases.write() {
+                        *map = app.command_aliases.clone();
+                    }
                 }
-            }
-            if option == "pane-border-status" {
-                resize_all_panes(app);
-            }
-            if option == "window-size" && crate::resize_window::refresh_dynamic_window_sizes(app) {
-                resize_all_panes(app);
+                if option == "pane-border-status" {
+                    resize_all_panes(app);
+                }
+                if option == "window-size" && crate::resize_window::refresh_dynamic_window_sizes(app) {
+                    resize_all_panes(app);
+                }
             }
         }
         CtrlReq::SetOptionAppend(option, value) => {
@@ -495,15 +497,16 @@ fn drain_plugin_req(
                     let _ = r.send(format!("ERROR: already set: {}", option));
                 }
             } else {
-                apply_set_option(app, &option, &value, false);
-                app.user_set_options.insert(option.clone());
-                if option == "command-alias" {
-                    if let Ok(mut map) = shared_aliases.write() {
-                        *map = app.command_aliases.clone();
+                if apply_set_option(app, &option, &value, false).is_ok() {
+                    app.user_set_options.insert(option.clone());
+                    if option == "command-alias" {
+                        if let Ok(mut map) = shared_aliases.write() {
+                            *map = app.command_aliases.clone();
+                        }
                     }
-                }
-                if let Some(r) = resp {
-                    let _ = r.send(String::new());
+                    if let Some(r) = resp {
+                        let _ = r.send(String::new());
+                    }
                 }
             }
         }
@@ -4126,28 +4129,29 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                     let _ = resp.send(output);
                 }
                 CtrlReq::SetOption(option, value) => {
-                    apply_set_option(&mut app, &option, &value, false);
-                    app.user_set_options.insert(option.clone());
-                    // Reconcile the warm pane with the new option value.
-                    // All option-driven warm-pane lifecycle decisions
-                    // route through this single module — see #271.
-                    let sync = crate::warm_pane_sync::for_option_change(&option, &app);
-                    crate::warm_pane_sync::apply(&mut app, &*pty_system, sync);
-                    // Update shared aliases if command-alias changed
-                    if option == "command-alias" {
-                        if let Ok(mut map) = shared_aliases_main.write() {
-                            *map = app.command_aliases.clone();
+                    if apply_set_option(&mut app, &option, &value, false).is_ok() {
+                        app.user_set_options.insert(option.clone());
+                        // Reconcile the warm pane with the new option value.
+                        // All option-driven warm-pane lifecycle decisions
+                        // route through this single module, see #271.
+                        let sync = crate::warm_pane_sync::for_option_change(&option, &app);
+                        crate::warm_pane_sync::apply(&mut app, &*pty_system, sync);
+                        // Update shared aliases if command-alias changed
+                        if option == "command-alias" {
+                            if let Ok(mut map) = shared_aliases_main.write() {
+                                *map = app.command_aliases.clone();
+                            }
                         }
+                        // pane-border-status changes the effective content height (#288)
+                        if option == "pane-border-status" {
+                            resize_all_panes(&mut app);
+                        }
+                        if option == "window-size" && crate::resize_window::refresh_dynamic_window_sizes(&mut app) {
+                            resize_all_panes(&mut app);
+                        }
+                        meta_dirty = true;
+                        state_dirty = true;
                     }
-                    // pane-border-status changes the effective content height (#288)
-                    if option == "pane-border-status" {
-                        resize_all_panes(&mut app);
-                    }
-                    if option == "window-size" && crate::resize_window::refresh_dynamic_window_sizes(&mut app) {
-                        resize_all_panes(&mut app);
-                    }
-                    meta_dirty = true;
-                    state_dirty = true;
                 }
                 CtrlReq::SetWindowSize(value) => {
                     match crate::resize_window::set_active_window_size_mode(&mut app, value) {
@@ -4161,30 +4165,31 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                     }
                 }
                 CtrlReq::SetOptionQuiet(option, value, quiet) => {
-                    apply_set_option(&mut app, &option, &value, quiet);
-                    app.user_set_options.insert(option.clone());
-                    // Reconcile the warm pane with the new option value.
-                    // Replaces the prior inline default-shell-only kill
-                    // (#99) with a uniform table-driven policy that
-                    // also covers history-limit (#271), allow-predictions,
-                    // default-terminal, and claude-code-* options.
-                    let sync = crate::warm_pane_sync::for_option_change(&option, &app);
-                    crate::warm_pane_sync::apply(&mut app, &*pty_system, sync);
-                    // Update shared aliases if command-alias changed
-                    if option == "command-alias" {
-                        if let Ok(mut map) = shared_aliases_main.write() {
-                            *map = app.command_aliases.clone();
+                    if apply_set_option(&mut app, &option, &value, quiet).is_ok() {
+                        app.user_set_options.insert(option.clone());
+                        // Reconcile the warm pane with the new option value.
+                        // Replaces the prior inline default-shell-only kill
+                        // (#99) with a uniform table-driven policy that
+                        // also covers history-limit (#271), allow-predictions,
+                        // default-terminal, and claude-code-* options.
+                        let sync = crate::warm_pane_sync::for_option_change(&option, &app);
+                        crate::warm_pane_sync::apply(&mut app, &*pty_system, sync);
+                        // Update shared aliases if command-alias changed
+                        if option == "command-alias" {
+                            if let Ok(mut map) = shared_aliases_main.write() {
+                                *map = app.command_aliases.clone();
+                            }
                         }
+                        // pane-border-status changes the effective content height (#288)
+                        if option == "pane-border-status" {
+                            resize_all_panes(&mut app);
+                        }
+                        if option == "window-size" && crate::resize_window::refresh_dynamic_window_sizes(&mut app) {
+                            resize_all_panes(&mut app);
+                        }
+                        meta_dirty = true;
+                        state_dirty = true;
                     }
-                    // pane-border-status changes the effective content height (#288)
-                    if option == "pane-border-status" {
-                        resize_all_panes(&mut app);
-                    }
-                    if option == "window-size" && crate::resize_window::refresh_dynamic_window_sizes(&mut app) {
-                        resize_all_panes(&mut app);
-                    }
-                    meta_dirty = true;
-                    state_dirty = true;
                 }
                 CtrlReq::SetOptionUnset(option) => {
                     // Restore the table default, or remove an @user-option.
@@ -4270,17 +4275,18 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                             let _ = r.send(format!("ERROR: already set: {}", option));
                         }
                     } else {
-                        apply_set_option(&mut app, &option, &value, false);
-                        app.user_set_options.insert(option.clone());
-                        if option == "command-alias" {
-                            if let Ok(mut map) = shared_aliases_main.write() {
-                                *map = app.command_aliases.clone();
+                        if apply_set_option(&mut app, &option, &value, false).is_ok() {
+                            app.user_set_options.insert(option.clone());
+                            if option == "command-alias" {
+                                if let Ok(mut map) = shared_aliases_main.write() {
+                                    *map = app.command_aliases.clone();
+                                }
                             }
-                        }
-                        meta_dirty = true;
-                        state_dirty = true;
-                        if let Some(r) = resp {
-                            let _ = r.send(String::new());
+                            meta_dirty = true;
+                            state_dirty = true;
+                            if let Some(r) = resp {
+                                let _ = r.send(String::new());
+                            }
                         }
                     }
                 }
@@ -6129,15 +6135,40 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                     }
                 }
                 CtrlReq::CustomizeEditConfirm => {
-                    if let Mode::CustomizeMode { ref mut options, selected, ref mut editing, ref edit_buffer, .. } = app.mode {
-                        if *editing {
-                            let name = options[selected].0.clone();
-                            let value = edit_buffer.clone();
-                            options[selected].1 = value.clone();
-                            *editing = false;
-                            options::apply_set_option(&mut app, &name, &value, true);
-                            state_dirty = true;
+                    let pending = match &app.mode {
+                        Mode::CustomizeMode {
+                            options,
+                            selected,
+                            editing: true,
+                            edit_buffer,
+                            ..
+                        } => Some((options[*selected].0.clone(), edit_buffer.clone())),
+                        _ => None,
+                    };
+                    if let Some((name, value)) = pending {
+                        match options::apply_set_option(&mut app, &name, &value, true) {
+                            Ok(()) => {
+                                app.user_set_options.insert(name.clone());
+                                if let Mode::CustomizeMode {
+                                    ref mut options,
+                                    selected,
+                                    ref mut editing,
+                                    ..
+                                } = app.mode
+                                {
+                                    options[selected].1 = value;
+                                    *editing = false;
+                                }
+                            }
+                            Err(error) => {
+                                app.status_message = Some((
+                                    format!("set-option: {}", error),
+                                    Instant::now(),
+                                    None,
+                                ));
+                            }
                         }
+                        state_dirty = true;
                     }
                 }
                 CtrlReq::CustomizeEditCancel => {
@@ -6150,16 +6181,40 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                     }
                 }
                 CtrlReq::CustomizeResetDefault => {
-                    if let Mode::CustomizeMode { ref mut options, selected, editing, .. } = app.mode {
-                        if !editing {
-                            if let Some(def) = option_catalog::default_for(&options[selected].0) {
-                                let name = options[selected].0.clone();
-                                let value = def.to_string();
-                                options[selected].1 = value.clone();
-                                options::apply_set_option(&mut app, &name, &value, true);
-                                state_dirty = true;
+                    let pending = match &app.mode {
+                        Mode::CustomizeMode {
+                            options,
+                            selected,
+                            editing: false,
+                            ..
+                        } => option_catalog::default_for(&options[*selected].0)
+                            .map(|value| {
+                                (options[*selected].0.clone(), value.to_string())
+                            }),
+                        _ => None,
+                    };
+                    if let Some((name, value)) = pending {
+                        match options::apply_set_option(&mut app, &name, &value, true) {
+                            Ok(()) => {
+                                app.user_set_options.remove(&name);
+                                if let Mode::CustomizeMode {
+                                    ref mut options,
+                                    selected,
+                                    ..
+                                } = app.mode
+                                {
+                                    options[selected].1 = value;
+                                }
+                            }
+                            Err(error) => {
+                                app.status_message = Some((
+                                    format!("set-option: {}", error),
+                                    Instant::now(),
+                                    None,
+                                ));
                             }
                         }
+                        state_dirty = true;
                     }
                 }
                 CtrlReq::CustomizeFilter(text) => {

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -6188,31 +6188,19 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                             editing: false,
                             ..
                         } => option_catalog::default_for(&options[*selected].0)
-                            .map(|value| {
-                                (options[*selected].0.clone(), value.to_string())
-                            }),
+                            .map(|_| options[*selected].0.clone()),
                         _ => None,
                     };
-                    if let Some((name, value)) = pending {
-                        match options::apply_set_option(&mut app, &name, &value, true) {
-                            Ok(()) => {
-                                app.user_set_options.remove(&name);
-                                if let Mode::CustomizeMode {
-                                    ref mut options,
-                                    selected,
-                                    ..
-                                } = app.mode
-                                {
-                                    options[selected].1 = value;
-                                }
-                            }
-                            Err(error) => {
-                                app.status_message = Some((
-                                    format!("set-option: {}", error),
-                                    Instant::now(),
-                                    None,
-                                ));
-                            }
+                    if let Some(name) = pending {
+                        options::reset_option_to_default(&mut app, &name);
+                        let value = options::get_option_value(&app, &name);
+                        if let Mode::CustomizeMode {
+                            ref mut options,
+                            selected,
+                            ..
+                        } = app.mode
+                        {
+                            options[selected].1 = value;
                         }
                         state_dirty = true;
                     }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -2566,9 +2566,60 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                         .unwrap_or_else(|_| "{}".to_string());
                     let _ = resp.send(json);
                 }
-                CtrlReq::WindowDump(wid, resp) => {
-                    let json = crate::layout::dump_window_layout_json(&mut app, wid)
-                        .unwrap_or_else(|_| "{}".to_string());
+                CtrlReq::WindowDump(wid, format, resp) => {
+                    let result = if format == crate::types::WindowDumpFormat::Layout {
+                        crate::layout::dump_window_layout_json(&mut app, wid)
+                    } else {
+                        crate::layout::dump_window_layout(&mut app, wid)
+                            .and_then(|layout| {
+                                let border_lines =
+                                    options::get_option_value(&app, "pane-border-lines");
+                                let border_indicators =
+                                    crate::pane_border::PaneBorderIndicators::parse(
+                                        &options::get_option_value(
+                                            &app,
+                                            "pane-border-indicators",
+                                        ),
+                                    )
+                                    .map_err(std::io::Error::other)?;
+                                let window_index = app.windows
+                                    .iter()
+                                    .position(|window| window.id == wid)
+                                    .ok_or_else(|| std::io::Error::other("window not found"))?;
+                                let _async_fmt = crate::format::AsyncFormatGuard::new();
+                                let pane_border_style = if app.pane_border_style.is_empty() {
+                                    String::new()
+                                } else {
+                                    crate::format::expand_format_for_window(
+                                        &app.pane_border_style,
+                                        &app,
+                                        window_index,
+                                    )
+                                };
+                                let pane_active_border_style =
+                                    if app.pane_active_border_style.is_empty() {
+                                        String::new()
+                                    } else {
+                                        crate::format::expand_format_for_window(
+                                            &app.pane_active_border_style,
+                                            &app,
+                                            window_index,
+                                        )
+                                    };
+                                let floating_pane_focused =
+                                    app.windows[window_index].floating_focus.is_some();
+                                serde_json::to_string(&crate::types::PreviewWindowState {
+                                    layout,
+                                    border_lines,
+                                    border_indicators,
+                                    pane_border_style: Some(pane_border_style),
+                                    pane_active_border_style: Some(pane_active_border_style),
+                                    floating_pane_focused,
+                                })
+                                .map_err(std::io::Error::other)
+                            })
+                    };
+                    let json = result.unwrap_or_else(|_| "{}".to_string());
                     let _ = resp.send(json);
                 }
                 CtrlReq::ToggleSync => { app.sync_input = !app.sync_input; }

--- a/src/server/option_catalog.rs
+++ b/src/server/option_catalog.rs
@@ -50,6 +50,7 @@ impl NumberKind {
 pub enum ChoiceKind {
     Priority,
     Unvalidated,
+    PaneBorderIndicators,
 }
 
 impl ChoiceKind {
@@ -60,6 +61,9 @@ impl ChoiceKind {
                 crate::platform::PRIORITY_VALUES.join(", "),
                 value,
             )),
+            Self::PaneBorderIndicators => {
+                crate::pane_border::PaneBorderIndicators::parse(value).map(|_| ())
+            }
             Self::Priority | Self::Unvalidated => Ok(()),
         }
     }
@@ -67,12 +71,14 @@ impl ChoiceKind {
     const fn allows_append(self) -> bool {
         match self {
             Self::Priority | Self::Unvalidated => true,
+            Self::PaneBorderIndicators => false,
         }
     }
 
     const fn allows_local_window_override(self) -> bool {
         match self {
             Self::Priority | Self::Unvalidated => true,
+            Self::PaneBorderIndicators => false,
         }
     }
 }
@@ -261,6 +267,7 @@ pub static OPTION_CATALOG: &[OptionDef] = &[
     OptionDef { name: "window-status-activity-style", scope: Window, option_type: OptionType::String, default: "reverse", description: "Window style on activity alert" },
     OptionDef { name: "window-status-bell-style", scope: Window, option_type: OptionType::String, default: "reverse", description: "Window style on bell alert" },
     OptionDef { name: "window-status-last-style", scope: Window, option_type: OptionType::String, default: "default", description: "Previously active window style" },
+    OptionDef { name: "pane-border-indicators", scope: Window, option_type: Choice(ChoiceKind::PaneBorderIndicators), default: crate::pane_border::INDICATORS_DEFAULT, description: "Active pane indicator mode (off/colour/arrows/both)" },
     // ── Pane options ──
     OptionDef { name: "pane-border-style", scope: Pane, option_type: OptionType::String, default: "default", description: "Inactive pane border style" },
     OptionDef { name: "pane-active-border-style", scope: Pane, option_type: OptionType::String, default: "fg=green", description: "Active pane border style" },
@@ -288,6 +295,7 @@ pub static WINDOW_OPTION_NAMES: &[&str] = &[
     "window-status-activity-style",
     "window-status-bell-style",
     "window-status-last-style",
+    "pane-border-indicators",
     "main-pane-width",
     "main-pane-height",
     "window-size",

--- a/src/server/option_catalog.rs
+++ b/src/server/option_catalog.rs
@@ -1,122 +1,338 @@
 /// Static catalog of all supported tmux options for customize-mode.
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum OptionScope {
+    Server,
+    Session,
+    Window,
+    Pane,
+}
+
+impl OptionScope {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Server => "server",
+            Self::Session => "session",
+            Self::Window => "window",
+            Self::Pane => "pane",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum NumberKind {
+    I64,
+    U16,
+    U64,
+    Usize,
+    Index,
+    RepeatTime,
+}
+
+impl NumberKind {
+    fn accepts(self, value: &str) -> bool {
+        match self {
+            Self::I64 => value.parse::<i64>().is_ok(),
+            Self::U16 => value.parse::<u16>().is_ok(),
+            Self::U64 => value.parse::<u64>().is_ok(),
+            Self::Usize => value.parse::<usize>().is_ok(),
+            Self::Index => value
+                .parse::<usize>()
+                .is_ok_and(|index| index <= isize::MAX as usize),
+            Self::RepeatTime => value
+                .parse::<i64>()
+                .is_ok_and(|ms| (0..=crate::server::options::REPEAT_TIME_MAX_MS).contains(&ms)),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ChoiceKind {
+    Priority,
+    Unvalidated,
+}
+
+impl ChoiceKind {
+    fn validate_value(self, value: &str) -> Result<(), String> {
+        match self {
+            Self::Priority if crate::platform::normalize_priority(value).is_none() => Err(format!(
+                "value for 'priority' must be one of {}, got '{}'",
+                crate::platform::PRIORITY_VALUES.join(", "),
+                value,
+            )),
+            Self::Priority | Self::Unvalidated => Ok(()),
+        }
+    }
+
+    const fn allows_append(self) -> bool {
+        match self {
+            Self::Priority | Self::Unvalidated => true,
+        }
+    }
+
+    const fn allows_local_window_override(self) -> bool {
+        match self {
+            Self::Priority | Self::Unvalidated => true,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum OptionType {
+    String,
+    Boolean,
+    Choice(ChoiceKind),
+    Number(NumberKind),
+}
+
+impl OptionType {
+    fn validate_value(self, name: &str, value: &str) -> Result<(), String> {
+        match self {
+            Self::Choice(kind) => kind.validate_value(value),
+            Self::Number(NumberKind::RepeatTime) => match value.parse::<i64>() {
+                Ok(ms) if ms < 0 => Err(format!("value is too small: {}", value)),
+                Ok(ms) if ms > crate::server::options::REPEAT_TIME_MAX_MS => {
+                    Err(format!("value is too large: {}", value))
+                }
+                Ok(_) => Ok(()),
+                Err(_) => Err(format!(
+                    "invalid value '{}' for option '{}' (expected a number)",
+                    value, name,
+                )),
+            },
+            Self::Number(kind) if !kind.accepts(value) => Err(format!(
+                "invalid value '{}' for option '{}' (expected a number)",
+                value, name,
+            )),
+            Self::String | Self::Boolean | Self::Number(_) => Ok(()),
+        }
+    }
+
+    const fn allows_append(self) -> bool {
+        match self {
+            Self::Choice(kind) => kind.allows_append(),
+            Self::String | Self::Boolean | Self::Number(_) => true,
+        }
+    }
+
+    const fn allows_local_window_override(self) -> bool {
+        match self {
+            Self::Choice(kind) => kind.allows_local_window_override(),
+            Self::String | Self::Boolean | Self::Number(_) => true,
+        }
+    }
+}
+
 pub struct OptionDef {
     pub name: &'static str,
-    pub scope: &'static str,
-    pub option_type: &'static str,
+    pub scope: OptionScope,
+    pub option_type: OptionType,
     pub default: &'static str,
     pub description: &'static str,
 }
 
+impl OptionDef {
+    pub fn validate_value(&self, value: &str) -> Result<(), String> {
+        self.option_type.validate_value(self.name, value)
+    }
+
+    pub fn validate_append(&self) -> Result<(), String> {
+        if self.option_type.allows_append() {
+            Ok(())
+        } else {
+            Err(format!("{} does not support append", self.name))
+        }
+    }
+
+    pub fn validate_local_window_override(&self) -> Result<(), String> {
+        if self.option_type.allows_local_window_override() {
+            Ok(())
+        } else {
+            Err(format!(
+                "{} does not support local window overrides",
+                self.name,
+            ))
+        }
+    }
+
+}
+
+pub struct ValidationOnlyOptionDef {
+    pub name: &'static str,
+    pub option_type: OptionType,
+}
+
+impl ValidationOnlyOptionDef {
+    fn validate_value(&self, value: &str) -> Result<(), String> {
+        self.option_type.validate_value(self.name, value)
+    }
+}
+
+use ChoiceKind::{Priority, Unvalidated};
+use NumberKind::{I64, Index, RepeatTime, U16, U64, Usize};
+use OptionScope::{Pane, Server, Session, Window};
+use OptionType::{Boolean, Choice, Number};
+
+const UNVALIDATED_CHOICE: OptionType = Choice(Unvalidated);
+
 pub static OPTION_CATALOG: &[OptionDef] = &[
     // ── Server options ──
-    OptionDef { name: "escape-time", scope: "server", option_type: "number", default: "500", description: "Time in ms to wait for escape sequence" },
-    OptionDef { name: "focus-events", scope: "server", option_type: "boolean", default: "off", description: "Send focus events to applications" },
-    OptionDef { name: "bold-is-bright", scope: "server", option_type: "boolean", default: "on", description: "Rewrite crossterm's 256-indexed basic colors to standard SGR so the terminal applies bold-is-bright (issue #425); off keeps explicit 256-indexed low colors byte-accurate" },
-    OptionDef { name: "history-limit", scope: "server", option_type: "number", default: "2000", description: "Maximum scrollback lines per pane" },
-    OptionDef { name: "alternate-screen", scope: "server", option_type: "boolean", default: "on", description: "Honour DEC 47/1049 alt-screen mode (off = TUI output goes to scrollback, #88)" },
-    OptionDef { name: "set-clipboard", scope: "server", option_type: "choice", default: "on", description: "OSC 52 clipboard integration" },
-    OptionDef { name: "default-shell", scope: "server", option_type: "string", default: "", description: "Default shell for new panes" },
-    OptionDef { name: "default-terminal", scope: "server", option_type: "string", default: "xterm-256color", description: "TERM value for new panes" },
-    OptionDef { name: "copy-command", scope: "server", option_type: "string", default: "", description: "External copy command (pipe selection)" },
-    OptionDef { name: "exit-empty", scope: "server", option_type: "boolean", default: "on", description: "Exit server when no sessions remain" },
-    OptionDef { name: "priority", scope: "server", option_type: "choice", default: "above-normal", description: "Scheduling class for psmux's own server and client processes (normal/above-normal/high). Pane children are never raised" },
+    OptionDef { name: "escape-time", scope: Server, option_type: Number(U64), default: "500", description: "Time in ms to wait for escape sequence" },
+    OptionDef { name: "focus-events", scope: Server, option_type: Boolean, default: "off", description: "Send focus events to applications" },
+    OptionDef { name: "bold-is-bright", scope: Server, option_type: Boolean, default: "on", description: "Rewrite crossterm's 256-indexed basic colors to standard SGR so the terminal applies bold-is-bright (issue #425); off keeps explicit 256-indexed low colors byte-accurate" },
+    OptionDef { name: "history-limit", scope: Server, option_type: Number(Usize), default: "2000", description: "Maximum scrollback lines per pane" },
+    OptionDef { name: "alternate-screen", scope: Server, option_type: Boolean, default: "on", description: "Honour DEC 47/1049 alt-screen mode (off = TUI output goes to scrollback, #88)" },
+    OptionDef { name: "set-clipboard", scope: Server, option_type: UNVALIDATED_CHOICE, default: "on", description: "OSC 52 clipboard integration" },
+    OptionDef { name: "default-shell", scope: Server, option_type: OptionType::String, default: "", description: "Default shell for new panes" },
+    OptionDef { name: "default-terminal", scope: Server, option_type: OptionType::String, default: "xterm-256color", description: "TERM value for new panes" },
+    OptionDef { name: "copy-command", scope: Server, option_type: OptionType::String, default: "", description: "External copy command (pipe selection)" },
+    OptionDef { name: "exit-empty", scope: Server, option_type: Boolean, default: "on", description: "Exit server when no sessions remain" },
+    OptionDef { name: "priority", scope: Server, option_type: Choice(Priority), default: "above-normal", description: "Scheduling class for psmux's own server and client processes (normal/above-normal/high). Pane children are never raised" },
     // ── Session options ──
-    OptionDef { name: "prefix", scope: "session", option_type: "string", default: "C-b", description: "Primary prefix key" },
-    OptionDef { name: "prefix2", scope: "session", option_type: "string", default: "none", description: "Secondary prefix key" },
-    OptionDef { name: "base-index", scope: "session", option_type: "number", default: "0", description: "Starting index for windows" },
-    OptionDef { name: "pane-base-index", scope: "session", option_type: "number", default: "0", description: "Starting index for panes" },
-    OptionDef { name: "display-time", scope: "session", option_type: "number", default: "750", description: "Duration of messages in ms" },
-    OptionDef { name: "display-panes-time", scope: "session", option_type: "number", default: "1000", description: "Duration of pane numbers display in ms" },
-    OptionDef { name: "repeat-time", scope: "session", option_type: "number", default: "500", description: "Repeat timeout for prefix keys in ms" },
-    OptionDef { name: "mouse", scope: "session", option_type: "boolean", default: "on", description: "Enable mouse support" },
-    OptionDef { name: "scroll-enter-copy-mode", scope: "session", option_type: "boolean", default: "on", description: "Enter copy mode on mouse scroll up at shell prompt" },
-    OptionDef { name: "pwsh-mouse-selection", scope: "session", option_type: "boolean", default: "off", description: "Windows 11 PowerShell-style drag selection (pane-aware, right-click to copy, word/line multi-click)" },
-    OptionDef { name: "mouse-selection", scope: "session", option_type: "boolean", default: "on", description: "Enable psmux's client-side drag-selection overlay. Set to off so apps inside a pane (opencode, etc.) can implement their own mouse selection without psmux drawing on top." },
-    OptionDef { name: "mouse-selection-force", scope: "session", option_type: "boolean", default: "off", description: "Keep psmux drag selection active in mouse-aware apps; replay plain clicks while consuming drags" },
-    OptionDef { name: "paste-detection", scope: "session", option_type: "boolean", default: "on", description: "Detect Ctrl+V paste from console host and send as bracketed paste (disable to let Ctrl+V reach child apps)" },
-    OptionDef { name: "mode-keys", scope: "session", option_type: "choice", default: "emacs", description: "Key bindings in copy mode (vi/emacs)" },
-    OptionDef { name: "copy-mode-line-numbers", scope: "window", option_type: "choice", default: "off", description: "Line number mode in copy mode (off/default/absolute/relative/hybrid)" },
-    OptionDef { name: "copy-mode-line-number-style", scope: "window", option_type: "string", default: "fg=brightblack", description: "Style for copy-mode line numbers" },
-    OptionDef { name: "copy-mode-current-line-number-style", scope: "window", option_type: "string", default: "fg=yellow,bold", description: "Style for the current copy-mode line number" },
-    OptionDef { name: "status", scope: "session", option_type: "boolean", default: "on", description: "Show/hide the status bar" },
-    OptionDef { name: "status-position", scope: "session", option_type: "choice", default: "bottom", description: "Status bar position (top/bottom)" },
-    OptionDef { name: "status-interval", scope: "session", option_type: "number", default: "15", description: "Status bar refresh interval in seconds" },
-    OptionDef { name: "status-justify", scope: "session", option_type: "choice", default: "left", description: "Window list alignment (left/centre/right)" },
-    OptionDef { name: "status-left", scope: "session", option_type: "string", default: "[#S] ", description: "Left side of the status bar" },
-    OptionDef { name: "status-right", scope: "session", option_type: "string", default: "#{?window_bigger,[#{window_offset_x}#,#{window_offset_y}] ,}\"#{=21:pane_title}\" %H:%M %d-%b-%y", description: "Right side of the status bar" },
-    OptionDef { name: "status-left-length", scope: "session", option_type: "number", default: "10", description: "Max width of left status section" },
-    OptionDef { name: "status-right-length", scope: "session", option_type: "number", default: "40", description: "Max width of right status section" },
-    OptionDef { name: "status-style", scope: "session", option_type: "string", default: "bg=green,fg=black", description: "Status bar style" },
-    OptionDef { name: "status-left-style", scope: "session", option_type: "string", default: "default", description: "Left status section style" },
-    OptionDef { name: "status-right-style", scope: "session", option_type: "string", default: "default", description: "Right status section style" },
-    OptionDef { name: "message-style", scope: "session", option_type: "string", default: "bg=yellow,fg=black", description: "Command prompt / message style" },
-    OptionDef { name: "message-command-style", scope: "session", option_type: "string", default: "bg=black,fg=yellow", description: "Command prompt editing style" },
-    OptionDef { name: "mode-style", scope: "session", option_type: "string", default: "bg=yellow,fg=black", description: "Copy mode selection style" },
-    OptionDef { name: "bell-action", scope: "session", option_type: "choice", default: "any", description: "Bell handling (any/none/current/other)" },
-    OptionDef { name: "visual-bell", scope: "session", option_type: "boolean", default: "off", description: "Show visual indicator on bell" },
-    OptionDef { name: "activity-action", scope: "session", option_type: "choice", default: "other", description: "Activity alert action" },
-    OptionDef { name: "silence-action", scope: "session", option_type: "choice", default: "other", description: "Silence alert action" },
-    OptionDef { name: "monitor-silence", scope: "window", option_type: "number", default: "0", description: "Seconds of silence before alert (0=off)" },
-    OptionDef { name: "destroy-unattached", scope: "session", option_type: "boolean", default: "off", description: "Destroy session when last client detaches" },
-    OptionDef { name: "renumber-windows", scope: "session", option_type: "boolean", default: "off", description: "Renumber windows on close" },
-    OptionDef { name: "set-titles", scope: "session", option_type: "boolean", default: "off", description: "Set terminal title" },
-    OptionDef { name: "set-titles-string", scope: "session", option_type: "string", default: "#S:#I:#W", description: "Terminal title format string" },
-    OptionDef { name: "word-separators", scope: "session", option_type: "string", default: " -_@", description: "Characters treated as word boundaries" },
-    OptionDef { name: "allow-passthrough", scope: "session", option_type: "choice", default: "off", description: "Allow passthrough escape sequences" },
-    OptionDef { name: "allow-rename", scope: "session", option_type: "boolean", default: "on", description: "Allow programs to rename windows" },
-    OptionDef { name: "allow-set-title", scope: "session", option_type: "boolean", default: "off", description: "Allow programs to set pane title via escape sequences" },
-    OptionDef { name: "update-environment", scope: "session", option_type: "string", default: "DISPLAY KRB5CCNAME SSH_ASKPASS SSH_AUTH_SOCK SSH_AGENT_PID SSH_CONNECTION WINDOWID XAUTHORITY", description: "Environment variables to update on attach" },
-    OptionDef { name: "synchronize-panes", scope: "session", option_type: "boolean", default: "off", description: "Send input to all panes simultaneously" },
-    // Catalogued for #619: `set-option -u` restores an option to its catalog
-    // default, so an option missing from here could not be restored at all.
-    // Both already had a hand written arm in the server's old restore table;
-    // this is the same value, in the one place that now owns it.
-    OptionDef { name: "choose-tree-preview", scope: "session", option_type: "boolean", default: "off", description: "Show a live pane preview in choose-tree" },
+    OptionDef { name: "prefix", scope: Session, option_type: OptionType::String, default: "C-b", description: "Primary prefix key" },
+    OptionDef { name: "prefix2", scope: Session, option_type: OptionType::String, default: "none", description: "Secondary prefix key" },
+    OptionDef { name: "base-index", scope: Session, option_type: Number(Index), default: "0", description: "Starting index for windows" },
+    OptionDef { name: "pane-base-index", scope: Session, option_type: Number(Index), default: "0", description: "Starting index for panes" },
+    OptionDef { name: "display-time", scope: Session, option_type: Number(U64), default: "750", description: "Duration of messages in ms" },
+    OptionDef { name: "display-panes-time", scope: Session, option_type: Number(U64), default: "1000", description: "Duration of pane numbers display in ms" },
+    OptionDef { name: "repeat-time", scope: Session, option_type: Number(RepeatTime), default: "500", description: "Repeat timeout for prefix keys in ms" },
+    OptionDef { name: "mouse", scope: Session, option_type: Boolean, default: "on", description: "Enable mouse support" },
+    OptionDef { name: "scroll-enter-copy-mode", scope: Session, option_type: Boolean, default: "on", description: "Enter copy mode on mouse scroll up at shell prompt" },
+    OptionDef { name: "pwsh-mouse-selection", scope: Session, option_type: Boolean, default: "off", description: "Windows 11 PowerShell-style drag selection (pane-aware, right-click to copy, word/line multi-click)" },
+    OptionDef { name: "mouse-selection", scope: Session, option_type: Boolean, default: "on", description: "Enable psmux's client-side drag-selection overlay. Set to off so apps inside a pane (opencode, etc.) can implement their own mouse selection without psmux drawing on top." },
+    OptionDef { name: "mouse-selection-force", scope: Session, option_type: Boolean, default: "off", description: "Keep psmux drag selection active in mouse-aware apps; replay plain clicks while consuming drags" },
+    OptionDef { name: "paste-detection", scope: Session, option_type: Boolean, default: "on", description: "Detect Ctrl+V paste from console host and send as bracketed paste (disable to let Ctrl+V reach child apps)" },
+    OptionDef { name: "mode-keys", scope: Session, option_type: UNVALIDATED_CHOICE, default: "emacs", description: "Key bindings in copy mode (vi/emacs)" },
+    OptionDef { name: "copy-mode-line-numbers", scope: Window, option_type: UNVALIDATED_CHOICE, default: "off", description: "Line number mode in copy mode (off/default/absolute/relative/hybrid)" },
+    OptionDef { name: "copy-mode-line-number-style", scope: Window, option_type: OptionType::String, default: "fg=brightblack", description: "Style for copy-mode line numbers" },
+    OptionDef { name: "copy-mode-current-line-number-style", scope: Window, option_type: OptionType::String, default: "fg=yellow,bold", description: "Style for the current copy-mode line number" },
+    OptionDef { name: "status", scope: Session, option_type: Boolean, default: "on", description: "Show/hide the status bar" },
+    OptionDef { name: "status-position", scope: Session, option_type: UNVALIDATED_CHOICE, default: "bottom", description: "Status bar position (top/bottom)" },
+    OptionDef { name: "status-interval", scope: Session, option_type: Number(U64), default: "15", description: "Status bar refresh interval in seconds" },
+    OptionDef { name: "status-justify", scope: Session, option_type: UNVALIDATED_CHOICE, default: "left", description: "Window list alignment (left/centre/right)" },
+    OptionDef { name: "status-left", scope: Session, option_type: OptionType::String, default: "[#S] ", description: "Left side of the status bar" },
+    OptionDef { name: "status-right", scope: Session, option_type: OptionType::String, default: "#{?window_bigger,[#{window_offset_x}#,#{window_offset_y}] ,}\"#{=21:pane_title}\" %H:%M %d-%b-%y", description: "Right side of the status bar" },
+    OptionDef { name: "status-left-length", scope: Session, option_type: Number(Usize), default: "10", description: "Max width of left status section" },
+    OptionDef { name: "status-right-length", scope: Session, option_type: Number(Usize), default: "40", description: "Max width of right status section" },
+    OptionDef { name: "status-style", scope: Session, option_type: OptionType::String, default: "bg=green,fg=black", description: "Status bar style" },
+    OptionDef { name: "status-left-style", scope: Session, option_type: OptionType::String, default: "default", description: "Left status section style" },
+    OptionDef { name: "status-right-style", scope: Session, option_type: OptionType::String, default: "default", description: "Right status section style" },
+    OptionDef { name: "message-style", scope: Session, option_type: OptionType::String, default: "bg=yellow,fg=black", description: "Command prompt / message style" },
+    OptionDef { name: "message-command-style", scope: Session, option_type: OptionType::String, default: "bg=black,fg=yellow", description: "Command prompt editing style" },
+    OptionDef { name: "mode-style", scope: Session, option_type: OptionType::String, default: "bg=yellow,fg=black", description: "Copy mode selection style" },
+    OptionDef { name: "bell-action", scope: Session, option_type: UNVALIDATED_CHOICE, default: "any", description: "Bell handling (any/none/current/other)" },
+    OptionDef { name: "visual-bell", scope: Session, option_type: Boolean, default: "off", description: "Show visual indicator on bell" },
+    OptionDef { name: "activity-action", scope: Session, option_type: UNVALIDATED_CHOICE, default: "other", description: "Activity alert action" },
+    OptionDef { name: "silence-action", scope: Session, option_type: UNVALIDATED_CHOICE, default: "other", description: "Silence alert action" },
+    OptionDef { name: "monitor-silence", scope: Window, option_type: Number(U64), default: "0", description: "Seconds of silence before alert (0=off)" },
+    OptionDef { name: "destroy-unattached", scope: Session, option_type: Boolean, default: "off", description: "Destroy session when last client detaches" },
+    OptionDef { name: "renumber-windows", scope: Session, option_type: Boolean, default: "off", description: "Renumber windows on close" },
+    OptionDef { name: "set-titles", scope: Session, option_type: Boolean, default: "off", description: "Set terminal title" },
+    OptionDef { name: "set-titles-string", scope: Session, option_type: OptionType::String, default: "#S:#I:#W", description: "Terminal title format string" },
+    OptionDef { name: "word-separators", scope: Session, option_type: OptionType::String, default: " -_@", description: "Characters treated as word boundaries" },
+    OptionDef { name: "allow-passthrough", scope: Session, option_type: UNVALIDATED_CHOICE, default: "off", description: "Allow passthrough escape sequences" },
+    OptionDef { name: "allow-rename", scope: Session, option_type: Boolean, default: "on", description: "Allow programs to rename windows" },
+    OptionDef { name: "allow-set-title", scope: Session, option_type: Boolean, default: "off", description: "Allow programs to set pane title via escape sequences" },
+    OptionDef { name: "update-environment", scope: Session, option_type: OptionType::String, default: "DISPLAY KRB5CCNAME SSH_ASKPASS SSH_AUTH_SOCK SSH_AGENT_PID SSH_CONNECTION WINDOWID XAUTHORITY", description: "Environment variables to update on attach" },
+    OptionDef { name: "synchronize-panes", scope: Session, option_type: Boolean, default: "off", description: "Send input to all panes simultaneously" },
+    // `set-option -u` restores catalog defaults, so every resettable option lives here.
+    OptionDef { name: "choose-tree-preview", scope: Session, option_type: Boolean, default: "off", description: "Show a live pane preview in choose-tree" },
     // ── psmux extensions (session scope) ──
-    OptionDef { name: "prediction-dimming", scope: "session", option_type: "boolean", default: "off", description: "Dim PSReadLine prediction text" },
-    OptionDef { name: "allow-predictions", scope: "session", option_type: "boolean", default: "off", description: "Allow PSReadLine predictions" },
-    OptionDef { name: "warm", scope: "session", option_type: "boolean", default: "on", description: "Pre-spawn warm shell for fast window creation" },
-    OptionDef { name: "cursor-style", scope: "session", option_type: "choice", default: "bar", description: "Cursor style (bar/block/underline)" },
-    OptionDef { name: "cursor-blink", scope: "session", option_type: "boolean", default: "on", description: "Blink the cursor" },
-    OptionDef { name: "claude-code-fix-tty", scope: "session", option_type: "boolean", default: "on", description: "Fix TTY for Claude Code sessions" },
-    OptionDef { name: "claude-code-force-interactive", scope: "session", option_type: "boolean", default: "on", description: "Force interactive mode for Claude Code" },
+    OptionDef { name: "prediction-dimming", scope: Session, option_type: Boolean, default: "off", description: "Dim PSReadLine prediction text" },
+    OptionDef { name: "allow-predictions", scope: Session, option_type: Boolean, default: "off", description: "Allow PSReadLine predictions" },
+    OptionDef { name: "warm", scope: Session, option_type: Boolean, default: "on", description: "Pre-spawn warm shell for fast window creation" },
+    OptionDef { name: "cursor-style", scope: Session, option_type: UNVALIDATED_CHOICE, default: "bar", description: "Cursor style (bar/block/underline)" },
+    OptionDef { name: "cursor-blink", scope: Session, option_type: Boolean, default: "on", description: "Blink the cursor" },
+    OptionDef { name: "claude-code-fix-tty", scope: Session, option_type: Boolean, default: "on", description: "Fix TTY for Claude Code" },
+    OptionDef { name: "claude-code-force-interactive", scope: Session, option_type: Boolean, default: "on", description: "Force interactive mode for Claude Code" },
     // ── Window options ──
-    OptionDef { name: "automatic-rename", scope: "window", option_type: "boolean", default: "on", description: "Auto-rename windows based on running command" },
-    OptionDef { name: "monitor-activity", scope: "window", option_type: "boolean", default: "off", description: "Monitor for activity in window" },
-    OptionDef { name: "remain-on-exit", scope: "window", option_type: "boolean", default: "off", description: "Keep pane open after command exits" },
-    OptionDef { name: "aggressive-resize", scope: "window", option_type: "boolean", default: "off", description: "Resize window to smallest attached client" },
-    OptionDef { name: "main-pane-width", scope: "window", option_type: "number", default: "0", description: "Width of main pane in main-* layouts (0 sizes it automatically)" },
-    OptionDef { name: "main-pane-height", scope: "window", option_type: "number", default: "0", description: "Height of main pane in main-* layouts (0 sizes it automatically)" },
-    OptionDef { name: "window-size", scope: "window", option_type: "choice", default: "latest", description: "Window sizing strategy" },
-    OptionDef { name: "window-status-format", scope: "window", option_type: "string", default: "#I:#W#{?window_flags,#{window_flags}, }", description: "Window status bar format" },
-    OptionDef { name: "window-status-current-format", scope: "window", option_type: "string", default: "#I:#W#{?window_flags,#{window_flags}, }", description: "Active window status bar format" },
-    OptionDef { name: "window-status-separator", scope: "window", option_type: "string", default: " ", description: "Separator between window entries" },
-    OptionDef { name: "window-status-style", scope: "window", option_type: "string", default: "default", description: "Inactive window style" },
-    OptionDef { name: "window-status-current-style", scope: "window", option_type: "string", default: "default", description: "Active window style" },
-    OptionDef { name: "window-status-activity-style", scope: "window", option_type: "string", default: "reverse", description: "Window style on activity alert" },
-    OptionDef { name: "window-status-bell-style", scope: "window", option_type: "string", default: "reverse", description: "Window style on bell alert" },
-    OptionDef { name: "window-status-last-style", scope: "window", option_type: "string", default: "default", description: "Previously active window style" },
+    OptionDef { name: "automatic-rename", scope: Window, option_type: Boolean, default: "on", description: "Auto-rename windows based on running command" },
+    OptionDef { name: "monitor-activity", scope: Window, option_type: Boolean, default: "off", description: "Monitor for activity in window" },
+    OptionDef { name: "remain-on-exit", scope: Window, option_type: Boolean, default: "off", description: "Keep pane open after command exits" },
+    OptionDef { name: "aggressive-resize", scope: Window, option_type: Boolean, default: "off", description: "Resize window to smallest attached client" },
+    OptionDef { name: "main-pane-width", scope: Window, option_type: Number(U16), default: "0", description: "Width of main pane in main-* layouts (0 sizes it automatically)" },
+    OptionDef { name: "main-pane-height", scope: Window, option_type: Number(U16), default: "0", description: "Height of main pane in main-* layouts (0 sizes it automatically)" },
+    OptionDef { name: "window-size", scope: Window, option_type: UNVALIDATED_CHOICE, default: "latest", description: "Window sizing strategy" },
+    OptionDef { name: "window-status-format", scope: Window, option_type: OptionType::String, default: "#I:#W#{?window_flags,#{window_flags}, }", description: "Window status bar format" },
+    OptionDef { name: "window-status-current-format", scope: Window, option_type: OptionType::String, default: "#I:#W#{?window_flags,#{window_flags}, }", description: "Active window status bar format" },
+    OptionDef { name: "window-status-separator", scope: Window, option_type: OptionType::String, default: " ", description: "Separator between window entries" },
+    OptionDef { name: "window-status-style", scope: Window, option_type: OptionType::String, default: "default", description: "Inactive window style" },
+    OptionDef { name: "window-status-current-style", scope: Window, option_type: OptionType::String, default: "default", description: "Active window style" },
+    OptionDef { name: "window-status-activity-style", scope: Window, option_type: OptionType::String, default: "reverse", description: "Window style on activity alert" },
+    OptionDef { name: "window-status-bell-style", scope: Window, option_type: OptionType::String, default: "reverse", description: "Window style on bell alert" },
+    OptionDef { name: "window-status-last-style", scope: Window, option_type: OptionType::String, default: "default", description: "Previously active window style" },
     // ── Pane options ──
-    OptionDef { name: "pane-border-style", scope: "pane", option_type: "string", default: "default", description: "Inactive pane border style" },
-    OptionDef { name: "pane-active-border-style", scope: "pane", option_type: "string", default: "fg=green", description: "Active pane border style" },
-    OptionDef { name: "pane-border-lines", scope: "pane", option_type: "choice", default: "single", description: "Pane border line style (single/double/heavy/simple/number/spaces/none)" },
-    // See the choose-tree-preview note above (#619).
-    OptionDef { name: "pane-border-hover-style", scope: "pane", option_type: "string", default: "fg=yellow", description: "Pane border style under the mouse pointer" },
+    OptionDef { name: "pane-border-style", scope: Pane, option_type: OptionType::String, default: "default", description: "Inactive pane border style" },
+    OptionDef { name: "pane-active-border-style", scope: Pane, option_type: OptionType::String, default: "fg=green", description: "Active pane border style" },
+    OptionDef { name: "pane-border-lines", scope: Pane, option_type: UNVALIDATED_CHOICE, default: "single", description: "Pane border line style (single/double/heavy/simple/number/spaces/none)" },
+    OptionDef { name: "pane-border-hover-style", scope: Pane, option_type: OptionType::String, default: "fg=yellow", description: "Pane border style under the mouse pointer" },
 ];
+
+/// Options validated on assignment but omitted from catalog listing and defaults.
+pub static VALIDATION_ONLY_OPTIONS: &[ValidationOnlyOptionDef] = &[
+    ValidationOnlyOptionDef { name: "message-limit", option_type: Number(I64) },
+    ValidationOnlyOptionDef { name: "history-file-limit", option_type: Number(I64) },
+];
+
+/// Ordered names emitted by `show-options -w`, not every Window-scoped catalog entry.
+pub static WINDOW_OPTION_NAMES: &[&str] = &[
+    "automatic-rename",
+    "monitor-activity",
+    "monitor-silence",
+    "remain-on-exit",
+    "window-status-format",
+    "window-status-current-format",
+    "window-status-separator",
+    "window-status-style",
+    "window-status-current-style",
+    "window-status-activity-style",
+    "window-status-bell-style",
+    "window-status-last-style",
+    "main-pane-width",
+    "main-pane-height",
+    "window-size",
+];
+
+pub fn option_definition(name: &str) -> Option<&'static OptionDef> {
+    OPTION_CATALOG.iter().find(|definition| definition.name == name)
+}
+
+pub fn validate_option_value(name: &str, value: &str) -> Result<(), String> {
+    if let Some(definition) = option_definition(name) {
+        return definition.validate_value(value);
+    }
+    if let Some(definition) = VALIDATION_ONLY_OPTIONS
+        .iter()
+        .find(|definition| definition.name == name)
+    {
+        return definition.validate_value(value);
+    }
+    Ok(())
+}
+
+pub fn validate_option_append(name: &str) -> Result<(), String> {
+    option_definition(name).map_or(Ok(()), OptionDef::validate_append)
+}
+
+pub fn validate_local_window_override(name: &str, local_window: bool) -> Result<(), String> {
+    if !local_window {
+        return Ok(());
+    }
+    option_definition(name).map_or(Ok(()), OptionDef::validate_local_window_override)
+}
 
 /// Build the flattened option list for CustomizeMode using live values from AppState.
 pub fn build_option_list(app: &crate::types::AppState) -> Vec<(String, String, String)> {
     use crate::server::options::get_option_value;
     OPTION_CATALOG.iter().map(|def| {
         let value = get_option_value(app, def.name);
-        (def.name.to_string(), value, def.scope.to_string())
+        (def.name.to_string(), value, def.scope.as_str().to_string())
     }).collect()
 }
 
 /// Look up the default value for a given option name.
 pub fn default_for(name: &str) -> Option<&'static str> {
-    OPTION_CATALOG.iter().find(|d| d.name == name).map(|d| d.default)
+    option_definition(name).map(|definition| definition.default)
 }
 
 /// Names of the options this catalog marks server scope, sorted.
@@ -130,7 +346,7 @@ pub fn default_for(name: &str) -> Option<&'static str> {
 pub fn server_option_names() -> Vec<&'static str> {
     let mut names: Vec<&'static str> = OPTION_CATALOG
         .iter()
-        .filter(|d| d.scope == "server")
+        .filter(|d| d.scope == Server)
         .map(|d| d.name)
         .collect();
     names.sort_unstable();
@@ -142,7 +358,9 @@ pub fn server_option_names() -> Vec<&'static str> {
 /// ignores `-s` entirely rather than erroring), so this only ever narrows a
 /// listing, never rejects a write.
 pub fn is_server_option(name: &str) -> bool {
-    OPTION_CATALOG.iter().any(|d| d.name == name && d.scope == "server")
+    OPTION_CATALOG
+        .iter()
+        .any(|d| d.name == name && d.scope == Server)
 }
 
 #[cfg(test)]

--- a/src/server/options.rs
+++ b/src/server/options.rs
@@ -1,5 +1,6 @@
 use crate::types::AppState;
 use crate::config::{format_key_binding, parse_key_string};
+use crate::server::option_catalog::WINDOW_OPTION_NAMES;
 
 /// Upper bound for `repeat-time`, in milliseconds. tmux declares the option as
 /// a number with minimum 0 and maximum 2000000 in options-table.c, so psmux
@@ -7,27 +8,7 @@ use crate::config::{format_key_binding, parse_key_string};
 pub(crate) const REPEAT_TIME_MAX_MS: i64 = 2_000_000;
 
 fn is_window_option(name: &str) -> bool {
-    matches!(
-        name,
-        "automatic-rename"
-            | "monitor-activity"
-            // #559: tmux classifies monitor-silence as a window option; without
-            // this entry `show-options -w monitor-silence` returned an empty
-            // value even after a successful `set -w monitor-silence N`.
-            | "monitor-silence"
-            | "remain-on-exit"
-            | "window-status-format"
-            | "window-status-current-format"
-            | "window-status-separator"
-            | "window-status-style"
-            | "window-status-current-style"
-            | "window-status-activity-style"
-            | "window-status-bell-style"
-            | "window-status-last-style"
-            | "main-pane-width"
-            | "main-pane-height"
-            | "window-size"
-    )
+    WINDOW_OPTION_NAMES.contains(&name)
 }
 
 /// Effective value of an option that is stored empty or not stored at all.
@@ -238,27 +219,13 @@ pub(crate) fn get_window_option_value_for(
 }
 
 pub(crate) fn render_window_options(app: &AppState) -> String {
-    let names = [
-        "automatic-rename",
-        "monitor-activity",
-        "monitor-silence",
-        "remain-on-exit",
-        "window-status-format",
-        "window-status-current-format",
-        "window-status-separator",
-        "window-status-style",
-        "window-status-current-style",
-        "window-status-activity-style",
-        "window-status-bell-style",
-        "window-status-last-style",
-        "main-pane-width",
-        "main-pane-height",
-        "window-size",
-    ];
-
     let mut output = String::new();
-    for name in names {
-        output.push_str(&format!("{} {}\n", name, get_window_option_value(app, name)));
+    for name in WINDOW_OPTION_NAMES {
+        output.push_str(&format!(
+            "{} {}\n",
+            name,
+            get_window_option_value(app, name),
+        ));
     }
     output
 }
@@ -326,8 +293,7 @@ pub(crate) fn toggle_option(app: &mut AppState, option: &str) -> bool {
     }
     let current = get_option_value(app, option);
     let new_value = if current == "on" { "off" } else { "on" };
-    apply_set_option(app, option, new_value, false);
-    true
+    apply_set_option(app, option, new_value, false).is_ok()
 }
 
 /// Restore one option to the value a freshly started server reports for it,
@@ -394,12 +360,18 @@ pub(crate) fn reset_option_to_default(app: &mut AppState, option: &str) {
     app.user_options.remove(key);
 
     if let Some(default) = crate::server::option_catalog::default_for(key) {
-        apply_set_option(app, key, default, true);
+        let _ = apply_set_option(app, key, default, true);
     }
 }
 
 /// Apply a set-option command. If `quiet` is true, unknown options are silently ignored.
-pub(crate) fn apply_set_option(app: &mut AppState, option: &str, value: &str, _quiet: bool) {
+pub(crate) fn apply_set_option(
+    app: &mut AppState,
+    option: &str,
+    value: &str,
+    _quiet: bool,
+) -> Result<(), String> {
+    crate::server::option_catalog::validate_option_value(option, value)?;
     match option {
         "status-left" => { app.status_left = value.to_string(); }
         "status-right" => { app.status_right = value.to_string(); }
@@ -691,7 +663,7 @@ pub(crate) fn apply_set_option(app: &mut AppState, option: &str, value: &str, _q
                         app.status_format.push(String::new());
                     }
                     app.status_format[idx] = value.to_string();
-                    return;
+                    return Ok(());
                 }
             }
             // Store @user-options in dedicated map (NOT environment) to avoid
@@ -714,6 +686,7 @@ pub(crate) fn apply_set_option(app: &mut AppState, option: &str, value: &str, _q
             }
         }
     }
+    Ok(())
 }
 
 #[cfg(test)]

--- a/src/server/options.rs
+++ b/src/server/options.rs
@@ -22,6 +22,7 @@ fn effective_when_unset(name: &str) -> Option<&'static str> {
     Some(match name {
         // Consumed at src/rendering.rs, missing entry means border_lines::DEFAULT.
         "pane-border-lines" => crate::border_lines::DEFAULT,
+        "pane-border-indicators" => crate::pane_border::INDICATORS_DEFAULT,
         // Consumed at src/server/helpers.rs, a missing entry disables the gutter.
         "copy-mode-line-numbers" => "off",
         "copy-mode-line-number-style" => "fg=brightblack",
@@ -353,11 +354,16 @@ pub(crate) fn reset_option_to_default(app: &mut AppState, option: &str) {
         return;
     }
 
-    // Drop any stored override first. Options that live ONLY in `user_options`
-    // (window-style and window-active-style, terminal-overrides) have no typed
-    // field to restore and `get_option_value` already answers with the built in
-    // for a missing entry, so removal is the whole restore for them.
+    // Drop any stored override first. Options whose default is represented by
+    // a missing entry are fully restored by removal; applying their catalog
+    // default would turn an unset option back into an explicit override.
     app.user_options.remove(key);
+    if matches!(
+        key,
+        "window-style" | "window-active-style" | "pane-border-indicators"
+    ) {
+        return;
+    }
 
     if let Some(default) = crate::server::option_catalog::default_for(key) {
         let _ = apply_set_option(app, key, default, true);

--- a/src/types.rs
+++ b/src/types.rs
@@ -1742,6 +1742,43 @@ pub enum Action {
 #[derive(Clone)]
 pub struct Bind { pub key: (KeyCode, KeyModifiers), pub action: Action, pub repeat: bool }
 
+/// Tiled layout, border settings, and focus state used by chooser previews.
+/// Persistent floating panes and pane title bars are not included.
+#[derive(Clone, serde::Deserialize, serde::Serialize)]
+pub struct PreviewWindowState {
+    pub layout: crate::layout::LayoutJson,
+    pub border_lines: String,
+    pub border_indicators: crate::pane_border::PaneBorderIndicators,
+    #[serde(default)]
+    pub pane_border_style: Option<String>,
+    #[serde(default)]
+    pub pane_active_border_style: Option<String>,
+    pub floating_pane_focused: bool,
+}
+
+/// Parse preview state while accepting the layout-only `window-dump <id>`
+/// response.
+pub(crate) fn parse_preview_window_state(raw: &str) -> Option<PreviewWindowState> {
+    if let Ok(state) = serde_json::from_str(raw) {
+        return Some(state);
+    }
+    let layout = serde_json::from_str(raw).ok()?;
+    Some(PreviewWindowState {
+        layout,
+        border_lines: crate::border_lines::DEFAULT.to_string(),
+        border_indicators: crate::pane_border::PaneBorderIndicators::default(),
+        pane_border_style: None,
+        pane_active_border_style: None,
+        floating_pane_focused: false,
+    })
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum WindowDumpFormat {
+    Layout,
+    PreviewState,
+}
+
 pub enum CtrlReq {
     NewWindow(Option<String>, Option<String>, bool, Option<String>, Option<String>, bool, Vec<(String, String)>),  // cmd, name, detached, start_dir, title (-T), empty (-E), env (-e, #489)
     NewWindowPrint(Option<String>, Option<String>, bool, Option<String>, Option<String>, mpsc::Sender<String>, Option<String>, bool, Vec<(String, String)>),  // cmd, name, detached, start_dir, format, resp, title (-T), empty (-E), env (-e, #489)
@@ -1880,11 +1917,8 @@ pub enum CtrlReq {
     /// Issue #257: simplified layout (split kind/sizes + pane ids)
     /// for a specific window, used for choose-tree preview rendering.
     WindowLayout(usize, mpsc::Sender<String>),
-    /// Issue #257: full styled `LayoutJson` (rows_v2 cell runs, titles,
-    /// etc.) for a specific window. Lets cross-session previews reuse the
-    /// exact same renderer the main viewport uses, instead of replaying
-    /// `capture-pane -e` per pane and parsing ANSI by hand.
-    WindowDump(usize, mpsc::Sender<String>),
+    /// Issue #257: fully styled layout or preview state for a specific window.
+    WindowDump(usize, WindowDumpFormat, mpsc::Sender<String>),
     ToggleSync,
     SetPaneTitle(String),
     SetPaneStyle(String),
@@ -2691,3 +2725,7 @@ mod tests_base_index_rebase;
 #[cfg(test)]
 #[path = "../tests-rs/test_issue601_602_move_swap_window.rs"]
 mod tests_issue601_602_move_swap_window;
+
+#[cfg(test)]
+#[path = "../tests-rs/test_preview_window_state.rs"]
+mod tests_preview_window_state;

--- a/tests-rs/test_config_exhaustive.rs
+++ b/tests-rs/test_config_exhaustive.rs
@@ -1169,6 +1169,20 @@ fn config_only_if_unset_sets_window_style_after_unset() {
 }
 
 #[test]
+fn negative_integer_is_rejected_before_only_if_unset_short_circuit() {
+    let mut app = mock_app();
+    parse_config_content(
+        &mut app,
+        "set -g history-limit 42\n\
+         set -go history-limit -1\n",
+    );
+    assert_eq!(app.history_limit, 42);
+    assert!(app.config_warnings.iter().any(|warning| {
+        warning.contains("history-limit") && warning.contains("-1")
+    }));
+}
+
+#[test]
 fn config_file_wrap_search() {
     let mut app = mock_app();
     parse_config_content(&mut app, "set -g wrap-search on\n");
@@ -1275,6 +1289,19 @@ fn config_flag_u_unset_numeric_option() {
     let mut app = mock_app();
     parse_config_content(&mut app, "set -g escape-time 100\nset -gu escape-time\n");
     assert_eq!(app.escape_time_ms, 500);
+}
+
+#[test]
+fn config_explicit_empty_numeric_value_is_rejected() {
+    let mut app = mock_app();
+    parse_config_content(
+        &mut app,
+        "set -g escape-time 100\nset -g escape-time \"\"\n",
+    );
+    assert_eq!(app.escape_time_ms, 100);
+    assert!(app.config_warnings.iter().any(|warning| {
+        warning.contains("escape-time") && warning.contains("expected a number")
+    }));
 }
 
 #[test]

--- a/tests-rs/test_copy_line_numbers_render.rs
+++ b/tests-rs/test_copy_line_numbers_render.rs
@@ -55,6 +55,7 @@ fn render_gutters(leaf: &LayoutJson, mode: CopyLnMode, hsize: usize, w: u16, h: 
             false, Color::Reset, active_rect, "", false, "off", "", 1,
             crate::border_lines::border_chars("single"), copy_ln,
             crate::client::WindowContentStyles::default(),
+            crate::pane_border::PaneBorderIndicators::Colour,
         );
     }).unwrap();
     let buf = term.backend().buffer().clone();
@@ -124,6 +125,7 @@ fn off_draws_no_gutter_and_keeps_content() {
             false, Color::Reset, active_rect, "", false, "off", "", 1,
             crate::border_lines::border_chars("single"), None,
             crate::client::WindowContentStyles::default(),
+            crate::pane_border::PaneBorderIndicators::Colour,
         );
     }).unwrap();
     let buf = term.backend().buffer().clone();
@@ -160,6 +162,7 @@ fn gutter_shifts_content_right() {
                 false, Color::Reset, active_rect, "", false, "off", "", 1,
                 crate::border_lines::border_chars("single"), copy_ln,
                 crate::client::WindowContentStyles::default(),
+                crate::pane_border::PaneBorderIndicators::Colour,
             );
         }).unwrap();
         let buf = term.backend().buffer().clone();

--- a/tests-rs/test_floating_render.rs
+++ b/tests-rs/test_floating_render.rs
@@ -26,6 +26,7 @@ fn render_with_styles(
     styles: WindowContentStyles,
     border_style: ratatui::style::Style,
     active_border_style: ratatui::style::Style,
+    indicators: crate::pane_border::PaneBorderIndicators,
 ) -> ratatui::buffer::Buffer {
     use ratatui::backend::TestBackend;
     use ratatui::layout::Rect;
@@ -40,6 +41,7 @@ fn render_with_styles(
             styles,
             border_style,
             active_border_style,
+            indicators,
         );
     }).unwrap();
     term.backend().buffer().clone()
@@ -53,6 +55,7 @@ fn render(fl: &FloatJson, cw: u16, ch: u16) -> ratatui::buffer::Buffer {
         WindowContentStyles::default(),
         ratatui::style::Style::default().fg(ratatui::style::Color::DarkGray),
         ratatui::style::Style::default().fg(ratatui::style::Color::Green),
+        crate::pane_border::PaneBorderIndicators::Colour,
     )
 }
 
@@ -136,6 +139,7 @@ fn floating_panes_apply_active_and_inactive_window_colors() {
         window_styles,
         Style::default().fg(Color::DarkGray),
         Style::default().fg(Color::Green),
+        crate::pane_border::PaneBorderIndicators::Colour,
     );
     assert_eq!(
         active_buffer[(2, 2)].style().fg,
@@ -156,6 +160,7 @@ fn floating_panes_apply_active_and_inactive_window_colors() {
         window_styles,
         Style::default().fg(Color::DarkGray),
         Style::default().fg(Color::Green),
+        crate::pane_border::PaneBorderIndicators::Colour,
     );
     assert_eq!(
         inactive_buffer[(2, 2)].style().bg,
@@ -236,6 +241,7 @@ fn focused_float_leaves_tiled_content_with_inactive_window_style() {
                 crate::border_lines::border_chars("single"),
                 None,
                 window_styles.for_tiled_panes(true),
+                crate::pane_border::PaneBorderIndicators::Colour,
             );
             render_float_overlays(
                 frame,
@@ -244,6 +250,7 @@ fn focused_float_leaves_tiled_content_with_inactive_window_style() {
                 window_styles,
                 Style::default().fg(Color::DarkGray),
                 Style::default().fg(Color::Green),
+                crate::pane_border::PaneBorderIndicators::Colour,
             );
         })
         .unwrap();
@@ -267,6 +274,7 @@ fn floating_panes_preserve_active_and_inactive_border_backgrounds() {
         WindowContentStyles::default(),
         inactive_style,
         active_style,
+        crate::pane_border::PaneBorderIndicators::Colour,
     );
     assert_eq!(active_buffer[(1, 1)].style().bg, Some(Color::Red));
 
@@ -279,6 +287,7 @@ fn floating_panes_preserve_active_and_inactive_border_backgrounds() {
         WindowContentStyles::default(),
         inactive_style,
         active_style,
+        crate::pane_border::PaneBorderIndicators::Colour,
     );
     assert_eq!(inactive_buffer[(1, 1)].style().bg, Some(Color::Blue));
 }

--- a/tests-rs/test_issue245_mouse_selection.rs
+++ b/tests-rs/test_issue245_mouse_selection.rs
@@ -83,8 +83,14 @@ fn option_catalog_registers_mouse_selection_force() {
         .find(|o| o.name == "mouse-selection-force")
         .expect("mouse-selection-force must be in catalog");
     assert_eq!(entry.default, "off");
-    assert_eq!(entry.option_type, "boolean");
-    assert_eq!(entry.scope, "session");
+    assert_eq!(
+        entry.option_type,
+        crate::server::option_catalog::OptionType::Boolean
+    );
+    assert_eq!(
+        entry.scope,
+        crate::server::option_catalog::OptionScope::Session,
+    );
 }
 
 #[test]
@@ -176,8 +182,14 @@ fn option_catalog_default_is_on() {
         .expect("mouse-selection must be in catalog");
     assert_eq!(entry.default, "on",
         "Catalog default for mouse-selection must be 'on' (preserves existing behavior)");
-    assert_eq!(entry.option_type, "boolean");
-    assert_eq!(entry.scope, "session");
+    assert_eq!(
+        entry.option_type,
+        crate::server::option_catalog::OptionType::Boolean
+    );
+    assert_eq!(
+        entry.scope,
+        crate::server::option_catalog::OptionScope::Session,
+    );
 }
 
 #[test]

--- a/tests-rs/test_issue370_config_warnings.rs
+++ b/tests-rs/test_issue370_config_warnings.rs
@@ -106,7 +106,7 @@ fn malformed_numeric_keeps_prior_value() {
     let mut a = app();
     crate::config::parse_config_content(&mut a, "set -g escape-time 77\nset -g escape-time notanumber\n");
     assert_eq!(a.escape_time_ms, 77, "bad value must not overwrite the good one");
-    assert!(warns_contain(&a, "invalid value 'notanumber'"));
+    assert!(warns_contain(&a, "expected a number"));
 }
 
 #[test]

--- a/tests-rs/test_issue425_bold_is_bright_option.rs
+++ b/tests-rs/test_issue425_bold_is_bright_option.rs
@@ -74,6 +74,9 @@ fn bold_is_bright_is_in_option_catalog_as_boolean() {
         .iter()
         .find(|d| d.name == "bold-is-bright")
         .expect("bold-is-bright must be registered in the option catalog");
-    assert_eq!(def.option_type, "boolean");
+    assert_eq!(
+        def.option_type,
+        crate::server::option_catalog::OptionType::Boolean
+    );
     assert_eq!(def.default, "on");
 }

--- a/tests-rs/test_issue606_repeat_time.rs
+++ b/tests-rs/test_issue606_repeat_time.rs
@@ -202,8 +202,16 @@ fn catalog_describes_repeat_time() {
         .iter()
         .find(|d| d.name == "repeat-time")
         .expect("repeat-time must be in the option catalog");
-    assert_eq!(def.option_type, "number");
-    assert_eq!(def.scope, "session");
+    assert_eq!(
+        def.option_type,
+        crate::server::option_catalog::OptionType::Number(
+            crate::server::option_catalog::NumberKind::RepeatTime,
+        ),
+    );
+    assert_eq!(
+        def.scope,
+        crate::server::option_catalog::OptionScope::Session,
+    );
     assert_eq!(def.default, "500");
 }
 

--- a/tests-rs/test_issue618_set_option_server_scope.rs
+++ b/tests-rs/test_issue618_set_option_server_scope.rs
@@ -120,17 +120,17 @@ fn command_set_sq_combined_applies() {
 }
 
 // ---------------------------------------------------------------------------
-// The CLI guard (src/main.rs). The guard runs inside run_main and cannot be
-// called from a test, so the accepted-flag set it consults is a named const
-// and that is what gets pinned here.
+// The CLI guard and shared parser consult the same accepted-flag set.
 // ---------------------------------------------------------------------------
 
 #[test]
 fn cli_flag_set_accepts_s() {
-    assert!(
-        crate::SET_OPTION_CLI_FLAGS.contains('s'),
-        "the set-option CLI guard must accept -s (#618)"
-    );
+    let parsed = crate::cli::parse_set_option_args(&[
+        "-s",
+        "default-terminal",
+        "xterm-256color",
+    ]);
+    assert_eq!(parsed.validate(false), Ok(()));
 }
 
 #[test]

--- a/tests-rs/test_issue619_set_option_already_set.rs
+++ b/tests-rs/test_issue619_set_option_already_set.rs
@@ -267,6 +267,11 @@ fn probe_value(def: &crate::server::option_catalog::OptionDef) -> String {
         crate::server::option_catalog::OptionType::Boolean => {
             if def.default == "on" { "off".to_string() } else { "on".to_string() }
         }
+        crate::server::option_catalog::OptionType::Choice(
+            crate::server::option_catalog::ChoiceKind::PaneBorderIndicators,
+        ) => {
+            if def.default == "colour" { "arrows".to_string() } else { "colour".to_string() }
+        }
         _ => {
             if def.default == "i619probe" {
                 "i619probe2".to_string()

--- a/tests-rs/test_issue619_set_option_already_set.rs
+++ b/tests-rs/test_issue619_set_option_already_set.rs
@@ -258,13 +258,13 @@ fn audit_exempt(name: &str) -> Option<&'static str> {
 /// the option before the unset is asked to move it back.
 fn probe_value(def: &crate::server::option_catalog::OptionDef) -> String {
     match def.option_type {
-        "number" => {
+        crate::server::option_catalog::OptionType::Number(_) => {
             let cur: i64 = def.default.trim().parse().unwrap_or(0);
             // Stay inside every bound psmux enforces (repeat-time caps at
             // 2000000) while still differing from the default.
             (cur + 7).to_string()
         }
-        "boolean" => {
+        crate::server::option_catalog::OptionType::Boolean => {
             if def.default == "on" { "off".to_string() } else { "on".to_string() }
         }
         _ => {

--- a/tests-rs/test_issue619_window_style_fallback.rs
+++ b/tests-rs/test_issue619_window_style_fallback.rs
@@ -246,6 +246,7 @@ fn dim_reaches_the_rendered_pane_background() {
             false,
             Color::Reset, active_rect, "", false, "off", "", 1,
             crate::border_lines::border_chars("single"), None, styles,
+            crate::pane_border::PaneBorderIndicators::Colour,
         );
     }).unwrap();
     let buffer = terminal.backend().buffer().clone();

--- a/tests-rs/test_live_client_styles.rs
+++ b/tests-rs/test_live_client_styles.rs
@@ -92,6 +92,26 @@ fn append_extra_style_json_emits_empty_global_window_content_styles_when_unset()
     assert_eq!(parsed["window_active_style"], "");
 }
 
+#[test]
+fn append_extra_style_json_emits_pane_border_indicators_and_default() {
+    let mut app = mk_app();
+    let mut default_buf = String::from("{\"layout\":{}}");
+    append_extra_style_json(&mut default_buf, &app);
+    let default_json: serde_json::Value =
+        serde_json::from_str(&default_buf).expect("valid default JSON");
+    assert_eq!(default_json["pane_border_indicators"], "colour");
+
+    app.user_options.insert(
+        "pane-border-indicators".to_string(),
+        "arrows".to_string(),
+    );
+    let mut arrows_buf = String::from("{\"layout\":{}}");
+    append_extra_style_json(&mut arrows_buf, &app);
+    let arrows_json: serde_json::Value =
+        serde_json::from_str(&arrows_buf).expect("valid arrows JSON");
+    assert_eq!(arrows_json["pane_border_indicators"], "arrows");
+}
+
 // Guard the injection contract: never touch a buffer that is not a closed object.
 #[test]
 fn append_extra_style_json_noop_when_not_object() {

--- a/tests-rs/test_option_default_parity.rs
+++ b/tests-rs/test_option_default_parity.rs
@@ -79,6 +79,23 @@ fn status_right_catalog_default_matches_runtime_default() {
     );
 }
 
+#[test]
+fn pane_border_indicators_is_listed_as_a_window_option_with_global_default() {
+    let app = fresh_app();
+    assert_eq!(
+        crate::server::options::get_window_option_value(
+            &app,
+            "pane-border-indicators",
+        ),
+        "colour",
+    );
+    assert!(
+        crate::server::options::render_window_options(&app)
+            .lines()
+            .any(|line| line == "pane-border-indicators colour"),
+    );
+}
+
 /// The catalog is what customize-mode renders. An option missing a default there
 /// cannot be reset at all, so a blank default on a non-string option is a defect.
 #[test]
@@ -123,6 +140,7 @@ fn window_option_listing_preserves_its_supported_surface() {
         "window-status-activity-style",
         "window-status-bell-style",
         "window-status-last-style",
+        "pane-border-indicators",
         "main-pane-width",
         "main-pane-height",
         "window-size",

--- a/tests-rs/test_option_default_parity.rs
+++ b/tests-rs/test_option_default_parity.rs
@@ -85,7 +85,12 @@ fn status_right_catalog_default_matches_runtime_default() {
 fn catalog_defaults_are_present_for_scalar_options() {
     let mut missing: Vec<&str> = Vec::new();
     for def in OPTION_CATALOG.iter() {
-        let scalar = matches!(def.option_type, "number" | "boolean" | "choice");
+        let scalar = matches!(
+            def.option_type,
+            crate::server::option_catalog::OptionType::Number(_)
+                | crate::server::option_catalog::OptionType::Boolean
+                | crate::server::option_catalog::OptionType::Choice(_)
+        );
         if scalar && def.default.trim().is_empty() {
             missing.push(def.name);
         }
@@ -95,4 +100,49 @@ fn catalog_defaults_are_present_for_scalar_options() {
         "these non-string options have an empty catalog default, so customize-mode \
          cannot reset them: {missing:?}"
     );
+}
+
+#[test]
+fn window_option_listing_preserves_its_supported_surface() {
+    let app = fresh_app();
+    let output = crate::server::options::render_window_options(&app);
+    let actual: Vec<&str> = output
+        .lines()
+        .filter_map(|line| line.split_whitespace().next())
+        .collect();
+    let expected = [
+        "automatic-rename",
+        "monitor-activity",
+        "monitor-silence",
+        "remain-on-exit",
+        "window-status-format",
+        "window-status-current-format",
+        "window-status-separator",
+        "window-status-style",
+        "window-status-current-style",
+        "window-status-activity-style",
+        "window-status-bell-style",
+        "window-status-last-style",
+        "main-pane-width",
+        "main-pane-height",
+        "window-size",
+    ];
+    assert_eq!(actual, expected);
+}
+
+#[test]
+fn window_option_lookup_preserves_its_supported_surface() {
+    let app = fresh_app();
+    for name in [
+        "copy-mode-line-numbers",
+        "copy-mode-line-number-style",
+        "copy-mode-current-line-number-style",
+        "aggressive-resize",
+    ] {
+        assert_eq!(
+            crate::server::options::get_window_option_value(&app, name),
+            "",
+            "{name} is catalogued as window-scoped but is not exposed by show-window-options",
+        );
+    }
 }

--- a/tests-rs/test_pane_border_backgrounds.rs
+++ b/tests-rs/test_pane_border_backgrounds.rs
@@ -152,13 +152,15 @@ fn preview_preserves_active_and_inactive_border_backgrounds() {
 
     terminal
         .draw(|frame| {
-            crate::preview::render_dump_tree(
+            crate::preview::render_preview_layout(
                 frame,
                 &layout,
                 Rect::new(0, 0, 10, 6),
                 inactive_style,
                 active_style,
-                None,
+                crate::border_lines::border_chars("single"),
+                PaneBorderIndicators::Colour,
+                false,
             );
         })
         .unwrap();
@@ -382,13 +384,15 @@ fn nested_preview_junction_background_tracks_active_pane() {
     let mut terminal = Terminal::new(backend).unwrap();
     terminal
         .draw(|frame| {
-            crate::preview::render_dump_tree(
+            crate::preview::render_preview_layout(
                 frame,
                 &layout,
                 Rect::new(0, 0, 12, 8),
                 inactive_style,
                 active_style,
-                None,
+                crate::border_lines::border_chars("single"),
+                PaneBorderIndicators::Colour,
+                false,
             );
         })
         .unwrap();

--- a/tests-rs/test_pane_border_backgrounds.rs
+++ b/tests-rs/test_pane_border_backgrounds.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::pane_border::PaneBorderIndicators;
 use crate::layout::LayoutJson;
 use ratatui::backend::TestBackend;
 use ratatui::layout::Rect;
@@ -106,6 +107,7 @@ fn two_pane_separator_and_labels_preserve_active_and_inactive_backgrounds() {
                 crate::border_lines::border_chars("single"),
                 None,
                 WindowContentStyles::default(),
+                PaneBorderIndicators::Colour,
             );
         })
         .unwrap();
@@ -231,6 +233,7 @@ fn render_border_layout(
                 chars,
                 None,
                 WindowContentStyles::default(),
+                PaneBorderIndicators::Colour,
             );
             borders = border_geometry_from_layout(
                 layout,

--- a/tests-rs/test_pane_border_indicator_control.rs
+++ b/tests-rs/test_pane_border_indicator_control.rs
@@ -1,0 +1,390 @@
+use super::*;
+use std::io::{BufRead, Read, Write};
+use std::net::{Shutdown, TcpListener, TcpStream};
+use std::sync::{Arc, RwLock};
+use std::time::Duration;
+
+const TEST_KEY: &str = "pane-border-indicator-test-key";
+
+fn assert_indicator_request(request: CtrlReq, expected: &str) {
+    match request {
+        CtrlReq::SetOptionQuiet(name, value, false) => {
+            assert_eq!(name, "pane-border-indicators");
+            assert_eq!(value, expected);
+        }
+        _ => panic!("expected a global pane-border-indicators assignment"),
+    }
+}
+
+fn simple_tcp_command(command: &str) -> (String, mpsc::Receiver<CtrlReq>) {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let address = listener.local_addr().unwrap();
+    let (request_tx, request_rx) = mpsc::channel();
+    let handler = std::thread::spawn(move || {
+        let (stream, _) = listener.accept().unwrap();
+        handle_connection(
+            stream,
+            request_tx,
+            TEST_KEY,
+            Arc::new(RwLock::new(std::collections::HashMap::new())),
+        );
+    });
+
+    let mut client = TcpStream::connect(address).unwrap();
+    client
+        .set_read_timeout(Some(Duration::from_secs(20)))
+        .unwrap();
+    write!(client, "AUTH {TEST_KEY}\n").unwrap();
+    let mut reader = std::io::BufReader::new(client.try_clone().unwrap());
+    let mut response = String::new();
+    reader.read_line(&mut response).unwrap();
+    assert_eq!(response, "OK\n");
+
+    write!(client, "{command}\n").unwrap();
+    client.shutdown(Shutdown::Write).unwrap();
+    response.clear();
+    reader.read_to_string(&mut response).unwrap();
+    handler.join().unwrap();
+    (response, request_rx)
+}
+
+fn rejected_control_command(command: &str, args: &[&str]) -> String {
+    let (request_tx, request_rx) = mpsc::channel();
+    let (response_tx, response_rx) = mpsc::channel();
+    assert!(dispatch_control_command(
+        command,
+        args,
+        &request_tx,
+        response_tx,
+        None,
+        false,
+        None,
+        0,
+    ));
+    let response = response_rx.recv().unwrap();
+    assert!(response.starts_with("\u{0001}ERR\u{0001}"));
+    assert!(matches!(
+        request_rx.try_recv(),
+        Err(mpsc::TryRecvError::Empty),
+    ));
+    response
+}
+
+#[test]
+fn control_mode_rejects_the_complete_indicator_value_without_dispatch() {
+    let response = rejected_control_command(
+        "set-option",
+        &[
+            "-gt",
+            ":1",
+            "pane-border-indicators",
+            "arrows",
+            "-junk",
+        ],
+    );
+    assert!(response.contains("arrows -junk"));
+}
+
+#[test]
+fn quiet_control_mode_preserves_indicator_validation_error() {
+    let response = rejected_control_command(
+        "set-option",
+        &["-gq", "pane-border-indicators", "sideways"],
+    );
+    assert!(response.contains("sideways"));
+}
+
+#[test]
+fn targeted_indicator_missing_operand_is_rejected_without_dispatch() {
+    let response = rejected_control_command(
+        "set-option",
+        &["-gt", ":1", "pane-border-indicators"],
+    );
+    assert!(response.contains("empty value"));
+}
+
+#[test]
+fn window_scoped_indicator_is_rejected_without_dispatch() {
+    let response = rejected_control_command(
+        "set-window-option",
+        &["pane-border-indicators", "arrows"],
+    );
+    assert!(response.contains("does not support local window overrides"));
+}
+
+#[test]
+fn control_mode_rejects_append_for_indicator_choices() {
+    let response = rejected_control_command(
+        "set-option",
+        &["-gat", ":1", "pane-border-indicators", "arrows"],
+    );
+    assert!(response.contains("does not support append"));
+}
+
+#[test]
+fn direct_validation_accepts_global_window_forms() {
+    for (command, args) in [
+        ("set-window-option", vec!["-g", "pane-border-indicators", "off"]),
+        ("setw", vec!["-g", "pane-border-indicators", "colour"]),
+        ("setw", vec!["-s", "pane-border-indicators", "arrows"]),
+        ("set-option", vec!["-gw", "pane-border-indicators", "arrows"]),
+        ("set-option", vec!["-sw", "pane-border-indicators", "both"]),
+        ("set", vec!["-wg", "pane-border-indicators", "both"]),
+    ] {
+        let parsed = parse_set_option_args(&args);
+        let window_command = matches!(command, "set-window-option" | "setw");
+        assert!(
+            parsed.validate(window_command).is_ok(),
+            "{command} {args:?} should be a global window assignment",
+        );
+    }
+}
+
+#[test]
+fn direct_validation_rejects_local_window_forms() {
+    for (command, args) in [
+        ("set-window-option", vec!["pane-border-indicators", "arrows"]),
+        ("setw", vec!["-t", ":1", "pane-border-indicators", "arrows"]),
+        ("set-option", vec!["-w", "pane-border-indicators", "arrows"]),
+        ("set", vec!["-wt", ":1", "pane-border-indicators", "arrows"]),
+    ] {
+        let parsed = parse_set_option_args(&args);
+        let window_command = matches!(command, "set-window-option" | "setw");
+        let error = parsed.validate(window_command).unwrap_err();
+        assert!(
+            error.contains("local window overrides"),
+            "{command} {args:?} should reject a local window assignment: {error}",
+        );
+    }
+}
+
+#[test]
+fn config_accepts_global_window_forms() {
+    for line in [
+        "set-window-option -g pane-border-indicators off",
+        "setw -g pane-border-indicators colour",
+        "setw -s pane-border-indicators arrows",
+        "set-option -gw pane-border-indicators arrows",
+        "set-option -sw pane-border-indicators both",
+        "set -wg pane-border-indicators both",
+    ] {
+        let mut app = crate::types::AppState::new("indicator-config".to_string());
+        crate::config::parse_config_content(&mut app, line);
+        assert!(
+            app.config_warnings.is_empty(),
+            "{line} should be accepted: {:?}",
+            app.config_warnings,
+        );
+        assert!(app.user_options.contains_key("pane-border-indicators"));
+    }
+}
+
+#[test]
+fn config_rejects_local_window_forms() {
+    for line in [
+        "set-window-option pane-border-indicators arrows",
+        "setw -t :1 pane-border-indicators arrows",
+        "set-option -w pane-border-indicators arrows",
+        "set -wt :1 pane-border-indicators arrows",
+    ] {
+        let mut app = crate::types::AppState::new("indicator-config".to_string());
+        crate::config::parse_config_content(&mut app, line);
+        assert!(
+            app.config_warnings
+                .iter()
+                .any(|warning| warning.contains("local window overrides")),
+            "{line} should reject a local window assignment: {:?}",
+            app.config_warnings,
+        );
+        assert!(!app.user_options.contains_key("pane-border-indicators"));
+    }
+}
+
+#[test]
+fn config_set_unset_and_only_if_unset_preserve_indicator_state() {
+    let mut app = crate::types::AppState::new("indicator-config".to_string());
+    crate::config::parse_config_content(
+        &mut app,
+        "set -g pane-border-indicators arrows\n",
+    );
+    assert_eq!(
+        app.user_options.get("pane-border-indicators").unwrap(),
+        "arrows",
+    );
+
+    crate::config::parse_config_content(
+        &mut app,
+        "set -gu pane-border-indicators\n",
+    );
+    assert!(!app.user_options.contains_key("pane-border-indicators"));
+    assert!(!app.user_set_options.contains("pane-border-indicators"));
+
+    crate::config::parse_config_content(
+        &mut app,
+        "set -go pane-border-indicators both\n",
+    );
+    assert_eq!(
+        app.user_options.get("pane-border-indicators").unwrap(),
+        "both",
+    );
+}
+
+#[test]
+fn config_rejects_invalid_and_append_indicator_assignments() {
+    let mut app = crate::types::AppState::new("indicator-config".to_string());
+    crate::config::parse_config_content(
+        &mut app,
+        "set -g pane-border-indicators arrows\n\
+         set -go pane-border-indicators sideways\n\
+         set -goa pane-border-indicators both\n",
+    );
+    assert_eq!(
+        app.user_options.get("pane-border-indicators").unwrap(),
+        "arrows",
+    );
+    assert!(
+        app.config_warnings
+            .iter()
+            .any(|warning| warning.contains("sideways")),
+    );
+    assert!(
+        app.config_warnings
+            .iter()
+            .any(|warning| warning.contains("does not support append")),
+    );
+}
+
+#[test]
+fn invalid_indicator_assignment_does_not_mutate_state() {
+    let mut app = crate::types::AppState::new("indicator-config".to_string());
+    assert!(crate::server::options::apply_set_option(
+        &mut app,
+        "pane-border-indicators",
+        "sideways",
+        true,
+    )
+    .is_err());
+    assert!(!app.user_options.contains_key("pane-border-indicators"));
+}
+
+#[test]
+fn simple_tcp_accepts_global_window_forms() {
+    for command in [
+        "set-window-option -g pane-border-indicators off",
+        "setw -g pane-border-indicators colour",
+        "setw -s pane-border-indicators arrows",
+        "set-option -gw pane-border-indicators arrows",
+        "set-option -sw pane-border-indicators both",
+        "set -wg pane-border-indicators both",
+    ] {
+        let expected = command.split_whitespace().last().unwrap();
+        let (response, requests) = simple_tcp_command(command);
+        assert_eq!(response, "", "{command} should not return an error");
+        let request = requests
+            .recv_timeout(Duration::from_secs(2))
+            .unwrap_or_else(|error| panic!("{command} was not dispatched: {error}"));
+        assert_indicator_request(request, expected);
+    }
+}
+
+#[test]
+fn simple_tcp_rejects_local_window_forms_before_dispatch() {
+    for command in [
+        "set-window-option pane-border-indicators arrows",
+        "setw -t :1 pane-border-indicators arrows",
+        "set-option -w pane-border-indicators arrows",
+        "set -wt :1 pane-border-indicators arrows",
+    ] {
+        let (response, requests) = simple_tcp_command(command);
+        assert!(
+            response.contains("local window overrides"),
+            "{command} should return the local override error: {response:?}",
+        );
+        assert!(
+            matches!(
+                requests.try_recv(),
+                Err(mpsc::TryRecvError::Empty | mpsc::TryRecvError::Disconnected),
+            ),
+            "{command} must be rejected before dispatch",
+        );
+    }
+}
+
+#[test]
+fn persistent_control_accepts_global_window_forms() {
+    for (command, args, expected) in [
+        (
+            "set-window-option",
+            vec!["-g", "pane-border-indicators", "off"],
+            "off",
+        ),
+        (
+            "setw",
+            vec!["-g", "pane-border-indicators", "colour"],
+            "colour",
+        ),
+        (
+            "setw",
+            vec!["-s", "pane-border-indicators", "arrows"],
+            "arrows",
+        ),
+        (
+            "set-option",
+            vec!["-gw", "pane-border-indicators", "arrows"],
+            "arrows",
+        ),
+        (
+            "set-option",
+            vec!["-sw", "pane-border-indicators", "both"],
+            "both",
+        ),
+        (
+            "set",
+            vec!["-wg", "pane-border-indicators", "both"],
+            "both",
+        ),
+    ] {
+        let (request_tx, request_rx) = mpsc::channel();
+        let (response_tx, response_rx) = mpsc::channel();
+        assert!(dispatch_control_command(
+            command,
+            &args,
+            &request_tx,
+            response_tx,
+            None,
+            false,
+            None,
+            0,
+        ));
+        assert_eq!(response_rx.recv().unwrap(), "");
+        assert_indicator_request(request_rx.recv().unwrap(), expected);
+    }
+}
+
+#[test]
+fn persistent_control_rejects_local_window_forms_before_dispatch() {
+    for (command, args) in [
+        (
+            "set-window-option",
+            vec!["pane-border-indicators", "arrows"],
+        ),
+        (
+            "setw",
+            vec!["-t", ":1", "pane-border-indicators", "arrows"],
+        ),
+        (
+            "set-option",
+            vec!["-w", "pane-border-indicators", "arrows"],
+        ),
+        (
+            "set",
+            vec!["-wt", ":1", "pane-border-indicators", "arrows"],
+        ),
+    ] {
+        let response = rejected_control_command(command, &args);
+        assert!(
+            response.contains("local window overrides"),
+            "{command} {args:?} should return the local override error: {response:?}",
+        );
+    }
+}

--- a/tests-rs/test_pane_border_indicators.rs
+++ b/tests-rs/test_pane_border_indicators.rs
@@ -1,0 +1,552 @@
+use super::*;
+use crate::client::{render_float_overlays, FloatJson};
+use crate::layout::{CellRunJson, LayoutJson, RowRunsJson};
+use crate::pane_border::PaneBorderIndicators;
+use ratatui::backend::TestBackend;
+use ratatui::layout::Rect;
+use ratatui::style::{Color, Style};
+use ratatui::Terminal;
+
+fn leaf(id: usize, active: bool) -> LayoutJson {
+    LayoutJson::Leaf {
+        id,
+        rows: 6,
+        cols: 4,
+        cursor_row: 0,
+        cursor_col: 0,
+        alternate_screen: false,
+        wants_mouse: false,
+        hide_cursor: true,
+        cursor_shape: 0,
+        active,
+        copy_mode: false,
+        scroll_offset: 0,
+        view_offset: 0,
+        sel_start_row: None,
+        sel_start_col: None,
+        sel_end_row: None,
+        sel_end_col: None,
+        sel_mode: None,
+        copy_cursor_row: None,
+        copy_cursor_col: None,
+        content: Vec::new(),
+        rows_v2: Vec::new(),
+        title: None,
+    }
+}
+
+fn render_layout(
+    layout: &LayoutJson,
+    indicators: PaneBorderIndicators,
+    line_mode: &str,
+    width: u16,
+    height: u16,
+) -> ratatui::buffer::Buffer {
+    let inactive = Style::default().fg(Color::DarkGray).bg(Color::Blue);
+    let active = Style::default().fg(Color::Green).bg(Color::Red);
+    let backend = TestBackend::new(width, height);
+    let mut terminal = Terminal::new(backend).unwrap();
+    terminal
+        .draw(|frame| {
+            let area = Rect::new(0, 0, width, height);
+            let active_rect = compute_active_rect_json(layout, area);
+            let chars = crate::border_lines::border_chars(line_mode);
+            render_layout_json(
+                frame,
+                layout,
+                area,
+                false,
+                inactive,
+                active,
+                false,
+                Color::Reset,
+                active_rect,
+                "",
+                false,
+                "off",
+                "",
+                layout.count_leaves(),
+                chars,
+                None,
+                WindowContentStyles::default(),
+                indicators,
+            );
+            let borders = border_geometry_from_layout(
+                layout,
+                area,
+                frame.buffer_mut().area,
+                false,
+            );
+            let junctions = crate::rendering::fix_border_intersections(
+                frame.buffer_mut(),
+                chars,
+                &borders,
+            );
+            recolor_border_junctions(
+                frame.buffer_mut(),
+                &junctions,
+                active_rect,
+                inactive,
+                active,
+            );
+            draw_pane_border_arrows(
+                frame.buffer_mut(),
+                &borders,
+                chars,
+                active_rect,
+                indicators,
+            );
+        })
+        .unwrap();
+    terminal.backend().buffer().clone()
+}
+
+fn render(
+    kind: &str,
+    indicators: PaneBorderIndicators,
+    line_mode: &str,
+    active_child: usize,
+) -> ratatui::buffer::Buffer {
+    let layout = LayoutJson::Split {
+        kind: kind.to_string(),
+        sizes: vec![50, 50],
+        children: vec![
+            leaf(0, active_child == 0),
+            leaf(1, active_child == 1),
+        ],
+    };
+    render_layout(&layout, indicators, line_mode, 10, 6)
+}
+
+fn contains_arrow(buffer: &ratatui::buffer::Buffer) -> bool {
+    buffer
+        .content
+        .iter()
+        .any(|cell| matches!(cell.symbol(), "←" | "→" | "↑" | "↓"))
+}
+
+fn float_row(ch: char, width: usize) -> RowRunsJson {
+    RowRunsJson {
+        runs: (0..width)
+            .map(|_| CellRunJson {
+                text: ch.to_string(),
+                fg: String::new(),
+                bg: String::new(),
+                flags: 0,
+                width: 1,
+                link: None,
+                ul: 0,
+                ulc: None,
+            })
+            .collect(),
+    }
+}
+
+fn floating_pane(width: u16, height: u16) -> FloatJson {
+    FloatJson {
+        x: 1,
+        y: 1,
+        w: width,
+        h: height,
+        border: "single".to_string(),
+        focused: true,
+        title: String::new(),
+        rows: (0..height.saturating_sub(2))
+            .map(|_| float_row('Z', width.saturating_sub(2) as usize))
+            .collect(),
+    }
+}
+
+fn render_float(
+    pane: &FloatJson,
+    width: u16,
+    height: u16,
+    inactive: Style,
+    active: Style,
+    indicators: PaneBorderIndicators,
+) -> ratatui::buffer::Buffer {
+    let backend = TestBackend::new(width, height);
+    let mut terminal = Terminal::new(backend).unwrap();
+    terminal
+        .draw(|frame| {
+            render_float_overlays(
+                frame,
+                Rect::new(0, 0, width, height),
+                std::slice::from_ref(pane),
+                crate::client::WindowContentStyles::default(),
+                inactive,
+                active,
+                indicators,
+            );
+        })
+        .unwrap();
+    terminal.backend().buffer().clone()
+}
+
+#[test]
+fn off_mode_keeps_the_active_style_across_the_divider() {
+    let buffer = render("Horizontal", PaneBorderIndicators::Off, "single", 0);
+    let x = 4;
+    assert!(!contains_arrow(&buffer), "off mode must not draw arrows");
+    for y in 0..6 {
+        assert_eq!(
+            buffer[(x, y)].style().bg,
+            Some(Color::Red),
+            "off mode must keep the active border style at divider row {y}",
+        );
+    }
+}
+
+#[test]
+fn colour_mode_splits_the_divider_style_at_the_active_pane_midpoint() {
+    let buffer = render("Horizontal", PaneBorderIndicators::Colour, "single", 0);
+    let x = 4;
+    assert_eq!(buffer[(x, 0)].symbol(), "│");
+    assert!(!contains_arrow(&buffer), "colour mode must not draw arrows");
+    for y in 0..3 {
+        assert_eq!(
+            buffer[(x, y)].style().bg,
+            Some(Color::Red),
+            "active half should use the active background at divider row {y}",
+        );
+    }
+    for y in 3..6 {
+        assert_eq!(
+            buffer[(x, y)].style().bg,
+            Some(Color::Blue),
+            "inactive half should use the inactive background at divider row {y}",
+        );
+    }
+}
+
+#[test]
+fn arrows_mode_adds_an_inward_arrow_without_splitting_the_style() {
+    let buffer = render("Horizontal", PaneBorderIndicators::Arrows, "single", 0);
+    let x = 4;
+    assert_eq!(buffer[(x, 1)].symbol(), "←");
+    assert_eq!(buffer[(x, 1)].style().bg, Some(Color::Red));
+    for y in [0, 2, 3, 4, 5] {
+        assert_eq!(
+            buffer[(x, y)].style().bg,
+            Some(Color::Red),
+            "arrows mode must keep the active border style at divider row {y}",
+        );
+    }
+}
+
+#[test]
+fn both_mode_combines_the_inward_arrow_and_split_style() {
+    let buffer = render("Horizontal", PaneBorderIndicators::Both, "single", 0);
+    let x = 4;
+    assert_eq!(buffer[(x, 1)].symbol(), "←");
+    for y in 0..3 {
+        assert_eq!(
+            buffer[(x, y)].style().bg,
+            Some(Color::Red),
+            "active half should use the active background at divider row {y}",
+        );
+    }
+    for y in 3..6 {
+        assert_eq!(
+            buffer[(x, y)].style().bg,
+            Some(Color::Blue),
+            "inactive half should use the inactive background at divider row {y}",
+        );
+    }
+}
+
+#[test]
+fn stacked_arrow_points_into_active_top_pane() {
+    let buffer = render("Vertical", PaneBorderIndicators::Arrows, "single", 0);
+    let arrow = buffer
+        .content
+        .iter()
+        .find(|cell| cell.symbol() == "↑")
+        .expect("up arrow below active top pane");
+    assert_eq!(arrow.style().bg, Some(Color::Red));
+}
+
+#[test]
+fn arrows_remain_visible_with_space_borders() {
+    let buffer = render("Horizontal", PaneBorderIndicators::Arrows, "spaces", 0);
+    assert!(buffer.content.iter().any(|cell| cell.symbol() == "←"));
+}
+
+#[test]
+fn arrows_point_into_active_right_and_bottom_panes() {
+    let side_by_side = render(
+        "Horizontal",
+        PaneBorderIndicators::Arrows,
+        "single",
+        1,
+    );
+    assert!(side_by_side.content.iter().any(|cell| cell.symbol() == "→"));
+
+    let stacked = render(
+        "Vertical",
+        PaneBorderIndicators::Arrows,
+        "single",
+        1,
+    );
+    assert!(stacked.content.iter().any(|cell| cell.symbol() == "↓"));
+}
+
+#[test]
+fn one_row_nested_split_keeps_arrow_on_the_vertical_divider() {
+    let layout = LayoutJson::Split {
+        kind: "Vertical".to_string(),
+        sizes: vec![50, 50],
+        children: vec![
+            LayoutJson::Split {
+                kind: "Horizontal".to_string(),
+                sizes: vec![50, 50],
+                children: vec![leaf(0, false), leaf(1, true)],
+            },
+            leaf(2, false),
+        ],
+    };
+    let area = Rect::new(0, 0, 4, 3);
+    let borders = border_geometry_from_layout(&layout, area, area, false);
+    let vertical_divider = 1;
+    let root_separator = area.width as usize + 1;
+    assert!(borders.contains_vertical(vertical_divider));
+    assert!(!borders.contains_horizontal(vertical_divider));
+    assert!(borders.contains_horizontal(root_separator));
+    assert!(!borders.contains_vertical(root_separator));
+
+    let buffer = render_layout(
+        &layout,
+        PaneBorderIndicators::Arrows,
+        "single",
+        area.width,
+        area.height,
+    );
+    assert_eq!(buffer[(1, 0)].symbol(), "→");
+    assert_ne!(buffer[(1, 1)].symbol(), "→");
+}
+
+#[test]
+fn one_column_nested_split_keeps_arrow_on_the_horizontal_divider() {
+    let layout = LayoutJson::Split {
+        kind: "Horizontal".to_string(),
+        sizes: vec![50, 50],
+        children: vec![
+            LayoutJson::Split {
+                kind: "Vertical".to_string(),
+                sizes: vec![50, 50],
+                children: vec![leaf(0, false), leaf(1, true)],
+            },
+            leaf(2, false),
+        ],
+    };
+    let area = Rect::new(0, 0, 3, 4);
+    let borders = border_geometry_from_layout(&layout, area, area, false);
+    let horizontal_divider = 3;
+    let root_separator = area.width as usize + 1;
+    assert!(borders.contains_horizontal(horizontal_divider));
+    assert!(!borders.contains_vertical(horizontal_divider));
+    assert!(borders.contains_vertical(root_separator));
+    assert!(!borders.contains_horizontal(root_separator));
+
+    let buffer = render_layout(
+        &layout,
+        PaneBorderIndicators::Arrows,
+        "single",
+        area.width,
+        area.height,
+    );
+    assert_eq!(buffer[(0, 1)].symbol(), "↓");
+    assert_ne!(buffer[(1, 1)].symbol(), "↓");
+}
+
+#[test]
+fn zero_row_nested_active_pane_does_not_mark_the_parent_separator() {
+    let layout = LayoutJson::Split {
+        kind: "Vertical".to_string(),
+        sizes: vec![50, 50],
+        children: vec![
+            LayoutJson::Split {
+                kind: "Horizontal".to_string(),
+                sizes: vec![50, 50],
+                children: vec![leaf(0, false), leaf(1, true)],
+            },
+            leaf(2, false),
+        ],
+    };
+    let area = Rect::new(0, 0, 4, 2);
+    let active_rect = compute_active_rect_json(&layout, area).unwrap();
+    assert!(active_rect.width > 0);
+    assert_eq!(active_rect.height, 0);
+
+    let buffer = render_layout(
+        &layout,
+        PaneBorderIndicators::Arrows,
+        "single",
+        area.width,
+        area.height,
+    );
+    assert!(!contains_arrow(&buffer));
+}
+
+#[test]
+fn zero_column_nested_active_pane_does_not_mark_the_parent_separator() {
+    let layout = LayoutJson::Split {
+        kind: "Horizontal".to_string(),
+        sizes: vec![50, 50],
+        children: vec![
+            LayoutJson::Split {
+                kind: "Vertical".to_string(),
+                sizes: vec![50, 50],
+                children: vec![leaf(0, false), leaf(1, true)],
+            },
+            leaf(2, false),
+        ],
+    };
+    let area = Rect::new(0, 0, 2, 4);
+    let active_rect = compute_active_rect_json(&layout, area).unwrap();
+    assert_eq!(active_rect.width, 0);
+    assert!(active_rect.height > 0);
+
+    let buffer = render_layout(
+        &layout,
+        PaneBorderIndicators::Arrows,
+        "single",
+        area.width,
+        area.height,
+    );
+    assert!(!contains_arrow(&buffer));
+}
+
+#[test]
+fn documented_values_parse_to_each_mode() {
+    for (raw, expected) in [
+        ("off", PaneBorderIndicators::Off),
+        ("colour", PaneBorderIndicators::Colour),
+        ("arrows", PaneBorderIndicators::Arrows),
+        ("both", PaneBorderIndicators::Both),
+    ] {
+        assert_eq!(PaneBorderIndicators::parse(raw), Ok(expected));
+    }
+}
+
+#[test]
+fn focused_float_suppresses_tiled_indicators() {
+    let inactive = Style::default().fg(Color::DarkGray);
+    let active = Style::default().fg(Color::Green);
+    let rect = Some(Rect::new(0, 0, 10, 6));
+    assert_eq!(tiled_border_focus(rect, inactive, active, true), (None, inactive));
+    assert_eq!(tiled_border_focus(rect, inactive, active, false), (rect, active));
+}
+
+#[test]
+fn focused_float_modes_preserve_title_and_active_border_style() {
+    let inactive = Style::default().fg(Color::DarkGray).bg(Color::Blue);
+    let active = Style::default().fg(Color::Green).bg(Color::Red);
+    let mut pane = floating_pane(8, 5);
+    pane.title = "T".to_string();
+
+    for (mode, expects_arrows) in [
+        (PaneBorderIndicators::Off, false),
+        (PaneBorderIndicators::Colour, false),
+        (PaneBorderIndicators::Arrows, true),
+        (PaneBorderIndicators::Both, true),
+    ] {
+        let buffer = render_float(&pane, 20, 10, inactive, active, mode);
+        assert_eq!(
+            buffer[(1, 1)].style().fg,
+            Some(Color::Green),
+            "{mode:?} must preserve the active foreground",
+        );
+        assert_eq!(
+            buffer[(1, 1)].style().bg,
+            Some(Color::Red),
+            "{mode:?} must preserve the active background",
+        );
+        assert!(
+            buffer.content.iter().any(|cell| cell.symbol() == "T"),
+            "{mode:?} must preserve the floating pane title",
+        );
+        assert_eq!(
+            contains_arrow(&buffer),
+            expects_arrows,
+            "{mode:?} arrow visibility",
+        );
+    }
+}
+
+#[test]
+fn floating_arrows_inherit_the_active_border_style() {
+    let inactive = Style::default().fg(Color::DarkGray).bg(Color::Blue);
+    let active = Style::default().fg(Color::Green).bg(Color::Red);
+    let pane = floating_pane(8, 5);
+    let buffer = render_float(
+        &pane,
+        20,
+        10,
+        inactive,
+        active,
+        PaneBorderIndicators::Arrows,
+    );
+
+    assert_eq!(buffer[(1, 3)].symbol(), "→");
+    assert_eq!(buffer[(1, 3)].style().fg, Some(Color::Green));
+    assert_eq!(buffer[(1, 3)].style().bg, Some(Color::Red));
+    assert_eq!(buffer[(5, 1)].symbol(), "↓");
+}
+
+#[test]
+fn minimum_float_places_all_four_inward_arrows() {
+    let pane = floating_pane(3, 3);
+    let buffer = render_float(
+        &pane,
+        5,
+        5,
+        Style::default(),
+        Style::default(),
+        PaneBorderIndicators::Arrows,
+    );
+
+    for (x, y, marker) in [
+        (2, 1, "↓"),
+        (2, 3, "↑"),
+        (1, 2, "→"),
+        (3, 2, "←"),
+    ] {
+        assert_eq!(
+            buffer[(x, y)].symbol(),
+            marker,
+            "minimum float marker at ({x}, {y})",
+        );
+    }
+}
+
+#[test]
+fn clipped_float_suppresses_arrows() {
+    let pane = floating_pane(3, 3);
+    let buffer = render_float(
+        &pane,
+        2,
+        2,
+        Style::default(),
+        Style::default(),
+        PaneBorderIndicators::Arrows,
+    );
+    assert!(!contains_arrow(&buffer));
+}
+
+#[test]
+fn oversized_float_title_does_not_overflow_arrow_placement() {
+    let mut pane = floating_pane(8, 5);
+    pane.title = "T".repeat(70_000);
+    let buffer = render_float(
+        &pane,
+        20,
+        10,
+        Style::default(),
+        Style::default(),
+        PaneBorderIndicators::Arrows,
+    );
+    assert_eq!(buffer[(1, 3)].symbol(), "→");
+    assert_eq!(buffer[(8, 3)].symbol(), "←");
+    assert!(!buffer.content.iter().any(|cell| cell.symbol() == "↓"));
+}

--- a/tests-rs/test_pane_border_lines_render.rs
+++ b/tests-rs/test_pane_border_lines_render.rs
@@ -72,6 +72,7 @@ fn render_counts(kind: &str, style: &str, w: u16, h: u16) -> std::collections::H
             bchars,
             None,
             crate::client::WindowContentStyles::default(),
+            crate::pane_border::PaneBorderIndicators::Colour,
         );
         let borders = crate::client::border_geometry_from_layout(
             &layout,
@@ -169,6 +170,7 @@ fn nested_split_produces_double_junction() {
             false, Color::Reset, active_rect, "", false, "off", "", total, bchars,
             None,
             crate::client::WindowContentStyles::default(),
+            crate::pane_border::PaneBorderIndicators::Colour,
         );
         let borders = crate::client::border_geometry_from_layout(
             &layout,

--- a/tests-rs/test_pane_content_box_drawing.rs
+++ b/tests-rs/test_pane_content_box_drawing.rs
@@ -84,6 +84,7 @@ fn fix_border_intersections_leaves_pane_content_table_untouched() {
             bchars,
             None,
             crate::client::WindowContentStyles::default(),
+            crate::pane_border::PaneBorderIndicators::Colour,
         );
 
         // Inject the fake table into the buffer as pane content would appear.
@@ -199,6 +200,7 @@ fn fix_border_intersections_leaves_zoomed_pane_content_untouched() {
             bchars,
             None,
             crate::client::WindowContentStyles::default(),
+            crate::pane_border::PaneBorderIndicators::Colour,
         );
 
         let buf = f.buffer_mut();

--- a/tests-rs/test_parity.rs
+++ b/tests-rs/test_parity.rs
@@ -345,30 +345,6 @@ fn option_catalog_default_for_unknown_returns_none() {
 }
 
 #[test]
-fn option_catalog_all_entries_have_valid_types() {
-    let valid_types = ["number", "boolean", "choice", "string"];
-    for def in crate::server::option_catalog::OPTION_CATALOG {
-        assert!(
-            valid_types.contains(&def.option_type),
-            "option '{}' has invalid type '{}' (expected one of {:?})",
-            def.name, def.option_type, valid_types
-        );
-    }
-}
-
-#[test]
-fn option_catalog_all_entries_have_valid_scopes() {
-    let valid_scopes = ["server", "session", "window", "pane"];
-    for def in crate::server::option_catalog::OPTION_CATALOG {
-        assert!(
-            valid_scopes.contains(&def.scope),
-            "option '{}' has invalid scope '{}' (expected one of {:?})",
-            def.name, def.scope, valid_scopes
-        );
-    }
-}
-
-#[test]
 fn option_catalog_no_duplicate_names() {
     let mut seen = std::collections::HashSet::new();
     for def in crate::server::option_catalog::OPTION_CATALOG {

--- a/tests-rs/test_pr255_active_border.rs
+++ b/tests-rs/test_pr255_active_border.rs
@@ -140,6 +140,7 @@ fn render_three_panes_does_not_color_unrelated_separator_active() {
             crate::border_lines::border_chars("single"),
             None,
             crate::client::WindowContentStyles::default(),
+            crate::pane_border::PaneBorderIndicators::Colour,
         );
         let borders = crate::client::border_geometry_from_layout(
             &layout,
@@ -219,6 +220,7 @@ fn render_two_panes_keeps_half_highlight_path() {
             crate::border_lines::border_chars("single"),
             None,
             crate::client::WindowContentStyles::default(),
+            crate::pane_border::PaneBorderIndicators::Colour,
         );
         let borders = crate::client::border_geometry_from_layout(
             &layout,

--- a/tests-rs/test_preview_window_state.rs
+++ b/tests-rs/test_preview_window_state.rs
@@ -1,0 +1,168 @@
+use super::*;
+use crate::layout::LayoutJson;
+use crate::pane_border::PaneBorderIndicators;
+use ratatui::backend::TestBackend;
+use ratatui::layout::Rect;
+use ratatui::style::{Color, Style};
+use ratatui::Terminal;
+
+fn leaf(id: usize, active: bool) -> LayoutJson {
+    LayoutJson::Leaf {
+        id,
+        rows: 6,
+        cols: 4,
+        cursor_row: 0,
+        cursor_col: 0,
+        alternate_screen: false,
+        wants_mouse: false,
+        hide_cursor: true,
+        cursor_shape: 0,
+        active,
+        copy_mode: false,
+        scroll_offset: 0,
+        view_offset: 0,
+        sel_start_row: None,
+        sel_start_col: None,
+        sel_end_row: None,
+        sel_end_col: None,
+        sel_mode: None,
+        copy_cursor_row: None,
+        copy_cursor_col: None,
+        content: Vec::new(),
+        rows_v2: Vec::new(),
+        title: None,
+    }
+}
+
+#[test]
+fn layout_only_response_uses_default_border_modes_and_chooser_styles() {
+    let raw = serde_json::to_string(&leaf(0, true)).unwrap();
+    let state = parse_preview_window_state(&raw).unwrap();
+    assert_eq!(state.border_lines, crate::border_lines::DEFAULT);
+    assert_eq!(state.border_indicators, PaneBorderIndicators::Colour);
+    assert!(state.pane_border_style.is_none());
+    assert!(state.pane_active_border_style.is_none());
+
+    let (inactive, active) = state.pane_border_styles(
+        Style::default().fg(Color::Magenta),
+        Style::default().fg(Color::Cyan),
+    );
+    assert_eq!(inactive.fg, Some(Color::Magenta));
+    assert_eq!(active.fg, Some(Color::Cyan));
+}
+
+#[test]
+fn state_response_preserves_target_border_styles() {
+    let state = PreviewWindowState {
+        layout: leaf(0, true),
+        border_lines: "single".to_string(),
+        border_indicators: PaneBorderIndicators::Arrows,
+        pane_border_style: Some("fg=blue,bg=black".to_string()),
+        pane_active_border_style: Some("fg=red,bg=yellow".to_string()),
+        floating_pane_focused: false,
+    };
+    let raw = serde_json::to_string(&state).unwrap();
+    let parsed = parse_preview_window_state(&raw).unwrap();
+    assert_eq!(
+        parsed.pane_border_style.as_deref(),
+        Some("fg=blue,bg=black"),
+    );
+    assert_eq!(
+        parsed.pane_active_border_style.as_deref(),
+        Some("fg=red,bg=yellow"),
+    );
+
+    let (inactive, active) = parsed.pane_border_styles(
+        Style::default().fg(Color::White),
+        Style::default().fg(Color::Green),
+    );
+    assert_eq!(inactive.fg, Some(Color::Blue));
+    assert_eq!(inactive.bg, Some(Color::Black));
+    assert_eq!(active.fg, Some(Color::Red));
+    assert_eq!(active.bg, Some(Color::Yellow));
+}
+
+#[test]
+fn explicit_empty_state_styles_use_target_defaults() {
+    let state = PreviewWindowState {
+        layout: leaf(0, true),
+        border_lines: "single".to_string(),
+        border_indicators: PaneBorderIndicators::Colour,
+        pane_border_style: Some(String::new()),
+        pane_active_border_style: Some(String::new()),
+        floating_pane_focused: false,
+    };
+    let (inactive, active) = state.pane_border_styles(
+        Style::default().fg(Color::White),
+        Style::default().fg(Color::Magenta),
+    );
+    assert_eq!(inactive.fg, Some(Color::DarkGray));
+    assert_eq!(active.fg, Some(Color::Green));
+    assert_eq!(inactive.bg, Some(Color::Reset));
+    assert_eq!(active.bg, Some(Color::Reset));
+}
+
+#[test]
+fn state_without_style_fields_uses_chooser_styles() {
+    let raw = serde_json::json!({
+        "layout": leaf(0, true),
+        "border_lines": "spaces",
+        "border_indicators": "both",
+        "floating_pane_focused": false,
+    })
+    .to_string();
+    let state = parse_preview_window_state(&raw).unwrap();
+    assert_eq!(state.border_lines, "spaces");
+    assert_eq!(state.border_indicators, PaneBorderIndicators::Both);
+    assert!(state.pane_border_style.is_none());
+    assert!(state.pane_active_border_style.is_none());
+
+    let (inactive, active) = state.pane_border_styles(
+        Style::default().fg(Color::Yellow),
+        Style::default().fg(Color::LightBlue),
+    );
+    assert_eq!(inactive.fg, Some(Color::Yellow));
+    assert_eq!(active.fg, Some(Color::LightBlue));
+}
+
+#[test]
+fn preview_suppresses_tiled_indicators_when_float_is_focused() {
+    let layout = LayoutJson::Split {
+        kind: "Horizontal".to_string(),
+        sizes: vec![50, 50],
+        children: vec![leaf(0, true), leaf(1, false)],
+    };
+    let inactive = Style::default().fg(Color::DarkGray).bg(Color::Blue);
+    let active = Style::default().fg(Color::Green).bg(Color::Red);
+    let backend = TestBackend::new(10, 6);
+    let mut terminal = Terminal::new(backend).unwrap();
+    terminal
+        .draw(|frame| {
+            crate::preview::render_preview_layout(
+                frame,
+                &layout,
+                Rect::new(0, 0, 10, 6),
+                inactive,
+                active,
+                crate::border_lines::border_chars("single"),
+                PaneBorderIndicators::Arrows,
+                true,
+            );
+        })
+        .unwrap();
+    let buffer = terminal.backend().buffer();
+    assert!(
+        !buffer
+            .content
+            .iter()
+            .any(|cell| matches!(cell.symbol(), "←" | "→" | "↑" | "↓")),
+        "a focused float suppresses tiled preview arrows",
+    );
+    for y in 0..6 {
+        assert_eq!(
+            buffer[(4, y)].style().bg,
+            Some(Color::Blue),
+            "a focused float keeps the tiled divider inactive at row {y}",
+        );
+    }
+}

--- a/tests-rs/test_set_option_control.rs
+++ b/tests-rs/test_set_option_control.rs
@@ -1,0 +1,206 @@
+use super::*;
+
+fn rejected_control_command(command: &str, args: &[&str]) -> String {
+    let (request_tx, request_rx) = mpsc::channel();
+    let (response_tx, response_rx) = mpsc::channel();
+    assert!(dispatch_control_command(
+        command,
+        args,
+        &request_tx,
+        response_tx,
+        None,
+        false,
+        None,
+        0,
+    ));
+    let response = response_rx.recv().unwrap();
+    assert!(response.starts_with("\u{0001}ERR\u{0001}"));
+    assert!(matches!(
+        request_rx.try_recv(),
+        Err(mpsc::TryRecvError::Empty),
+    ));
+    response
+}
+
+#[test]
+fn combined_target_flags_consume_the_target_before_the_option_name() {
+    let parsed = parse_set_option_args(&[
+        "-gat",
+        "target",
+        "history-limit",
+        "42",
+    ]);
+    assert_eq!(parsed.flag_chars, "gat");
+    assert_eq!(parsed.target, Some("target"));
+    assert_eq!(parsed.positionals, ["history-limit", "42"]);
+}
+
+#[test]
+fn target_last_is_supported_and_dash_dash_preserves_literal_target_tokens() {
+    let target_last = parse_set_option_args(&[
+        "mouse",
+        "on",
+        "-t",
+        "target",
+    ]);
+    assert_eq!(target_last.target, Some("target"));
+    assert_eq!(target_last.positionals, ["mouse", "on"]);
+
+    let literal = parse_set_option_args(&[
+        "@value",
+        "--",
+        "-t",
+        "target",
+    ]);
+    assert_eq!(literal.target, None);
+    assert_eq!(literal.positionals, ["@value", "-t", "target"]);
+}
+
+#[test]
+fn dangling_target_is_rejected_without_dispatch() {
+    let parsed = parse_set_option_args(&["mouse", "off", "-t"]);
+    assert!(parsed.missing_target);
+    assert!(parsed.validate(false).is_err());
+
+    let response = rejected_control_command(
+        "set-option",
+        &["-g", "mouse", "off", "-t"],
+    );
+    assert!(response.contains("target required"));
+}
+
+#[test]
+fn malformed_flag_tokens_remain_flags_for_cli_rejection() {
+    let parsed = parse_set_option_args(&[
+        "-g1",
+        "history-limit",
+        "42",
+    ]);
+    assert_eq!(parsed.flag_chars, "g1");
+    assert_eq!(parsed.target, None);
+    assert_eq!(parsed.positionals, ["history-limit", "42"]);
+}
+
+#[test]
+fn control_mode_rejects_malformed_flag_tokens() {
+    let response = rejected_control_command(
+        "set-option",
+        &["-g1t", ":1", "history-limit", "42"],
+    );
+    assert!(response.contains("unknown flag -1"));
+}
+
+#[test]
+fn missing_option_name_is_rejected_without_dispatch() {
+    let response = rejected_control_command("set-option", &["-g"]);
+    assert!(response.contains("too few arguments"));
+}
+
+#[test]
+fn targeted_invalid_assignment_is_rejected_without_dispatch() {
+    let response = rejected_control_command(
+        "set-option",
+        &["-gt", ":1", "history-limit"],
+    );
+    assert!(response.contains("empty value"));
+}
+
+#[test]
+fn multi_token_integer_is_rejected_without_dispatch() {
+    let response = rejected_control_command(
+        "set-option",
+        &["-g", "history-limit", "42", "junk"],
+    );
+    assert!(response.contains("42 junk"));
+}
+
+#[test]
+fn negative_integer_is_rejected_without_dispatch() {
+    let response = rejected_control_command(
+        "set-option",
+        &["-g", "history-limit", "-1"],
+    );
+    assert!(response.contains("-1"));
+}
+
+#[test]
+fn numeric_options_use_catalog_destination_ranges() {
+    use crate::server::option_catalog::{NumberKind, OptionType, OPTION_CATALOG};
+
+    let cases = [
+        ("main-pane-width", NumberKind::U16, u16::MAX as u128),
+        ("escape-time", NumberKind::U64, u64::MAX as u128),
+        ("history-limit", NumberKind::Usize, usize::MAX as u128),
+        ("base-index", NumberKind::Index, isize::MAX as u128),
+        ("pane-base-index", NumberKind::Index, isize::MAX as u128),
+    ];
+
+    for (name, expected_kind, maximum) in cases {
+        let definition = OPTION_CATALOG
+            .iter()
+            .find(|definition| definition.name == name)
+            .unwrap();
+        assert_eq!(definition.option_type, OptionType::Number(expected_kind));
+        let maximum = maximum.to_string();
+        assert!(
+            parse_set_option_args(&["-g", name, &maximum])
+                .validate(false)
+                .is_ok(),
+            "{name} should accept {maximum}",
+        );
+
+        let too_large = (maximum.parse::<u128>().unwrap() + 1).to_string();
+        assert!(
+            parse_set_option_args(&["-g", name, &too_large])
+                .validate(false)
+                .is_err(),
+            "{name} should reject {too_large}",
+        );
+    }
+}
+
+#[test]
+fn index_options_reject_negative_and_malformed_values() {
+    for name in ["base-index", "pane-base-index"] {
+        for value in ["-1", "1x"] {
+            assert!(
+                parse_set_option_args(&["-g", name, value])
+                    .validate(false)
+                    .is_err(),
+                "{name} should reject {value}",
+            );
+        }
+    }
+}
+
+#[test]
+fn validation_only_numeric_options_preserve_cli_compatibility() {
+    use crate::server::option_catalog::{OPTION_CATALOG, VALIDATION_ONLY_OPTIONS};
+
+    for name in ["message-limit", "history-file-limit"] {
+        assert!(
+            OPTION_CATALOG
+                .iter()
+                .all(|definition| definition.name != name),
+            "{name} is validation-only and must not appear in option listings",
+        );
+        assert!(
+            VALIDATION_ONLY_OPTIONS
+                .iter()
+                .any(|definition| definition.name == name),
+            "{name} must have explicit validation metadata",
+        );
+        assert!(
+            parse_set_option_args(&["-g", name, "-1"])
+                .validate(false)
+                .is_ok(),
+            "{name} historically accepts signed integers",
+        );
+        assert!(
+            parse_set_option_args(&["-g", name, "invalid"])
+                .validate(false)
+                .is_err(),
+            "{name} should reject malformed integers",
+        );
+    }
+}

--- a/tests-rs/test_window_content_styles.rs
+++ b/tests-rs/test_window_content_styles.rs
@@ -98,6 +98,7 @@ fn render_at(
                 crate::border_lines::border_chars("single"),
                 None,
                 styles,
+                crate::pane_border::PaneBorderIndicators::Colour,
             );
         })
         .unwrap();

--- a/tests-rs/test_zoom_bleed.rs
+++ b/tests-rs/test_zoom_bleed.rs
@@ -78,6 +78,7 @@ fn zoomed_left_active_hidden_pane_label_never_rendered() {
             crate::border_lines::border_chars("single"),
             None,
             crate::client::WindowContentStyles::default(),
+            crate::pane_border::PaneBorderIndicators::Colour,
         );
     }).unwrap();
 
@@ -136,6 +137,7 @@ fn zoomed_right_active_hidden_pane_label_never_rendered() {
             crate::border_lines::border_chars("single"),
             None,
             crate::client::WindowContentStyles::default(),
+            crate::pane_border::PaneBorderIndicators::Colour,
         );
     }).unwrap();
 
@@ -194,6 +196,7 @@ fn zoomed_top_active_hidden_pane_label_never_rendered() {
             crate::border_lines::border_chars("single"),
             None,
             crate::client::WindowContentStyles::default(),
+            crate::pane_border::PaneBorderIndicators::Colour,
         );
     }).unwrap();
 
@@ -252,6 +255,7 @@ fn zoomed_bottom_active_hidden_pane_label_never_rendered() {
             crate::border_lines::border_chars("single"),
             None,
             crate::client::WindowContentStyles::default(),
+            crate::pane_border::PaneBorderIndicators::Colour,
         );
     }).unwrap();
 

--- a/tests/test_pane_border_indicator_preview.ps1
+++ b/tests/test_pane_border_indicator_preview.ps1
@@ -1,0 +1,194 @@
+$ErrorActionPreference = "Stop"
+[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new()
+$OutputEncoding = [System.Text.UTF8Encoding]::new()
+$psmux = (Get-Command psmux -ErrorAction Stop).Source
+$runId = [guid]::NewGuid().ToString("N")
+$namespace = "borderpreview_$($runId.Substring(0, 12))"
+$session = "borderpreview"
+$artifactRoot = Join-Path $env:TEMP "psmux-border-preview-$runId"
+$failed = 0
+
+function Wait-Until([scriptblock]$Condition, [int]$TimeoutSeconds, [string]$Failure) {
+    $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+    do {
+        if (& $Condition) { return }
+        Start-Sleep -Milliseconds 100
+    } while ((Get-Date) -lt $deadline)
+    throw $Failure
+}
+
+function Get-DefaultSessions {
+    $previousPreference = $PSNativeCommandUseErrorActionPreference
+    $PSNativeCommandUseErrorActionPreference = $false
+    try {
+        return @(& $psmux list-sessions -F '#{session_name}' 2>$null) | Sort-Object
+    } finally {
+        $PSNativeCommandUseErrorActionPreference = $previousPreference
+    }
+}
+
+function Invoke-RawPsmux([string]$SessionBase, [string]$Command) {
+    $port = [int](Get-Content (Join-Path $env:USERPROFILE ".psmux\$SessionBase.port"))
+    $key = (Get-Content (Join-Path $env:USERPROFILE ".psmux\$SessionBase.key") -Raw).Trim()
+    $client = [System.Net.Sockets.TcpClient]::new()
+    try {
+        $client.Connect("127.0.0.1", $port)
+        $stream = $client.GetStream()
+        $utf8 = [System.Text.UTF8Encoding]::new($false)
+        $writer = [System.IO.StreamWriter]::new($stream, $utf8, 1024, $true)
+        $reader = [System.IO.StreamReader]::new($stream, $utf8, $false, 1024, $true)
+        $writer.NewLine = "`n"
+        $writer.WriteLine("AUTH $key")
+        $writer.WriteLine($Command)
+        $writer.Flush()
+        $client.Client.Shutdown([System.Net.Sockets.SocketShutdown]::Send)
+        $authResponse = $reader.ReadLine()
+        if ($authResponse -ne "OK") {
+            throw "Raw psmux authentication failed: $authResponse"
+        }
+        return $reader.ReadToEnd()
+    } finally {
+        $client.Dispose()
+    }
+}
+
+function Render-Preview([string]$WindowId, [string]$Label) {
+    $stdoutPath = Join-Path $artifactRoot "$Label.out"
+    $stderrPath = Join-Path $artifactRoot "$Label.err"
+    $process = Start-Process `
+        -FilePath $psmux `
+        -ArgumentList @(
+            "-L",
+            $namespace,
+            "_render-preview",
+            "${namespace}__${session}",
+            $WindowId,
+            "40",
+            "12"
+        ) `
+        -RedirectStandardOutput $stdoutPath `
+        -RedirectStandardError $stderrPath `
+        -Wait `
+        -PassThru `
+        -WindowStyle Hidden
+    $utf8 = [System.Text.UTF8Encoding]::new($false, $true)
+    $stdout = $utf8.GetString([System.IO.File]::ReadAllBytes($stdoutPath))
+    if ($process.ExitCode -ne 0) {
+        $stderr = $utf8.GetString([System.IO.File]::ReadAllBytes($stderrPath))
+        throw "_render-preview failed with exit $($process.ExitCode): $stderr"
+    }
+    return $stdout
+}
+
+New-Item -ItemType Directory -Path $artifactRoot | Out-Null
+$defaultSessionsBefore = @(Get-DefaultSessions)
+
+try {
+    & $psmux -L $namespace kill-server 2>$null | Out-Null
+    & $psmux -L $namespace new-session -d -s $session 2>&1 | Out-Null
+    $portFile = Join-Path $env:USERPROFILE ".psmux\${namespace}__${session}.port"
+    Wait-Until { Test-Path $portFile } 10 "Session port file was not created"
+
+    & $psmux -L $namespace split-window -h -t $session 2>&1 | Out-Null
+    & $psmux -L $namespace set-option -g '@preview-border' red 2>&1 | Out-Null
+    & $psmux -L $namespace set-option -g pane-border-style 'fg=#{@preview-border}' 2>&1 | Out-Null
+    & $psmux -L $namespace set-option -g pane-active-border-style fg=blue 2>&1 | Out-Null
+    & $psmux -L $namespace set-option -g pane-border-indicators both 2>&1 | Out-Null
+    & $psmux -L $namespace set-option -g pane-border-lines spaces 2>&1 | Out-Null
+
+    $windowId = (& $psmux -L $namespace list-windows -t $session -F '#{window_id}').TrimStart("@")
+    $sessionBase = "${namespace}__${session}"
+    $layoutRaw = Invoke-RawPsmux $sessionBase "window-dump $windowId"
+    try {
+        $layout = ConvertFrom-Json -InputObject $layoutRaw
+    } catch {
+        throw "raw window-dump returned invalid JSON: $layoutRaw"
+    }
+    if ($null -ne $layout.layout -or $null -eq $layout.kind) {
+        throw "raw window-dump does not return the layout-only wire format: $layoutRaw"
+    }
+
+    $stateRaw = Invoke-RawPsmux $sessionBase "window-dump $windowId state"
+    try {
+        $state = ConvertFrom-Json -InputObject $stateRaw
+    } catch {
+        throw "window-dump state returned invalid JSON: $stateRaw"
+    }
+    if ($state.border_lines -cne "spaces") {
+        throw "window-dump state returned border_lines '$($state.border_lines)', expected exactly 'spaces'"
+    }
+    if ($state.border_indicators -ne "both") {
+        throw "window-dump state returned indicators '$($state.border_indicators)', expected 'both'"
+    }
+    if (
+        $state.pane_border_style -ne "fg=red" -or
+        $state.pane_active_border_style -ne "fg=blue"
+    ) {
+        throw "window-dump state did not carry expanded border styles: $stateRaw"
+    }
+    if ($state.floating_pane_focused) {
+        throw "window-dump state reported a focused float before one existed"
+    }
+
+    $preview = Render-Preview $windowId "tiled"
+    if (-not $preview.Contains([string][char]0x2192)) {
+        throw "_render-preview did not use the target window's spaces+both settings"
+    }
+    if (
+        -not $preview.Contains("$([char]27)[31m") -or
+        -not $preview.Contains("$([char]27)[34m")
+    ) {
+        throw "_render-preview did not use the target window's expanded border styles"
+    }
+    $singleLineGlyphs = @(
+        0x2500, 0x2502, 0x250C, 0x2510, 0x2514, 0x2518,
+        0x251C, 0x2524, 0x252C, 0x2534, 0x253C
+    ) | ForEach-Object { [string][char]$_ }
+    $ordinaryBorders = @($singleLineGlyphs | Where-Object { $preview.Contains($_) })
+    if ($ordinaryBorders.Count -ne 0) {
+        throw "_render-preview emitted single-line glyphs in spaces mode: $($ordinaryBorders -join '')"
+    }
+
+    & $psmux -L $namespace set-option -g pane-border-lines single 2>&1 | Out-Null
+    & $psmux -L $namespace new-pane -t $session -E -X 2 -Y 2 -x 8 -y 5 2>&1 | Out-Null
+    Wait-Until {
+        $raw = Invoke-RawPsmux $sessionBase "window-dump $windowId state"
+        try {
+            (ConvertFrom-Json -InputObject $raw).floating_pane_focused -eq $true
+        } catch {
+            $false
+        }
+    } 10 "window-dump state did not report the focused floating pane"
+
+    $floatingPreview = Render-Preview $windowId "floating"
+    foreach ($arrow in @(
+        [string][char]0x2190,
+        [string][char]0x2191,
+        [string][char]0x2192,
+        [string][char]0x2193
+    )) {
+        if ($floatingPreview.Contains($arrow)) {
+            throw "_render-preview kept tiled arrows while a floating pane was focused"
+        }
+    }
+    if (-not $floatingPreview.Contains("$([char]27)[31m")) {
+        throw "_render-preview did not keep the inactive target border style with floating focus"
+    }
+
+    Write-Host "[PASS] preview carries pane border settings and floating focus" -ForegroundColor Green
+}
+catch {
+    $failed++
+    Write-Host "[FAIL] $($_.InvocationInfo.PositionMessage) $_" -ForegroundColor Red
+}
+finally {
+    & $psmux -L $namespace kill-server 2>$null | Out-Null
+    $defaultSessionsAfter = @(Get-DefaultSessions)
+    if (Compare-Object $defaultSessionsBefore $defaultSessionsAfter) {
+        $failed++
+        Write-Host "[FAIL] Default namespace changed during isolated test" -ForegroundColor Red
+    }
+    Remove-Item $artifactRoot -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+exit $failed

--- a/tests/test_pane_border_indicators.ps1
+++ b/tests/test_pane_border_indicators.ps1
@@ -1,0 +1,242 @@
+$ErrorActionPreference = "Stop"
+[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new()
+$OutputEncoding = [System.Text.UTF8Encoding]::new()
+$psmux = (Get-Command psmux -ErrorAction Stop).Source
+$runId = [guid]::NewGuid().ToString("N")
+$namespace = "borderind_$($runId.Substring(0, 12))"
+$session = "borderind"
+$targetSession = "borderindtarget"
+$artifactRoot = Join-Path $env:TEMP "psmux-border-indicators-$runId"
+$hostExe = Join-Path $artifactRoot "conpty_host.exe"
+$outputFile = Join-Path $artifactRoot "conpty_out.bin"
+$controlFile = Join-Path $artifactRoot "conpty_ctrl.txt"
+$logFile = Join-Path $artifactRoot "conpty_host.log"
+$pidFile = Join-Path $artifactRoot "conpty_childpid.txt"
+$rightArrow = "<E2><86><92>"
+$failed = 0
+
+function Read-BinEscaped([long]$Start = 0) {
+    if (-not (Test-Path $outputFile)) { return "" }
+    $stream = [System.IO.File]::Open($outputFile, "Open", "Read", "ReadWrite")
+    $length = [Math]::Max(0, $stream.Length - $Start)
+    [void]$stream.Seek($Start, [System.IO.SeekOrigin]::Begin)
+    $buffer = New-Object byte[] $length
+    [void]$stream.Read($buffer, 0, $length)
+    $stream.Close()
+    $builder = [System.Text.StringBuilder]::new()
+    foreach ($byte in $buffer) {
+        if ($byte -eq 0x1b) { [void]$builder.Append("<ESC>") }
+        elseif ($byte -ge 32 -and $byte -lt 127) { [void]$builder.Append([char]$byte) }
+        elseif ($byte -eq 0x0a) { [void]$builder.Append("\n") }
+        else { [void]$builder.Append(("<{0:X2}>" -f $byte)) }
+    }
+    return $builder.ToString()
+}
+
+function Wait-Until([scriptblock]$Condition, [int]$TimeoutSeconds, [string]$Failure) {
+    $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+    do {
+        if (& $Condition) { return }
+        Start-Sleep -Milliseconds 100
+    } while ((Get-Date) -lt $deadline)
+    throw $Failure
+}
+
+function Get-DefaultSessions {
+    $previousPreference = $PSNativeCommandUseErrorActionPreference
+    $PSNativeCommandUseErrorActionPreference = $false
+    try {
+        return @(& $psmux list-sessions -F '#{session_name}' 2>$null) |
+            Sort-Object
+    } finally {
+        $PSNativeCommandUseErrorActionPreference = $previousPreference
+    }
+}
+
+function Assert-RejectedIndicator([string]$Label, [string[]]$CommandArguments) {
+    $slug = $Label -replace "[^a-z0-9]+", "-"
+    $stdoutPath = Join-Path $artifactRoot "$slug.out"
+    $stderrPath = Join-Path $artifactRoot "$slug.err"
+    $process = Start-Process `
+        -FilePath $psmux `
+        -ArgumentList $CommandArguments `
+        -RedirectStandardOutput $stdoutPath `
+        -RedirectStandardError $stderrPath `
+        -Wait `
+        -PassThru `
+        -WindowStyle Hidden
+    $value = (& $psmux -L $namespace show-options -t $session -g -v pane-border-indicators).Trim()
+    if ($process.ExitCode -eq 0 -or $value -ne "colour") {
+        $stdout = Get-Content $stdoutPath -Raw -ErrorAction SilentlyContinue
+        $stderr = Get-Content $stderrPath -Raw -ErrorAction SilentlyContinue
+        throw "Expected indicator rejection without mutation for $Label (exit=$($process.ExitCode), value='$value', stdout='$stdout', stderr='$stderr')"
+    }
+}
+
+function Invoke-RawPsmux([string]$SessionBase, [string]$Command) {
+    $port = [int](Get-Content (Join-Path $env:USERPROFILE ".psmux\$SessionBase.port"))
+    $key = (Get-Content (Join-Path $env:USERPROFILE ".psmux\$SessionBase.key") -Raw).Trim()
+    $client = [System.Net.Sockets.TcpClient]::new()
+    try {
+        $client.Connect("127.0.0.1", $port)
+        $stream = $client.GetStream()
+        $utf8 = [System.Text.UTF8Encoding]::new($false)
+        $writer = [System.IO.StreamWriter]::new($stream, $utf8, 1024, $true)
+        $reader = [System.IO.StreamReader]::new($stream, $utf8, $false, 1024, $true)
+        $writer.NewLine = "`n"
+        $writer.WriteLine("AUTH $key")
+        $writer.WriteLine($Command)
+        $writer.Flush()
+        $client.Client.Shutdown([System.Net.Sockets.SocketShutdown]::Send)
+        return $reader.ReadToEnd()
+    } finally {
+        $client.Dispose()
+    }
+}
+
+New-Item -ItemType Directory -Path $artifactRoot | Out-Null
+$defaultSessionsBefore = @(Get-DefaultSessions)
+$variables = @(
+    "PSMUX_CONPTY_OUT",
+    "PSMUX_CONPTY_CTRL",
+    "PSMUX_CONPTY_LOG",
+    "PSMUX_CONPTY_PID"
+)
+$previous = @{}
+foreach ($name in $variables) {
+    $previous[$name] = if (Test-Path "Env:\$name") { (Get-Item "Env:\$name").Value } else { $null }
+}
+$client = $null
+
+try {
+    $compiler = "C:\Windows\Microsoft.NET\Framework64\v4.0.30319\csc.exe"
+    $compilerOutput = & $compiler /nologo /optimize /out:$hostExe tests\conpty_host_0xE.cs 2>&1
+    if (-not (Test-Path $hostExe)) {
+        throw "ConPTY host compilation failed: $($compilerOutput -join [Environment]::NewLine)"
+    }
+
+    $env:PSMUX_CONPTY_OUT = $outputFile
+    $env:PSMUX_CONPTY_CTRL = $controlFile
+    $env:PSMUX_CONPTY_LOG = $logFile
+    $env:PSMUX_CONPTY_PID = $pidFile
+    & $psmux -L $namespace kill-server 2>$null | Out-Null
+    $client = Start-Process `
+        -FilePath $hostExe `
+        -ArgumentList "`"$psmux`" -L $namespace new-session -s $session" `
+        -PassThru `
+        -WindowStyle Hidden
+
+    $portFile = Join-Path $env:USERPROFILE ".psmux\${namespace}__${session}.port"
+    Wait-Until { Test-Path $portFile } 10 "Session port file was not created"
+    Wait-Until { (Test-Path $outputFile) -and (Get-Item $outputFile).Length -gt 0 } 10 "Initial render was not captured"
+
+    $default = (& $psmux -L $namespace show-options -g -v pane-border-indicators).Trim()
+    if ($default -ne "colour") { throw "Default indicator was '$default', expected 'colour'" }
+
+    $splitOffset = (Get-Item $outputFile).Length
+    & $psmux -L $namespace split-window -h -t $session 2>&1 | Out-Null
+    Wait-Until {
+        $paneCount = (& $psmux -L $namespace display-message -t $session -p '#{window_panes}' 2>$null).Trim()
+        $paneCount -eq "2" -and (Get-Item $outputFile).Length -gt $splitOffset
+    } 10 "Two-pane render was not observed"
+
+    $before = Read-BinEscaped
+    if ($before -match $rightArrow) { throw "Arrow appeared in default colour mode" }
+
+    $arrowOffset = (Get-Item $outputFile).Length
+    & $psmux -L $namespace set-option -g pane-border-indicators arrows 2>&1 | Out-Null
+    Wait-Until {
+        (Read-BinEscaped -Start $arrowOffset) -match $rightArrow
+    } 10 "Right arrow was not emitted after selecting arrows mode"
+
+    $resetOffset = (Get-Item $outputFile).Length
+    & $psmux -L $namespace set-option -gu pane-border-indicators 2>&1 | Out-Null
+    Wait-Until {
+        (Get-Item $outputFile).Length -gt $resetOffset
+    } 10 "No repaint followed indicator reset"
+    $afterReset = Read-BinEscaped -Start $resetOffset
+    $resetValue = (& $psmux -L $namespace show-options -g -v pane-border-indicators).Trim()
+    if ($resetValue -ne "colour" -or $afterReset -match $rightArrow) {
+        throw "Reset failed (value='$resetValue', arrow=$($afterReset -match $rightArrow))"
+    }
+
+    & $psmux -L $namespace new-window -d -t $session -n focus-probe 2>&1 | Out-Null
+    $sourceBase = "${namespace}__${session}"
+    foreach ($rawCommand in @(
+        "set-option -gt :1 pane-border-indicators arrows -junk",
+        "set-option -gat :1 pane-border-indicators arrows",
+        "set-option -gt :1 pane-border-indicators",
+        "set-option -gqt :1 pane-border-indicators sideways"
+    )) {
+        $rejection = Invoke-RawPsmux $sourceBase $rawCommand
+        if ($rejection -notmatch "ERROR:") {
+            throw "Raw targeted rejection returned no error: $rawCommand"
+        }
+        $focusResponse = Invoke-RawPsmux $sourceBase 'display-message -p "#{window_index}"'
+        $windowIndices = @($focusResponse -split "\r?\n" | Where-Object { $_ -match "^\d+$" })
+        if ($windowIndices.Count -eq 0 -or $windowIndices[-1] -ne "0") {
+            throw "Rejected targeted set leaked focus after '$rawCommand': $focusResponse"
+        }
+    }
+
+    & $psmux -L $namespace new-session -d -s $targetSession 2>&1 | Out-Null
+    $targetPortFile = Join-Path $env:USERPROFILE ".psmux\${namespace}__${targetSession}.port"
+    Wait-Until { Test-Path $targetPortFile } 10 "Target session port file was not created"
+    & $psmux -L $namespace set-option -gt $targetSession pane-border-indicators arrows 2>&1 | Out-Null
+    $sourceValue = (& $psmux -L $namespace show-options -t $session -g -v pane-border-indicators).Trim()
+    $targetValue = (& $psmux -L $namespace show-options -t $targetSession -g -v pane-border-indicators).Trim()
+    if ($sourceValue -ne "colour" -or $targetValue -ne "arrows") {
+        throw "Combined target routed incorrectly (source='$sourceValue', target='$targetValue')"
+    }
+
+    foreach ($case in @(
+        @{
+            Label = "invalid value"
+            Arguments = @("-L", $namespace, "set-option", "-g", "pane-border-indicators", "sideways")
+        },
+        @{
+            Label = "multi-token invalid value"
+            Arguments = @("-L", $namespace, "set-option", "-g", "pane-border-indicators", "arrows", "junk")
+        },
+        @{
+            Label = "append"
+            Arguments = @("-L", $namespace, "set-option", "-ga", "pane-border-indicators", "arrows")
+        },
+        @{
+            Label = "window command"
+            Arguments = @("-L", $namespace, "set-window-option", "pane-border-indicators", "arrows")
+        },
+        @{
+            Label = "window flag"
+            Arguments = @("-L", $namespace, "set-option", "-w", "pane-border-indicators", "arrows")
+        }
+    )) {
+        Assert-RejectedIndicator $case.Label $case.Arguments
+    }
+
+    Write-Host "[PASS] pane-border-indicators colour -> arrows -> colour" -ForegroundColor Green
+}
+catch {
+    $failed++
+    Write-Host "[FAIL] $($_.InvocationInfo.PositionMessage) $_" -ForegroundColor Red
+}
+finally {
+    if ($null -ne $client -and -not $client.HasExited) {
+        Set-Content -Path $controlFile -Value "QUIT`n" -NoNewline -ErrorAction SilentlyContinue
+        Start-Sleep -Milliseconds 300
+        Stop-Process -Id $client.Id -Force -ErrorAction SilentlyContinue
+    }
+    & $psmux -L $namespace kill-server 2>$null | Out-Null
+    $defaultSessionsAfter = @(Get-DefaultSessions)
+    if (Compare-Object $defaultSessionsBefore $defaultSessionsAfter) {
+        $failed++
+        Write-Host "[FAIL] Default namespace changed during isolated test" -ForegroundColor Red
+    }
+    foreach ($name in $variables) {
+        if ($null -eq $previous[$name]) { Remove-Item "Env:\$name" -ErrorAction SilentlyContinue }
+        else { Set-Item "Env:\$name" $previous[$name] }
+    }
+    Remove-Item $artifactRoot -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+exit $failed


### PR DESCRIPTION
## Summary

This PR makes the active-pane cues on pane borders configurable with `pane-border-indicators`. The existing `colour` behavior remains the default, so current configurations keep the same focus indication.

- `off` draws no split or arrows; the focused pane's border keeps `pane-active-border-style`.
- `colour` splits a two-pane divider between the active and inactive border colours.
- `arrows` places inward-pointing markers on dividers around the active tiled pane and on the focused floating pane.
- `both` combines the colour and arrow cues.

When a floating pane owns focus, the tiled layout no longer highlights an inactive pane.

Chooser previews now carry the target window's border line mode, border styles, indicator mode, and floating-focus state. `choose-tree` and `choose-session` therefore show the same active-pane cues as the target window while still omitting floating panes.

## Screenshots

![Pane border indicator modes: off, colour, arrows, and both](https://github.com/user-attachments/assets/c1aa3a74-3c7a-4586-ae4c-faf536aaeebc)

## Compatibility and option behavior

`set-option -u pane-border-indicators` restores the default. The option is a global/default window setting. It rejects per-window overrides and unsupported values.

The preview protocol keeps its layout-only fallback. A client that receives no preview state uses single border lines, chooser border colours, and `colour` indicators.

This PR also shares `set-option` argument parsing across the CLI, TCP, and control-mode paths, while config parsing uses the same option catalog validation. Missing or invalid values are rejected before dispatch without changing existing `-s`, `-u`, `-o`/`-q`, append, target, or literal-value behavior.

## Implementation

The renderer models the four modes as a typed `PaneBorderIndicators` value. Tiled borders use shared geometry to place arrows beside the active pane and split the divider colour in two-pane windows; floating borders apply the same mode after drawing the pane title. Preview state extends `window-dump` with the target's border settings.

## Validation

- All 3,335 Rust tests pass per binary target.
- All four smoke integration suites pass.
- Live server-scope and set-option diagnostic regression suites pass.
- Live pane-border background, indicator, preview, and client-style scenarios pass.
