### PR TITLE
fix(kill-window): require a value for -t

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -940,6 +940,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
+name = "lexopt"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "803ec87c9cfb29b9d2633f20cba1f488db3fd53f2158b1024cbefb47ba05d413"
+
+[[package]]
 name = "libc"
 version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1369,6 +1375,7 @@ dependencies = [
  "chrono",
  "crossterm",
  "glob",
+ "lexopt",
  "parking_lot",
  "portable-pty-psmux",
  "ratatui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,10 @@ name = "test_pr469_osc_command_safety"
 path = "tests-rs/test_pr469_osc_command_safety.rs"
 
 [[test]]
+name = "test_kill_window_cli_error"
+path = "tests-rs/test_kill_window_cli_error.rs"
+
+[[test]]
 name = "test_issue494_copymode_freeze"
 path = "tests-rs/test_issue494_copymode_freeze.rs"
 
@@ -117,6 +121,7 @@ regex = "1.13.1"
 glob = "0.3.4"
 anyhow = "1.0.104"
 base64 = "0.23.1"
+lexopt = "0.3.2"
 
 [profile.release]
 opt-level = 3

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -632,6 +632,89 @@ pub fn parse_command_to_action(cmd: &str) -> Option<Action> {
     }
 }
 
+/// Joins tokens into a command string while preserving ordinary token
+/// boundaries; `;` and `\;` remain command-chain separators.
+pub fn requote_command_tail<S: AsRef<str>>(args: &[S]) -> String {
+    args.iter()
+        .map(|token| {
+            let token = token.as_ref();
+            if token.is_empty() {
+                "''".to_string()
+            } else if token == ";" || token == "\\;" {
+                token.to_string()
+            } else if token.contains('\'') {
+                format!(
+                    "\"{}\"",
+                    token.replace('\\', "\\\\").replace('"', "\\\"")
+                )
+            } else if token.chars().any(|c| c.is_whitespace() || c == '"') {
+                format!("'{}'", token)
+            } else {
+                token.to_string()
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+/// Validates nested `kill-window` syntax in bindings, hooks, and confirmation
+/// commands, returning `Err` when nesting exceeds `MAX_DEFERRED_COMMAND_DEPTH`.
+pub fn validate_deferred_command<S: AsRef<str>>(
+    command: &str,
+    args: &[S],
+) -> Result<(), String> {
+    validate_deferred_command_at_depth(command, args, 0)
+}
+
+// Maliciously nested config/binding commands would otherwise recurse until
+// the process stack overflows.
+const MAX_DEFERRED_COMMAND_DEPTH: usize = 64;
+
+fn validate_deferred_command_at_depth<S: AsRef<str>>(
+    command: &str,
+    args: &[S],
+    depth: usize,
+) -> Result<(), String> {
+    let Some(start) = crate::cli::deferred_command_start(command, args) else {
+        return Ok(());
+    };
+    if depth >= MAX_DEFERRED_COMMAND_DEPTH {
+        return Err(format!(
+            "command nesting exceeds {MAX_DEFERRED_COMMAND_DEPTH} levels"
+        ));
+    }
+    let nested = if args[start..].len() == 1 {
+        // Quoted deferred commands arrive as one already-unquoted token.
+        args[start].as_ref().to_string()
+    } else {
+        requote_command_tail(&args[start..])
+    };
+    validate_command_sequence_at_depth(&nested, depth + 1)
+}
+
+/// Validates `kill-window` syntax and nested deferred commands in a chain.
+pub fn validate_command_sequence(command: &str) -> Result<(), String> {
+    validate_command_sequence_at_depth(command, 0)
+}
+
+fn validate_command_sequence_at_depth(command: &str, depth: usize) -> Result<(), String> {
+    for command in crate::config::split_chained_commands_pub(command) {
+        let tokens = parse_command_line(&command);
+        let Some(name) = tokens.first() else {
+            continue;
+        };
+        let args = &tokens[1..];
+        if let Some(parsed) = crate::kill_window::KillWindowCommand::parse(
+            name,
+            args.iter(),
+        ) {
+            parsed.map_err(|error| error.to_string())?;
+        }
+        validate_deferred_command_at_depth(name, args, depth)?;
+    }
+    Ok(())
+}
+
 /// Format an Action back to a command string
 pub fn format_action(action: &Action) -> String {
     match action {
@@ -972,7 +1055,73 @@ pub fn execute_command_string(app: &mut AppState, cmd: &str) -> io::Result<()> {
     execute_command_string_single(app, cmd)
 }
 
+/// Applies a parsed `kill-window` command in process without removing the
+/// session's final window.
+fn execute_kill_window(app: &mut AppState, command: &crate::kill_window::KillWindowCommand) {
+    let mut removed_pos = Some(app.active_idx);
+    if let Some(target) = command.target() {
+        let parsed = crate::cli::parse_target(target);
+        // A named target that does not resolve must not fall back to the active
+        // window; tmux reports "can't find window" and leaves state unchanged.
+        removed_pos = if let Some(window) = parsed.window {
+            if parsed.window_is_id {
+                app.windows.iter().position(|candidate| candidate.id == window)
+            } else {
+                app.win_pos(window)
+            }
+        } else if let Some(name) = parsed.window_name {
+            app.windows
+                .iter()
+                .position(|candidate| candidate.name == name)
+        } else {
+            // A bare session target means the active window, matching tmux.
+            Some(app.active_idx)
+        };
+        if removed_pos.is_none() {
+            app.status_message = Some((
+                format!("can't find window: {target}"),
+                std::time::Instant::now(),
+                None,
+            ));
+        }
+    }
+    if let Some(pos) = removed_pos {
+        if app.windows.len() > 1 && pos < app.windows.len() {
+            let mut window = app.windows.remove(pos);
+            kill_all_children(&mut window.root);
+            app.on_window_removed(pos);
+            if app.active_idx > pos {
+                app.active_idx -= 1;
+            }
+            if app.active_idx >= app.windows.len() {
+                app.active_idx = app.windows.len() - 1;
+            }
+        }
+    }
+}
+
 fn execute_command_string_single(app: &mut AppState, cmd: &str) -> io::Result<()> {
+    let parsed = parse_command_line(cmd);
+    if let Some(name) = parsed.first() {
+        if let Err(error) = validate_deferred_command(name, &parsed[1..]) {
+            app.status_message = Some((error.clone(), std::time::Instant::now(), None));
+            return Err(io::Error::new(io::ErrorKind::InvalidInput, error));
+        }
+        if let Some(command) = crate::kill_window::KillWindowCommand::parse(
+            name,
+            parsed.iter().skip(1),
+        ) {
+            let command = command.map_err(|error| {
+                let message = error.to_string();
+                app.status_message =
+                    Some((message.clone(), std::time::Instant::now(), None));
+                io::Error::new(io::ErrorKind::InvalidInput, message)
+            })?;
+            execute_kill_window(app, &command);
+            return Ok(());
+        }
+    }
+
     let parts: Vec<&str> = cmd.split_whitespace().collect();
     if parts.is_empty() { return Ok(()); }
     
@@ -995,48 +1144,6 @@ fn execute_command_string_single(app: &mut AppState, cmd: &str) -> io::Result<()
         }
         "kill-pane" => {
             let _ = kill_active_pane(app);
-        }
-        "kill-window" | "killw" => {
-            // Resolve an explicit -t here; an unresolvable target is an error,
-            // not a fallback to the active window (tmux: "can't find window").
-            let mut removed_pos = Some(app.active_idx);
-            if let Some(t_pos) = parts.iter().position(|p| *p == "-t") {
-                if let Some(t) = parts.get(t_pos + 1) {
-                    let pt = crate::cli::parse_target(t);
-                    removed_pos = if let Some(w) = pt.window {
-                        if pt.window_is_id {
-                            app.windows.iter().position(|x| x.id == w)
-                        } else {
-                            app.win_pos(w)
-                        }
-                    } else if let Some(ref n) = pt.window_name {
-                        app.windows.iter().position(|x| x.name == *n)
-                    } else {
-                        // Bare session target: the active window, like tmux.
-                        Some(app.active_idx)
-                    };
-                    if removed_pos.is_none() {
-                        app.status_message = Some((
-                            format!("can't find window: {}", t),
-                            std::time::Instant::now(),
-                            None,
-                        ));
-                    }
-                }
-            }
-            if let Some(pos) = removed_pos {
-                if app.windows.len() > 1 && pos < app.windows.len() {
-                    let mut win = app.windows.remove(pos);
-                    kill_all_children(&mut win.root);
-                    app.on_window_removed(pos);
-                    if app.active_idx > pos {
-                        app.active_idx -= 1;
-                    }
-                    if app.active_idx >= app.windows.len() {
-                        app.active_idx = app.windows.len() - 1;
-                    }
-                }
-            }
         }
         "next-window" | "next" => {
             if !app.windows.is_empty() {

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,7 +3,7 @@ use std::cell::RefCell;
 use crossterm::event::{KeyCode, KeyModifiers};
 
 use crate::types::{AppState, Action, Bind};
-use crate::commands::parse_command_to_action;
+use crate::commands::{parse_command_to_action, validate_command_sequence};
 
 // Track the current config file being parsed (for #{current_file}, #{d:current_file})
 thread_local! {
@@ -763,6 +763,10 @@ pub fn parse_config_line(app: &mut AppState, line: &str) {
                     cmd
                 }
             };
+            if let Err(error) = validate_command_sequence(&cmd) {
+                warn_config(app, error);
+                return;
+            }
             if append {
                 // -a/-ga: append to existing hook list (tmux multi-handler).
                 // Dedup identical commands so a re-sourced config does not
@@ -793,6 +797,10 @@ pub fn parse_config_line(app: &mut AppState, line: &str) {
         }
     }
     else {
+        if let Err(error) = validate_command_sequence(l) {
+            warn_config(app, error);
+            return;
+        }
         // Unrecognized directive. Warn only when the first token is not a known
         // command (a known-but-unrouted command like `new-window` stays silent
         // to match prior behavior; a genuine typo like `bnid-key` is surfaced).
@@ -1652,6 +1660,10 @@ pub fn parse_bind_key(app: &mut AppState, line: &str) {
     
     if i >= parts.len() { return; }
     let command = parts[i..].join(" ");
+    if let Err(error) = validate_command_sequence(&command) {
+        warn_config(app, error);
+        return;
+    }
     
     // Split on `\;` or `;` to support command chaining (like tmux `bind x split-window \; select-pane -D`)
     let sub_commands: Vec<String> = split_chained_commands(&command);

--- a/src/kill_window.rs
+++ b/src/kill_window.rs
@@ -1,0 +1,251 @@
+use std::ffi::OsString;
+use std::fmt;
+
+use lexopt::Arg::{Long, Short, Value};
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct KillWindowCommand {
+    target: Option<String>,
+    all: bool,
+}
+
+impl KillWindowCommand {
+    pub fn parse<I, S>(command: &str, args: I) -> Option<Result<Self, ParseError>>
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        if !matches!(command, "kill-window" | "killw") {
+            return None;
+        }
+
+        Some(Self::parse_args(args))
+    }
+
+    fn parse_args<I, S>(args: I) -> Result<Self, ParseError>
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        let args = crate::cli::normalize_flag_equals(
+            args.into_iter()
+                .map(|argument| argument.as_ref().to_string())
+                .collect(),
+        );
+        let args = args.into_iter().map(OsString::from);
+        let mut parser = lexopt::Parser::from_args(args);
+        let mut command = Self::default();
+
+        while let Some(argument) = parser.next().map_err(|_| ParseError::InvalidArguments)? {
+            match argument {
+                Short('a') => command.all = true,
+                Short('t') => {
+                    command.target = Some(
+                        parser
+                            .value()
+                            .map_err(|_| ParseError::MissingValue('t'))?
+                            .into_string()
+                            .map_err(|_| ParseError::InvalidArguments)?,
+                    );
+                }
+                Long(_) => {
+                    let _ = parser.optional_value();
+                }
+                // Preserve the old leniency for options this slice does not own.
+                Short(_) | Value(_) => {}
+            }
+        }
+
+        Ok(command)
+    }
+
+    pub fn target(&self) -> Option<&str> {
+        self.target.as_deref()
+    }
+
+    pub fn effective_target(&self, transport_target: Option<&str>) -> Option<String> {
+        let Some(command_target) = self.target() else {
+            return transport_target.map(str::to_string);
+        };
+        let Some(transport_target) = transport_target else {
+            return Some(command_target.to_string());
+        };
+        let parsed_command_target = crate::cli::parse_target(command_target);
+        // An inline target that names no window keeps the transport window.
+        if parsed_command_target.window.is_none()
+            && parsed_command_target.window_name.is_none()
+        {
+            return Some(transport_target.to_string());
+        }
+        if has_explicit_session(command_target) {
+            return Some(command_target.to_string());
+        }
+        let Some(session) = crate::cli::parse_target(transport_target).session else {
+            return Some(command_target.to_string());
+        };
+        let command_target = crate::cli::strip_exact_match_prefix(command_target);
+        if command_target.starts_with(':') {
+            Some(format!("{session}{command_target}"))
+        } else {
+            Some(format!("{session}:{command_target}"))
+        }
+    }
+
+    /// The target travels in the protocol's `TARGET` line; other flags stay in
+    /// the command body.
+    pub fn to_wire_command(&self) -> String {
+        let mut line = String::from("kill-window");
+        if self.all {
+            line.push_str(" -a");
+        }
+        line.push('\n');
+        line
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ParseError {
+    MissingValue(char),
+    InvalidArguments,
+}
+
+impl fmt::Display for ParseError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::MissingValue(option) => write!(formatter, "-{option} expects an argument"),
+            Self::InvalidArguments => write!(formatter, "kill-window: invalid arguments"),
+        }
+    }
+}
+
+impl std::error::Error for ParseError {}
+
+fn has_explicit_session(target: &str) -> bool {
+    let target = crate::cli::strip_exact_match_prefix(target);
+    // parse_target reads an unqualified token as a session name; this asks
+    // whether the user wrote a session qualifier.
+    if matches!(target.as_bytes().first(), Some(b':' | b'@' | b'%')) {
+        return false;
+    }
+    if let Some((session, _)) = target.split_once(':') {
+        return !session.is_empty();
+    }
+    if target.starts_with('.') {
+        return false;
+    }
+    if let Some((session, pane)) = target.rsplit_once('.') {
+        if pane.parse::<usize>().is_ok() {
+            return !session.is_empty();
+        }
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(args: &[&str]) -> Result<KillWindowCommand, ParseError> {
+        KillWindowCommand::parse("kill-window", args.iter().copied()).unwrap()
+    }
+
+    #[test]
+    fn aliases_share_the_parser() {
+        for command in ["kill-window", "killw"] {
+            assert_eq!(
+                KillWindowCommand::parse(command, ["-t"]).unwrap(),
+                Err(ParseError::MissingValue('t'))
+            );
+        }
+        assert!(KillWindowCommand::parse("kill-session", ["-t"]).is_none());
+    }
+
+    #[test]
+    fn accepts_separate_attached_clustered_and_equals_target_forms() {
+        for (args, expected) in [
+            (&["-t", "@42"][..], "@42"),
+            (&["-t@42"][..], "@42"),
+            (&["-at", "@42"][..], "@42"),
+            (&["-t=@42"][..], "@42"),
+        ] {
+            assert_eq!(parse(args).unwrap().target(), Some(expected));
+        }
+    }
+
+    #[test]
+    fn last_target_wins() {
+        let command = parse(&["-t", ":1", "-t:2"]).unwrap();
+        assert_eq!(command.target(), Some(":2"));
+    }
+
+    #[test]
+    fn option_value_may_begin_with_a_dash() {
+        let command = parse(&["-t", "-a"]).unwrap();
+        assert_eq!(command.target(), Some("-a"));
+    }
+
+    #[test]
+    fn double_dash_ends_option_parsing() {
+        let command = parse(&["--", "-t", "@42"]).unwrap();
+        assert_eq!(command.target(), None);
+    }
+
+    #[test]
+    fn explicit_target_overrides_transport_target() {
+        let inherited = parse(&[]).unwrap();
+        let explicit = parse(&["-t", ":2"]).unwrap();
+
+        assert_eq!(
+            inherited.effective_target(Some("work:1.%3")).as_deref(),
+            Some("work:1.%3")
+        );
+        assert_eq!(
+            explicit.effective_target(Some("work:1.%3")).as_deref(),
+            Some("work:2")
+        );
+    }
+
+    #[test]
+    fn explicit_session_replaces_transport_session() {
+        for target in ["other:2", "$0:2", ".other:2"] {
+            let command = parse(&["-t", target]).unwrap();
+            assert_eq!(
+                command.effective_target(Some("work:1")).as_deref(),
+                Some(target)
+            );
+        }
+    }
+
+    #[test]
+    fn bare_and_pane_only_targets_do_not_discard_the_transport_window() {
+        for target in ["2", "logs", "%3", ".1", "work.2", "other:%3", "$0"] {
+            let command = parse(&["-t", target]).unwrap();
+            assert_eq!(
+                command.effective_target(Some("work:1")).as_deref(),
+                Some("work:1")
+            );
+        }
+    }
+
+    #[test]
+    fn window_id_with_pane_inherits_the_transport_session() {
+        let command = parse(&["-t", "@2.0"]).unwrap();
+        assert_eq!(
+            command.effective_target(Some("work:1")).as_deref(),
+            Some("work:@2.0")
+        );
+    }
+
+    #[test]
+    fn wire_command_preserves_non_transport_flags() {
+        let command = parse(&["-a", "-t", ":Build Logs"]).unwrap();
+        assert_eq!(command.to_wire_command(), "kill-window -a\n");
+    }
+
+    #[test]
+    fn unknown_options_are_ignored() {
+        for args in [&["--future=value"][..], &["-x=value"][..]] {
+            assert_eq!(parse(args).unwrap(), KillWindowCommand::default());
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,6 +35,7 @@ mod ssh_input;
 mod debug_log;
 mod control;
 mod resize_window;
+mod kill_window;
 mod proxy_pane;
 mod cross_session;
 mod cross_session_server;
@@ -749,6 +750,18 @@ fn run_main() -> io::Result<()> {
             crate::cli::normalize_flag_equals(env::args().collect()),
         ),
     );
+    let command_index = process_command_index(&args);
+    // Reject malformed kill-window arguments before cleanup, probing, or any
+    // server connection.
+    let kill_window_command = command_index
+        .and_then(|index| {
+            crate::kill_window::KillWindowCommand::parse(
+                &args[index],
+                args[index + 1..].iter(),
+            )
+        })
+        .transpose()
+        .map_err(|error| io::Error::new(io::ErrorKind::InvalidInput, error))?;
     
     // Set console code page to UTF-8 early so ALL output paths (CLI commands
     // like capture-pane, list-sessions, display-message, etc.) correctly
@@ -822,7 +835,6 @@ fn run_main() -> io::Result<()> {
     // $TMUX-based resolution below so a stale PSMUX_TARGET_SESSION inherited from
     // the pane environment (e.g. a warm-pool shell frozen at `__warm__`) can never
     // hijack the current session. See issue #485.
-    let command_index = process_command_index(&args);
     let target_position = command_index.and_then(|index| process_target_position(&args, index));
     let strip_target_position = command_index
         .filter(|index| !matches!(args[*index].as_str(), "detach-client" | "detach"))
@@ -847,10 +859,17 @@ fn run_main() -> io::Result<()> {
     } else {
         None
     };
-    let explicit_target = if is_set_option_command {
-        set_option_target.as_ref().or(precommand_target.as_ref())
+    let kill_window_target = kill_window_command
+        .as_ref()
+        .and_then(|command| command.effective_target(precommand_target.as_deref()));
+    let explicit_target: Option<&str> = if kill_window_command.is_some() {
+        kill_window_target.as_deref()
+    } else if is_set_option_command {
+        set_option_target.as_deref().or(precommand_target.as_deref())
     } else {
-        target_position.and_then(|position| args.get(position + 1))
+        target_position
+            .and_then(|position| args.get(position + 1))
+            .map(String::as_str)
     };
     let mut explicit_session_target = false;
     if let Some(target) = explicit_target {
@@ -2699,26 +2718,16 @@ fn run_main() -> io::Result<()> {
             }
             // kill-window - Kill a window
             "kill-window" | "killw" => {
-                let mut cmd = "kill-window".to_string();
-                let mut i = 1;
-                while i < cmd_args.len() {
-                    match cmd_args[i].as_str() {
-                        "-t" => {
-                            if let Some(t) = cmd_args.get(i + 1) {
-                                cmd.push_str(&format!(" -t {}", t));
-                                i += 1;
-                            }
-                        }
-                        "-a" => { cmd.push_str(" -a"); }
-                        _ => {}
-                    }
-                    i += 1;
-                }
-                cmd.push('\n');
+                let command = kill_window_command.as_ref().ok_or_else(|| {
+                    io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "kill-window command was not parsed",
+                    )
+                })?;
                 // #559: the server already answers "ERROR: can't find window"
                 // for a bad -t, but the fire-and-forget send discarded it and
                 // exited 0 — a silent no-op (tmux exits 1). Read the reply.
-                let resp = send_control_with_response(cmd)?;
+                let resp = send_control_with_response(command.to_wire_command())?;
                 if !resp.trim().is_empty() {
                     eprint!("{}", resp);
                     std::process::exit(1);

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -90,7 +90,7 @@ fn auth_debug(msg: &str) {
         }
     }
 }
-use crate::commands::parse_command_line;
+use crate::commands::{parse_command_line, requote_command_tail};
 use super::helpers::TMUX_COMMANDS;
 
 /// Split a command line on top-level `;` separators, respecting single and
@@ -238,20 +238,48 @@ fn flag_value(args: &[&str], flag: &str) -> Option<String> {
     args.windows(2).find(|w| w[0] == flag).map(|w| w[1].to_string())
 }
 
-fn requote_command_tail(args: &[&str]) -> String {
-    args.iter().map(|t| {
-        if t.is_empty() {
-            "''".to_string()
-        } else if *t == ";" || *t == "\\;" {
-            t.to_string()
-        } else if t.contains('\'') {
-            format!("\"{}\"", t.replace('\\', "\\\\").replace('"', "\\\""))
-        } else if t.chars().any(|c| c.is_whitespace() || c == '"') {
-            format!("'{}'", t)
-        } else {
-            t.to_string()
+fn parse_and_validate_ingress(
+    command: &str,
+    args: &[&str],
+) -> Result<Option<crate::kill_window::KillWindowCommand>, String> {
+    let parsed = crate::kill_window::KillWindowCommand::parse(
+        command,
+        args.iter().copied(),
+    )
+    .transpose()
+    .map_err(|error| error.to_string())?;
+
+    crate::commands::validate_deferred_command(command, args)?;
+
+    Ok(parsed)
+}
+
+fn dispatch_kill_window(
+    tx: &mpsc::Sender<CtrlReq>,
+    target: Option<&str>,
+) -> Result<(), String> {
+    let parsed = target.map(parse_target);
+    let (window, window_is_id, name) = match parsed {
+        Some(target) => (target.window, target.window_is_id, target.window_name),
+        None => (None, false, None),
+    };
+    if window.is_some() || name.is_some() {
+        // Resolve explicitly instead of focusing then issuing a bare kill:
+        // a missing target must error rather than kill the active window.
+        let (response_tx, response_rx) = mpsc::channel();
+        let _ = tx.send(CtrlReq::KillWindowTarget {
+            win: window,
+            win_is_id: window_is_id,
+            name,
+            resp: response_tx,
+        });
+        if let Ok(result) = response_rx.recv_timeout(Duration::from_secs(5)) {
+            result?;
         }
-    }).collect::<Vec<String>>().join(" ")
+    } else {
+        let _ = tx.send(CtrlReq::KillWindow);
+    }
+    Ok(())
 }
 
 /// The positional `shell-command` operand of `respawn-pane` / `respawn-window`
@@ -784,6 +812,20 @@ if control_echo || control_noecho {
         } else {
             (raw_cmd, parsed.iter().skip(1).map(|s| s.as_str()).collect())
         };
+        let kill_window = match parse_and_validate_ingress(cmd_name, &cmd_args) {
+            Ok(command) => command,
+            Err(error) => {
+                let mut ws = write_lock.lock().unwrap();
+                if control_echo {
+                    let _ = writeln!(ws, "{}", trimmed);
+                }
+                let _ = writeln!(ws, "{}", control::format_begin(ts, cmd_counter));
+                let _ = writeln!(ws, "psmux: {}", error);
+                let _ = writeln!(ws, "{}", control::format_error(ts, cmd_counter));
+                let _ = ws.flush();
+                continue;
+            }
+        };
 
         // Parse -t from command args
         let mut ctrl_target_win: Option<usize> = None;
@@ -800,7 +842,11 @@ if control_echo || control_noecho {
             matches!(cmd_name, "set-window-option" | "setw");
         let ctrl_set_args = ctrl_set_option
             .then(|| parse_set_option_args(&cmd_args));
-        if let Some(parsed_set) = ctrl_set_args.as_ref() {
+        if let Some(command) = kill_window.as_ref() {
+            ctrl_raw_target = command
+                .effective_target(None)
+                .map(|target| crate::cli::strip_exact_match_prefix(&target).to_string());
+        } else if let Some(parsed_set) = ctrl_set_args.as_ref() {
             if let Some(value) = parsed_set.target {
                 ctrl_raw_target =
                     Some(crate::cli::strip_exact_match_prefix(value).to_string());
@@ -860,7 +906,8 @@ if control_echo || control_noecho {
         // swap-window/switch-client resolve their own targets (or name a
         // destination that need not exist yet), so temp-focusing here would
         // either undo the change (#483) or misdirect it (#442) for
-        // control-mode clients exactly as it did for one-shot ones.
+        // control-mode clients exactly as it did for one-shot ones. kill-window
+        // resolves explicitly so a miss never falls through to a bare kill.
         let skip_target_focus = matches!(cmd_name, "join-pane" | "joinp" | "move-pane" | "movep"
             | "move-window" | "movew" | "swap-window" | "swapw"
             | "switch-client" | "switchc" | "resize-window" | "resizew"
@@ -1080,6 +1127,18 @@ loop {
     } else {
         (raw_cmd, parsed.iter().skip(1).map(|s| s.as_str()).collect())
     };
+    let kill_window = match parse_and_validate_ingress(cmd, &args) {
+        Ok(command) => command,
+        Err(error) => {
+            let _ = writeln!(write_stream, "psmux: {}", error);
+            let _ = write_stream.flush();
+            if !persistent {
+                break;
+            }
+            line.clear();
+            continue;
+        }
+    };
 
 // Parse -t argument from command line (takes precedence over global TARGET)
 let mut target_win: Option<usize> = global_target_win;
@@ -1094,7 +1153,11 @@ let set_option_command = matches!(
     cmd,
     "set-option" | "set" | "set-window-option" | "setw"
 );
-if set_option_command {
+if let Some(command) = kill_window.as_ref() {
+    raw_target = command
+        .effective_target(global_raw_target.as_deref())
+        .map(|target| crate::cli::strip_exact_match_prefix(&target).to_string());
+} else if set_option_command {
     if let Some(value) = parse_set_option_args(&args).target {
         raw_target = Some(crate::cli::strip_exact_match_prefix(value).to_string());
         let parsed_target = parse_target(value);
@@ -1165,6 +1228,8 @@ let is_focus_cmd = matches!(cmd, "select-window" | "selectw" | "select-pane" | "
 // switch-client resolves the window/pane target itself (#483) and makes the
 // change PERMANENT; letting the generic block issue a temporary focus here
 // would restore the old focus after the batch and silently undo the switch.
+// kill-window resolves its target before dispatch so a miss cannot leave
+// the previous window focused and then kill it with a bare request.
 // detach-client's -t is a CLIENT spec (numeric id, %ID, or tty name) that
 // its handler resolves itself — it must never be validated as a pane/window
 // target (a client id shaped like %N would be rejected whenever no pane %N
@@ -1864,28 +1929,12 @@ match cmd {
         if !persistent { break; }
     }
     "kill-window" | "killw" => {
-        // Resolve the -t target server-side. The generic temp-focus block is
-        // skipped for kill-window (see skip_target_focus): focusing a target
-        // that fails to resolve silently left the PREVIOUS window focused and
-        // the bare KillWindow then killed it — `kill-window -t sess:typo`
-        // destroyed whatever was active (tmux: "can't find window", no kill).
-        if target_win.is_some() || target_win_name.is_some() {
-            let (resp_s, resp_r) = mpsc::channel();
-            let _ = tx.send(CtrlReq::KillWindowTarget {
-                win: target_win,
-                win_is_id: target_win_is_id,
-                name: target_win_name.clone(),
-                resp: resp_s,
-            });
-            if let Ok(Err(e)) = resp_r.recv_timeout(Duration::from_secs(5)) {
-                if !persistent {
-                    let _ = writeln!(write_stream, "ERROR: {}", e);
-                    let _ = write_stream.flush();
-                }
-                // persistent clients see it in the status bar (set server-side)
+        if let Err(error) = dispatch_kill_window(&tx, raw_target.as_deref()) {
+            if !persistent {
+                let _ = writeln!(write_stream, "ERROR: {}", error);
+                let _ = write_stream.flush();
             }
-        } else {
-            let _ = tx.send(CtrlReq::KillWindow);
+            // Persistent clients see the server-side status message.
         }
     }
     "kill-session" | "kill-ses" => {
@@ -4299,28 +4348,13 @@ fn dispatch_control_command(
             true
         }
         "kill-window" | "killw" => {
-            // Resolve any -t target server-side and error on a miss instead
-            // of killing the active window (same fix as the one-shot path).
-            let parsed = raw_target.map(parse_target);
-            let (t_win, t_win_is_id, t_name) = match parsed {
-                Some(pt) => (pt.window, pt.window_is_id, pt.window_name),
-                None => (None, false, None),
-            };
-            if t_win.is_some() || t_name.is_some() {
-                let (resp_s, resp_r) = mpsc::channel();
-                let _ = tx.send(CtrlReq::KillWindowTarget {
-                    win: t_win,
-                    win_is_id: t_win_is_id,
-                    name: t_name,
-                    resp: resp_s,
-                });
-                match resp_r.recv_timeout(Duration::from_secs(5)) {
-                    Ok(Err(e)) => { let _ = resp_tx.send(format!("\u{0001}ERR\u{0001}{}", e)); }
-                    _ => { let _ = resp_tx.send(String::new()); }
+            match dispatch_kill_window(tx, raw_target) {
+                Ok(()) => {
+                    let _ = resp_tx.send(String::new());
                 }
-            } else {
-                let _ = tx.send(CtrlReq::KillWindow);
-                let _ = resp_tx.send(String::new());
+                Err(error) => {
+                    let _ = resp_tx.send(format!("\u{0001}ERR\u{0001}{}", error));
+                }
             }
             true
         }
@@ -5108,6 +5142,10 @@ mod tests_send_keys_literal_byte;
 #[cfg(test)]
 #[path = "../../tests-rs/test_refresh_client_flags.rs"]
 mod tests_refresh_client_flags;
+
+#[cfg(test)]
+#[path = "../../tests-rs/test_kill_window_parser_ingress.rs"]
+mod tests_kill_window_parser_ingress;
 
 #[cfg(test)]
 #[path = "../../tests-rs/test_set_option_control.rs"]

--- a/tests-rs/test_issue370_config_warnings.rs
+++ b/tests-rs/test_issue370_config_warnings.rs
@@ -53,6 +53,30 @@ fn routed_commands_do_not_warn() {
         "valid routed directives must not warn, got: {:?}", a.config_warnings);
 }
 
+#[test]
+fn kill_window_missing_target_warns_before_storing_deferred_commands() {
+    let mut a = app();
+
+    crate::config::parse_config_content(
+        &mut a,
+        "kill-window -t\nbind-key x killw -t\nset-hook pane-died kill-window -t\n",
+    );
+
+    assert_eq!(
+        a.config_warnings
+            .iter()
+            .filter(|warning| warning.contains("-t expects an argument"))
+            .count(),
+        3
+    );
+    assert!(a.key_tables.get("prefix").is_none_or(|bindings| {
+        bindings
+            .iter()
+            .all(|binding| binding.key.0 != crossterm::event::KeyCode::Char('x'))
+    }));
+    assert!(!a.hooks.contains_key("pane-died"));
+}
+
 // ---- Unknown options ----
 
 #[test]

--- a/tests-rs/test_kill_window_cli_error.rs
+++ b/tests-rs/test_kill_window_cli_error.rs
@@ -1,0 +1,42 @@
+use std::fs;
+use std::io;
+use std::net::TcpListener;
+use std::process::Command;
+
+#[test]
+fn missing_target_fails_before_cli_dispatch() {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind mock control port");
+    let port = listener.local_addr().unwrap().port();
+    let profile = std::env::temp_dir()
+        .join(format!(
+            "psmux_kill_window_cli_error_{}_{port}",
+            std::process::id()
+        ));
+    let psmux_dir = profile.join(".psmux");
+    fs::create_dir_all(&psmux_dir).unwrap();
+    fs::write(psmux_dir.join("probe.port"), port.to_string()).unwrap();
+    fs::write(psmux_dir.join("probe.key"), "test-key").unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_psmux"))
+        .args(["killw", "-t"])
+        .env("USERPROFILE", &profile)
+        .env("PSMUX_TARGET_SESSION", "probe")
+        .env_remove("PSMUX_TARGET_FULL")
+        .env_remove("TMUX")
+        .output()
+        .expect("run psmux CLI");
+
+    listener.set_nonblocking(true).unwrap();
+    let no_connection = matches!(
+        listener.accept(),
+        Err(error) if error.kind() == io::ErrorKind::WouldBlock
+    );
+    fs::remove_dir_all(&profile).unwrap();
+
+    assert_eq!(output.status.code(), Some(1));
+    assert_eq!(
+        String::from_utf8_lossy(&output.stderr),
+        "psmux: -t expects an argument\n"
+    );
+    assert!(no_connection, "invalid command must not reach the server");
+}

--- a/tests-rs/test_kill_window_parser_ingress.rs
+++ b/tests-rs/test_kill_window_parser_ingress.rs
@@ -1,0 +1,261 @@
+use super::*;
+
+use std::collections::HashMap;
+use std::io::{BufRead, BufReader, Write};
+use std::net::{Shutdown, TcpListener, TcpStream};
+use std::sync::{Arc, RwLock};
+use std::thread;
+
+fn start_connection(
+    aliases: HashMap<String, String>,
+) -> (TcpStream, mpsc::Receiver<CtrlReq>, thread::JoinHandle<()>) {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let address = listener.local_addr().unwrap();
+    let (request_tx, request_rx) = mpsc::channel();
+    let aliases = Arc::new(RwLock::new(aliases));
+    let handle = thread::spawn(move || {
+        let (stream, _) = listener.accept().unwrap();
+        handle_connection(stream, request_tx, "test-key", aliases);
+    });
+    let stream = TcpStream::connect(address).unwrap();
+    stream
+        .set_read_timeout(Some(Duration::from_secs(2)))
+        .unwrap();
+    (stream, request_rx, handle)
+}
+
+fn read_line(reader: &mut BufReader<TcpStream>) -> String {
+    let mut line = String::new();
+    reader.read_line(&mut line).unwrap();
+    line.trim_end().to_string()
+}
+
+fn authenticate(stream: &mut TcpStream, reader: &mut BufReader<TcpStream>) {
+    stream.write_all(b"AUTH test-key\n").unwrap();
+    stream.flush().unwrap();
+    assert_eq!(read_line(reader), "OK");
+}
+
+fn assert_no_requests(requests: &mpsc::Receiver<CtrlReq>) {
+    assert!(matches!(
+        requests.try_recv(),
+        Err(mpsc::TryRecvError::Disconnected)
+    ));
+}
+
+fn assert_no_control_command_dispatch(requests: &mpsc::Receiver<CtrlReq>) {
+    let mut saw_registration = false;
+    for request in requests.try_iter() {
+        match request {
+            CtrlReq::ControlRegister { .. } => saw_registration = true,
+            CtrlReq::KillWindow
+            | CtrlReq::KillWindowTarget { .. }
+            | CtrlReq::BindKey(..)
+            | CtrlReq::ConfirmBefore(..)
+            | CtrlReq::SetHook(..)
+            | CtrlReq::AppendHook(..) => panic!("invalid command was dispatched"),
+            _ => {}
+        }
+    }
+    assert!(saw_registration);
+}
+
+#[test]
+fn simple_connection_rejects_missing_target_without_dispatch() {
+    let (mut stream, requests, handle) = start_connection(HashMap::new());
+    let mut reader = BufReader::new(stream.try_clone().unwrap());
+    authenticate(&mut stream, &mut reader);
+
+    stream.write_all(b"kill-window -t\n").unwrap();
+    stream.flush().unwrap();
+
+    assert_eq!(read_line(&mut reader), "psmux: -t expects an argument");
+    stream.shutdown(Shutdown::Both).unwrap();
+    handle.join().unwrap();
+    assert_no_requests(&requests);
+}
+
+#[test]
+fn command_alias_rejects_missing_target_without_dispatch() {
+    let aliases = HashMap::from([("close".to_string(), "kill-window".to_string())]);
+    let (mut stream, requests, handle) = start_connection(aliases);
+    let mut reader = BufReader::new(stream.try_clone().unwrap());
+    authenticate(&mut stream, &mut reader);
+
+    stream.write_all(b"close -t\n").unwrap();
+    stream.flush().unwrap();
+
+    assert_eq!(read_line(&mut reader), "psmux: -t expects an argument");
+    stream.shutdown(Shutdown::Both).unwrap();
+    handle.join().unwrap();
+    assert_no_requests(&requests);
+}
+
+#[test]
+fn simple_connection_rejects_invalid_deferred_commands() {
+    for command in [
+        "bind-key x kill-window -t\n",
+        "confirm-before kill-window -t\n",
+        "confirm-before 'kill-window -t'\n",
+        "set-hook pane-died kill-window -t\n",
+    ] {
+        let (mut stream, requests, handle) = start_connection(HashMap::new());
+        let mut reader = BufReader::new(stream.try_clone().unwrap());
+        authenticate(&mut stream, &mut reader);
+
+        stream.write_all(command.as_bytes()).unwrap();
+        stream.flush().unwrap();
+
+        assert_eq!(read_line(&mut reader), "psmux: -t expects an argument");
+        stream.shutdown(Shutdown::Both).unwrap();
+        handle.join().unwrap();
+        assert_no_requests(&requests);
+    }
+}
+
+#[test]
+fn command_target_overrides_transport_target_after_alias_expansion() {
+    let aliases = HashMap::from([(
+        "close".to_string(),
+        "kill-window -t :1".to_string(),
+    )]);
+    let (mut stream, requests, handle) = start_connection(aliases);
+    let mut reader = BufReader::new(stream.try_clone().unwrap());
+    authenticate(&mut stream, &mut reader);
+
+    stream
+        .write_all(b"TARGET :0\nclose -t:2\n")
+        .unwrap();
+    stream.flush().unwrap();
+
+    let request = requests.recv_timeout(Duration::from_secs(2)).unwrap();
+    let CtrlReq::KillWindowTarget {
+        win,
+        win_is_id,
+        name,
+        resp,
+    } = request
+    else {
+        panic!("expected targeted kill-window request");
+    };
+    assert_eq!(win, Some(2));
+    assert!(!win_is_id);
+    assert_eq!(name, None);
+    resp.send(Ok(())).unwrap();
+
+    stream.shutdown(Shutdown::Both).unwrap();
+    handle.join().unwrap();
+}
+
+#[test]
+fn transport_target_is_used_when_command_has_no_target() {
+    let (mut stream, requests, handle) = start_connection(HashMap::new());
+    let mut reader = BufReader::new(stream.try_clone().unwrap());
+    authenticate(&mut stream, &mut reader);
+
+    stream.write_all(b"TARGET :3\nkill-window\n").unwrap();
+    stream.flush().unwrap();
+
+    let request = requests.recv_timeout(Duration::from_secs(2)).unwrap();
+    let CtrlReq::KillWindowTarget {
+        win,
+        win_is_id,
+        name,
+        resp,
+    } = request
+    else {
+        panic!("expected targeted kill-window request");
+    };
+    assert_eq!(win, Some(3));
+    assert!(!win_is_id);
+    assert_eq!(name, None);
+    resp.send(Ok(())).unwrap();
+
+    stream.shutdown(Shutdown::Both).unwrap();
+    handle.join().unwrap();
+}
+
+#[test]
+fn bare_command_target_does_not_discard_the_transport_window() {
+    for target in ["2", "work.2"] {
+        let (mut stream, requests, handle) = start_connection(HashMap::new());
+        let mut reader = BufReader::new(stream.try_clone().unwrap());
+        authenticate(&mut stream, &mut reader);
+
+        stream
+            .write_all(format!("TARGET work:1\nkill-window -t {target}\n").as_bytes())
+            .unwrap();
+        stream.flush().unwrap();
+
+        let request = requests.recv_timeout(Duration::from_secs(2)).unwrap();
+        let CtrlReq::KillWindowTarget {
+            win,
+            win_is_id,
+            name,
+            resp,
+        } = request
+        else {
+            panic!("expected targeted kill-window request");
+        };
+        assert_eq!(win, Some(1));
+        assert!(!win_is_id);
+        assert_eq!(name, None);
+        resp.send(Ok(())).unwrap();
+
+        stream.shutdown(Shutdown::Both).unwrap();
+        handle.join().unwrap();
+    }
+}
+
+#[test]
+fn valid_deferred_command_is_still_dispatched() {
+    let (mut stream, requests, handle) = start_connection(HashMap::new());
+    let mut reader = BufReader::new(stream.try_clone().unwrap());
+    authenticate(&mut stream, &mut reader);
+
+    stream
+        .write_all(b"bind-key x kill-window -t :1\n")
+        .unwrap();
+    stream.flush().unwrap();
+
+    let request = requests.recv_timeout(Duration::from_secs(2)).unwrap();
+    let CtrlReq::BindKey(table, key, command, repeat) = request else {
+        panic!("expected bind-key request");
+    };
+    assert_eq!(table, "prefix");
+    assert_eq!(key, "x");
+    assert_eq!(command, "kill-window -t :1");
+    assert!(!repeat);
+
+    stream.shutdown(Shutdown::Both).unwrap();
+    handle.join().unwrap();
+}
+
+#[test]
+fn control_connection_reports_missing_target_and_stays_usable() {
+    let (mut stream, requests, handle) = start_connection(HashMap::new());
+    let mut reader = BufReader::new(stream.try_clone().unwrap());
+    authenticate(&mut stream, &mut reader);
+
+    stream.write_all(b"CONTROL_NOECHO\n").unwrap();
+    stream.flush().unwrap();
+    assert!(read_line(&mut reader).starts_with("\u{1b}P1000p%begin "));
+    assert!(read_line(&mut reader).starts_with("%end "));
+
+    for command in [
+        "killw -t\n",
+        "bind-key x kill-window -t\n",
+        "confirm-before kill-window -t\n",
+        "set-hook pane-died kill-window -t\n",
+    ] {
+        stream.write_all(command.as_bytes()).unwrap();
+        stream.flush().unwrap();
+        assert!(read_line(&mut reader).starts_with("%begin "));
+        assert_eq!(read_line(&mut reader), "psmux: -t expects an argument");
+        assert!(read_line(&mut reader).starts_with("%error "));
+    }
+
+    stream.shutdown(Shutdown::Both).unwrap();
+    handle.join().unwrap();
+    assert_no_control_command_dispatch(&requests);
+}

--- a/tests-rs/test_killwindow_bad_target.rs
+++ b/tests-rs/test_killwindow_bad_target.rs
@@ -146,3 +146,63 @@ fn bare_session_target_kills_the_active_window() {
 
     assert_eq!(window_names(&app), vec!["beta"]);
 }
+
+#[test]
+fn missing_target_value_fails_before_local_mutation() {
+    let mut app = app_with_windows(&["alpha", "beta"]);
+
+    let error = execute_command_string(&mut app, "kill-window -t").unwrap_err();
+
+    assert_eq!(error.kind(), std::io::ErrorKind::InvalidInput);
+    assert_eq!(error.to_string(), "-t expects an argument");
+    assert_eq!(window_names(&app), vec!["alpha", "beta"]);
+    assert_eq!(
+        app.status_message.as_ref().map(|message| message.0.as_str()),
+        Some("-t expects an argument")
+    );
+}
+
+#[test]
+fn missing_target_value_rejects_local_deferred_commands() {
+    let mut app = app_with_windows(&["alpha", "beta"]);
+
+    for command in [
+        "confirm-before kill-window -t",
+        "confirm-before 'kill-window -t'",
+        "bind-key x kill-window -t",
+        "set-hook pane-died killw -t",
+    ] {
+        let error = execute_command_string(&mut app, command).unwrap_err();
+        assert_eq!(error.to_string(), "-t expects an argument");
+    }
+    assert!(!matches!(app.mode, Mode::ConfirmMode { .. }));
+    assert!(app.key_tables.get("prefix").is_none_or(|bindings| {
+        bindings
+            .iter()
+            .all(|binding| binding.key.0 != crossterm::event::KeyCode::Char('x'))
+    }));
+    assert!(!app.hooks.contains_key("pane-died"));
+}
+
+#[test]
+fn repeated_targets_use_the_last_value() {
+    let mut app = app_with_windows(&["alpha", "beta", "gamma"]);
+
+    execute_command_string(&mut app, "kill-window -t @1 -t@2").unwrap();
+
+    assert_eq!(window_names(&app), vec!["alpha", "beta"]);
+}
+
+#[test]
+fn deferred_command_nesting_is_bounded() {
+    let mut app = app_with_windows(&["alpha", "beta"]);
+    let command = format!("{}kill-window", "confirm-before ".repeat(65));
+
+    let error = execute_command_string(&mut app, &command).unwrap_err();
+
+    assert_eq!(
+        error.to_string(),
+        "command nesting exceeds 64 levels"
+    );
+    assert_eq!(window_names(&app), vec!["alpha", "beta"]);
+}


### PR DESCRIPTION
## Summary

This PR fixes `kill-window -t` and `killw -t` so a missing target fails with `-t expects an argument` before server connection, command storage, dispatch, or window mutation.

The same fix has to hold across the process CLI, local execution, simple TCP, control mode, config, bindings, hooks, `confirm-before`, and aliases. One typed command parser therefore owns `kill-window` option parsing.

## Details

- The parser uses `lexopt` and handles separate, attached, clustered, and equals-form targets. Repeated `-t` uses the last value, `--` ends option parsing, and unknown options are ignored.
- The CLI sends the composed target through the existing `TARGET` protocol line. Relative targets that name a window inherit the transport session; window targets with an explicitly qualified session replace it.
- Invalid local commands return `InvalidInput` and set the status message.
- Recursive deferred-command nesting is capped at 64 levels.
- Server request types and execution effects are unchanged. New parse errors use the existing one-shot and control-mode error formats.
- Tests cover each path, aliases, deferred commands, target composition, mutation safety, and early CLI rejection.

## Validation

- Full validation on an isolated `psmux-dev` VM
- `cargo test --all-targets`: the shared 3,456-test unit suite passed for each binary alias, along with all integration and example targets
- Release build succeeded
- `test_smoke_pr.ps1`, `test_session_mgmt.ps1`, `test_run_shell.ps1`, and `test_issue209_e2e_verify.ps1`