### PR TITLE
fix(reliability): preserve live sessions and isolate command failures under load

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1,4 +1,4 @@
-use std::io::{self, Write, BufRead, BufReader};
+use std::io::{self, Write, BufReader};
 use std::time::{Duration, Instant};
 use std::env;
 
@@ -1860,19 +1860,17 @@ fn establish_connection_with_timeout(
     // answers would otherwise block the attach forever with no feedback. The
     // persistent read timeout is (re)set to 2s just below, after auth.
     let _ = reader.get_ref().set_read_timeout(Some(Duration::from_secs(3)));
-    let _ = writer.write_all(format!("AUTH {}\n", key).as_bytes());
-    let _ = writer.flush();
+    let key = crate::session::validate_auth_key(key)
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "invalid session key"))?;
+    writer.write_all(format!("AUTH {}\n", key).as_bytes())?;
+    writer.flush()?;
     let mut auth_line = String::new();
-    let read_res = reader.read_line(&mut auth_line);
-    if std::env::var("PSMUX_AUTH_DEBUG").map(|v| v == "1").unwrap_or(false) {
-        eprintln!(
-            "[auth-debug pid={}] establish_connection addr={} key={} read_res={:?} got_line={:?}",
-            std::process::id(), addr, key, read_res.as_ref().map(|n| *n), auth_line
-        );
+    let n = std::io::BufRead::read_line(&mut std::io::Read::take(&mut reader, 4097), &mut auth_line)?;
+    if n == 0 || !auth_line.ends_with('\n') {
+        return Err(io::Error::new(io::ErrorKind::UnexpectedEof, "incomplete authentication acknowledgement"));
     }
-    read_res?;
-    if !auth_line.trim().starts_with("OK") {
-        return Err(io::Error::new(io::ErrorKind::PermissionDenied, "auth failed"));
+    if auth_line != "OK\n" && auth_line != "OK\r\n" {
+        return Err(io::Error::new(io::ErrorKind::PermissionDenied, "authentication rejected"));
     }
 
     let _ = writer.write_all(b"PERSISTENT\n");
@@ -1901,15 +1899,19 @@ fn establish_connection_with_timeout(
 
     // 2-second read timeout keeps the thread from blocking forever on process exit.
     let _ = reader.get_ref().set_read_timeout(Some(Duration::from_secs(2)));
-    let (frame_tx, frame_rx) = std::sync::mpsc::channel::<String>();
+    let (frame_tx, frame_rx) = std::sync::mpsc::sync_channel::<String>(4);
     std::thread::spawn(move || {
         let mut reader = reader;
         let mut buf = String::with_capacity(64 * 1024);
         loop {
             buf.clear();
             loop {
-                match reader.read_line(&mut buf) {
+                const MAX_CLIENT_FRAME_BYTES: usize = 16 * 1024 * 1024;
+                if buf.len() > MAX_CLIENT_FRAME_BYTES { return; }
+                let remaining = (MAX_CLIENT_FRAME_BYTES - buf.len() + 1) as u64;
+                match std::io::BufRead::read_line(&mut std::io::Read::take(&mut reader, remaining), &mut buf) {
                     Ok(0) => return,
+                    Ok(_) if buf.len() > MAX_CLIENT_FRAME_BYTES || !buf.ends_with('\n') => return,
                     Ok(_) => break,
                     Err(ref e) if e.kind() == std::io::ErrorKind::TimedOut
                         || e.kind() == std::io::ErrorKind::WouldBlock => {
@@ -1966,27 +1968,21 @@ pub(crate) fn no_such_session(name: &str) -> io::Error {
 
 pub fn run_remote(terminal: &mut Terminal<crate::platform::PsmuxBackend>, input: &crate::ssh_input::InputSource) -> io::Result<()> {
     let name = env::var("PSMUX_SESSION_NAME").unwrap_or_else(|_| "default".to_string());
-    let path = crate::paths::port_file(&name);
-    let port = std::fs::read_to_string(&path).ok().and_then(|s| s.trim().parse::<u16>().ok())
-        .ok_or_else(|| no_such_session(&name))?;
-    let addr = format!("127.0.0.1:{}", port);
-    // The .port file can be visible a beat before the .key has readable
-    // content (servers before the issue #496 fix wrote .port first, and a
-    // just-claimed warm server rewrites its files). Never AUTH with an empty
-    // key — that is guaranteed to fail — poll briefly for the credential.
-    let mut session_key = read_session_key(&name).unwrap_or_default();
-    if session_key.is_empty() {
-        for _ in 0..400 {
-            std::thread::sleep(Duration::from_millis(5));
-            session_key = read_session_key(&name).unwrap_or_default();
-            if !session_key.is_empty() { break; }
+    let deadline = std::time::Instant::now() + Duration::from_secs(2);
+    let (port, session_key) = loop {
+        match crate::session::read_session_endpoint(&name) {
+            Ok(endpoint) => break endpoint,
+            Err(error) if error.kind() == io::ErrorKind::NotFound && std::time::Instant::now() < deadline => {
+                std::thread::sleep(Duration::from_millis(5));
+            }
+            Err(error) => return Err(io::Error::new(error.kind(), format!("cannot read session '{}': {}", crate::paths::registry_session_name(&name), error))),
         }
-    }
-    let session_key = session_key;
+    };
+    let addr = format!("127.0.0.1:{}", port);
     if std::env::var("PSMUX_AUTH_DEBUG").map(|v| v == "1").unwrap_or(false) {
         eprintln!(
-            "[auth-debug pid={}] run_remote name={} port={} key={}",
-            std::process::id(), name, port, session_key
+            "[auth-debug pid={}] run_remote name={} port={}",
+            std::process::id(), name, port
         );
     }
     let last_path = crate::paths::psmux_dir_file("last_session");
@@ -2015,14 +2011,7 @@ pub fn run_remote(terminal: &mut Terminal<crate::platform::PsmuxBackend>, input:
         match establish_connection_with_timeout(&addr, &session_key, ATTACH_CONNECT_TIMEOUT) {
             Ok(conn) => conn,
             Err(e) => {
-                // Nothing answered on the registered port. Reap the entry so
-                // the next `ls`/`attach` is clean, but only once the pid anchor
-                // agrees the process is gone: a live server that was merely too
-                // slow must keep its registration (it rewrites these files on
-                // its own 5s tick anyway).
-                if crate::session::registry_pid_anchor_alive(&name) != Some(true) {
-                    crate::session::remove_session_registry(&name);
-                }
+                // A failed attach is observational: retain the registration.
                 if std::env::var("PSMUX_AUTH_DEBUG").map(|v| v == "1").unwrap_or(false) {
                     eprintln!(
                         "[auth-debug pid={}] attach connect to {} failed: {} (kind {:?})",
@@ -2723,13 +2712,10 @@ pub fn run_remote(terminal: &mut Terminal<crate::platform::PsmuxBackend>, input:
                 }
                 Err(std::sync::mpsc::TryRecvError::Empty) => break,
                 Err(std::sync::mpsc::TryRecvError::Disconnected) => {
-                    // TCP connection dropped. If the server already removed its port
-                    // file (all clean-shutdown paths do this before calling
-                    // shutdown_persistent_streams), treat the disconnect as intentional
-                    // and quit immediately instead of burning 5 s of reconnect backoff.
-                    if !quit && !std::path::Path::new(&path).exists() {
-                        quit = true;
-                    } else if reconnect_pending.is_none() && !quit {
+                    // A missing registration can be a rename or interrupted
+                    // repair. Only an explicit DETACH ends the client immediately;
+                    // otherwise try the authenticated endpoint we already own.
+                    if reconnect_pending.is_none() && !quit {
                         let addr_c = addr.clone();
                         let key_c = session_key.clone();
                         let (rtx, rrx) = std::sync::mpsc::channel();
@@ -3606,46 +3592,27 @@ pub fn run_remote(terminal: &mut Terminal<crate::platform::PsmuxBackend>, input:
                                 popup_rect_last = None;
                                 if choose_tree_preview_default { preview_enabled = true; }
                                 // Query ALL sessions (like tmux choose-tree)
-                                let dir = crate::paths::psmux_dir();
                                 // A -L socket is a separate server in tmux; a client never
                                 // sees another socket's sessions. Same rule `ls` applies
                                 // and the same predicate the session picker uses (ed52715).
                                 let tree_ns = crate::session::session_namespace(&current_session);
-                                if let Ok(entries) = std::fs::read_dir(&dir) {
+                                {
                                     let mut sessions: Vec<(String, Vec<(usize, String, bool, Vec<(usize, String)>, usize)>)> = Vec::new();
-                                    for e in entries.flatten() {
-                                        if let Some(fname) = e.file_name().to_str().map(|s| s.to_string()) {
-                                            if let Some((base, ext)) = fname.rsplit_once('.') {
-                                                if ext == "port" {
-                                                    if crate::session::is_warm_session(base) { continue; }
-                                                    if !crate::session::session_visible_from(base, tree_ns) { continue; }
-                                                    if let Ok(port_str) = std::fs::read_to_string(e.path()) {
-                                                        if let Ok(p) = port_str.trim().parse::<u16>() {
-                                                            let sess_addr = format!("127.0.0.1:{}", p);
-                                                            let sess_key = read_session_key(base).unwrap_or_default();
-                                                            // Centralized AUTH+command helper handles the OK ack race
-                                                            // (issue #250) and bounds the response size.
-                                                            if let Some(tree_line) = crate::session::fetch_authed_response_multi(
-                                                                &sess_addr,
-                                                                &sess_key,
-                                                                b"list-tree\n",
-                                                                Duration::from_millis(50),
-                                                                Duration::from_millis(100),
-                                                            ) {
-                                                                if let Ok(wins) = serde_json::from_str::<Vec<WinTree>>(tree_line.trim()) {
-                                                                    let mut win_data = Vec::new();
-                                                                    for w in &wins {
-                                                                        let panes: Vec<(usize, String)> = w.panes.iter().map(|p| (p.id, p.title.clone())).collect();
-                                                                        win_data.push((w.id, w.name.clone(), w.active, panes, w.idx));
-                                                                    }
-                                                                    sessions.push((base.to_string(), win_data));
-                                                                }
-                                                            }
-                                                        }
+                                    for base in crate::session::list_session_names_ns(tree_ns.as_deref()) {
+                                        let mut win_data = Vec::new();
+                                        if let Ok((port, key)) = crate::session::read_session_endpoint(&base) {
+                                            if let Some(tree_line) = crate::session::fetch_authed_response_multi(
+                                                &format!("127.0.0.1:{}", port), &key, b"list-tree\n",
+                                                Duration::from_millis(100), Duration::from_millis(500)) {
+                                                if let Ok(wins) = serde_json::from_str::<Vec<WinTree>>(tree_line.trim()) {
+                                                    for w in &wins {
+                                                        let panes = w.panes.iter().map(|p| (p.id, p.title.clone())).collect();
+                                                        win_data.push((w.id, w.name.clone(), w.active, panes, w.idx));
                                                     }
                                                 }
                                             }
                                         }
+                                        sessions.push((base, win_data));
                                     }
                                     sessions.sort_by(|a, b| {
                                         if a.0 == current_session { std::cmp::Ordering::Less }
@@ -3726,34 +3693,16 @@ pub fn run_remote(terminal: &mut Terminal<crate::platform::PsmuxBackend>, input:
                                 popup_dragging = false;
                                 popup_rect_last = None;
                                 if choose_tree_preview_default { preview_enabled = true; }
-                                let dir = crate::paths::psmux_dir();
-                                // Collect (label, addr, key) for every port file, then run ONE
-                                // bounded liveness probe per session in parallel. This both lists
-                                // and prunes: total wall time is ~one probe window regardless of
-                                // how many sessions exist, so the picker stays responsive (no
-                                // sequential O(N * timeout) cleanup pass).
-                                let mut targets: Vec<(String, String, String)> = Vec::new();
-                                // A -L socket is a separate server in tmux; a client never
-                                // sees another socket's sessions. Same rule `ls` applies.
+                                // Keep every registered session visible, including
+                                // malformed or temporarily unresponsive endpoints.
                                 let picker_ns = crate::session::session_namespace(&current_session);
-                                if let Ok(entries) = std::fs::read_dir(&dir) {
-                                    for e in entries.flatten() {
-                                        if let Some(fname) = e.file_name().to_str() {
-                                            if let Some((base, ext)) = fname.rsplit_once('.') {
-                                                if ext == "port" {
-                                                    if crate::session::is_warm_session(base) { continue; }
-                                                    if !crate::session::session_visible_from(base, picker_ns) { continue; }
-                                                    if let Ok(port_str) = std::fs::read_to_string(e.path()) {
-                                                        if let Ok(p) = port_str.trim().parse::<u16>() {
-                                                            let sess_addr = format!("127.0.0.1:{}", p);
-                                                            let sess_key = read_session_key(base).unwrap_or_default();
-                                                            targets.push((base.to_string(), sess_addr, sess_key));
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        }
-                                    }
+                                let mut targets = Vec::new();
+                                for base in crate::session::list_session_names_ns(picker_ns.as_deref()) {
+                                    let (addr, key) = match crate::session::read_session_endpoint(&base) {
+                                        Ok((port, key)) => (format!("127.0.0.1:{}", port), key),
+                                        Err(_) => (String::new(), String::new()),
+                                    };
+                                    targets.push((base, addr, key));
                                 }
                                 // Issue #259 (batch D): sort by label so the picker's order is
                                 // deterministic, matching the tree_chooser's established
@@ -3772,21 +3721,9 @@ pub fn run_remote(terminal: &mut Terminal<crate::platform::PsmuxBackend>, input:
                                         crate::session::SessionLiveness::Alive(info) => {
                                             session_entries.push((label, info));
                                         }
-                                        crate::session::SessionLiveness::Dead => {
-                                            // Server gone (crashed, killed by a reboot, or its
-                                            // port reused by another server). Reap it so it never
-                                            // shows as a "(not responding)" zombie. A live-but-slow
-                                            // server self-heals on its next 5s registry tick.
-                                            if crate::debug_log::session_log_enabled() {
-                                                crate::debug_log::session_log("picker",
-                                                    &format!("reaping dead session '{}' from chooser", label));
-                                            }
-                                            crate::session::remove_session_registry(&label);
-                                        }
+                                        crate::session::SessionLiveness::Dead => {},
+                                        crate::session::SessionLiveness::Unresponsive |
                                         crate::session::SessionLiveness::Unreachable => {
-                                            // Could not connect (transient, non-refused). Keep it
-                                            // and show the honest "(not responding)" rather than
-                                            // deleting on an ambiguous failure.
                                             session_entries.push((label.clone(), format!("{}: (not responding)", label)));
                                         }
                                     }

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -2273,55 +2273,47 @@ fn execute_command_string_single(app: &mut AppState, cmd: &str) -> io::Result<()
                 || crate::config::is_warm_disabled_by_config();
             let claimed_warm = if !warm_disabled && initial_command.is_none() && start_dir.is_none() && env_vars.is_empty() {
                 let warm_base = crate::paths::storage_base(app.socket_name.as_deref(), "__warm__");
-                let warm_port_path = crate::paths::port_file(&warm_base);
-                if std::path::Path::new(&warm_port_path).exists() {
-                    if let Ok(warm_port_str) = std::fs::read_to_string(&warm_port_path) {
-                        if let Ok(warm_port) = warm_port_str.trim().parse::<u16>() {
-                            let warm_addr = format!("127.0.0.1:{}", warm_port);
-                            if std::net::TcpStream::connect_timeout(
-                                &warm_addr.parse().unwrap(),
-                                std::time::Duration::from_millis(100),
-                            ).is_ok() {
-                                let warm_key = crate::session::read_session_key(&warm_base).unwrap_or_default();
-                                if !warm_key.is_empty() {
-                                    // In-TUI new-session runs inside psmux, so the
-                                    // resolve reads this server's own environment and
-                                    // config rather than a user shell. Sending it is
-                                    // still right: a session created from the TUI
-                                    // should land on the same class as the psmux the
-                                    // user is sitting in, not on the standby's stale
-                                    // one (#608).
-                                    let claim_prio = crate::platform::claim_priority_arg();
-                                    let claim_cmd = format!("claim-session {} -p {}\n", crate::util::quote_arg(&name), crate::util::quote_arg(&claim_prio));
-                                    match crate::session::send_auth_cmd_response(
-                                        &warm_addr, &warm_key,
-                                        claim_cmd.as_bytes(),
-                                    ) {
-                                        Ok(resp) if resp.contains("OK") => {
-                                            if let Some(ref wn) = window_name {
-                                                let new_key = crate::session::read_session_key(&port_file_base).unwrap_or_default();
-                                                let _ = crate::session::send_auth_cmd(
-                                                    &warm_addr, &new_key,
-                                                    format!("rename-window {}\n", crate::util::quote_arg(wn)).as_bytes(),
-                                                );
-                                            }
-                                            // Apply -e environment variables to the claimed warm session
-                                            if !env_vars.is_empty() {
-                                                let new_key = crate::session::read_session_key(&port_file_base).unwrap_or_default();
-                                                for (k, v) in &env_vars {
-                                                    let _ = crate::session::send_auth_cmd(
-                                                        &warm_addr, &new_key,
-                                                        format!("set-environment {} {}\n", crate::util::quote_arg(k), crate::util::quote_arg(v)).as_bytes(),
-                                                    );
-                                                }
-                                            }
-                                            true
-                                        }
-                                        _ => false,
+                if let Ok(Some((warm_port, warm_key))) = crate::registry::read_warm_claim_endpoint(&warm_base) {
+                    let warm_addr = format!("127.0.0.1:{}", warm_port);
+                    if std::net::TcpStream::connect_timeout(
+                        &warm_addr.parse().unwrap(),
+                        std::time::Duration::from_millis(100),
+                    ).is_ok() {
+                        // In-TUI new-session runs inside psmux, so the
+                        // resolve reads this server's own environment and
+                        // config rather than a user shell. Sending it is
+                        // still right: a session created from the TUI
+                        // should land on the same class as the psmux the
+                        // user is sitting in, not on the standby's stale
+                        // one (#608).
+                        let claim_prio = crate::platform::claim_priority_arg();
+                        let claim_cmd = format!("claim-session {} -p {}\n", crate::util::quote_arg(&name), crate::util::quote_arg(&claim_prio));
+                        match crate::session::send_auth_cmd_response(
+                            &warm_addr, &warm_key,
+                            claim_cmd.as_bytes(),
+                        ) {
+                            Ok(resp) if resp.contains("OK") => {
+                                if let Some(ref wn) = window_name {
+                                    let new_key = crate::session::read_session_key(&port_file_base).unwrap_or_default();
+                                    let _ = crate::session::send_auth_cmd(
+                                        &warm_addr, &new_key,
+                                        format!("rename-window {}\n", crate::util::quote_arg(wn)).as_bytes(),
+                                    );
+                                }
+                                // Apply -e environment variables to the claimed warm session
+                                if !env_vars.is_empty() {
+                                    let new_key = crate::session::read_session_key(&port_file_base).unwrap_or_default();
+                                    for (k, v) in &env_vars {
+                                        let _ = crate::session::send_auth_cmd(
+                                            &warm_addr, &new_key,
+                                            format!("set-environment {} {}\n", crate::util::quote_arg(k), crate::util::quote_arg(v)).as_bytes(),
+                                        );
                                     }
-                                } else { false }
-                            } else { false }
-                        } else { false }
+                                }
+                                true
+                            }
+                            _ => false,
+                        }
                     } else { false }
                 } else { false }
             } else { false };

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -9,7 +9,7 @@ use crate::tree::{compute_rects, kill_all_children, get_active_pane_id};
 use crate::pane::{create_window, split_active, kill_active_pane};
 use crate::copy_mode::{enter_copy_mode, scroll_copy_up, switch_with_copy_save, paste_latest,
     capture_active_pane, save_latest_buffer};
-use crate::session::{send_control_to_port, list_all_sessions_tree};
+use crate::session::{enqueue_control, list_all_sessions_tree};
 use crate::window_ops::{toggle_zoom, unzoom_if_zoomed};
 
 /// Parse a popup dimension spec: "80" (absolute) or "95%" (percentage of term_dim).
@@ -979,13 +979,13 @@ fn execute_command_string_single(app: &mut AppState, cmd: &str) -> io::Result<()
     match parts[0] {
         "new-window" | "neww" => {
             if let Some(port) = app.control_port {
-                let _ = send_control_to_port(port, &format!("{}\n", cmd), &app.session_key);
+                enqueue_control(app, port, &format!("{}\n", cmd))?;
             }
         }
         "split-window" | "splitw" | "split-pane" | "splitp" => {
             if let Some(port) = app.control_port {
                 // Forward the full command string to preserve -c, -d, -p etc. flags
-                let _ = send_control_to_port(port, &format!("{}\n", cmd), &app.session_key);
+                enqueue_control(app, port, &format!("{}\n", cmd))?;
             } else if parts.iter().any(|p| *p == "-Z") {
                 let kind = if parts.iter().any(|p| *p == "-h") { LayoutKind::Horizontal } else { LayoutKind::Vertical };
                 unzoom_if_zoomed(app);
@@ -1177,7 +1177,7 @@ fn execute_command_string_single(app: &mut AppState, cmd: &str) -> io::Result<()
                 }
                 // Forward to server so external queries (display-message, list-windows) see the new name
                 if let Some(port) = app.control_port {
-                    let _ = send_control_to_port(port, &format!("rename-window {}\n", crate::util::quote_arg(&name)), &app.session_key);
+                    enqueue_control(app, port, &format!("rename-window {}\n", crate::util::quote_arg(&name)))?;
                 }
             }
         }
@@ -1320,7 +1320,7 @@ fn execute_command_string_single(app: &mut AppState, cmd: &str) -> io::Result<()
             if parts.iter().any(|p| *p == "-Z") {
                 toggle_zoom(app);
             } else if let Some(port) = app.control_port {
-                let _ = send_control_to_port(port, &format!("{}\n", cmd), &app.session_key);
+                enqueue_control(app, port, &format!("{}\n", cmd))?;
             } else {
                 // Local resize
                 let amount = parts.windows(2).find(|w| w[0] == "-x" || w[0] == "-y")
@@ -1349,7 +1349,7 @@ fn execute_command_string_single(app: &mut AppState, cmd: &str) -> io::Result<()
             if let (Some(src), Some(tgt)) = (source.as_ref(), target.as_ref()) {
                 if let Some(port) = app.control_port {
                     let d = if detach { " -d" } else { "" };
-                    let _ = send_control_to_port(port, &format!("swap-pane{} -s {} -t {}\n", d, src, tgt), &app.session_key);
+                    enqueue_control(app, port, &format!("swap-pane{} -s {} -t {}\n", d, src, tgt))?;
                 } else {
                     match (resolve_swap_pane_target_path(app, src), resolve_swap_pane_target_path(app, tgt)) {
                         (Some(sp), Some(dp)) => { crate::window_ops::swap_pane_between(app, sp, dp, detach); }
@@ -1358,7 +1358,7 @@ fn execute_command_string_single(app: &mut AppState, cmd: &str) -> io::Result<()
                 }
             } else if let Some(tgt) = target {
                 if let Some(port) = app.control_port {
-                    let _ = send_control_to_port(port, &format!("swap-pane -t {}\n", tgt), &app.session_key);
+                    enqueue_control(app, port, &format!("swap-pane -t {}\n", tgt))?;
                 } else {
                     let path = resolve_swap_pane_target_path(app, &tgt);
                     if let Some(path) = path {
@@ -1372,7 +1372,7 @@ fn execute_command_string_single(app: &mut AppState, cmd: &str) -> io::Result<()
                     else if parts.iter().any(|p| *p == "-L") { "-L" }
                     else if parts.iter().any(|p| *p == "-R") { "-R" }
                     else { "-D" };
-                let _ = send_control_to_port(port, &format!("swap-pane {}\n", dir), &app.session_key);
+                enqueue_control(app, port, &format!("swap-pane {}\n", dir))?;
             } else {
                 let dir = if parts.iter().any(|p| *p == "-L") { FocusDir::Left }
                     else if parts.iter().any(|p| *p == "-R") { FocusDir::Right }
@@ -1384,21 +1384,21 @@ fn execute_command_string_single(app: &mut AppState, cmd: &str) -> io::Result<()
         "rotate-window" | "rotatew" => {
             if let Some(port) = app.control_port {
                 let flag = if parts.iter().any(|p| *p == "-D") { "-D" } else { "" };
-                let _ = send_control_to_port(port, &format!("rotate-window {}\n", flag), &app.session_key);
+                enqueue_control(app, port, &format!("rotate-window {}\n", flag))?;
             } else {
                 crate::window_ops::rotate_panes(app, !parts.iter().any(|p| *p == "-D"));
             }
         }
         "break-pane" | "breakp" => {
             if let Some(port) = app.control_port {
-                let _ = send_control_to_port(port, "break-pane\n", &app.session_key);
+                enqueue_control(app, port, "break-pane\n")?;
             } else {
                 crate::window_ops::break_pane_to_window(app);
             }
         }
         "respawn-pane" | "respawnp" => {
             if let Some(port) = app.control_port {
-                let _ = send_control_to_port(port, &format!("{}\n", cmd), &app.session_key);
+                enqueue_control(app, port, &format!("{}\n", cmd))?;
             } else {
                 let empty = parts.iter().any(|p| *p == "-E");
                 let kill = parts.iter().any(|p| *p == "-k") || empty;
@@ -1417,21 +1417,21 @@ fn execute_command_string_single(app: &mut AppState, cmd: &str) -> io::Result<()
             // Always apply locally first (fix #179: TCP server drops these)
             crate::config::parse_config_line(app, cmd);
             if let Some(port) = app.control_port {
-                let _ = send_control_to_port(port, &format!("{}\n", cmd), &app.session_key);
+                enqueue_control(app, port, &format!("{}\n", cmd))?;
             }
         }
         "bind-key" | "bind" => {
             // Always apply locally first (fix #179: TCP server drops these)
             crate::config::parse_config_line(app, cmd);
             if let Some(port) = app.control_port {
-                let _ = send_control_to_port(port, &format!("{}\n", cmd), &app.session_key);
+                enqueue_control(app, port, &format!("{}\n", cmd))?;
             }
         }
         "unbind-key" | "unbind" => {
             // Always apply locally first (fix #179: TCP server drops these)
             crate::config::parse_config_line(app, cmd);
             if let Some(port) = app.control_port {
-                let _ = send_control_to_port(port, &format!("{}\n", cmd), &app.session_key);
+                enqueue_control(app, port, &format!("{}\n", cmd))?;
             }
         }
         "source-file" | "source" => {
@@ -1441,12 +1441,12 @@ fn execute_command_string_single(app: &mut AppState, cmd: &str) -> io::Result<()
                 crate::config::source_file(app, path);
             }
             if let Some(port) = app.control_port {
-                let _ = send_control_to_port(port, &format!("{}\n", cmd), &app.session_key);
+                enqueue_control(app, port, &format!("{}\n", cmd))?;
             }
         }
         "send-keys" | "send" => {
             if let Some(port) = app.control_port {
-                let _ = send_control_to_port(port, &format!("{}\n", cmd), &app.session_key);
+                enqueue_control(app, port, &format!("{}\n", cmd))?;
             } else {
                 // Local: write key text directly to active pane
                 let literal = parts.iter().any(|p| *p == "-l");
@@ -1562,7 +1562,7 @@ fn execute_command_string_single(app: &mut AppState, cmd: &str) -> io::Result<()
                             if let Some(win) = app.windows.get_mut(app.active_idx) {
                                 if let Some(p) = crate::tree::active_pane_mut(&mut win.root, &win.active_path) {
                                     // DECCKM app-cursor mode: SS3, not CSI (see crate::input::write_key_seq).
-                                    crate::input::write_key_seq(p, expanded.as_bytes());
+                                    crate::input::write_key_seq(p, expanded.as_bytes())?;
                                     let _ = p.writer.flush();
                                 }
                             }
@@ -1579,13 +1579,13 @@ fn execute_command_string_single(app: &mut AppState, cmd: &str) -> io::Result<()
                 app.session_name = name.to_string();
                 // Forward to server so external queries see the new session name
                 if let Some(port) = app.control_port {
-                    let _ = send_control_to_port(port, &format!("rename-session {}\n", crate::util::quote_arg(name)), &app.session_key);
+                    enqueue_control(app, port, &format!("rename-session {}\n", crate::util::quote_arg(name)))?;
                 }
             }
         }
         "select-layout" | "selectl" => {
             if let Some(port) = app.control_port {
-                let _ = send_control_to_port(port, &format!("{}\n", cmd), &app.session_key);
+                enqueue_control(app, port, &format!("{}\n", cmd))?;
             } else {
                 let layout = parts.get(1).unwrap_or(&"tiled");
                 crate::layout::apply_layout(app, layout);
@@ -1593,14 +1593,14 @@ fn execute_command_string_single(app: &mut AppState, cmd: &str) -> io::Result<()
         }
         "next-layout" => {
             if let Some(port) = app.control_port {
-                let _ = send_control_to_port(port, "next-layout\n", &app.session_key);
+                enqueue_control(app, port, "next-layout\n")?;
             } else {
                 crate::layout::cycle_layout(app);
             }
         }
         "pipe-pane" | "pipep" => {
             if let Some(port) = app.control_port {
-                let _ = send_control_to_port(port, &format!("{}\n", cmd), &app.session_key);
+                enqueue_control(app, port, &format!("{}\n", cmd))?;
             }
         }
         "choose-tree" | "choose-window" | "choose-session" => {
@@ -1701,7 +1701,7 @@ fn execute_command_string_single(app: &mut AppState, cmd: &str) -> io::Result<()
         }
         "clear-history" | "clearhist" => {
             if let Some(port) = app.control_port {
-                let _ = send_control_to_port(port, "clear-history\n", &app.session_key);
+                enqueue_control(app, port, "clear-history\n")?;
             } else {
                 let allow_alt = app.allow_alternate_screen;
                 let history_limit = app.history_limit;
@@ -1717,12 +1717,12 @@ fn execute_command_string_single(app: &mut AppState, cmd: &str) -> io::Result<()
         }
         "kill-session" | "kill-ses" => {
             if let Some(port) = app.control_port {
-                let _ = send_control_to_port(port, "kill-session\n", &app.session_key);
+                enqueue_control(app, port, "kill-session\n")?;
             }
         }
         "kill-server" => {
             if let Some(port) = app.control_port {
-                let _ = send_control_to_port(port, "kill-server\n", &app.session_key);
+                enqueue_control(app, port, "kill-server\n")?;
             }
         }
         "has-session" | "has" => {
@@ -1767,7 +1767,7 @@ fn execute_command_string_single(app: &mut AppState, cmd: &str) -> io::Result<()
         "show-options" | "show" | "show-window-options" | "showw"
         | "show-option" | "show-window-option" => {
             if let Some(port) = app.control_port {
-                let _ = send_control_to_port(port, &format!("{}\n", cmd), &app.session_key);
+                enqueue_control(app, port, &format!("{}\n", cmd))?;
             } else {
                 let output = generate_show_options(app);
                 show_output_popup(app, "show-options", output);
@@ -1781,7 +1781,7 @@ fn execute_command_string_single(app: &mut AppState, cmd: &str) -> io::Result<()
                 } else {
                     cmd.to_string()
                 };
-                let _ = send_control_to_port(port, &format!("{}\n", effective_cmd), &app.session_key);
+                enqueue_control(app, port, &format!("{}\n", effective_cmd))?;
             } else {
                 // Local: expand format string and show as status message
                 // Parse flags from parts (same as CLI/server):
@@ -1818,14 +1818,14 @@ fn execute_command_string_single(app: &mut AppState, cmd: &str) -> io::Result<()
         }
         "show-messages" | "showmsgs" => {
             if let Some(port) = app.control_port {
-                let _ = send_control_to_port(port, &format!("{}\n", cmd), &app.session_key);
+                enqueue_control(app, port, &format!("{}\n", cmd))?;
             } else {
                 show_output_popup(app, "show-messages", "(no messages)\n".to_string());
             }
         }
         "set-environment" | "setenv" => {
             if let Some(port) = app.control_port {
-                let _ = send_control_to_port(port, &format!("{}\n", cmd), &app.session_key);
+                enqueue_control(app, port, &format!("{}\n", cmd))?;
             } else {
                 let has_u = parts.iter().any(|p| *p == "-u");
                 let non_flag: Vec<&str> = parts[1..].iter().filter(|p| !p.starts_with('-')).copied().collect();
@@ -1845,7 +1845,7 @@ fn execute_command_string_single(app: &mut AppState, cmd: &str) -> io::Result<()
         }
         "show-environment" | "showenv" => {
             if let Some(port) = app.control_port {
-                let _ = send_control_to_port(port, &format!("{}\n", cmd), &app.session_key);
+                enqueue_control(app, port, &format!("{}\n", cmd))?;
             } else {
                 let mut output = String::new();
                 for (key, value) in &app.environment {
@@ -1857,7 +1857,7 @@ fn execute_command_string_single(app: &mut AppState, cmd: &str) -> io::Result<()
         }
         "set-hook" => {
             if let Some(port) = app.control_port {
-                let _ = send_control_to_port(port, &format!("{}\n", cmd), &app.session_key);
+                enqueue_control(app, port, &format!("{}\n", cmd))?;
             } else {
                 let has_unset = parts.iter().any(|p| *p == "-u" || *p == "-gu" || *p == "-ug");
                 let has_append = parts.iter().any(|p| *p == "-a" || *p == "-ga" || *p == "-ag");
@@ -1893,7 +1893,7 @@ fn execute_command_string_single(app: &mut AppState, cmd: &str) -> io::Result<()
         }
         "send-prefix" => {
             if let Some(port) = app.control_port {
-                let _ = send_control_to_port(port, "send-prefix\n", &app.session_key);
+                enqueue_control(app, port, "send-prefix\n")?;
             } else {
                 // Send the prefix key to the active pane as if typed
                 let prefix = app.prefix_key;
@@ -1916,7 +1916,7 @@ fn execute_command_string_single(app: &mut AppState, cmd: &str) -> io::Result<()
         }
         "if-shell" | "if" => {
             if let Some(port) = app.control_port {
-                let _ = send_control_to_port(port, &format!("{}\n", cmd), &app.session_key);
+                enqueue_control(app, port, &format!("{}\n", cmd))?;
             } else {
                 // Re-parse with quote-aware tokenizer so quoted args are handled
                 let parsed = parse_command_line(cmd);
@@ -1958,13 +1958,13 @@ fn execute_command_string_single(app: &mut AppState, cmd: &str) -> io::Result<()
         }
         "wait-for" | "wait" => {
             if let Some(port) = app.control_port {
-                let _ = send_control_to_port(port, &format!("{}\n", cmd), &app.session_key);
+                enqueue_control(app, port, &format!("{}\n", cmd))?;
             }
             // Local wait-for is a no-op (requires server coordination)
         }
         "find-window" | "findw" => {
             if let Some(port) = app.control_port {
-                let _ = send_control_to_port(port, &format!("{}\n", cmd), &app.session_key);
+                enqueue_control(app, port, &format!("{}\n", cmd))?;
             } else {
                 let pattern = parts[1..].iter().find(|p| !p.starts_with('-')).unwrap_or(&"");
                 let mut output = String::new();
@@ -1979,7 +1979,7 @@ fn execute_command_string_single(app: &mut AppState, cmd: &str) -> io::Result<()
         }
         "move-window" | "movew" => {
             if let Some(port) = app.control_port {
-                let _ = send_control_to_port(port, &format!("{}\n", cmd), &app.session_key);
+                enqueue_control(app, port, &format!("{}\n", cmd))?;
             } else {
                 // Same shared resolver the server path uses, so the command
                 // prompt and a config `move-window` agree with the CLI on what
@@ -1998,7 +1998,7 @@ fn execute_command_string_single(app: &mut AppState, cmd: &str) -> io::Result<()
         }
         "swap-window" | "swapw" => {
             if let Some(port) = app.control_port {
-                let _ = send_control_to_port(port, &format!("{}\n", cmd), &app.session_key);
+                enqueue_control(app, port, &format!("{}\n", cmd))?;
             } else {
                 let src = parts.windows(2).find(|w| w[0] == "-s").map(|w| w[1].to_string());
                 let dst = parts.windows(2).find(|w| w[0] == "-t").map(|w| w[1].to_string())
@@ -2033,7 +2033,7 @@ fn execute_command_string_single(app: &mut AppState, cmd: &str) -> io::Result<()
         }
         "link-window" | "linkw" => {
             if let Some(port) = app.control_port {
-                let _ = send_control_to_port(port, &format!("{}\n", cmd), &app.session_key);
+                enqueue_control(app, port, &format!("{}\n", cmd))?;
             } else {
                 // Intra-session link-window: parse -s and -t flags
                 let src_idx = parts.windows(2).find(|w| w[0] == "-s")
@@ -2066,7 +2066,7 @@ fn execute_command_string_single(app: &mut AppState, cmd: &str) -> io::Result<()
         }
         "unlink-window" | "unlinkw" => {
             if let Some(port) = app.control_port {
-                let _ = send_control_to_port(port, &format!("{}\n", cmd), &app.session_key);
+                enqueue_control(app, port, &format!("{}\n", cmd))?;
             } else if app.windows.len() > 1 {
                 let removed_pos = app.active_idx;
                 let mut win = app.windows.remove(removed_pos);
@@ -2080,7 +2080,7 @@ fn execute_command_string_single(app: &mut AppState, cmd: &str) -> io::Result<()
         }
         "move-pane" | "movep" => {
             if let Some(port) = app.control_port {
-                let _ = send_control_to_port(port, &format!("{}\n", cmd), &app.session_key);
+                enqueue_control(app, port, &format!("{}\n", cmd))?;
             } else {
                 let horizontal = parts[1..].iter().any(|a| *a == "-h");
                 let mut src_win: Option<usize> = None;
@@ -2122,7 +2122,7 @@ fn execute_command_string_single(app: &mut AppState, cmd: &str) -> io::Result<()
         }
         "join-pane" | "joinp" => {
             if let Some(port) = app.control_port {
-                let _ = send_control_to_port(port, &format!("{}\n", cmd), &app.session_key);
+                enqueue_control(app, port, &format!("{}\n", cmd))?;
             } else {
                 let horizontal = parts[1..].iter().any(|a| *a == "-h");
                 let mut src_win: Option<usize> = None;
@@ -2164,19 +2164,19 @@ fn execute_command_string_single(app: &mut AppState, cmd: &str) -> io::Result<()
         }
         "resize-window" | "resizew" => {
             if let Some(port) = app.control_port {
-                let _ = send_control_to_port(port, &format!("{}\n", cmd), &app.session_key);
+                enqueue_control(app, port, &format!("{}\n", cmd))?;
             }
             // resize-window depends on terminal size, only meaningful on server
         }
         "respawn-window" | "respawnw" => {
             if let Some(port) = app.control_port {
-                let _ = send_control_to_port(port, &format!("{}\n", cmd), &app.session_key);
+                enqueue_control(app, port, &format!("{}\n", cmd))?;
             }
             // respawn-window requires PTY system from server context
         }
         "previous-layout" | "prevl" => {
             if let Some(port) = app.control_port {
-                let _ = send_control_to_port(port, "previous-layout\n", &app.session_key);
+                enqueue_control(app, port, "previous-layout\n")?;
             } else {
                 crate::layout::cycle_layout_reverse(app);
             }
@@ -2189,7 +2189,7 @@ fn execute_command_string_single(app: &mut AppState, cmd: &str) -> io::Result<()
         }
         "server-info" | "info" => {
             if let Some(port) = app.control_port {
-                let _ = send_control_to_port(port, "server-info\n", &app.session_key);
+                enqueue_control(app, port, "server-info\n")?;
             } else {
                 let output = format!("psmux {}\nSession: {}\nWindows: {}\nActive: {}\n",
                     crate::types::VERSION, app.session_name, app.windows.len(), app.active_idx);
@@ -2242,11 +2242,8 @@ fn execute_command_string_single(app: &mut AppState, cmd: &str) -> io::Result<()
             let name = session_name.unwrap_or_else(|| crate::session::next_session_name(ns_prefix));
 
             // Build port file base (with namespace prefix if applicable)
-            let port_file_base = if let Some(ref sn) = app.socket_name {
-                format!("{}__{}", sn, name)
-            } else {
-                name.clone()
-            };
+            crate::paths::validate_registry_base(app.socket_name.as_deref(), &name)?;
+            let port_file_base = crate::paths::storage_base(app.socket_name.as_deref(), &name);
 
             // Check if session already exists
             let port_path = crate::paths::port_file(&port_file_base);
@@ -2263,19 +2260,19 @@ fn execute_command_string_single(app: &mut AppState, cmd: &str) -> io::Result<()
                         }
                     }
                 }
-                // Stale port file, remove it
-                let _ = std::fs::remove_file(&port_path);
+                if crate::session::registry_pid_anchor_alive(&port_file_base) != Some(false) {
+                    return Err(io::Error::new(io::ErrorKind::AlreadyExists,
+                        format!("session '{}' exists but is not responding; registry preserved", name)));
+                }
+                // Only the new server's ownership transaction may replace a
+                // positively dead record; clients never delete registry files.
             }
 
             // Try to claim a warm server first (fast path)
             let warm_disabled = std::env::var("PSMUX_NO_WARM").map(|v| v == "1" || v == "true").unwrap_or(false)
                 || crate::config::is_warm_disabled_by_config();
             let claimed_warm = if !warm_disabled && initial_command.is_none() && start_dir.is_none() && env_vars.is_empty() {
-                let warm_base = if let Some(ref sn) = app.socket_name {
-                    format!("{}____warm__", sn)
-                } else {
-                    "__warm__".to_string()
-                };
+                let warm_base = crate::paths::storage_base(app.socket_name.as_deref(), "__warm__");
                 let warm_port_path = crate::paths::port_file(&warm_base);
                 if std::path::Path::new(&warm_port_path).exists() {
                     if let Ok(warm_port_str) = std::fs::read_to_string(&warm_port_path) {
@@ -2389,7 +2386,7 @@ fn execute_command_string_single(app: &mut AppState, cmd: &str) -> io::Result<()
                     // Switch to the new session
                     if let Some(port) = app.control_port {
                         let switch_cmd = format!("switch-client -t {}\n", crate::util::quote_arg(&name));
-                        let _ = send_control_to_port(port, &switch_cmd, &app.session_key);
+                        enqueue_control(app, port, &switch_cmd)?;
                     }
                 }
                 app.status_message = Some((format!("created session '{}'", name), Instant::now(), None));
@@ -2399,20 +2396,20 @@ fn execute_command_string_single(app: &mut AppState, cmd: &str) -> io::Result<()
         }
         "lock-client" | "lockc" | "lock-server" | "lock" | "lock-session" | "locks" => {
             if let Some(port) = app.control_port {
-                let _ = send_control_to_port(port, "lock-server\n", &app.session_key);
+                enqueue_control(app, port, "lock-server\n")?;
             }
             app.status_message = Some(("lock: not available on Windows".to_string(), Instant::now(), None));
         }
         "refresh-client" | "refresh" => {
             if let Some(port) = app.control_port {
-                let _ = send_control_to_port(port, "refresh-client\n", &app.session_key);
+                enqueue_control(app, port, "refresh-client\n")?;
             }
             // Trigger redraw in all modes
             app.status_message = Some(("client refreshed".to_string(), Instant::now(), None));
         }
         "suspend-client" | "suspendc" => {
             if let Some(port) = app.control_port {
-                let _ = send_control_to_port(port, "suspend-client\n", &app.session_key);
+                enqueue_control(app, port, "suspend-client\n")?;
             }
             app.status_message = Some(("suspend: not available on Windows".to_string(), Instant::now(), None));
         }
@@ -2422,7 +2419,7 @@ fn execute_command_string_single(app: &mut AppState, cmd: &str) -> io::Result<()
         "customize-mode" => {
             // tmux 3.2+ customize-mode: interactive options editor
             if let Some(port) = app.control_port {
-                let _ = send_control_to_port(port, "customize-mode\n", &app.session_key);
+                enqueue_control(app, port, "customize-mode\n")?;
             } else {
                 // In-process fallback: build option list directly
                 let options = crate::server::option_catalog::build_option_list(app);
@@ -2548,7 +2545,7 @@ fn execute_command_string_single(app: &mut AppState, cmd: &str) -> io::Result<()
             }
             // Also forward unknown commands to server (catch-all for tmux compat)
             if let Some(port) = app.control_port {
-                let _ = send_control_to_port(port, &format!("{}\n", cmd), &app.session_key);
+                enqueue_control(app, port, &format!("{}\n", cmd))?;
             }
         }
     }

--- a/src/control.rs
+++ b/src/control.rs
@@ -165,7 +165,8 @@ pub fn format_error(timestamp: i64, cmd_number: u64) -> String {
 }
 
 /// Emit a control notification to all connected control mode clients.
-/// Non-blocking: if a client's channel is full, the notification is dropped for that client.
+/// Non-blocking: disconnect a stalled consumer instead of silently losing an
+/// ordered state update or output bytes while presenting a healthy session.
 pub fn emit_notification(app: &AppState, notif: ControlNotification) {
     for client in app.control_clients.values() {
         if let ControlNotification::Output { pane_id, .. } = &notif {
@@ -173,14 +174,22 @@ pub fn emit_notification(app: &AppState, notif: ControlNotification) {
                 continue;
             }
         }
-        let _ = client.notification_tx.try_send(notif.clone());
+        if client.notification_tx.try_send(notif.clone()).is_err() {
+            crate::types::shutdown_client_stream(client.client_id);
+        }
     }
+}
+
+pub fn send_notification_checked(client_id: u64, tx: &std::sync::mpsc::SyncSender<ControlNotification>, notif: ControlNotification) {
+    if tx.try_send(notif).is_err() { crate::types::shutdown_client_stream(client_id); }
 }
 
 /// Send a notification to a single control client by id (no-op if unknown).
 pub fn emit_to_client(app: &AppState, client_id: u64, notif: ControlNotification) {
     if let Some(client) = app.control_clients.get(&client_id) {
-        let _ = client.notification_tx.try_send(notif);
+        if client.notification_tx.try_send(notif).is_err() {
+            crate::types::shutdown_client_stream(client_id);
+        }
     }
 }
 

--- a/src/cross_session_server.rs
+++ b/src/cross_session_server.rs
@@ -128,11 +128,7 @@ pub fn handle_pane_forward_extract(
             let _ = stream.set_nodelay(true);
             match stream.try_clone() {
                 Ok(tcp_writer) => {
-                    if let Ok(mut writers) = crate::types::PIPE_WRITERS.lock() {
-                        writers.push((pane_local_id, Box::new(tcp_writer)));
-                        crate::types::PIPE_PANE_COUNT
-                            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                    }
+                    if crate::pane::pipe::register_tunnel(pane_local_id, Box::new(tcp_writer)).is_err() { return; }
                 }
                 Err(_) => return,
             }

--- a/src/input.rs
+++ b/src/input.rs
@@ -1154,32 +1154,32 @@ pub fn handle_key(app: &mut AppState, key: KeyEvent) -> io::Result<bool> {
                             should_close = true;
                         } else {
                             // Forward Escape to the PTY
-                            let _ = pty.writer.write_all(b"\x1b");
+                            pty.writer.write_all(b"\x1b")?;
                         }
                     }
                     KeyCode::Char(c) => {
                         if key.modifiers.contains(crossterm::event::KeyModifiers::CONTROL) {
                             let ctrl = (c as u8) & 0x1F;
-                            let _ = pty.writer.write_all(&[ctrl]);
+                            pty.writer.write_all(&[ctrl])?;
                         } else {
                             let mut buf = [0u8; 4];
                             let s = c.encode_utf8(&mut buf);
-                            let _ = pty.writer.write_all(s.as_bytes());
+                            pty.writer.write_all(s.as_bytes())?;
                         }
                     }
-                    KeyCode::Enter => { let _ = pty.writer.write_all(b"\r"); }
-                    KeyCode::Backspace => { let _ = pty.writer.write_all(b"\x7f"); }
-                    KeyCode::Tab => { let _ = pty.writer.write_all(b"\t"); }
-                    KeyCode::BackTab => { let _ = pty.writer.write_all(b"\x1b[Z"); }
-                    KeyCode::Up => { let _ = pty.writer.write_all(b"\x1b[A"); }
-                    KeyCode::Down => { let _ = pty.writer.write_all(b"\x1b[B"); }
-                    KeyCode::Right => { let _ = pty.writer.write_all(b"\x1b[C"); }
-                    KeyCode::Left => { let _ = pty.writer.write_all(b"\x1b[D"); }
-                    KeyCode::Home => { let _ = pty.writer.write_all(b"\x1b[H"); }
-                    KeyCode::End => { let _ = pty.writer.write_all(b"\x1b[F"); }
-                    KeyCode::PageUp => { let _ = pty.writer.write_all(b"\x1b[5~"); }
-                    KeyCode::PageDown => { let _ = pty.writer.write_all(b"\x1b[6~"); }
-                    KeyCode::Delete => { let _ = pty.writer.write_all(b"\x1b[3~"); }
+                    KeyCode::Enter => { pty.writer.write_all(b"\r")?; }
+                    KeyCode::Backspace => { pty.writer.write_all(b"\x7f")?; }
+                    KeyCode::Tab => { pty.writer.write_all(b"\t")?; }
+                    KeyCode::BackTab => { pty.writer.write_all(b"\x1b[Z")?; }
+                    KeyCode::Up => { pty.writer.write_all(b"\x1b[A")?; }
+                    KeyCode::Down => { pty.writer.write_all(b"\x1b[B")?; }
+                    KeyCode::Right => { pty.writer.write_all(b"\x1b[C")?; }
+                    KeyCode::Left => { pty.writer.write_all(b"\x1b[D")?; }
+                    KeyCode::Home => { pty.writer.write_all(b"\x1b[H")?; }
+                    KeyCode::End => { pty.writer.write_all(b"\x1b[F")?; }
+                    KeyCode::PageUp => { pty.writer.write_all(b"\x1b[5~")?; }
+                    KeyCode::PageDown => { pty.writer.write_all(b"\x1b[6~")?; }
+                    KeyCode::Delete => { pty.writer.write_all(b"\x1b[3~")?; }
                     _ => {}
                 }
                 // Check if child exited
@@ -1494,7 +1494,7 @@ pub fn handle_key(app: &mut AppState, key: KeyEvent) -> io::Result<bool> {
                         app.mode = Mode::Passthrough;
                         let win = &mut app.windows[app.active_idx];
                         if let Some(p) = active_pane_mut(&mut win.root, &win.active_path) {
-                            let _ = write!(p.writer, "{}", text);
+                            p.writer.write_all(text.as_bytes())?;
                         }
                     } else {
                         app.mode = Mode::Passthrough;
@@ -2112,7 +2112,7 @@ pub(crate) fn csi_cursor_to_ss3(seq: &[u8], app_cursor: bool) -> Option<[u8; 3]>
 /// form when the pane is in DECCKM application-cursor mode (see csi_cursor_to_ss3).
 /// The transform no-ops on every other sequence, so all named keys route through
 /// this uniformly. Does not flush; callers flush once after the write.
-pub(crate) fn write_key_seq(p: &mut crate::types::Pane, seq: &[u8]) {
+pub(crate) fn write_key_seq(p: &mut crate::types::Pane, seq: &[u8]) -> io::Result<()> {
     let app_cursor = p.term.lock()
         .map(|t| t.screen().application_cursor())
         .unwrap_or(false);
@@ -2156,7 +2156,7 @@ pub(crate) fn win32_input_key_seq(vk: u16, scan: u16, uchar: u16, ctrl_state: u3
 /// ESC byte: that is the only dangling-ESC write psmux makes.  Everything else
 /// it sends is either a complete escape sequence or plain text, and is passed
 /// through untouched — as is every byte on a pane that was never latched.
-pub(crate) fn write_pane_input(p: &mut crate::types::Pane, bytes: &[u8]) {
+pub(crate) fn write_pane_input(p: &mut crate::types::Pane, bytes: &[u8]) -> io::Result<()> {
     use std::io::Write as _;
     #[cfg(windows)]
     {
@@ -2164,13 +2164,12 @@ pub(crate) fn write_pane_input(p: &mut crate::types::Pane, bytes: &[u8]) {
             const VK_ESCAPE: u16 = 0x1B;
             let scan = crate::platform::mouse_inject::vk_to_scan(VK_ESCAPE);
             let seq = win32_input_key_seq(VK_ESCAPE, scan, VK_ESCAPE, 0);
-            let _ = p.writer.write_all(seq.as_bytes());
-            let _ = p.writer.flush();
-            return;
+            p.writer.write_all(seq.as_bytes())?;
+            return p.writer.flush();
         }
     }
-    let _ = p.writer.write_all(bytes);
-    let _ = p.writer.flush();
+    p.writer.write_all(bytes)?;
+    p.writer.flush()
 }
 
 /// Record that psmux has just written a win32 input mode sequence to the panes
@@ -2349,7 +2348,7 @@ pub fn forward_key_to_active(app: &mut AppState, key: KeyEvent) -> io::Result<()
 
                 if app.sync_input {
                     let win = &mut app.windows[app.active_idx];
-                    fn inject_all(node: &mut Node, ctrl: bool, alt: bool, shift: bool) {
+                    fn inject_all(node: &mut Node, ctrl: bool, alt: bool, shift: bool) -> io::Result<()> {
                         match node {
                             Node::Leaf(p) if !p.dead => {
                                 if let Some(pid) = p.child_pid {
@@ -2357,18 +2356,19 @@ pub fn forward_key_to_active(app: &mut AppState, key: KeyEvent) -> io::Result<()
                                         // Fallback: xterm CSI encoding for non-console apps
                                         let m: u8 = 1 + (shift as u8) + (alt as u8) * 2 + (ctrl as u8) * 4;
                                         let bytes = if m > 1 { format!("\x1b[13;{}~", m).into_bytes() } else { b"\r".to_vec() };
-                                        let _ = p.writer.write_all(&bytes);
-                                        let _ = p.writer.flush();
+                                        p.writer.write_all(&bytes)?;
+                                        p.writer.flush()?;
                                     }
                                 }
                             }
                             Node::Leaf(_) => {}
                             Node::Split { children, .. } => {
-                                for c in children { inject_all(c, ctrl, alt, shift); }
+                                for c in children { inject_all(c, ctrl, alt, shift)?; }
                             }
                         }
+                        Ok(())
                     }
-                    inject_all(&mut win.root, ctrl, alt, shift);
+                    inject_all(&mut win.root, ctrl, alt, shift)?;
                     return Ok(());
                 } else {
                     let win = &mut app.windows[app.active_idx];
@@ -2418,7 +2418,7 @@ pub fn forward_key_to_active(app: &mut AppState, key: KeyEvent) -> io::Result<()
 
                 if app.sync_input {
                     let win = &mut app.windows[app.active_idx];
-                    fn inject_ctrl_all(node: &mut Node, ch: char, raw: u8, is_ctrl_c: bool) {
+                    fn inject_ctrl_all(node: &mut Node, ch: char, raw: u8, is_ctrl_c: bool) -> io::Result<()> {
                         match node {
                             Node::Leaf(p) if !p.dead => {
                                 // Ctrl+C: consult the interrupt router BEFORE writing the
@@ -2433,8 +2433,8 @@ pub fn forward_key_to_active(app: &mut AppState, key: KeyEvent) -> io::Result<()
                                         crate::platform::mouse_inject::send_ctrl_c_event(pid, false);
                                     }
                                 }
-                                let _ = p.writer.write_all(&[raw]);
-                                let _ = p.writer.flush();
+                                p.writer.write_all(&[raw])?;
+                                p.writer.flush()?;
                                 #[cfg(windows)]
                                 if !is_ctrl_c {
                                     if let Some(pid) = p.child_pid {
@@ -2446,11 +2446,12 @@ pub fn forward_key_to_active(app: &mut AppState, key: KeyEvent) -> io::Result<()
                             }
                             Node::Leaf(_) => {}
                             Node::Split { children, .. } => {
-                                for child in children { inject_ctrl_all(child, ch, raw, is_ctrl_c); }
+                                for child in children { inject_ctrl_all(child, ch, raw, is_ctrl_c)?; }
                             }
                         }
+                        Ok(())
                     }
-                    inject_ctrl_all(&mut win.root, inject_char, ctrl_char, is_ctrl_c);
+                    inject_ctrl_all(&mut win.root, inject_char, ctrl_char, is_ctrl_c)?;
                 } else {
                     let win = &mut app.windows[app.active_idx];
                     if let Some(active) = active_pane_mut(&mut win.root, &win.active_path) {
@@ -2463,8 +2464,8 @@ pub fn forward_key_to_active(app: &mut AppState, key: KeyEvent) -> io::Result<()
                                     crate::platform::mouse_inject::send_ctrl_c_event(pid, false);
                                 }
                             }
-                            let _ = active.writer.write_all(&[ctrl_char]);
-                            let _ = active.writer.flush();
+                            active.writer.write_all(&[ctrl_char])?;
+                            active.writer.flush()?;
                             #[cfg(windows)]
                             if !is_ctrl_c {
                                 if let Some(pid) = active.child_pid {
@@ -2489,21 +2490,22 @@ pub fn forward_key_to_active(app: &mut AppState, key: KeyEvent) -> io::Result<()
     if app.sync_input {
         // Fan out to ALL panes in the current window
         let win = &mut app.windows[app.active_idx];
-        fn write_all_panes(node: &mut Node, data: &[u8]) {
+        fn write_all_panes(node: &mut Node, data: &[u8]) -> io::Result<()> {
             match node {
-                Node::Leaf(p) if !p.dead => { let _ = p.writer.write_all(data); let _ = p.writer.flush(); }
+                Node::Leaf(p) if !p.dead => { p.writer.write_all(data)?; p.writer.flush()?; }
                 Node::Leaf(_) => {}
-                Node::Split { children, .. } => { for c in children { write_all_panes(c, data); } }
+                Node::Split { children, .. } => { for c in children { write_all_panes(c, data)?; } }
             }
+            Ok(())
         }
-        write_all_panes(&mut win.root, &encoded);
+        write_all_panes(&mut win.root, &encoded)?;
 
     } else {
         let win = &mut app.windows[app.active_idx];
         if let Some(active) = active_pane_mut(&mut win.root, &win.active_path) {
             if !active.dead {
-                let _ = active.writer.write_all(&encoded);
-                let _ = active.writer.flush();
+                active.writer.write_all(&encoded)?;
+                active.writer.flush()?;
 
             }
         }
@@ -2511,60 +2513,30 @@ pub fn forward_key_to_active(app: &mut AppState, key: KeyEvent) -> io::Result<()
     Ok(())
 }
 
-/// Chunked PTY write for paste delivery.  The PTY pipe can silently
-/// drop bytes when a large payload (140+ lines) is written in a single
-/// call because the OS pipe buffer fills up.  We split the text into
-/// ~2 KiB chunks with small yields between them so the consumer
-/// (shell / PSReadLine / nvim) has time to drain.  Bracket sequences
-/// are tiny and always written in one shot.
-fn write_paste_chunked(writer: &mut dyn std::io::Write, text: &[u8], bracket: bool) {
-    const CHUNK: usize = 512;
-    // Normalize line endings to CR for ConPTY.  Clipboard text may arrive
-    // with LF (\n) or CRLF (\r\n), but ConPTY's input parser expects CR
-    // (\r) for Enter.  Bare LF is misinterpreted by PSReadLine, causing
-    // multi-line pastes to appear in reverse order.
-    let text = {
-        let mut out = Vec::with_capacity(text.len());
-        let mut i = 0;
-        while i < text.len() {
-            if text[i] == b'\r' && i + 1 < text.len() && text[i + 1] == b'\n' {
-                out.push(b'\r');
-                i += 2; // CRLF → CR
-            } else if text[i] == b'\n' {
-                out.push(b'\r');
-                i += 1; // LF → CR
-            } else {
-                out.push(text[i]);
-                i += 1;
-            }
-        }
-        out
-    };
-    let text = &text[..];
-    if bracket { let _ = writer.write_all(b"\x1b[200~"); }
-    let mut offset: usize = 0;
-    while offset < text.len() {
-        let remaining = (text.len() - offset).min(CHUNK);
-        let chunk = &text[offset..offset + remaining];
-        match writer.write(chunk) {
-            Ok(0) => {
-                // Zero bytes written — yield and retry once
-                std::thread::sleep(std::time::Duration::from_millis(10));
-                match writer.write(chunk) {
-                    Ok(n) if n > 0 => { offset += n; }
-                    _ => break, // give up on persistent failure
-                }
-            }
-            Ok(n) => { offset += n; }
-            Err(_) => break,
-        }
-        // Yield between chunks to let the consumer drain the buffer
-        if offset < text.len() {
-            std::thread::sleep(std::time::Duration::from_millis(5));
+/// Normalize and admit a whole paste atomically, including its bracket markers.
+/// The pane's dedicated writer performs bounded writes. Never sleep/retry on the
+/// event loop or leave a child inside bracketed-paste mode after partial admission.
+fn write_paste_chunked(writer: &mut dyn std::io::Write, text: &[u8], bracket: bool) -> io::Result<()> {
+    const MAX_PASTE: usize = 1024 * 1024 - 12;
+    if text.len() > MAX_PASTE {
+        return Err(io::Error::new(io::ErrorKind::InvalidInput,
+            "paste exceeds the 1 MiB pane input budget; split it into smaller pastes"));
+    }
+    let mut normalized = Vec::with_capacity(text.len() + if bracket { 12 } else { 0 });
+    if bracket { normalized.extend_from_slice(b"\x1b[200~"); }
+    let mut i = 0;
+    while i < text.len() {
+        if text[i] == b'\r' && i + 1 < text.len() && text[i + 1] == b'\n' {
+            normalized.push(b'\r');
+            i += 2;
+        } else {
+            normalized.push(if text[i] == b'\n' { b'\r' } else { text[i] });
+            i += 1;
         }
     }
-    if bracket { let _ = writer.write_all(b"\x1b[201~"); }
-    let _ = writer.flush();
+    if bracket { normalized.extend_from_slice(b"\x1b[201~"); }
+    writer.write_all(&normalized)?;
+    writer.flush()
 }
 
 /// Send pasted text to the active pane, wrapping in bracketed-paste
@@ -2573,104 +2545,40 @@ fn write_paste_chunked(writer: &mut dyn std::io::Write, text: &[u8], bracket: bo
 /// drag-and-drop file paths, ensuring applications like Claude CLI can
 /// distinguish paste/drop from typed input.
 pub fn send_paste_to_active(app: &mut AppState, text: &str) -> io::Result<()> {
-    // In clock mode, any input exits back to passthrough
     if matches!(app.mode, Mode::ClockMode) {
         app.mode = Mode::Passthrough;
         return Ok(());
     }
-    // In copy / copy-search modes, treat like regular text
-    if matches!(app.mode, Mode::CopyMode) {
+    if matches!(app.mode, Mode::CopyMode | Mode::CopySearch { .. } | Mode::ConfirmMode { .. }
+        | Mode::MenuMode { .. } | Mode::PaneChooser { .. }) {
         return send_text_to_active(app, text);
     }
-    if matches!(app.mode, Mode::CopySearch { .. }) {
-        return send_text_to_active(app, text);
+    fn paste(pane: &mut Pane, text: &[u8]) -> io::Result<()> {
+        let bracket = pane.term.lock().map(|p| p.screen().bracketed_paste()).unwrap_or(false);
+        write_paste_chunked(&mut pane.writer, text, bracket)
+            .map_err(|error| io::Error::new(error.kind(), format!("pane %{}: {}", pane.id, error)))
     }
-
-    // Check if the child requested bracketed paste mode
-    let use_bracket = {
-        let win = &app.windows[app.active_idx];
-        if let Some(p) = crate::tree::active_pane(&win.root, &win.active_path) {
-            if let Ok(parser) = p.term.lock() {
-                let bp = parser.screen().bracketed_paste();
-                crate::debug_log::input_log("paste", &format!("child bracketed_paste()={}", bp));
-                bp
-            } else {
-                crate::debug_log::input_log("paste", "term lock failed");
-                false
-            }
-        } else {
-            crate::debug_log::input_log("paste", "no active pane");
-            false
-        }
-    };
-    crate::debug_log::input_log("paste", &format!("use_bracket={} text_len={} text_preview={:?}", use_bracket, text.len(), &text.chars().take(100).collect::<String>()));
-
-    // On Windows, bracketed paste delivery is tricky:
-    //
-    // - ConPTY may strip \x1b[200~/201~ from the PTY input pipe (older Windows).
-    // - WriteConsoleInputW can bypass ConPTY, but it sends each byte of the
-    //   bracket sequence as a separate KEY_EVENT record.  Apps that read via
-    //   ReadConsoleInputW (crossterm-based apps like Helix) cannot reassemble
-    //   VT sequences from individual key events, so \x1b[200~ appears as the
-    //   literal characters Esc [ 2 0 0 ~ in the editor (issue #98).
-    // - Apps that read raw bytes via ReadFile (nvim via libuv) CAN parse the
-    //   bracket sequences from console-injected KEY_EVENTs.
-    //
-    // Strategy: try the PTY pipe first with bracket markers.  This works on
-    // newer Windows where ConPTY passes VT input through, and also works for
-    // byte-stream readers (nvim).  If the child uses ReadConsoleInputW
-    // (crossterm), ConPTY converts the VT bytes to KEY_EVENTs anyway, so the
-    // brackets may still not be parsed -- but at least the text content
-    // arrives correctly without stray visible bracket characters.
-    //
-    // For apps where PTY-pipe brackets get stripped by ConPTY, fall back to
-    // console injection for the TEXT ONLY (no bracket markers) so the content
-    // still arrives reliably.
-    #[cfg(windows)]
-    {
-        if app.sync_input {
-            let win = &mut app.windows[app.active_idx];
-            fn write_all_panes(node: &mut crate::types::Node, text: &[u8], bracket: bool) {
-                match node {
-                    crate::types::Node::Leaf(p) => {
-                        write_paste_chunked(&mut p.writer, text, bracket);
-                    }
-                    crate::types::Node::Split { children, .. } => {
-                        for c in children { write_all_panes(c, text, bracket); }
-                    }
+    if let Mode::PopupMode { ref mut popup_pane, .. } = app.mode {
+        if let Some(pane) = popup_pane { paste(pane, text.as_bytes())?; }
+        return Ok(());
+    }
+    let win = &mut app.windows[app.active_idx];
+    if let Some(fi) = win.floating_focus {
+        if let Some(fp) = win.floating.get_mut(fi) { return paste(&mut fp.pane, text.as_bytes()); }
+    }
+    if app.sync_input {
+        fn all(node: &mut Node, text: &[u8]) -> io::Result<()> {
+            match node {
+                Node::Leaf(pane) => paste(pane, text),
+                Node::Split { children, .. } => {
+                    for child in children { all(child, text)?; }
+                    Ok(())
                 }
             }
-            write_all_panes(&mut win.root, text.as_bytes(), use_bracket);
-        } else {
-            let win = &mut app.windows[app.active_idx];
-            if let Some(p) = active_pane_mut(&mut win.root, &win.active_path) {
-                write_paste_chunked(&mut p.writer, text.as_bytes(), use_bracket);
-            }
         }
-    }
-
-    // On non-Windows, use standard PTY pipe write with bracket sequences
-    #[cfg(not(windows))]
-    {
-        if app.sync_input {
-            let win = &mut app.windows[app.active_idx];
-            fn write_paste_all_panes(node: &mut Node, text: &[u8], bracket: bool) {
-                match node {
-                    Node::Leaf(p) => {
-                        write_paste_chunked(&mut p.writer, text, bracket);
-                    }
-                    Node::Split { children, .. } => {
-                        for c in children { write_paste_all_panes(c, text, bracket); }
-                    }
-                }
-            }
-            write_paste_all_panes(&mut win.root, text.as_bytes(), use_bracket);
-        } else {
-            let win = &mut app.windows[app.active_idx];
-            if let Some(p) = active_pane_mut(&mut win.root, &win.active_path) {
-                write_paste_chunked(&mut p.writer, text.as_bytes(), use_bracket);
-            }
-        }
+        all(&mut win.root, text.as_bytes())?;
+    } else if let Some(pane) = active_pane_mut(&mut win.root, &win.active_path) {
+        paste(pane, text.as_bytes())?;
     }
     Ok(())
 }
@@ -2691,26 +2599,27 @@ pub fn send_bytes_to_active(app: &mut AppState, bytes: &[u8]) -> io::Result<()> 
         let win = &mut app.windows[app.active_idx];
         if let Some(fi) = win.floating_focus {
             if let Some(fp) = win.floating.get_mut(fi) {
-                let _ = fp.pane.writer.write_all(bytes);
-                let _ = fp.pane.writer.flush();
+                fp.pane.writer.write_all(bytes)?;
+                fp.pane.writer.flush()?;
                 return Ok(());
             }
         }
     }
     if app.sync_input {
         let win = &mut app.windows[app.active_idx];
-        fn write_all_panes(node: &mut Node, data: &[u8]) {
+        fn write_all_panes(node: &mut Node, data: &[u8]) -> io::Result<()> {
             match node {
-                Node::Leaf(p) => { let _ = p.writer.write_all(data); let _ = p.writer.flush(); }
-                Node::Split { children, .. } => { for c in children { write_all_panes(c, data); } }
+                Node::Leaf(p) => { p.writer.write_all(data)?; p.writer.flush()?; }
+                Node::Split { children, .. } => { for c in children { write_all_panes(c, data)?; } }
             }
+            Ok(())
         }
-        write_all_panes(&mut win.root, bytes);
+        write_all_panes(&mut win.root, bytes)?;
     } else {
         let win = &mut app.windows[app.active_idx];
         if let Some(p) = active_pane_mut(&mut win.root, &win.active_path) {
-            let _ = p.writer.write_all(bytes);
-            let _ = p.writer.flush();
+            p.writer.write_all(bytes)?;
+            p.writer.flush()?;
         }
     }
     Ok(())
@@ -2731,8 +2640,8 @@ pub fn send_text_to_active(app: &mut AppState, text: &str) -> io::Result<()> {
         }
         if let Mode::PopupMode { ref mut popup_pane, .. } = app.mode {
             if let Some(ref mut pty) = popup_pane {
-                let _ = pty.writer.write_all(text.as_bytes());
-                let _ = pty.writer.flush();
+                pty.writer.write_all(text.as_bytes())?;
+                pty.writer.flush()?;
             }
         }
         return Ok(());
@@ -2810,7 +2719,7 @@ pub fn send_text_to_active(app: &mut AppState, text: &str) -> io::Result<()> {
         let win = &mut app.windows[app.active_idx];
         if let Some(fi) = win.floating_focus {
             if let Some(fp) = win.floating.get_mut(fi) {
-                write_pane_input(&mut fp.pane, text.as_bytes());
+                write_pane_input(&mut fp.pane, text.as_bytes())?;
                 return Ok(());
             }
         }
@@ -2819,17 +2728,18 @@ pub fn send_text_to_active(app: &mut AppState, text: &str) -> io::Result<()> {
     if app.sync_input {
         // Fan out to ALL panes in the current window
         let win = &mut app.windows[app.active_idx];
-        fn write_all_panes(node: &mut Node, text: &[u8]) {
+        fn write_all_panes(node: &mut Node, text: &[u8]) -> io::Result<()> {
             match node {
-                Node::Leaf(p) => write_pane_input(p, text),
-                Node::Split { children, .. } => { for c in children { write_all_panes(c, text); } }
+                Node::Leaf(p) => write_pane_input(p, text)?,
+                Node::Split { children, .. } => { for c in children { write_all_panes(c, text)?; } }
             }
+            Ok(())
         }
-        write_all_panes(&mut win.root, text.as_bytes());
+        write_all_panes(&mut win.root, text.as_bytes())?;
     } else {
         let win = &mut app.windows[app.active_idx];
         if let Some(p) = active_pane_mut(&mut win.root, &win.active_path) {
-            write_pane_input(p, text.as_bytes());
+            write_pane_input(p, text.as_bytes())?;
         }
     }
     Ok(())
@@ -3025,8 +2935,8 @@ pub fn send_key_to_active(app: &mut AppState, k: &str) -> io::Result<()> {
         if let Some(seq) = seq {
             if let Mode::PopupMode { ref mut popup_pane, .. } = app.mode {
                 if let Some(ref mut pty) = popup_pane {
-                    let _ = pty.writer.write_all(seq.as_bytes());
-                    let _ = pty.writer.flush();
+                    pty.writer.write_all(seq.as_bytes())?;
+                    pty.writer.flush()?;
                 }
             }
         }
@@ -3226,25 +3136,25 @@ pub fn send_key_to_active(app: &mut AppState, k: &str) -> io::Result<()> {
     }
     
     // Write a named key to a single pane (extracted for sync_input support).
-    fn write_named_key_to_pane(p: &mut crate::types::Pane, k: &str) {
+    fn write_named_key_to_pane(p: &mut crate::types::Pane, k: &str) -> io::Result<()> {
         use std::io::Write as _;
         match k {
-            "enter" => write_key_seq(p, b"\r"),
-            "tab" => write_key_seq(p, b"\t"),
-            "btab" | "backtab" => write_key_seq(p, b"\x1b[Z"),
-            "backspace" => write_key_seq(p, b"\x7f"),
-            "delete" => write_key_seq(p, b"\x1b[3~"),
-            "esc" => write_key_seq(p, b"\x1b"),
-            "up" => write_key_seq(p, b"\x1b[A"),
-            "down" => write_key_seq(p, b"\x1b[B"),
-            "right" => write_key_seq(p, b"\x1b[C"),
-            "left" => write_key_seq(p, b"\x1b[D"),
-            "home" => write_key_seq(p, b"\x1b[H"),
-            "end" => write_key_seq(p, b"\x1b[F"),
-            "pageup" => write_key_seq(p, b"\x1b[5~"),
-            "pagedown" => write_key_seq(p, b"\x1b[6~"),
-            "insert" => write_key_seq(p, b"\x1b[2~"),
-            "space" => write_key_seq(p, b" "),
+            "enter" => write_key_seq(p, b"\r")?,
+            "tab" => write_key_seq(p, b"\t")?,
+            "btab" | "backtab" => write_key_seq(p, b"\x1b[Z")?,
+            "backspace" => write_key_seq(p, b"\x7f")?,
+            "delete" => write_key_seq(p, b"\x1b[3~")?,
+            "esc" => write_key_seq(p, b"\x1b")?,
+            "up" => write_key_seq(p, b"\x1b[A")?,
+            "down" => write_key_seq(p, b"\x1b[B")?,
+            "right" => write_key_seq(p, b"\x1b[C")?,
+            "left" => write_key_seq(p, b"\x1b[D")?,
+            "home" => write_key_seq(p, b"\x1b[H")?,
+            "end" => write_key_seq(p, b"\x1b[F")?,
+            "pageup" => write_key_seq(p, b"\x1b[5~")?,
+            "pagedown" => write_key_seq(p, b"\x1b[6~")?,
+            "insert" => write_key_seq(p, b"\x1b[2~")?,
+            "space" => write_key_seq(p, b" ")?,
             s if s.starts_with("f") && s.len() >= 2 && s.len() <= 3 => {
                 if let Ok(n) = s[1..].parse::<u8>() {
                     let seq = match n {
@@ -3262,7 +3172,7 @@ pub fn send_key_to_active(app: &mut AppState, k: &str) -> io::Result<()> {
                         12 => "\x1b[24~",
                         _ => "",
                     };
-                    if !seq.is_empty() { let _ = write!(p.writer, "{}", seq); }
+                    if !seq.is_empty() { p.writer.write_all(seq.as_bytes())?; }
                 }
             }
             // Ctrl+Shift+<letter>: inject a native KEY_EVENT carrying BOTH the
@@ -3288,14 +3198,14 @@ pub fn send_key_to_active(app: &mut AppState, k: &str) -> io::Result<()> {
                     if !injected {
                         // No child pid / injection failed: fall back to the raw
                         // control byte (Shift unrepresentable, but key still arrives).
-                        let _ = p.writer.write_all(&[ctrl_char]);
+                        p.writer.write_all(&[ctrl_char])?;
                     }
                 }
                 #[cfg(not(windows))]
                 {
                     // Non-Windows: no console-input modifier channel; legacy VT has
                     // no distinct Ctrl+Shift+<letter> encoding, so deliver the byte.
-                    let _ = p.writer.write_all(&[ctrl_char]);
+                    p.writer.write_all(&[ctrl_char])?;
                 }
             }
             // Ctrl+Shift+<punctuation/digit> that collapses to a single C0 byte.
@@ -3313,8 +3223,8 @@ pub fn send_key_to_active(app: &mut AppState, k: &str) -> io::Result<()> {
             {
                 let c = s.chars().nth(4).unwrap();
                 if let Some(byte) = ctrl_char_send_keys_byte(c) {
-                    let _ = p.writer.write_all(&[byte]);
-                    let _ = p.writer.flush();
+                    p.writer.write_all(&[byte])?;
+                    p.writer.flush()?;
                 }
             }
             // Ctrl+Break (issue #454).  The attached client traps the Ctrl+Break
@@ -3370,8 +3280,8 @@ pub fn send_key_to_active(app: &mut AppState, k: &str) -> io::Result<()> {
                         crate::platform::mouse_inject::send_ctrl_c_event(pid, false);
                     }
                 }
-                let _ = p.writer.write_all(&[ctrl_char]);
-                let _ = p.writer.flush();
+                p.writer.write_all(&[ctrl_char])?;
+                p.writer.flush()?;
             }
             s if (s.starts_with("M-") || s.starts_with("m-")) && s.len() == 3 => {
                 let c = s.chars().nth(2).unwrap_or('a');
@@ -3385,7 +3295,7 @@ pub fn send_key_to_active(app: &mut AppState, k: &str) -> io::Result<()> {
                 };
                 if !injected {
                     // Fallback: VT encoding (ESC + char) — works for VT-native apps
-                    let _ = write!(p.writer, "\x1b{}", c);
+                    p.writer.write_all(format!("\x1b{}", c).as_bytes())?;
                 }
             }
             s if (s.starts_with("C-M-") || s.starts_with("c-m-")) && s.len() == 5 => {
@@ -3400,7 +3310,7 @@ pub fn send_key_to_active(app: &mut AppState, k: &str) -> io::Result<()> {
                 };
                 if !injected {
                     let ctrl_char = (c.to_ascii_lowercase() as u8) & 0x1F;
-                    let _ = p.writer.write_all(&[0x1b, ctrl_char]);
+                    p.writer.write_all(&[0x1b, ctrl_char])?;
                 }
             }
             // Modified Enter: for Ctrl combos, try native console injection
@@ -3432,14 +3342,14 @@ pub fn send_key_to_active(app: &mut AppState, k: &str) -> io::Result<()> {
                 if !injected {
                     if has_ctrl && !has_shift && !has_alt {
                         // Fallback: plain Ctrl+Enter is LF, matching WT (#409).
-                        let _ = p.writer.write_all(b"\n");
+                        p.writer.write_all(b"\n")?;
                     } else if (has_shift || has_alt) && !has_ctrl {
                         // Fallback: ESC + CR for VT-native apps (Claude Code, etc.)
-                        let _ = p.writer.write_all(b"\x1b\r");
+                        p.writer.write_all(b"\x1b\r")?;
                     } else {
                         // Ctrl+Shift/Ctrl+Alt+Enter and other combos: CSI encoding
                         if let Some(seq) = parse_modified_special_key(s) {
-                            let _ = p.writer.write_all(seq.as_bytes());
+                            p.writer.write_all(seq.as_bytes())?;
                         }
                     }
                 }
@@ -3447,11 +3357,12 @@ pub fn send_key_to_active(app: &mut AppState, k: &str) -> io::Result<()> {
             // Modifier + special key combos: C-Left, S-Right, C-S-Up, C-M-Home, etc.
             s if parse_modified_special_key(s).is_some() => {
                 let seq = parse_modified_special_key(s).unwrap();
-                let _ = p.writer.write_all(seq.as_bytes());
+                p.writer.write_all(seq.as_bytes())?;
             }
             _ => {}
         }
-        let _ = p.writer.flush();
+        p.writer.flush()?;
+        Ok(())
     }
 
     // A focused floating pane (tmux new-pane) receives the key instead of the
@@ -3460,7 +3371,7 @@ pub fn send_key_to_active(app: &mut AppState, k: &str) -> io::Result<()> {
         let win = &mut app.windows[app.active_idx];
         if let Some(fi) = win.floating_focus {
             if let Some(fp) = win.floating.get_mut(fi) {
-                write_named_key_to_pane(&mut fp.pane, k);
+                write_named_key_to_pane(&mut fp.pane, k)?;
                 return Ok(());
             }
         }
@@ -3469,19 +3380,20 @@ pub fn send_key_to_active(app: &mut AppState, k: &str) -> io::Result<()> {
     // Distribute the key to all panes (sync) or just the active pane.
     if app.sync_input {
         let win = &mut app.windows[app.active_idx];
-        fn send_key_all_panes(node: &mut crate::types::Node, k: &str) {
+        fn send_key_all_panes(node: &mut crate::types::Node, k: &str) -> io::Result<()> {
             match node {
-                crate::types::Node::Leaf(p) => write_named_key_to_pane(p, k),
+                crate::types::Node::Leaf(p) => write_named_key_to_pane(p, k)?,
                 crate::types::Node::Split { children, .. } => {
-                    for c in children { send_key_all_panes(c, k); }
+                    for c in children { send_key_all_panes(c, k)?; }
                 }
             }
+            Ok(())
         }
-        send_key_all_panes(&mut win.root, k);
+        send_key_all_panes(&mut win.root, k)?;
     } else {
         let win = &mut app.windows[app.active_idx];
         if let Some(p) = active_pane_mut(&mut win.root, &win.active_path) {
-            write_named_key_to_pane(p, k);
+            write_named_key_to_pane(p, k)?;
         }
     }
     Ok(())
@@ -3490,6 +3402,10 @@ pub fn send_key_to_active(app: &mut AppState, k: &str) -> io::Result<()> {
 #[cfg(test)]
 #[path = "../tests-rs/test_input.rs"]
 mod tests;
+
+#[cfg(test)]
+#[path = "../tests-rs/test_audit_input_errors.rs"]
+mod tests_audit_input_errors;
 
 #[cfg(test)]
 #[path = "../tests-rs/test_issue226_ctrl_slash.rs"]

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ mod types;
 mod platform;
 mod cli;
 mod session;
+mod registry;
 mod tree;
 mod choose_tree;
 mod style;
@@ -55,9 +56,7 @@ use crossterm::event::{EnableMouseCapture, DisableMouseCapture, EnableBracketedP
 
 use crate::platform::enable_virtual_terminal_processing;
 use crate::cli::{print_help, print_version, print_commands};
-use crate::session::{cleanup_stale_port_files, reap_orphaned_servers, read_session_key, send_control,
-    send_control_with_response, resolve_default_session_name,
-    force_kill_targets, confirms_identity};
+use crate::session::{send_control, send_control_with_response, resolve_default_session_name};
 use crate::rendering::apply_cursor_style;
 use crate::server::run_server;
 use crate::client::run_remote;
@@ -283,11 +282,8 @@ fn cli_sessions_owning_id(ns: Option<&str>, probe: &[u8], id: &str) -> Vec<Strin
 /// Strip the `-L` namespace prefix off a registry base name so the message
 /// names the session the caller can actually type: inside a `-L` namespace the
 /// registry base is `<ns>__<session>` but the user addresses the short name.
-fn cli_display_session_name(ns: Option<&str>, base: &str) -> String {
-    match ns {
-        Some(p) => base.strip_prefix(&format!("{}__", p)).unwrap_or(base).to_string(),
-        None => base.to_string(),
-    }
+fn cli_display_session_name(_ns: Option<&str>, base: &str) -> String {
+    crate::paths::registry_session_name(base)
 }
 
 /// What an unqualified `%N`/`@N` target resolved to across the namespace.
@@ -551,33 +547,12 @@ fn probe_session_alive_strict(session_name: &str) -> bool {
 }
 
 fn probe_session_alive_inner(session_name: &str, connect_failure_means_alive: bool) -> bool {
-    let path = crate::paths::port_file(session_name);
-    let port = match std::fs::read_to_string(&path).ok().and_then(|s| s.trim().parse::<u16>().ok()) {
-        Some(p) => p,
-        None => return false, // no port file → gone
-    };
-    let addr: std::net::SocketAddr = match format!("127.0.0.1:{}", port).parse() {
-        Ok(a) => a,
-        Err(_) => return false,
-    };
-    let key = read_session_key(session_name).unwrap_or_default();
-    match std::net::TcpStream::connect_timeout(&addr, Duration::from_millis(500)) {
-        Ok(mut s) => {
-            let _ = s.set_read_timeout(Some(Duration::from_millis(500)));
-            let _ = write!(s, "AUTH {}\n", key);
-            let _ = write!(s, "session-info\n");
-            let _ = s.flush();
-            let mut buf = [0u8; 256];
-            match std::io::Read::read(&mut s, &mut buf) {
-                Ok(n) if n > 0 => String::from_utf8_lossy(&buf[..n]).contains("OK"),
-                // Connected but silent. Something IS listening, so the attach
-                // will at worst report an auth/read failure rather than a
-                // connect error; treat it as alive in both modes.
-                _ => true,
-            }
-        }
-        Err(e) if e.kind() == io::ErrorKind::ConnectionRefused => false, // gone
-        Err(_) => connect_failure_means_alive,
+    if !std::path::Path::new(&crate::paths::port_file(session_name)).exists()
+        && !crate::registry::manifest_path(session_name).exists() { return false; }
+    match crate::session::existing_session_state(session_name) {
+        crate::session::SessionLiveness::Alive(_) => true,
+        crate::session::SessionLiveness::Dead => false,
+        _ => connect_failure_means_alive,
     }
 }
 
@@ -740,6 +715,53 @@ mod process_command_arg_tests {
     }
 }
 
+/// The server owns the claim transaction and serializes competing clients.
+/// Never hide a live warm registration by renaming its port file client-side.
+fn try_claim_warm_session(namespace: Option<&str>, name: &str) -> io::Result<bool> {
+    let warm = crate::paths::storage_base(namespace, "__warm__");
+    let endpoint = match crate::session::read_session_endpoint(&warm) {
+        Ok(endpoint) => endpoint,
+        Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(false),
+        Err(e) => return Err(e),
+    };
+    if crate::session::registry_pid_anchor_alive(&warm) == Some(false) { return Ok(false); }
+    let cwd = std::env::current_dir().ok().and_then(|p| p.to_str().map(str::to_string));
+    let priority = crate::platform::claim_priority_arg();
+    let mut cmd = format!("claim-session {}", crate::util::quote_arg(name));
+    if let Some(cwd) = cwd { cmd.push_str(&format!(" {}", crate::util::quote_arg(&cwd))); }
+    cmd.push_str(&format!(" -p {}\n", crate::util::quote_arg(&priority)));
+    let result = crate::session::query_authed_line(&format!("127.0.0.1:{}", endpoint.0), &endpoint.1,
+        cmd.as_bytes(), Duration::from_millis(500), Duration::from_millis(3000));
+    match result {
+        Ok(reply) if reply == "OK" => Ok(true),
+        // Another client won the warm source. No claim occurred on our behalf.
+        Err(e) if e.to_string().contains("not a warm") => Ok(false),
+        Ok(_) => Err(io::Error::new(io::ErrorKind::InvalidData, "invalid warm claim acknowledgement")),
+        Err(e) => Err(io::Error::new(e.kind(), format!("warm claim was not confirmed; no replacement started: {}", e))),
+    }
+}
+
+fn query_namespace(namespace: Option<&str>, query: &[u8]) -> io::Result<()> {
+    let bases = crate::session::list_session_names_ns(namespace);
+    if bases.is_empty() { return Err(io::Error::new(io::ErrorKind::NotFound, "no server running")); }
+    let mut failures = 0usize;
+    for base in bases {
+        let result = crate::session::read_session_endpoint(&base).and_then(|(port, key)| {
+            crate::session::query_authed_all(&format!("127.0.0.1:{}", port), &key, query,
+                Duration::from_millis(500), Duration::from_millis(2000))
+        });
+        match result {
+            Ok(output) => print!("{}", output),
+            Err(error) => {
+                failures += 1;
+                eprintln!("psmux: {}: {}", crate::paths::registry_session_name(&base), error);
+            }
+        }
+    }
+    if failures == 0 { Ok(()) }
+    else { Err(io::Error::other(format!("incomplete listing: {} session(s) could not be queried", failures))) }
+}
+
 fn run_main() -> io::Result<()> {
     // `-L=foo` first (flag_equals), then `-Lfoo` (attached globals), then
     // command-level `-tname` (attached target): running attached passes
@@ -755,18 +777,8 @@ fn run_main() -> io::Result<()> {
     // render multi-byte Unicode characters instead of mojibake.
     enable_virtual_terminal_processing();
 
-    // Clean up any stale port files at startup
-    cleanup_stale_port_files();
-    // Then drop registry files whose `.port` entry is already gone (issue
-    // #530). The sweep above is the only thing that can reach them, and it
-    // finds entries BY their `.port` file — so a satellite that outlives its
-    // port is invisible to it and accumulates forever.
-    crate::session::prune_orphaned_registry_files();
-    // Then reap any LIVE but orphaned server processes (issue #448): duplicates
-    // or crashed-client headless servers that cleanup_stale_port_files cannot
-    // see because they have no registry file. Bounds the process count so
-    // orphans can't accumulate to the point of exhausting Windows desktop-heap.
-    reap_orphaned_servers();
+    // Startup and observational commands never reclaim registry or processes.
+    // Missing metadata and failed probes are not lifecycle evidence.
 
     // Parse -L flag early (tmux-compatible: names the server socket for namespace isolation)
     // In psmux, -L <name> creates a namespace prefix for session port/key files.
@@ -804,6 +816,15 @@ fn run_main() -> io::Result<()> {
                 break; // hit the subcommand name — stop scanning for global flags
             }
         }
+    }
+
+    l_socket_name = crate::session::effective_namespace(
+        l_socket_name.as_deref(), env::var("PSMUX_SOCKET_NAME").ok().as_deref(),
+        env::var("TMUX").ok().as_deref(), std::path::Path::new(&crate::paths::psmux_dir()),
+    );
+    if let Some(ref namespace) = l_socket_name {
+        crate::paths::validate_namespace(namespace)?;
+        env::set_var("PSMUX_SOCKET_NAME", namespace);
     }
 
     // Set PSMUX_CONFIG_FILE if -f was provided, so load_config() picks it up.
@@ -900,12 +921,12 @@ fn run_main() -> io::Result<()> {
             // already been resolved to the on disk name, which carries the
             // prefix, so do not add it a second time: `-L ns cmd -t $N` used
             // to route to `ns__ns__name`, a server that does not exist.
-            let port_file_base = match l_socket_name {
-                Some(ref l) if !session.starts_with(&format!("{}__", l)) => {
-                    format!("{}__{}", l, session)
+            let port_file_base = if target.trim_start_matches('=').starts_with('$') {
+                if !crate::paths::registry_visible_from(&session, l_socket_name.as_deref()) {
+                    return Err(io::Error::new(io::ErrorKind::NotFound, "session id is outside the selected namespace"));
                 }
-                _ => session.clone(),
-            };
+                session.clone()
+            } else { crate::paths::storage_base(l_socket_name.as_deref(), &session) };
             // If the -t target includes an explicit session name, use it
             // directly. Otherwise (e.g. -t %2, -t :1.0) fall through to
             // the TMUX env var resolution below so we connect to the right
@@ -1085,88 +1106,7 @@ fn run_main() -> io::Result<()> {
     match cmd {
         // kill-server MUST be handled early before any potential fall-through
         "kill-server" => {
-            let psmux_dir = crate::paths::psmux_dir();
-            // Compute namespace prefix for -L filtering (matches list-sessions behavior)
-            let ns_prefix = l_socket_name.as_ref().map(|l| format!("{l}__"));
-            // Snapshot the force-kill candidates from this data dir's .pid files
-            // BEFORE the graceful pass removes them. Scoped to this dir and (with
-            // -L) this namespace, so the fallback can never reach another instance.
-            let fk_targets =
-                force_kill_targets(std::path::Path::new(&psmux_dir), ns_prefix.as_deref());
-            let mut targets: Vec<(std::path::PathBuf, u16, String)> = Vec::new();
-            let mut stale_ports: Vec<std::path::PathBuf> = Vec::new();
-            if let Ok(entries) = std::fs::read_dir(&psmux_dir) {
-                for entry in entries.flatten() {
-                    let path = entry.path();
-                    if path.extension().map(|e| e == "port").unwrap_or(false) {
-                        if let Some(session_name) = path.file_stem().and_then(|s| s.to_str()) {
-                            // Apply -L namespace filtering:
-                            // With -L: only kill sessions under that namespace
-                            // Without -L: kill ALL sessions (tmux behavior)
-                            if let Some(ref pfx) = ns_prefix {
-                                if !session_name.starts_with(pfx.as_str()) { continue; }
-                            }
-                            if let Ok(port_str) = std::fs::read_to_string(&path) {
-                                if let Ok(port) = port_str.trim().parse::<u16>() {
-                                    let sess_key = read_session_key(session_name).unwrap_or_default();
-                                    targets.push((path.clone(), port, sess_key));
-                                }
-                            } else {
-                                stale_ports.push(path.clone());
-                            }
-                        }
-                    }
-                }
-            }
-            // Send kill-server to all sessions in parallel via threads
-            let handles: Vec<std::thread::JoinHandle<()>> = targets.into_iter().map(|(path, port, sess_key)| {
-                std::thread::spawn(move || {
-                    let addr = format!("127.0.0.1:{}", port);
-                    if let Ok(mut stream) = std::net::TcpStream::connect_timeout(
-                        &addr.parse().unwrap(),
-                        Duration::from_millis(500),
-                    ) {
-                        let _ = stream.set_nodelay(true);
-                        let _ = write!(stream, "AUTH {}\n", sess_key);
-                        let _ = stream.flush();
-                        let _ = std::io::Write::write_all(&mut stream, b"kill-server\n");
-                        let _ = stream.flush();
-                        let _ = stream.shutdown(std::net::Shutdown::Write);
-                        // Wait for server to exit (EOF = done)
-                        let _ = stream.set_read_timeout(Some(Duration::from_millis(2000)));
-                        let mut buf = [0u8; 64];
-                        loop {
-                            match std::io::Read::read(&mut stream, &mut buf) {
-                                Ok(0) => break,
-                                Err(_) => break,
-                                Ok(_) => continue,
-                            }
-                        }
-                    }
-                    // Remove the whole registry set regardless. Deleting only
-                    // port/key/pid used to strand the `.sid`, which no sweep can
-                    // reach once its `.port` is gone (#530).
-                    crate::session::remove_session_registry_files(&path);
-                })
-            }).collect();
-            // Wait for all threads to complete
-            for h in handles { let _ = h.join(); }
-            // Clean up stale registry sets (whole set, including `.sid` — #530)
-            for path in &stale_ports {
-                crate::session::remove_session_registry_files(path);
-            }
-            // Force-kill any wedged server that ignored the graceful kill. The
-            // candidates were read from this data dir's (and, with -L, this
-            // namespace's) own .pid files before the graceful pass removed them,
-            // so nothing outside this instance is ever reached. The identity gate
-            // (exact process-creation-time match) skips any pid that has already
-            // exited or been recycled — no machine-wide, name-based scan.
-            std::thread::sleep(Duration::from_millis(50));
-            for t in fk_targets {
-                if confirms_identity(crate::platform::process_kill::process_creation_time(t.pid), t.creation_time) {
-                    crate::platform::process_kill::terminate_server_pid(t.pid, None);
-                }
-            }
+            crate::session::kill_registered_servers(l_socket_name.as_deref())?;
             return Ok(());
         }
         "ls" | "list-sessions" => {
@@ -1204,150 +1144,49 @@ fn run_main() -> io::Result<()> {
                     }
                 }
                 let dir = crate::paths::psmux_dir();
-                // Compute namespace prefix for -L filtering
-                let ns_prefix = l_socket_name.as_ref().map(|l| format!("{l}__"));
-                // Servers that answered in this namespace, counted BEFORE the
-                // -f filter is applied. tmux exits 1 with `no server running`
-                // when there is nothing to list at all, but a filter that
-                // matches nothing on a live server is an empty listing at
-                // exit 0, and the two must stay distinguishable to scripts.
-                let mut live_servers: usize = 0;
-                if let Ok(entries) = std::fs::read_dir(&dir) {
-                    for e in entries.flatten() {
-                        if let Some(name) = e.file_name().to_str() {
-                            if let Some((base, ext)) = name.rsplit_once('.') {
-                                if ext == "port" {
-                                    // Skip warm (standby) sessions — internal-only
-                                    if crate::session::is_warm_session(base) { continue; }
-                                    // Filter by -L namespace: when -L is given, only show
-                                    // sessions with that prefix; when no -L, only show
-                                    // sessions without any namespace prefix
-                                    if let Some(ref pfx) = ns_prefix {
-                                        if !base.starts_with(pfx.as_str()) { continue; }
-                                    } else {
-                                        if base.contains("__") { continue; }
-                                    }
-                                    // PID-anchor fast path: a dead entry would
-                                    // otherwise cost a full TCP connect timeout
-                                    // here (dead loopback ports can time out
-                                    // rather than refuse on Windows). Reap it
-                                    // and move on without touching the network.
-                                    if crate::session::registry_pid_anchor_alive(base) == Some(false) {
-                                        crate::session::remove_session_registry(base);
-                                        continue;
-                                    }
-                                    if let Ok(port_str) = std::fs::read_to_string(e.path()) {
-                                        if let Ok(_p) = port_str.trim().parse::<u16>() {
-                                            let addr = format!("127.0.0.1:{}", port_str.trim());
-                                            let conn = std::net::TcpStream::connect_timeout(
-                                                &addr.parse().unwrap(),
-                                                Duration::from_millis(200)
-                                            );
-                                            // Only prune a session that ACTIVELY refused (truly dead);
-                                            // a timeout means busy-but-alive and must not be deleted.
-                                            let refused = matches!(&conn, Err(e) if e.kind() == io::ErrorKind::ConnectionRefused);
-                                            if let Ok(mut s) = conn {
-                                                // Format expansion for variables like
-                                                // pane_current_command/pane_current_path can
-                                                // take 40+ ms each (OS process queries), so
-                                                // 50 ms was too tight for multi-variable
-                                                // format strings (e.g. libtmux's 123-field
-                                                // format). 500 ms allows complex formats
-                                                // while still detecting dead sessions quickly.
-                                                let _ = s.set_read_timeout(Some(Duration::from_millis(500)));
-                                                // Read session key and authenticate
-                                                let key_path = crate::paths::key_file(&base);
-                                                if let Ok(key) = std::fs::read_to_string(&key_path) {
-                                                    let _ = std::io::Write::write_all(&mut s, format!("AUTH {}\n", key.trim()).as_bytes());
-                                                }
-                                                // Use -F format if provided, otherwise session-info
-                                                let query = if let Some(ref fmt) = format_str {
-                                                    format!("list-sessions -F {}\n", crate::util::quote_arg(&fmt))
-                                                } else {
-                                                    "session-info\n".to_string()
-                                                };
-                                                let _ = std::io::Write::write_all(&mut s, query.as_bytes());
-                                                let mut br = std::io::BufReader::new(s);
-                                                let mut line = String::new();
-                                                // Skip "OK" response from AUTH
-                                                let _ = br.read_line(&mut line);
-                                                if line.trim() == "OK" {
-                                                    line.clear();
-                                                    let _ = br.read_line(&mut line);
-                                                }
-                                                if line.trim() == "ERROR: Authentication required" {
-                                                    // Auth failed, skip this session
-                                                    continue;
-                                                }
-                                                live_servers += 1;
-                                                // When -F format is provided, the server already
-                                                // expanded it; use the result even if empty (tmux
-                                                // prints an empty line for unknown format vars).
-                                                // Only fall back to display_name when no -F was given.
-                                                if format_str.is_some() || !line.trim().is_empty() {
-                                                    let output = line.trim_end().to_string();
-                                                    // Apply -f filter if provided.
-                                                    // tmux -f accepts format expressions; support
-                                                    // the common #{==:#{session_name},NAME} pattern
-                                                    // as well as a plain substring fallback.
-                                                    if let Some(ref flt) = filter_str {
-                                                        let passes = if let Some(target) = flt
-                                                            .strip_prefix("#{==:#{session_name},")
-                                                            .and_then(|s| s.strip_suffix('}'))
-                                                        {
-                                                            // Compare port-file display name against literal
-                                                            let display_name = if let Some(ref pfx) = ns_prefix {
-                                                                base.strip_prefix(pfx.as_str()).unwrap_or(base)
-                                                            } else {
-                                                                base
-                                                            };
-                                                            display_name == target
-                                                        } else {
-                                                            // Fallback: plain substring match
-                                                            output.contains(flt.as_str())
-                                                        };
-                                                        if !passes { continue; }
-                                                    }
-                                                    println!("{}", output);
-                                                } else {
-                                                    // Strip namespace prefix for display (e.g. "foo__dev" -> "dev")
-                                                    let display_name = if let Some(ref pfx) = ns_prefix {
-                                                        base.strip_prefix(pfx.as_str()).unwrap_or(base)
-                                                    } else {
-                                                        base
-                                                    };
-                                                    if let Some(ref flt) = filter_str {
-                                                        let passes = if let Some(target) = flt
-                                                            .strip_prefix("#{==:#{session_name},")
-                                                            .and_then(|s| s.strip_suffix('}'))
-                                                        {
-                                                            display_name == target
-                                                        } else {
-                                                            display_name.contains(flt.as_str())
-                                                        };
-                                                        if !passes { continue; }
-                                                    }
-                                                    println!("{}", display_name); 
-                                                }
-                                            } else if refused {
-                                                // Actively refused → truly dead. Remove the WHOLE
-                                                // set: dropping the `.port` alone would strand its
-                                                // siblings where no sweep can reach them (#530).
-                                                crate::session::remove_session_registry_files(&e.path());
-                                            }
-                                        }
-                                    }
-                                }
+                let mut live_servers = 0usize;
+                let mut failed_servers = 0usize;
+                let mut candidates = crate::session::list_session_names_ns(l_socket_name.as_deref());
+                candidates.sort();
+                for base in candidates {
+                    let query = if let Some(ref fmt) = format_str {
+                        format!("list-sessions -F {}\n", crate::util::quote_arg(fmt))
+                    } else { "session-info\n".to_string() };
+                    let result = crate::session::read_session_endpoint(&base).and_then(|(port, key)| {
+                        crate::session::query_authed_line(
+                            &format!("127.0.0.1:{}", port), &key, query.as_bytes(),
+                            Duration::from_millis(500), Duration::from_millis(2000),
+                        )
+                    });
+                    match result {
+                        Ok(output) if format_str.is_some() || !output.is_empty() => {
+                            live_servers += 1;
+                            if let Some(ref flt) = filter_str {
+                                let passes = if let Some(target) = flt
+                                    .strip_prefix("#{==:#{session_name},")
+                                    .and_then(|s| s.strip_suffix('}'))
+                                {
+                                    crate::paths::registry_session_name(&base) == target
+                                } else { output.contains(flt) };
+                                if !passes { continue; }
                             }
+                            println!("{}", output);
+                        }
+                        Ok(_) => {
+                            failed_servers += 1;
+                            eprintln!("psmux: list-sessions: {}: empty session-info response", crate::paths::registry_session_name(&base));
+                        }
+                        Err(error) => {
+                            failed_servers += 1;
+                            eprintln!("psmux: list-sessions: {}: {}", crate::paths::registry_session_name(&base), error);
                         }
                     }
                 }
+                if failed_servers != 0 {
+                    // Return usable rows, but report partial listing as failure.
+                    std::process::exit(1);
+                }
                 if live_servers == 0 {
-                    // Nothing answered: no user session in this namespace (a
-                    // `__warm__` standby is not a session). tmux prints
-                    // `no server running on <socket>` and exits 1 here, and
-                    // scripts lean on that code (`tmux ls || start`), so an
-                    // empty listing at exit 0 was a portability trap.
                     match l_socket_name.as_deref() {
                         Some(l) => eprintln!("psmux: no server running on {} (-L {})", dir, l),
                         None => eprintln!("psmux: no server running on {}", dir),
@@ -1380,11 +1219,8 @@ fn run_main() -> io::Result<()> {
                         let session = crate::cli::parse_target(target)
                             .session
                             .unwrap_or_else(|| target.clone());
-                        if let Some(ref l) = l_socket_name {
-                            format!("{}__{}", l, session)
-                        } else {
-                            session
-                        }
+                        if target.trim_start_matches('=').starts_with('$') { session }
+                        else { crate::paths::storage_base(l_socket_name.as_deref(), &session) }
                     })
                     .or_else(|| {
                         // Accept positional argument as target session name
@@ -1392,11 +1228,7 @@ fn run_main() -> io::Result<()> {
                         let t_val_idx = sub_args.iter().position(|a| *a == "-t").map(|i| i + 1);
                         sub_args.iter().enumerate().find_map(|(i, a)| {
                             if !a.starts_with('-') && Some(i) != t_val_idx {
-                                Some(if let Some(ref l) = l_socket_name {
-                                    format!("{}__{}", l, a)
-                                } else {
-                                    (*a).clone()
-                                })
+                                Some(crate::paths::storage_base(l_socket_name.as_deref(), a))
                             } else {
                                 None
                             }
@@ -1406,7 +1238,7 @@ fn run_main() -> io::Result<()> {
                     .or_else(|| crate::session::resolve_last_session_name_ns(l_socket_name.as_deref()))
                     .unwrap_or_else(|| {
                         if let Some(ref l) = l_socket_name {
-                            format!("{}__0", l)
+                            crate::paths::storage_base(Some(l), "0")
                         } else {
                             "0".to_string()
                         }
@@ -1444,18 +1276,9 @@ fn run_main() -> io::Result<()> {
                 // complete means no server, whatever error the OS chose to
                 // report. The lenient reading let a stale registry entry pass
                 // the gate and the raw winsock error surfaced from the client.
-                let shown = l_socket_name
-                    .as_deref()
-                    .and_then(|l| name.strip_prefix(&format!("{}__", l)))
-                    .unwrap_or(&name)
-                    .to_string();
+                let shown = crate::paths::registry_session_name(&name);
                 if !probe_session_alive_strict(&name) {
-                    // Nothing is listening on the registered port. Reap the
-                    // entry so the next `ls`/`attach` does not re-litigate it,
-                    // unless the pid anchor still vouches for a live server.
-                    if crate::session::registry_pid_anchor_alive(&name) != Some(true) {
-                        crate::session::remove_session_registry(&name);
-                    }
+                    // Failed communication does not authorize registry cleanup.
                     // tmux wording: a bare `attach` that finds nothing to attach
                     // to says `no sessions`; only an explicit target names the
                     // session it could not find. The fallback name here was
@@ -1636,10 +1459,11 @@ fn run_main() -> io::Result<()> {
                 });
                 // Compute port file base name: with -L namespace prefix if specified
                 let port_file_base = if let Some(ref l) = l_socket_name {
-                    format!("{}__{}", l, name)
+                    crate::paths::storage_base(Some(l), &name)
                 } else {
-                    name.clone()
+                    crate::paths::storage_base(None, &name)
                 };
+                crate::paths::validate_registry_base(l_socket_name.as_deref(), &name)?;
                 // Check for -- separator: everything after it is a raw command (direct execution)
                 let raw_cmd_args: Option<Vec<String>> = raw_cmd_after_dd.filter(|v| !v.is_empty());
                 // Parse initial command from positional args (legacy mode, no --)
@@ -1650,41 +1474,30 @@ fn run_main() -> io::Result<()> {
                 };
                 
                 // Check if session already exists AND is actually running
-                let psmux_dir = crate::paths::psmux_dir();
                 let port_path = crate::paths::port_file(&port_file_base);
                 // PID of the server we spawn on the cold path (None when we adopt
                 // a warm server or attach to a remote one). The readiness gate
                 // below uses it to fail fast if the freshly spawned server dies.
                 let mut server_pid: Option<u32> = None;
-                if std::path::Path::new(&port_path).exists() {
-                    // Verify server is actually running
-                    let server_alive = if let Ok(port_str) = std::fs::read_to_string(&port_path) {
-                        if let Ok(port) = port_str.trim().parse::<u16>() {
-                            let addr = format!("127.0.0.1:{}", port);
-                            std::net::TcpStream::connect_timeout(
-                                &addr.parse().unwrap(),
-                                Duration::from_millis(100)
-                            ).is_ok()
-                        } else { false }
-                    } else { false };
-                    
-                    if server_alive {
-                        if attach_if_exists {
-                            // -A flag: attach to existing session instead of erroring
-                            env::set_var("PSMUX_SESSION_NAME", &port_file_base);
-                            env::set_var("PSMUX_REMOTE_ATTACH", "1");
-                            // Skip server creation, jump straight to attach
-                            // (handled at the bottom of this match block)
-                        } else {
-                            eprintln!("duplicate session: {}", name);
-                            std::process::exit(1);
+                if std::path::Path::new(&port_path).exists() || crate::registry::manifest_path(&port_file_base).exists() {
+                    match crate::session::existing_session_state(&port_file_base) {
+                        crate::session::SessionLiveness::Alive(_) => {
+                            if attach_if_exists {
+                                env::set_var("PSMUX_SESSION_NAME", &port_file_base);
+                                env::set_var("PSMUX_REMOTE_ATTACH", "1");
+                            } else {
+                                return Err(io::Error::new(io::ErrorKind::AlreadyExists, format!("duplicate session: {}", name)));
+                            }
                         }
-                    } else {
-                        // Stale port file - remove it and continue
-                        let _ = std::fs::remove_file(&port_path);
+                        crate::session::SessionLiveness::Dead => {
+                            // The server reserves the destination before replacing
+                            // this verified old process generation.
+                        }
+                        _ => return Err(io::Error::new(io::ErrorKind::WouldBlock,
+                            format!("session '{}' is registered but is not responding; registration preserved", name))),
                     }
                 }
-                
+
                 // If -A attached to an existing session, skip server creation
                 if env::var("PSMUX_REMOTE_ATTACH").ok().as_deref() == Some("1") {
                     // Already set up for attach — skip server spawn
@@ -1703,115 +1516,16 @@ fn run_main() -> io::Result<()> {
                     || crate::config::is_warm_disabled_by_config();
                 let has_custom_config = f_config_file.is_some() || std::env::var("PSMUX_CONFIG_FILE").is_ok();
                 let claimed_warm = if !warm_disabled && !has_custom_config && initial_cmd.is_none() && raw_cmd_args.is_none() && start_dir.is_none() && env_vars.is_empty() && init_width.is_none() && init_height.is_none() {
-                    let warm_base = if let Some(ref l) = l_socket_name {
-                        format!("{}____warm__", l)
-                    } else {
-                        "__warm__".to_string()
-                    };
-                    let warm_port_path = crate::paths::port_file(&warm_base);
-                    // Atomically CLAIM the warm server before connecting. The
-                    // __warm__.port file is a shared handoff: under rapid
-                    // new-session, several clients could read the SAME file (and
-                    // OS ephemeral-port reuse can make a stale entry point at an
-                    // already-claimed server), which intermittently dropped a
-                    // session. Renaming the port file is atomic on the same dir,
-                    // so exactly one client wins the claim; losers cold-spawn.
-                    let warm_port_opt = std::fs::read_to_string(&warm_port_path)
-                        .ok()
-                        .and_then(|s| s.trim().parse::<u16>().ok());
-                    let claim_path = format!("{}\\{}.claiming.{}", psmux_dir, warm_base, std::process::id());
-                    if let Some(warm_port) = warm_port_opt {
-                        if std::fs::rename(&warm_port_path, &claim_path).is_ok() {
-                            let warm_addr = format!("127.0.0.1:{}", warm_port);
-                            let result = if std::net::TcpStream::connect_timeout(
-                                &warm_addr.parse().unwrap(),
-                                Duration::from_millis(100),
-                            ).is_ok() {
-                                let warm_key = crate::session::read_session_key(&warm_base).unwrap_or_default();
-                                if !warm_key.is_empty() {
-                                    let client_cwd = std::env::current_dir()
-                                        .ok()
-                                        .and_then(|p| p.to_str().map(|s| s.to_string()));
-                                    // -p carries this shell's PSMUX_PRIORITY (or the
-                                    // config value) onto the standby, which set its
-                                    // own class before this shell existed (#608).
-                                    let claim_prio = crate::platform::claim_priority_arg();
-                                    let claim_cmd = if let Some(ref cwd) = client_cwd {
-                                        format!("claim-session {} {} -p {}\n", crate::util::quote_arg(&name), crate::util::quote_arg(cwd), crate::util::quote_arg(&claim_prio))
-                                    } else {
-                                        format!("claim-session {} -p {}\n", crate::util::quote_arg(&name), crate::util::quote_arg(&claim_prio))
-                                    };
-                                    match crate::session::send_auth_cmd_response(
-                                        &warm_addr, &warm_key,
-                                        claim_cmd.as_bytes(),
-                                    ) {
-                                        Ok(resp) if resp.contains("OK") => {
-                                            if let Some(ref wn) = window_name {
-                                                let new_key = crate::session::read_session_key(&port_file_base).unwrap_or_default();
-                                                let _ = crate::session::send_auth_cmd(
-                                                    &warm_addr, &new_key,
-                                                    format!("rename-window {}\n", crate::util::quote_arg(wn)).as_bytes(),
-                                                );
-                                            }
-                                            // Apply -e environment variables to the claimed warm session
-                                            if !env_vars.is_empty() {
-                                                let new_key = crate::session::read_session_key(&port_file_base).unwrap_or_default();
-                                                for (k, v) in &env_vars {
-                                                    let _ = crate::session::send_auth_cmd(
-                                                        &warm_addr, &new_key,
-                                                        format!("set-environment {} {}\n", crate::util::quote_arg(k), crate::util::quote_arg(v)).as_bytes(),
-                                                    );
-                                                }
-                                            }
-                                            true
-                                        }
-                                        // Explicit rejection: the server answered
-                                        // but it is NOT a warm server (e.g. a stale
-                                        // __warm__.port left pointing at an already-
-                                        // claimed session, or OS ephemeral-port reuse
-                                        // routing us to a live non-warm server). This
-                                        // claim will NEVER produce our session, so do
-                                        // NOT commit — fall through to a clean cold
-                                        // spawn. The stale handoff file was already
-                                        // consumed (renamed to .claiming then removed
-                                        // below), so the bad warm pointer self-heals
-                                        // and the next open is fast again. Without
-                                        // this, we would wait the full port-file
-                                        // timeout (~5s) for a session that never
-                                        // appears and then fail the open entirely.
-                                        Ok(resp) if resp.contains("ERR") => false,
-                                        // We have ALREADY atomically claimed this
-                                        // warm (won the .port rename) and sent
-                                        // claim-session to a live server, so it WILL
-                                        // become our session. A slow/missing response
-                                        // here must NOT trigger a cold spawn: doing so
-                                        // would create a SECOND server with the same
-                                        // name (duplicate -> desynced .port/.key ->
-                                        // the session appears lost). Commit to the
-                                        // claim; the post-claim port-wait below
-                                        // verifies completion (and errors cleanly if
-                                        // the warm somehow died mid-claim).
-                                        _ => true,
-                                    }
-                                } else { false }
-                            } else {
-                                // Connect failed: the warm is dead and will NOT become
-                                // our session, so a cold spawn is correct (no duplicate
-                                // is possible because nothing claimed this name).
-                                false
-                            };
-                            // The server writes <session>.port on a successful
-                            // claim; our renamed handoff file is now orphaned
-                            // either way, so remove it. On failure this also
-                            // ensures the dead/stale warm entry does not linger.
-                            let _ = std::fs::remove_file(&claim_path);
-                            result
-                        } else {
-                            // Lost the claim race (another client renamed it
-                            // first) or the file vanished — fall back to cold spawn.
-                            false
+                    let claimed = try_claim_warm_session(l_socket_name.as_deref(), &name)?;
+                    if claimed {
+                        if let Some(ref wn) = window_name {
+                            let (port, key) = crate::session::read_session_endpoint(&port_file_base)?;
+                            crate::session::query_authed_line(&format!("127.0.0.1:{}", port), &key,
+                                format!("rename-window {}\nsession-info\n", crate::util::quote_arg(wn)).as_bytes(),
+                                Duration::from_millis(500), Duration::from_millis(2000))?;
                         }
-                    } else { false }
+                    }
+                    claimed
                 } else { false };
 
                 if !claimed_warm {
@@ -2492,76 +2206,10 @@ fn run_main() -> io::Result<()> {
                 }
 
                 if all_sessions {
-                    // Iterate over all session port files (like list-sessions does)
-                    let dir = crate::paths::psmux_dir();
-                    let ns_prefix = l_socket_name.as_ref().map(|l| format!("{l}__"));
-                    if let Ok(entries) = std::fs::read_dir(&dir) {
-                        for e in entries.flatten() {
-                            if let Some(name) = e.file_name().to_str() {
-                                if let Some((base, ext)) = name.rsplit_once('.') {
-                                    if ext != "port" { continue; }
-                                    if crate::session::is_warm_session(base) { continue; }
-                                    if let Some(ref pfx) = ns_prefix {
-                                        if !base.starts_with(pfx.as_str()) { continue; }
-                                    } else if base.contains("__") { continue; }
-                                    if let Ok(port_str) = std::fs::read_to_string(e.path()) {
-                                        if let Ok(_p) = port_str.trim().parse::<u16>() {
-                                            let addr = format!("127.0.0.1:{}", port_str.trim());
-                                            let conn = std::net::TcpStream::connect_timeout(
-                                                &addr.parse().unwrap(),
-                                                Duration::from_millis(500),
-                                            );
-                                            // Only prune a session that ACTIVELY refused (truly dead);
-                                            // a timeout means busy-but-alive and must not be deleted.
-                                            let refused = matches!(&conn, Err(e) if e.kind() == io::ErrorKind::ConnectionRefused);
-                                            if let Ok(mut s) = conn {
-                                                let _ = s.set_read_timeout(Some(Duration::from_millis(500)));
-                                                let key_path = crate::paths::key_file(&base);
-                                                if let Ok(key) = std::fs::read_to_string(&key_path) {
-                                                    let _ = std::io::Write::write_all(&mut s, format!("AUTH {}\n", key.trim()).as_bytes());
-                                                }
-                                                // Send list-panes -s (all panes in this session) to each server
-                                                let query = if let Some(ref fmt) = format_str {
-                                                    format!("list-panes -s -F {}\n", crate::util::quote_arg(&fmt))
-                                                } else {
-                                                    "list-panes -s\n".to_string()
-                                                };
-                                                let _ = std::io::Write::write_all(&mut s, query.as_bytes());
-                                                let _ = s.flush();
-                                                let mut br = std::io::BufReader::new(s);
-                                                let mut line = String::new();
-                                                let _ = std::io::BufRead::read_line(&mut br, &mut line);
-                                                if line.trim() == "OK" {
-                                                    line.clear();
-                                                    let _ = std::io::BufRead::read_line(&mut br, &mut line);
-                                                }
-                                                if line.trim() == "ERROR: Authentication required" { continue; }
-                                                // Print all lines from this session
-                                                if !line.trim().is_empty() {
-                                                    print!("{}", line);
-                                                }
-                                                loop {
-                                                    let mut next = String::new();
-                                                    match std::io::BufRead::read_line(&mut br, &mut next) {
-                                                        Ok(0) => break,
-                                                        Ok(_) => {
-                                                            if !next.trim().is_empty() {
-                                                                print!("{}", next);
-                                                            }
-                                                        }
-                                                        Err(_) => break,
-                                                    }
-                                                }
-                                            } else if refused {
-                                                // Whole set, not just port+key (#530).
-                                                crate::session::remove_session_registry_files(&e.path());
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
+                    let query = if let Some(ref fmt) = format_str {
+                        format!("list-panes -s -F {}\n", crate::util::quote_arg(fmt))
+                    } else { "list-panes -s\n".to_string() };
+                    query_namespace(l_socket_name.as_deref(), query.as_bytes())?;
                 } else {
                     // Single session: build command and send to target session
                     let mut cmd = "list-panes".to_string();
@@ -2610,77 +2258,11 @@ fn run_main() -> io::Result<()> {
                 }
 
                 if all_sessions {
-                    // Iterate over all session port files (like list-sessions does)
-                    let dir = crate::paths::psmux_dir();
-                    let ns_prefix = l_socket_name.as_ref().map(|l| format!("{l}__"));
-                    if let Ok(entries) = std::fs::read_dir(&dir) {
-                        for e in entries.flatten() {
-                            if let Some(name) = e.file_name().to_str() {
-                                if let Some((base, ext)) = name.rsplit_once('.') {
-                                    if ext != "port" { continue; }
-                                    if crate::session::is_warm_session(base) { continue; }
-                                    if let Some(ref pfx) = ns_prefix {
-                                        if !base.starts_with(pfx.as_str()) { continue; }
-                                    } else if base.contains("__") { continue; }
-                                    if let Ok(port_str) = std::fs::read_to_string(e.path()) {
-                                        if let Ok(_p) = port_str.trim().parse::<u16>() {
-                                            let addr = format!("127.0.0.1:{}", port_str.trim());
-                                            let conn = std::net::TcpStream::connect_timeout(
-                                                &addr.parse().unwrap(),
-                                                Duration::from_millis(500),
-                                            );
-                                            // Only prune a session that ACTIVELY refused (truly dead);
-                                            // a timeout means busy-but-alive and must not be deleted.
-                                            let refused = matches!(&conn, Err(e) if e.kind() == io::ErrorKind::ConnectionRefused);
-                                            if let Ok(mut s) = conn {
-                                                let _ = s.set_read_timeout(Some(Duration::from_millis(500)));
-                                                let key_path = crate::paths::key_file(&base);
-                                                if let Ok(key) = std::fs::read_to_string(&key_path) {
-                                                    let _ = std::io::Write::write_all(&mut s, format!("AUTH {}\n", key.trim()).as_bytes());
-                                                }
-                                                // Send list-windows to each server (without -a to avoid recursion)
-                                                let query = if let Some(ref fmt) = format_str {
-                                                    format!("list-windows -F {}\n", crate::util::quote_arg(&fmt))
-                                                } else if json_mode {
-                                                    "list-windows -J\n".to_string()
-                                                } else {
-                                                    "list-windows\n".to_string()
-                                                };
-                                                let _ = std::io::Write::write_all(&mut s, query.as_bytes());
-                                                let _ = s.flush();
-                                                let mut br = std::io::BufReader::new(s);
-                                                let mut line = String::new();
-                                                let _ = std::io::BufRead::read_line(&mut br, &mut line);
-                                                if line.trim() == "OK" {
-                                                    line.clear();
-                                                    let _ = std::io::BufRead::read_line(&mut br, &mut line);
-                                                }
-                                                if line.trim() == "ERROR: Authentication required" { continue; }
-                                                if !line.trim().is_empty() {
-                                                    print!("{}", line);
-                                                }
-                                                loop {
-                                                    let mut next = String::new();
-                                                    match std::io::BufRead::read_line(&mut br, &mut next) {
-                                                        Ok(0) => break,
-                                                        Ok(_) => {
-                                                            if !next.trim().is_empty() {
-                                                                print!("{}", next);
-                                                            }
-                                                        }
-                                                        Err(_) => break,
-                                                    }
-                                                }
-                                            } else if refused {
-                                                // Whole set, not just port+key (#530).
-                                                crate::session::remove_session_registry_files(&e.path());
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
+                    let query = if let Some(ref fmt) = format_str {
+                        format!("list-windows -F {}\n", crate::util::quote_arg(fmt))
+                    } else if json_mode { "list-windows -J\n".to_string() }
+                    else { "list-windows\n".to_string() };
+                    query_namespace(l_socket_name.as_deref(), query.as_bytes())?;
                 } else {
                     // Single session: build command and send to target session
                     let mut cmd = "list-windows".to_string();
@@ -2762,15 +2344,11 @@ fn run_main() -> io::Result<()> {
                 // Apply -L namespace prefix to -s session lookup so users can
                 // target a namespaced session by its short name.
                 let session_for_routing = if let Some(s) = &s_target {
-                    if let Some(ref l) = l_socket_name {
-                        format!("{}__{}", l, s)
-                    } else {
-                        s.clone()
-                    }
+                    crate::paths::storage_base(l_socket_name.as_deref(), s)
                 } else {
                     env::var("PSMUX_TARGET_SESSION").unwrap_or_else(|_| {
                         if let Some(ref l) = l_socket_name {
-                            format!("{}__{}", l, "default")
+                            crate::paths::storage_base(Some(l), &"default")
                         } else {
                             "default".to_string()
                         }
@@ -2847,12 +2425,9 @@ fn run_main() -> io::Result<()> {
                                 // already carries the prefix, so do not add it
                                 // twice: `-L ns kill-session -t $N` used to look
                                 // for `ns__ns__name`, find nothing, and exit 0.
-                                let namespaced = match l_socket_name {
-                                    Some(ref l) if !resolved.starts_with(&format!("{}__", l)) => {
-                                        format!("{}__{}", l, resolved)
-                                    }
-                                    _ => resolved,
-                                };
+                                let namespaced = if t.trim_start_matches('=').starts_with('$') {
+                                    resolved
+                                } else { crate::paths::storage_base(l_socket_name.as_deref(), &resolved) };
                                 target = Some(namespaced);
                                 i += 1;
                             }
@@ -2865,7 +2440,7 @@ fn run_main() -> io::Result<()> {
                     env::var("PSMUX_TARGET_SESSION").unwrap_or_else(|_| {
                         // Apply -L namespace prefix to default
                         if let Some(ref l) = l_socket_name {
-                            format!("{}__{}", l, "default")
+                            crate::paths::storage_base(Some(l), &"default")
                         } else {
                             "default".to_string()
                         }
@@ -2886,23 +2461,18 @@ fn run_main() -> io::Result<()> {
                 // "no port file" as "already gone" and return success, so a
                 // misspelt name, or a script killing a session it never
                 // created, reported OK for a kill that did nothing.
-                let shown = l_socket_name
-                    .as_deref()
-                    .and_then(|l| session_name.strip_prefix(&format!("{}__", l)))
-                    .unwrap_or(&session_name)
-                    .to_string();
+                let shown = crate::paths::registry_session_name(&session_name);
                 if !std::path::Path::new(&port_path).exists() {
                     eprintln!("psmux: can't find session: {}", shown);
                     std::process::exit(1);
                 }
                 let deadline = std::time::Instant::now() + Duration::from_secs(5);
                 let was_alive = probe_session_alive(&session_name);
-                if !was_alive && crate::session::registry_pid_anchor_alive(&session_name) != Some(true) {
+                if !was_alive && crate::session::registry_pid_anchor_alive(&session_name) == Some(false) {
                     // A registry with nobody behind it: the server went away and
                     // left its files. Reap them so the next `ls` does not stall
                     // on them, and tell the caller the truth, which is that
                     // there was no such session to kill.
-                    crate::session::remove_session_registry(&session_name);
                     eprintln!("psmux: can't find session: {}", shown);
                     std::process::exit(1);
                 }
@@ -2918,11 +2488,10 @@ fn run_main() -> io::Result<()> {
                     if !probe_session_alive(&session_name) { gone = true; break; }
                     if std::time::Instant::now() >= deadline { break; }
                 }
-                if gone || refused {
+                if gone || (refused && crate::session::registry_pid_anchor_alive(&session_name) == Some(false)) {
                     // Server is down (killed or actively refused) → remove the
                     // now-stale port file. (Idempotent: the server also removes
                     // its own on a clean exit.)
-                    let _ = std::fs::remove_file(&port_path);
                     return Ok(());
                 }
                 // Still alive after the deadline → genuine failure. Exit non-zero
@@ -2955,59 +2524,22 @@ fn run_main() -> io::Result<()> {
                         i += 1;
                     }
                     // Apply -L namespace prefix for port file lookup
-                    if let Some(ref l) = l_socket_name {
-                        format!("{}__{}", l, t)
-                    } else {
-                        t
-                    }
+                    crate::paths::storage_base(l_socket_name.as_deref(), &t)
                 });
                 // Warm (standby) sessions are internal-only — treat as non-existent
                 if crate::session::is_warm_session(&target) {
                     std::process::exit(1);
                 }
-                let path = crate::paths::port_file(&target);
-                if let Ok(port_str) = std::fs::read_to_string(&path) {
-                    if let Ok(port) = port_str.trim().parse::<u16>() {
-                        let addr = format!("127.0.0.1:{}", port);
-                        // Actually authenticate and query the server to ensure it's healthy
-                        let session_key = read_session_key(&target).unwrap_or_default();
-                        let conn = std::net::TcpStream::connect_timeout(
-                            &addr.parse().unwrap(),
-                            Duration::from_millis(500)
-                        );
-                        // Only prune a session that ACTIVELY refused (truly dead);
-                        // a timeout means busy-but-alive and must not be deleted.
-                        let refused = matches!(&conn, Err(e) if e.kind() == io::ErrorKind::ConnectionRefused);
-                        if let Ok(mut s) = conn {
-                            let _ = s.set_read_timeout(Some(Duration::from_millis(500)));
-                            let _ = write!(s, "AUTH {}\n", session_key);
-                            let _ = write!(s, "session-info\n");
-                            let _ = s.flush();
-                            let mut buf = [0u8; 256];
-                            if let Ok(n) = std::io::Read::read(&mut s, &mut buf) {
-                                if n > 0 {
-                                    let resp = String::from_utf8_lossy(&buf[..n]);
-                                    if resp.contains("OK") {
-                                        std::process::exit(0);
-                                    }
-                                }
-                            }
-                            // Fallback: connection succeeded so session likely exists
-                            std::process::exit(0);
-                        } else if refused
-                            || crate::session::registry_pid_anchor_alive(&target) == Some(false)
-                        {
-                            // Truly dead: it either refused outright, or its PID
-                            // anchor names a process that is gone (a dead loopback
-                            // port can time out rather than refuse on Windows).
-                            // Reap the WHOLE set: dropping the `.port` alone would
-                            // strand its siblings where no sweep can reach them (#530).
-                            crate::session::remove_session_registry(&target);
-                        }
-                        // Anything else (a plain timeout against a live server that
-                        // was merely slow to accept) exits 1 without touching the
-                        // registry: has-session is a predicate, not a reaper (#622).
-                    }
+                let result = crate::session::read_session_endpoint(&target).and_then(|(port, key)| {
+                    crate::session::query_authed_line(
+                        &format!("127.0.0.1:{}", port), &key, b"session-info\n",
+                        Duration::from_millis(500), Duration::from_millis(2000),
+                    )
+                });
+                match result {
+                    Ok(info) if !info.is_empty() => std::process::exit(0),
+                    Ok(_) => eprintln!("psmux: has-session: empty session-info response"),
+                    Err(error) => eprintln!("psmux: has-session: {}", error),
                 }
                 std::process::exit(1);
             }
@@ -4578,27 +4110,19 @@ fn run_main() -> io::Result<()> {
                 // instant.  Also triggers Windows Defender's scan cache on the
                 // binary, eliminating the ~200-400ms first-run penalty.
                 let warm_base = if let Some(ref l) = l_socket_name {
-                    format!("{}____warm__", l)
+                    crate::paths::storage_base(Some(l), "__warm__")
                 } else {
                     "__warm__".to_string()
                 };
                 let warm_port_path = crate::paths::port_file(&warm_base);
-                // Check if warm server is already running
-                let already_running = if std::path::Path::new(&warm_port_path).exists() {
-                    if let Ok(port_str) = std::fs::read_to_string(&warm_port_path) {
-                        if let Ok(port) = port_str.trim().parse::<u16>() {
-                            std::net::TcpStream::connect_timeout(
-                                &format!("127.0.0.1:{}", port).parse().unwrap(),
-                                Duration::from_millis(100),
-                            ).is_ok()
-                        } else { false }
-                    } else { false }
-                } else { false };
-                if already_running {
-                    return Ok(());
+                if std::path::Path::new(&warm_port_path).exists() || crate::registry::manifest_path(&warm_base).exists() {
+                    match crate::session::existing_session_state(&warm_base) {
+                        crate::session::SessionLiveness::Alive(_) => return Ok(()),
+                        crate::session::SessionLiveness::Dead => {},
+                        _ => return Err(io::Error::new(io::ErrorKind::WouldBlock,
+                            "warm server is registered but not responding; registration preserved")),
+                    }
                 }
-                // Clean up stale port file if any
-                let _ = std::fs::remove_file(&warm_port_path);
                 // Spawn the warm server
                 let exe = std::env::current_exe().unwrap_or_else(|_| std::path::PathBuf::from("psmux"));
                 let mut server_args: Vec<String> = vec!["server".into(), "-s".into(), "__warm__".into()];
@@ -4819,15 +4343,15 @@ fn run_main() -> io::Result<()> {
     // starts the server and creates a session automatically; we do the same.
 
     if env::var("PSMUX_REMOTE_ATTACH").ok().as_deref() != Some("1") {
-        let psmux_dir = crate::paths::psmux_dir();
         let session_name = env::var("PSMUX_SESSION_NAME").unwrap_or_else(|_| {
             crate::session::next_session_name(l_socket_name.as_deref())
         });
         let port_file_base = if let Some(ref l) = l_socket_name {
-            format!("{}__{}", l, session_name)
+            crate::paths::storage_base(Some(l), &session_name)
         } else {
-            session_name.clone()
+            crate::paths::storage_base(None, &session_name)
         };
+        crate::paths::validate_registry_base(l_socket_name.as_deref(), &session_name)?;
         let port_path = crate::paths::port_file(&port_file_base);
 
         // If a server is ALREADY alive under this exact name (e.g. PSMUX_SESSION_NAME
@@ -4838,14 +4362,14 @@ fn run_main() -> io::Result<()> {
         // empty-scrollback server on every single bare/control-mode connection,
         // silently orphaning the running session. Mirrors the liveness check the
         // explicit `new-session` command path already performs above.
-        let server_already_alive = std::fs::read_to_string(&port_path)
-            .ok()
-            .and_then(|s| s.trim().parse::<u16>().ok())
-            .map(|p| std::net::TcpStream::connect_timeout(
-                &format!("127.0.0.1:{}", p).parse().unwrap(),
-                Duration::from_millis(100),
-            ).is_ok())
-            .unwrap_or(false);
+        let server_already_alive = if std::path::Path::new(&port_path).exists() || crate::registry::manifest_path(&port_file_base).exists() {
+            match crate::session::existing_session_state(&port_file_base) {
+                crate::session::SessionLiveness::Alive(_) => true,
+                crate::session::SessionLiveness::Dead => false,
+                _ => return Err(io::Error::new(io::ErrorKind::WouldBlock,
+                    format!("session '{}' is registered but not responding; registration preserved", session_name))),
+            }
+        } else { false };
 
         // Try warm server claim first (fast path)
         // Skipped when PSMUX_NO_WARM=1 is set or config has 'set -g warm off',
@@ -4853,99 +4377,9 @@ fn run_main() -> io::Result<()> {
         let warm_disabled = server_already_alive
             || std::env::var("PSMUX_NO_WARM").map(|v| v == "1" || v == "true").unwrap_or(false)
             || crate::config::is_warm_disabled_by_config();
-        let warm_base = if let Some(ref l) = l_socket_name {
-            format!("{}____warm__", l)
-        } else {
-            "__warm__".to_string()
+        let warm_claimed = if warm_disabled { false } else {
+            try_claim_warm_session(l_socket_name.as_deref(), &session_name)?
         };
-        let warm_port_path = crate::paths::port_file(&warm_base);
-        let mut warm_claimed = false;
-        // Atomically CLAIM the warm server before connecting (see the detached
-        // path above for the full rationale): renaming the shared __warm__.port
-        // file is atomic, so exactly one concurrent new-session wins a given warm
-        // server and the rest cold-spawn. Prevents the rapid-creation race where
-        // two clients claim the same warm and one session is lost.
-        let warm_port_opt = if warm_disabled { None } else {
-            std::fs::read_to_string(&warm_port_path).ok().and_then(|s| s.trim().parse::<u16>().ok())
-        };
-        let warm_claim_path = format!("{}\\{}.claiming.{}", psmux_dir, warm_base, std::process::id());
-        if let Some(port) = warm_port_opt {
-            if std::fs::rename(&warm_port_path, &warm_claim_path).is_ok() {
-            let warm_key = crate::session::read_session_key(&warm_base).unwrap_or_default();
-            {
-                {
-                    let addr = format!("127.0.0.1:{}", port);
-                    if let Ok(mut stream) = std::net::TcpStream::connect_timeout(
-                        &addr.parse().unwrap(),
-                        Duration::from_millis(500),
-                    ) {
-                        let _ = stream.set_nodelay(true);
-                        let _ = stream.set_read_timeout(Some(Duration::from_millis(3000)));
-                        let _ = write!(stream, "AUTH {}\n", warm_key);
-                        let client_cwd = std::env::current_dir()
-                            .ok()
-                            .and_then(|p| p.to_str().map(|s| s.to_string()));
-                        // See the new-session claim above: -p is what lets a bare
-                        // `psmux` in a shell with PSMUX_PRIORITY set reach a standby
-                        // that was spawned long before that shell (#608).
-                        let claim_prio = crate::platform::claim_priority_arg();
-                        if let Some(ref cwd) = client_cwd {
-                            let _ = write!(stream, "claim-session {} {} -p {}\n", crate::util::quote_arg(&session_name), crate::util::quote_arg(cwd), crate::util::quote_arg(&claim_prio));
-                        } else {
-                            let _ = write!(stream, "claim-session {} -p {}\n", crate::util::quote_arg(&session_name), crate::util::quote_arg(&claim_prio));
-                        }
-                        let _ = stream.flush();
-                        // Committed: we atomically own this warm (won the .port
-                        // rename) and have sent claim-session, so it WILL become our
-                        // session. Set warm_claimed NOW so a slow/missing response
-                        // does not trigger a duplicate cold spawn (the duplicate was
-                        // the residual cause of rapid-creation session loss). The OK
-                        // read below still waits for the rename to finish (issue
-                        // #136), and the port-file wait after this block covers a
-                        // slow response.
-                        warm_claimed = true;
-                        // Use send_auth_cmd_response pattern: read AUTH
-                        // "OK" line first, then read the claim-session
-                        // response.  Previously a single raw read() would
-                        // pick up only the AUTH "OK" and proceed before
-                        // the server finished renaming port/key files,
-                        // causing "auth failed" on the subsequent attach
-                        // (issue #136).
-                        if let Ok(reader_stream) = stream.try_clone() {
-                            let mut br = std::io::BufReader::new(reader_stream);
-                            let mut auth_line = String::new();
-                            if std::io::BufRead::read_line(&mut br, &mut auth_line).unwrap_or(0) > 0
-                                && auth_line.trim().starts_with("OK")
-                            {
-                                // Auth succeeded — now wait for the claim
-                                // response so files are renamed before we
-                                // try to attach.
-                                let mut claim_line = String::new();
-                                let got = std::io::BufRead::read_line(&mut br, &mut claim_line).unwrap_or(0) > 0;
-                                if got && claim_line.contains("OK") {
-                                    warm_claimed = true;
-                                } else if got && claim_line.contains("ERR") {
-                                    // Explicit rejection: this server is NOT a warm
-                                    // server (stale __warm__.port -> already-claimed
-                                    // session, or OS port reuse). Do NOT commit; the
-                                    // handoff file was already consumed above, so the
-                                    // bad warm pointer self-heals. Cold-spawn instead
-                                    // of waiting ~5s for a session that never appears.
-                                    warm_claimed = false;
-                                }
-                                // No/garbled response: leave warm_claimed = true
-                                // (set above) to preserve the rapid-creation race
-                                // fix — we own a live warm that will complete.
-                            }
-                        }
-                    }
-                }
-            }
-            }
-            // Orphaned handoff file: server wrote <session>.port on success.
-            let _ = std::fs::remove_file(&warm_claim_path);
-        }
-
 
         if !warm_claimed && !server_already_alive {
             // Cold path: spawn a new background server

--- a/src/main.rs
+++ b/src/main.rs
@@ -719,9 +719,9 @@ mod process_command_arg_tests {
 /// Never hide a live warm registration by renaming its port file client-side.
 fn try_claim_warm_session(namespace: Option<&str>, name: &str) -> io::Result<bool> {
     let warm = crate::paths::storage_base(namespace, "__warm__");
-    let endpoint = match crate::session::read_session_endpoint(&warm) {
-        Ok(endpoint) => endpoint,
-        Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(false),
+    let endpoint = match crate::registry::read_warm_claim_endpoint(&warm) {
+        Ok(Some(endpoint)) => endpoint,
+        Ok(None) => return Ok(false),
         Err(e) => return Err(e),
     };
     if crate::session::registry_pid_anchor_alive(&warm) == Some(false) { return Ok(false); }

--- a/src/pane.rs
+++ b/src/pane.rs
@@ -1,6 +1,6 @@
 use std::io;
-use std::sync::{Arc, Condvar, Mutex};
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::sync::atomic::Ordering;
 use std::thread;
 use std::time::{Duration, Instant};
 
@@ -9,6 +9,12 @@ use portable_pty::{CommandBuilder, PtySize, native_pty_system};
 use crate::types::{AppState, Pane, Node, LayoutKind, Window};
 use crate::tree::{replace_leaf_with_split, active_pane_mut, kill_leaf};
 use crate::format::hostname_cached;
+
+mod io_queue;
+pub mod pipe;
+mod staging;
+mod warm;
+pub use warm::{WarmPaneTask, retire_warm_pane};
 
 /// Sentinel value for cursor_shape: means "no DECSCUSR received from child yet".
 /// When ConPTY passthrough mode is unavailable, DECSCUSR sequences from child
@@ -31,68 +37,76 @@ pub fn conpty_preemptive_dsr_response(_writer: &mut dyn std::io::Write) {
     // no-op: reactive CPR responder handles all ESC[6n queries (#313)
 }
 
-/// Non-blocking pane writer: queues bytes to a dedicated flush thread.
-///
-/// The ConPTY input pipe has a fixed 64KB buffer. A pane child that stops
-/// reading stdin (e.g. a TUI busy with a long redraw) makes a direct
-/// `write_all` on the server thread block, wedging every session on the
-/// server. tmux never has this problem because pty writes go through a
-/// libevent bufferevent that buffers in memory and flushes asynchronously;
-/// this queue mirrors that contract: writes always complete immediately,
-/// bytes are delivered in order, and backpressure is absorbed by memory
-/// exactly like tmux's event buffer.
-struct QueuedPaneWriter {
-    tx: std::sync::mpsc::Sender<Vec<u8>>,
-}
-
-impl std::io::Write for QueuedPaneWriter {
-    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-        if buf.is_empty() {
-            return Ok(0);
-        }
-        self.tx.send(buf.to_vec()).map_err(|_| {
-            std::io::Error::new(std::io::ErrorKind::BrokenPipe, "pane writer thread exited")
-        })?;
-        Ok(buf.len())
-    }
-
-    fn flush(&mut self) -> std::io::Result<()> {
-        Ok(())
-    }
-}
-
-/// Wrap a raw PTY writer in a queue drained by a dedicated thread.
-///
-/// The inner writer's lifetime must match the pane's: dropping the ConPTY
-/// master writer closes the child's input pipe, which a shell reads as EOF
-/// and exits on — closing the whole window. A transient write error (e.g.
-/// while a TUI child is tearing down) must therefore NOT end the thread;
-/// it only stops further writes. The thread — and with it the inner
-/// writer — goes away only when the queue side is dropped with the pane.
+/// Wrap a raw PTY writer in a nonblocking 1 MiB admission queue. In-flight
+/// writes remain charged to the budget; saturation returns WouldBlock before
+/// accepting any of a write. A permanent asynchronous error is returned by
+/// subsequent writes/flush without closing an otherwise healthy pane's stdin.
 pub fn spawn_pane_write_queue(
-    mut inner: Box<dyn std::io::Write + Send>,
+    inner: Box<dyn std::io::Write + Send>,
 ) -> Box<dyn std::io::Write + Send> {
-    let (tx, rx) = std::sync::mpsc::channel::<Vec<u8>>();
-    let _ = std::thread::Builder::new()
-        .name("pane-writer".to_string())
-        .spawn(move || {
-            let mut broken = false;
-            while let Ok(mut buf) = rx.recv() {
-                // Coalesce whatever else is already queued into one write.
-                while let Ok(more) = rx.try_recv() {
-                    buf.extend_from_slice(&more);
-                }
-                if broken {
-                    continue;
-                }
-                if inner.write_all(&buf).is_err() {
-                    broken = true;
-                    continue;
-                }
-                let _ = inner.flush();
+    // Retain a raw handle on thread-creation failure as well: returning a
+    // failing writer should not inadvertently deliver EOF to the child.
+    let retained = Arc::new(Mutex::new(Some(inner)));
+    let worker_inner = retained.clone();
+    match io_queue::ByteWriter::spawn("pane-writer", io_queue::INPUT_BYTE_LIMIT, true,
+        move || Ok(worker_inner.lock().unwrap_or_else(|e| e.into_inner()).take().unwrap())) {
+        Ok(writer) => Box::new(writer),
+        Err(error) => {
+            struct FailedWriter {
+                _inner: Arc<Mutex<Option<Box<dyn std::io::Write + Send>>>>,
+                message: String,
             }
-        });
-    Box::new(QueuedPaneWriter { tx })
+            impl std::io::Write for FailedWriter {
+                fn write(&mut self, _: &[u8]) -> io::Result<usize> { Err(io::Error::other(self.message.clone())) }
+                fn flush(&mut self) -> io::Result<()> { Err(io::Error::other(self.message.clone())) }
+            }
+            Box::new(FailedWriter { _inner: retained, message: format!("cannot start pane writer: {}", error) })
+        }
+    }
+}
+
+/// Surface permanent asynchronous input failures even when no further key is
+/// sent. All live pane writers are queues whose flush only inspects status.
+/// Retain at most one previous message per current pane, so this poll neither
+/// grows an event queue nor repeatedly overwrites the status bar for one error.
+pub fn take_input_failures(app: &mut AppState) -> Vec<(usize, String)> {
+    use std::collections::{HashMap, HashSet};
+    static REPORTED: std::sync::OnceLock<Mutex<HashMap<usize, String>>> = std::sync::OnceLock::new();
+    let mut observed = Vec::new();
+    fn inspect(pane: &mut Pane, observed: &mut Vec<(usize, Option<String>)>) {
+        observed.push((pane.id, pane.writer.flush().err().map(|error| error.to_string())));
+    }
+    fn walk(node: &mut Node, observed: &mut Vec<(usize, Option<String>)>) {
+        match node {
+            Node::Leaf(pane) => inspect(pane, observed),
+            Node::Split { children, .. } => for child in children { walk(child, observed); },
+        }
+    }
+    for window in &mut app.windows {
+        walk(&mut window.root, &mut observed);
+        for floating in &mut window.floating { inspect(&mut floating.pane, &mut observed); }
+    }
+    if let Some(warm) = &mut app.warm_pane {
+        observed.push((warm.pane_id, warm.writer.flush().err().map(|error| error.to_string())));
+    }
+    if let crate::types::Mode::PopupMode { popup_pane: Some(pane), .. } = &mut app.mode {
+        inspect(pane, &mut observed);
+    }
+    let mut reported = REPORTED.get_or_init(|| Mutex::new(HashMap::new()))
+        .lock().unwrap_or_else(|e| e.into_inner());
+    let mut failures = Vec::new();
+    let mut seen = HashSet::new();
+    for (id, error) in observed {
+        seen.insert(id);
+        if let Some(message) = error {
+            if reported.get(&id) != Some(&message) {
+                reported.insert(id, message.clone());
+                failures.push((id, message));
+            }
+        } else { reported.remove(&id); }
+    }
+    reported.retain(|id, _| seen.contains(id));
+    failures
 }
 
 /// Cached resolved shell path to avoid repeated `which::which()` PATH scans.
@@ -697,32 +711,39 @@ pub fn spawn_warm_pane(pty_system: &dyn portable_pty::PtySystem, app: &mut AppSt
     if !app.warm_enabled {
         return Err(io::Error::new(io::ErrorKind::Other, "warm panes disabled"));
     }
-    let area = app.client_area;
-    let rows = if area.height > 1 { area.height } else { 30 }.max(MIN_PANE_DIM);
-    let cols = if area.width > 1 { area.width } else { 120 }.max(MIN_PANE_DIM);
+    let config = warm::WarmPaneConfig::capture(app);
+    let pane_id = app.next_pane_id;
+    app.next_pane_id = app.next_pane_id.checked_add(1)
+        .ok_or_else(|| io::Error::other("pane ID space exhausted"))?;
+    spawn_warm_pane_config(pty_system, config, pane_id)
+}
+
+fn spawn_warm_pane_config(
+    pty_system: &dyn portable_pty::PtySystem,
+    config: warm::WarmPaneConfig,
+    pane_id: usize,
+) -> io::Result<crate::types::WarmPane> {
+    let rows = config.rows;
+    let cols = config.cols;
     let size = PtySize { rows, cols, pixel_width: 0, pixel_height: 0 };
     let pair = pty_system
         .openpty(size)
         .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("openpty error: {e}")))?;
     // Expand format variables like #{pane_current_path} at spawn time (#111).
-    let expanded_shell = crate::format::expand_format(&app.default_shell, app);
-    let mut shell_cmd = if !expanded_shell.is_empty() {
-        build_default_shell(&expanded_shell, app.env_shim, app.allow_predictions)
+    let mut shell_cmd = if !config.shell.is_empty() {
+        build_default_shell(&config.shell, config.env_shim, config.allow_predictions)
     } else {
-        build_command(None, app.env_shim, app.allow_predictions)
+        build_command(None, config.env_shim, config.allow_predictions)
     };
-    let pane_id = app.next_pane_id;
-    app.next_pane_id += 1;
-    set_tmux_env(&mut shell_cmd, pane_id, app.control_port, app.socket_name.as_deref(), &app.session_name, app.claude_code_fix_tty, app.claude_code_force_interactive);
-    set_host_colors_env(&mut shell_cmd, app.host_colors.as_ref());
-    apply_user_environment(&mut shell_cmd, &app.environment);
+    set_tmux_env(&mut shell_cmd, pane_id, config.control_port, config.socket_name.as_deref(), &config.session_name, config.fix_tty, config.force_interactive);
+    set_host_colors_env(&mut shell_cmd, config.host_colors.as_ref());
+    apply_user_environment(&mut shell_cmd, &config.environment);
     let child = pair.slave
         .spawn_command(shell_cmd)
         .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("spawn shell error: {e}")))?;
     drop(pair.slave);
-    let scrollback = app.history_limit as u32;
-    let mut parser = vt100::Parser::new(rows, cols, scrollback as usize);
-    parser.screen_mut().set_allow_alternate_screen(app.allow_alternate_screen);
+    let mut parser = vt100::Parser::new(rows, cols, config.history_limit);
+    parser.screen_mut().set_allow_alternate_screen(config.allow_alternate_screen);
     let term: Arc<Mutex<vt100::Parser>> = Arc::new(Mutex::new(parser));
     let term_reader = term.clone();
     let data_version = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
@@ -2515,15 +2536,14 @@ pub fn spawn_reader_thread(
     // client as the visible "sparse cells" / "remnant characters" artifact.
     //
     // Fix:
-    //   • Reader thread: tight loop, ONLY does reader.read() and pushes raw
-    //     bytes into a staging buffer. Never touches the parser mutex, so
-    //     reads cannot be starved by snapshot work.
+    //   • Reader thread: reads into a bounded staging buffer. A slow parser
+    //     applies lossless backpressure to this thread and then to the PTY,
+    //     without making a server request wait for queue capacity.
     //   • Parser thread: waits for staged bytes, then ADAPTIVELY coalesces:
     //     sleeps 1ms; if more bytes arrived, sleeps again; hard cap 8ms total.
-    //     Then locks the parser ONCE and processes the entire batch
-    //     atomically. Multi-chunk frames that arrive within the coalescing
-    //     window land as a single unit — the snapshot can no longer observe
-    //     a partial frame.
+    //     Then locks the parser once for at most 64 KiB. Small multi-chunk
+    //     frames remain atomic; sustained output cannot hold the parser lock
+    //     for an unbounded batch or grow the staging buffer indefinitely.
     //
     // Latency cost: 1ms minimum between byte arrival and render for streaming
     // output, capped at 8ms for sustained streams. Imperceptible to humans
@@ -2531,14 +2551,17 @@ pub fn spawn_reader_thread(
     const COALESCE_TICK_MS: u64 = 1;
     const COALESCE_MAX_MS: u128 = 8;
 
-    let staging: Arc<(Mutex<Vec<u8>>, Condvar)> = Arc::new((Mutex::new(Vec::with_capacity(131072)), Condvar::new()));
-    let reader_done: Arc<AtomicBool> = Arc::new(AtomicBool::new(false));
+    let staging = Arc::new(staging::Staging::new(staging::OUTPUT_BYTE_LIMIT));
 
     // ── Reader thread: pure I/O, no parser lock ──
     let staging_r = staging.clone();
-    let reader_done_r = reader_done.clone();
     let output_ring_r = output_ring.clone();
     thread::spawn(move || {
+        struct ReaderDone(Arc<staging::Staging>);
+        impl Drop for ReaderDone {
+            fn drop(&mut self) { self.0.finish_reader(); }
+        }
+        let _done = ReaderDone(staging_r.clone());
         // TEST-ONLY (PSMUX_TEST_READER_DELAY_MS): hold off this reader's first
         // read by a fixed duration. The reader is what drains conhost's startup
         // ESC[6n cursor-position request; with PSEUDOCONSOLE_INHERIT_CURSOR set,
@@ -2567,11 +2590,7 @@ pub fn spawn_reader_thread(
                 Ok(n) if n > 0 => {
                     zero_reads = 0;
                     // Push raw bytes into staging (no parser lock involved).
-                    let (lock, cv) = &*staging_r;
-                    if let Ok(mut buf) = lock.lock() {
-                        buf.extend_from_slice(&local[..n]);
-                        cv.notify_one();
-                    }
+                    if !staging_r.push(&local[..n]) { break; }
                     // Issue #556: answer terminal color queries (OSC 4/10/11,
                     // CSI ?996n, issue #473) HERE, straight off the read,
                     // rather than signaling the server loop.  The old
@@ -2597,39 +2616,20 @@ pub fn spawn_reader_thread(
                     // Append raw output to ring buffer for control mode %output.
                     // This is independent of parser state and must stay live.
                     if let Ok(mut ring) = output_ring_r.lock() {
-                        const MAX_RING: usize = 65536;
+                        const MAX_RING: usize = 1024 * 1024;
                         let space = MAX_RING.saturating_sub(ring.len());
                         if n <= space {
                             ring.extend(&local[..n]);
                         } else {
+                            if crate::types::CONTROL_CLIENTS_ACTIVE.load(Ordering::Acquire) {
+                                crate::types::CONTROL_OUTPUT_LOST.store(true, Ordering::Release);
+                            }
                             let drop_count = (n - space).min(ring.len());
                             ring.drain(..drop_count);
                             ring.extend(&local[..n]);
                         }
                     }
-                    // Issue #440: tee raw pane output to any registered pipe-pane
-                    // writer for this pane. The atomic gate keeps this a single
-                    // relaxed load (no mutex) whenever nothing is being piped,
-                    // which is the common case. When a writer's child has exited
-                    // its pipe write fails; drop that entry and decrement the gate
-                    // so the reader stops trying.
-                    if crate::types::PIPE_PANE_COUNT.load(Ordering::Relaxed) > 0 {
-                        if let Ok(mut writers) = crate::types::PIPE_WRITERS.lock() {
-                            use std::io::Write;
-                            let mut i = 0;
-                            while i < writers.len() {
-                                if writers[i].0 == pane_id {
-                                    let w = &mut writers[i].1;
-                                    if w.write_all(&local[..n]).is_err() || w.flush().is_err() {
-                                        writers.remove(i);
-                                        crate::types::PIPE_PANE_COUNT.fetch_sub(1, Ordering::Relaxed);
-                                        continue;
-                                    }
-                                }
-                                i += 1;
-                            }
-                        }
-                    }
+                    pipe::tee(pane_id, &local[..n]);
                 }
                 Ok(_) => {
                     zero_reads += 1;
@@ -2639,78 +2639,44 @@ pub fn spawn_reader_thread(
                 Err(_) => break,
             }
         }
-        // Issue #440: this pane is gone. Drop any pipe-pane writer still bound
-        // to it so the piped command sees EOF instead of blocking forever on a
-        // stdin that will never fill, and keep the count gate in sync. pane_id
-        // is monotonic and never reused, so this can only match this pane.
-        if crate::types::PIPE_PANE_COUNT.load(Ordering::Relaxed) > 0 {
-            if let Ok(mut writers) = crate::types::PIPE_WRITERS.lock() {
-                let before = writers.len();
-                writers.retain(|(id, _)| *id != pane_id);
-                let removed = before - writers.len();
-                if removed > 0 {
-                    crate::types::PIPE_PANE_COUNT.fetch_sub(removed, Ordering::Relaxed);
-                }
-            }
-        }
+        // Normal EOF drains accepted sink bytes before closing its stdin.
+        pipe::finish_pane(pane_id);
         // Signal end-of-stream and wake parser thread one last time so it
         // can drain remaining bytes and run the alt-screen cleanup.
-        reader_done_r.store(true, Ordering::Release);
-        let (_, cv) = &*staging_r;
-        cv.notify_all();
+        staging_r.finish_reader();
     });
 
     // ── Parser thread: coalesces staged bytes, processes under one lock ──
     thread::spawn(move || {
+        struct ParserDone(Arc<staging::Staging>);
+        impl Drop for ParserDone {
+            fn drop(&mut self) { self.0.finish_parser(); }
+        }
+        let _done = ParserDone(staging.clone());
         let mut cpr_scanner = CprScanner::new();
         loop {
             // Wait for at least one byte (or shutdown).
-            {
-                let (lock, cv) = &*staging;
-                let mut buf = match lock.lock() {
-                    Ok(g) => g,
-                    Err(_) => break,
-                };
-                while buf.is_empty() {
-                    if reader_done.load(Ordering::Acquire) {
-                        // Reader is gone and nothing left to drain — exit
-                        // after running alt-screen cleanup below.
-                        drop(buf);
-                        if let Ok(mut parser) = term_reader.lock() {
-                            if parser.screen().alternate_screen() {
-                                parser.process(b"\x1b[?25h\x1b[?1049l");
-                                cursor_shape.store(0, Ordering::Release);
-                                dv_writer.fetch_add(1, Ordering::Release);
-                                crate::types::PTY_DATA_READY.store(true, Ordering::Release);
-                            }
-                        }
-                        return;
+            if !staging.wait_for_data() {
+                if let Ok(mut parser) = term_reader.lock() {
+                    if parser.screen().alternate_screen() {
+                        parser.process(b"\x1b[?25h\x1b[?1049l");
+                        cursor_shape.store(0, Ordering::Release);
+                        dv_writer.fetch_add(1, Ordering::Release);
+                        crate::types::PTY_DATA_READY.store(true, Ordering::Release);
                     }
-                    let res = cv.wait_timeout(buf, Duration::from_millis(100));
-                    buf = match res {
-                        Ok((g, _)) => g,
-                        Err(_) => return,
-                    };
                 }
-                // First bytes are present — release the lock so the reader can
-                // keep pushing while we run the adaptive coalescing wait.
+                return;
             }
 
             // Adaptive coalescing: keep waiting in 1ms ticks while new bytes
             // are still arriving, hard-capped at 8ms total. This bridges
             // multi-chunk frames into a single atomic parser update.
             let coalesce_start = Instant::now();
-            let mut last_len: usize = {
-                let (lock, _) = &*staging;
-                lock.lock().map(|b| b.len()).unwrap_or(0)
-            };
+            let mut last_len = staging.len();
             loop {
-                if coalesce_start.elapsed().as_millis() >= COALESCE_MAX_MS { break; }
+                if last_len >= staging::PARSE_BATCH_LIMIT || coalesce_start.elapsed().as_millis() >= COALESCE_MAX_MS { break; }
                 thread::sleep(Duration::from_millis(COALESCE_TICK_MS));
-                let cur_len = {
-                    let (lock, _) = &*staging;
-                    lock.lock().map(|b| b.len()).unwrap_or(0)
-                };
+                let cur_len = staging.len();
                 if cur_len == last_len {
                     // No new bytes arrived in the last tick — frame boundary.
                     break;
@@ -2718,14 +2684,8 @@ pub fn spawn_reader_thread(
                 last_len = cur_len;
             }
 
-            // Take the entire staged batch.
-            let bytes = {
-                let (lock, _) = &*staging;
-                match lock.lock() {
-                    Ok(mut buf) => std::mem::take(&mut *buf),
-                    Err(_) => break,
-                }
-            };
+            // A fixed byte budget bounds work while holding the parser lock.
+            let bytes = staging.take(staging::PARSE_BATCH_LIMIT);
             if bytes.is_empty() { continue; }
 
             // Scan for cursor shape and RMCUP on the raw batch BEFORE

--- a/src/pane/io_queue.rs
+++ b/src/pane/io_queue.rs
@@ -1,0 +1,308 @@
+//! Byte-budgeted admission to a writer that may block indefinitely.
+//!
+//! The budget includes bytes in flight, not only queued messages. Producers
+//! never perform I/O or wait for space. A successful write means admission;
+//! a subsequent `flush`/write exposes asynchronous failure. PTY handles remain
+//! alive after failure until their owner drops the queue, avoiding spurious EOF.
+
+use std::collections::VecDeque;
+use std::io::{self, Write};
+use std::sync::{Arc, Condvar, Mutex, OnceLock};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::thread::{self, JoinHandle};
+use std::time::{Duration, Instant};
+
+pub(super) const INPUT_BYTE_LIMIT: usize = 1024 * 1024;
+pub(super) const WRITE_BATCH_LIMIT: usize = 64 * 1024;
+const MAX_WRITER_WORKERS: usize = 256;
+static WRITER_WORKERS: AtomicUsize = AtomicUsize::new(0);
+
+/// Permits belong to the JoinHandle, not its thread closure. A cancelled
+/// operation that cannot be interrupted keeps its permit until confirmed exit;
+/// repeated replace/cancel therefore cannot leak arbitrarily many workers.
+struct WorkerPermit;
+impl WorkerPermit {
+    fn acquire() -> io::Result<Self> {
+        WRITER_WORKERS.fetch_update(Ordering::AcqRel, Ordering::Acquire,
+            |n| (n < MAX_WRITER_WORKERS).then_some(n + 1))
+            .map(|_| Self)
+            .map_err(|_| io::Error::new(io::ErrorKind::WouldBlock,
+                "writer task limit reached (256 active or cancelling writers)"))
+    }
+}
+impl Drop for WorkerPermit {
+    fn drop(&mut self) { WRITER_WORKERS.fetch_sub(1, Ordering::AcqRel); }
+}
+
+struct Worker {
+    thread: JoinHandle<()>,
+    _permit: WorkerPermit,
+}
+
+static CANCELLED: Mutex<Vec<Worker>> = Mutex::new(Vec::new());
+static CANCEL_WAKE: Condvar = Condvar::new();
+static REAPER_STARTED: OnceLock<Result<(), String>> = OnceLock::new();
+
+fn ensure_reaper() -> io::Result<()> {
+    REAPER_STARTED.get_or_init(|| {
+        thread::Builder::new().name("writer-cancel-reaper".into()).spawn(|| loop {
+            let pending = {
+                let mut cancelled = CANCELLED.lock().unwrap_or_else(|e| e.into_inner());
+                while cancelled.is_empty() {
+                    cancelled = CANCEL_WAKE.wait(cancelled).unwrap_or_else(|e| e.into_inner());
+                }
+                std::mem::take(&mut *cancelled)
+            };
+            let mut still_running = Vec::new();
+            for worker in pending {
+                if worker.thread.is_finished() {
+                    let Worker { thread, _permit } = worker;
+                    let _ = thread.join();
+                } else {
+                    cancel_synchronous_io(&worker.thread);
+                    still_running.push(worker);
+                }
+            }
+            let mut cancelled = CANCELLED.lock().unwrap_or_else(|e| e.into_inner());
+            cancelled.extend(still_running);
+            if !cancelled.is_empty() {
+                let _ = CANCEL_WAKE.wait_timeout(cancelled, Duration::from_millis(10));
+            }
+        }).map(|_| ()).map_err(|error| error.to_string())
+    }).as_ref().map(|_| ()).map_err(|error| io::Error::other(error.clone()))
+}
+
+#[derive(Clone)]
+struct Failure {
+    kind: io::ErrorKind,
+    message: String,
+}
+
+impl Failure {
+    fn error(&self) -> io::Error { io::Error::new(self.kind, self.message.clone()) }
+}
+
+#[derive(Default)]
+struct State {
+    chunks: VecDeque<Vec<u8>>,
+    /// Includes the worker's current batch until the underlying write succeeds.
+    bytes: usize,
+    closed: bool,
+    cancelled: bool,
+    finished_at: Option<Instant>,
+    failure: Option<Failure>,
+}
+
+struct Shared {
+    state: Mutex<State>,
+    changed: Condvar,
+    limit: usize,
+}
+
+impl Shared {
+    fn fail(&self, error: io::Error) {
+        let mut state = self.state.lock().unwrap_or_else(|e| e.into_inner());
+        if state.failure.is_none() {
+            state.failure = Some(Failure {
+                kind: error.kind(),
+                message: error.to_string().chars().take(512).collect(),
+            });
+        }
+        self.changed.notify_all();
+    }
+}
+
+pub(super) struct ByteWriter {
+    shared: Arc<Shared>,
+    worker: Mutex<Option<Worker>>,
+}
+
+impl ByteWriter {
+    pub(super) fn spawn(
+        name: &str,
+        limit: usize,
+        retain_after_failure: bool,
+        open: impl FnOnce() -> io::Result<Box<dyn Write + Send>> + Send + 'static,
+    ) -> io::Result<Self> {
+        ensure_reaper()?;
+        let permit = WorkerPermit::acquire()?;
+        let shared = Arc::new(Shared {
+            state: Mutex::new(State::default()),
+            changed: Condvar::new(),
+            limit,
+        });
+        let worker_shared = shared.clone();
+        let worker = thread::Builder::new().name(name.into()).spawn(move || {
+            // A panic must become visible to producers even if it happened in
+            // user-supplied writer code. No registry or PTY cleanup in a hook.
+            struct ExitGuard(Arc<Shared>);
+            impl Drop for ExitGuard {
+                fn drop(&mut self) {
+                    if thread::panicking() {
+                        self.0.fail(io::Error::other("writer task panicked"));
+                    }
+                }
+            }
+            let _guard = ExitGuard(worker_shared.clone());
+            let mut inner = match open() {
+                Ok(inner) => inner,
+                Err(error) => { worker_shared.fail(error); return; }
+            };
+            run_writer(&worker_shared, &mut *inner, retain_after_failure);
+        })?;
+        Ok(Self { shared, worker: Mutex::new(Some(Worker { thread: worker, _permit: permit })) })
+    }
+
+    pub(super) fn enqueue(&self, bytes: &[u8]) -> io::Result<usize> {
+        let mut state = self.shared.state.lock().unwrap_or_else(|e| e.into_inner());
+        if let Some(error) = &state.failure { return Err(error.error()); }
+        if state.closed { return Err(io::Error::new(io::ErrorKind::BrokenPipe, "writer closed")); }
+        if bytes.len() > self.shared.limit.saturating_sub(state.bytes) {
+            return Err(io::Error::new(io::ErrorKind::WouldBlock,
+                format!("writer input queue full ({} byte limit); retry after the pane drains", self.shared.limit)));
+        }
+        // Allocate only after the complete write has been admitted. Partial
+        // admission makes retrying a failed write_all duplicate input prefixes.
+        let mut remaining = bytes;
+        if let Some(last) = state.chunks.back_mut() {
+            let append = remaining.len().min(WRITE_BATCH_LIMIT - last.len());
+            last.extend_from_slice(&remaining[..append]);
+            remaining = &remaining[append..];
+        }
+        for chunk in remaining.chunks(WRITE_BATCH_LIMIT) {
+            state.chunks.push_back(chunk.to_vec());
+        }
+        state.bytes += bytes.len();
+        self.shared.changed.notify_one();
+        Ok(bytes.len())
+    }
+
+    pub(super) fn check(&self) -> io::Result<()> {
+        let state = self.shared.state.lock().unwrap_or_else(|e| e.into_inner());
+        if let Some(error) = &state.failure { return Err(error.error()); }
+        if state.closed { return Err(io::Error::new(io::ErrorKind::BrokenPipe, "writer closed")); }
+        Ok(())
+    }
+
+    pub(super) fn fail(&self, error: io::Error) { self.shared.fail(error); }
+
+    pub(super) fn failure(&self) -> Option<io::Error> {
+        self.shared.state.lock().unwrap_or_else(|e| e.into_inner()).failure.as_ref().map(Failure::error)
+    }
+
+    pub(super) fn finish(&self) {
+        let mut state = self.shared.state.lock().unwrap_or_else(|e| e.into_inner());
+        state.closed = true;
+        state.finished_at = Some(Instant::now());
+        self.shared.changed.notify_all();
+    }
+
+    pub(super) fn finish_expired(&self, timeout: Duration) -> bool {
+        self.shared.state.lock().unwrap_or_else(|e| e.into_inner()).finished_at
+            .is_some_and(|at| at.elapsed() >= timeout)
+    }
+
+    pub(super) fn is_finished(&self) -> bool {
+        self.worker.lock().unwrap_or_else(|e| e.into_inner()).as_ref().is_none_or(|worker| worker.thread.is_finished())
+    }
+
+    /// Does not wait for the writer. Windows cancellation is repeated on a
+    /// shared reaper because a single CancelSynchronousIo can race the worker
+    /// between its closed check and entering WriteFile/CreateFile.
+    pub(super) fn cancel(&self) {
+        {
+            let mut state = self.shared.state.lock().unwrap_or_else(|e| e.into_inner());
+            state.closed = true;
+            state.cancelled = true;
+            self.shared.changed.notify_all();
+        }
+        if let Some(worker) = self.worker.lock().unwrap_or_else(|e| e.into_inner()).take() {
+            cancel_synchronous_io(&worker.thread);
+            CANCELLED.lock().unwrap_or_else(|e| e.into_inner()).push(worker);
+            CANCEL_WAKE.notify_one();
+        }
+    }
+
+    #[cfg(test)]
+    fn outstanding(&self) -> usize { self.shared.state.lock().unwrap().bytes }
+}
+
+impl Write for ByteWriter {
+    fn write(&mut self, bytes: &[u8]) -> io::Result<usize> { self.enqueue(bytes) }
+    fn flush(&mut self) -> io::Result<()> { self.check() }
+}
+
+impl Drop for ByteWriter {
+    fn drop(&mut self) {
+        // Owner drop is explicit cancellation (pane closed/replaced). Normal
+        // transcript EOF instead calls finish() and keeps its owner registered
+        // until the accepted suffix drains. Cancel blocked PTY writes too.
+        self.cancel();
+    }
+}
+
+#[cfg(windows)]
+fn cancel_synchronous_io(worker: &JoinHandle<()>) {
+    use std::os::windows::io::AsRawHandle;
+    #[link(name = "kernel32")]
+    unsafe extern "system" {
+        fn CancelSynchronousIo(thread: *mut std::ffi::c_void) -> i32;
+    }
+    // The owned JoinHandle keeps the OS thread handle valid throughout the call.
+    unsafe { CancelSynchronousIo(worker.as_raw_handle()); }
+}
+
+#[cfg(not(windows))]
+fn cancel_synchronous_io(_worker: &JoinHandle<()>) {}
+
+fn run_writer(shared: &Shared, inner: &mut dyn Write, retain_after_failure: bool) {
+    loop {
+        let batch = {
+            let mut state = shared.state.lock().unwrap_or_else(|e| e.into_inner());
+            loop {
+                if state.failure.is_some() {
+                    if !retain_after_failure || state.closed { return; }
+                } else if state.cancelled {
+                    return;
+                } else if let Some(chunk) = state.chunks.pop_front() {
+                    break chunk;
+                } else if state.closed { return; }
+                state = shared.changed.wait(state).unwrap_or_else(|e| e.into_inner());
+            }
+        };
+        let mut offset = 0;
+        while offset < batch.len() {
+            {
+                let state = shared.state.lock().unwrap_or_else(|e| e.into_inner());
+                if state.cancelled || state.failure.is_some() { break; }
+            }
+            match inner.write(&batch[offset..]) {
+                Ok(0) => { shared.fail(io::Error::new(io::ErrorKind::WriteZero, "writer returned zero bytes")); break; }
+                Ok(n) if n <= batch.len() - offset => {
+                    offset += n;
+                    shared.state.lock().unwrap_or_else(|e| e.into_inner()).bytes -= n;
+                }
+                Ok(_) => { shared.fail(io::Error::other("writer returned an invalid byte count")); break; }
+                Err(error) if matches!(error.kind(), io::ErrorKind::Interrupted | io::ErrorKind::WouldBlock) => {
+                    // Keep precisely the unwritten suffix; never replay an
+                    // already accepted prefix after a short/transient write.
+                    let state = shared.state.lock().unwrap_or_else(|e| e.into_inner());
+                    let _ = shared.changed.wait_timeout(state, Duration::from_millis(2));
+                }
+                Err(error) => { shared.fail(error); break; }
+            }
+        }
+        if offset == batch.len() {
+            if let Err(error) = inner.flush() { shared.fail(error); }
+        } else {
+            // Preserve accepted but unwritten bytes until the failure is
+            // observed/the queue is dropped. This is bounded by the byte budget.
+            let mut state = shared.state.lock().unwrap_or_else(|e| e.into_inner());
+            state.chunks.push_front(batch[offset..].to_vec());
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "../../tests-rs/test_audit_io_queue.rs"]
+mod tests;

--- a/src/pane/pipe.rs
+++ b/src/pane/pipe.rs
@@ -1,0 +1,128 @@
+//! Independent pipe-pane sinks. The registry stores queue handles, never raw
+//! writers, and its mutex is never held while a sink performs blocking I/O.
+
+use std::io::{self, Write};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+
+use super::io_queue::ByteWriter;
+
+const SINK_BYTE_LIMIT: usize = 1024 * 1024;
+
+struct Sink {
+    pane_id: usize,
+    writer: Arc<ByteWriter>,
+    tunnel: bool,
+}
+
+static SINKS: Mutex<Vec<Sink>> = Mutex::new(Vec::new());
+static COUNT: AtomicUsize = AtomicUsize::new(0);
+
+fn register_factory(
+    pane_id: usize,
+    tunnel: bool,
+    open: impl FnOnce() -> io::Result<Box<dyn Write + Send>> + Send + 'static,
+) -> io::Result<()> {
+    let writer = ByteWriter::spawn("pipe-sink", SINK_BYTE_LIMIT, false, open)?;
+    let mut sinks = SINKS.lock().unwrap_or_else(|e| e.into_inner());
+    sinks.push(Sink { pane_id, writer: Arc::new(writer), tunnel });
+    COUNT.store(sinks.len(), Ordering::Release);
+    Ok(())
+}
+
+pub fn register(pane_id: usize, writer: Box<dyn Write + Send>) -> io::Result<()> {
+    register_factory(pane_id, false, move || Ok(writer))
+}
+
+pub fn register_tunnel(pane_id: usize, writer: Box<dyn Write + Send>) -> io::Result<()> {
+    register_factory(pane_id, true, move || Ok(writer))
+}
+
+/// Opening a path can block too (including through a local junction). Resolve
+/// and open it on the cancellable worker, never on the server's event loop.
+pub fn register_file(pane_id: usize, path: String, append: bool) -> io::Result<()> {
+    register_factory(pane_id, false, move || {
+        let mut opts = std::fs::OpenOptions::new();
+        opts.create(true).write(true);
+        if append { opts.append(true); } else { opts.truncate(true); }
+        opts.open(&path).map(|file| Box::new(file) as Box<dyn Write + Send>)
+            .map_err(|error| io::Error::new(error.kind(), format!("can't open {}: {}", path, error)))
+    })
+}
+
+pub fn is_registered(pane_id: usize) -> bool {
+    SINKS.lock().unwrap_or_else(|e| e.into_inner()).iter()
+        .any(|sink| sink.pane_id == pane_id && !sink.tunnel && sink.writer.check().is_ok())
+}
+
+pub fn unregister(pane_id: usize) {
+    remove_where(|sink| sink.pane_id == pane_id);
+}
+
+/// Normal PTY EOF must deliver the bytes already admitted before closing the
+/// sink's stdin. Explicit cancel/replace uses unregister instead.
+pub(super) fn finish_pane(pane_id: usize) {
+    let sinks = SINKS.lock().unwrap_or_else(|e| e.into_inner());
+    for sink in sinks.iter().filter(|sink| sink.pane_id == pane_id) {
+        sink.writer.finish();
+    }
+}
+
+fn remove_where(mut remove: impl FnMut(&Sink) -> bool) {
+    let removed = {
+        let mut sinks = SINKS.lock().unwrap_or_else(|e| e.into_inner());
+        let mut removed = Vec::new();
+        let mut index = 0;
+        while index < sinks.len() {
+            if remove(&sinks[index]) { removed.push(sinks.remove(index)); }
+            else { index += 1; }
+        }
+        COUNT.store(sinks.len(), Ordering::Release);
+        removed
+    };
+    for sink in removed { sink.writer.cancel(); }
+}
+
+/// Called from PTY readers. Admission is bounded and never waits for sink I/O.
+/// Overflow terminates that sink with a visible failure; it cannot deadlock
+/// other sinks, the parser, or cancel/replace on the main loop.
+pub(super) fn tee(pane_id: usize, bytes: &[u8]) {
+    if COUNT.load(Ordering::Acquire) == 0 { return; }
+    let writers: Vec<_> = SINKS.lock().unwrap_or_else(|e| e.into_inner()).iter()
+        .filter(|sink| sink.pane_id == pane_id)
+        .map(|sink| sink.writer.clone()).collect();
+    for writer in writers {
+        if let Err(error) = writer.enqueue(bytes) {
+            writer.fail(io::Error::new(error.kind(), format!("pipe-pane sink stopped: {}", error)));
+            writer.cancel();
+        }
+    }
+}
+
+/// The server drains this once per tick, reports the failure and kills/reaps
+/// the corresponding sink child. A failed sink itself is the pending record:
+/// there is no separate unbounded error queue, and idle sink failures are seen.
+pub fn take_failures() -> Vec<(usize, String)> {
+    let mut failures = Vec::new();
+    let mut tunnel_failures = Vec::new();
+    remove_where(|sink| {
+        let finished = sink.writer.is_finished();
+        if !finished && sink.writer.finish_expired(std::time::Duration::from_secs(5)) {
+            sink.writer.fail(io::Error::new(io::ErrorKind::TimedOut,
+                "pipe-pane sink did not drain within five seconds after pane EOF"));
+        }
+        if let Some(error) = sink.writer.failure() {
+            if !sink.tunnel { failures.push((sink.pane_id, error.to_string())); }
+            else { tunnel_failures.push((sink.pane_id, error.to_string())); }
+            true
+        } else { finished }
+    });
+    for (pane_id, error) in tunnel_failures {
+        crate::debug_log::server_log("pipe", &format!("pane tunnel %{} stopped: {}", pane_id, error));
+    }
+    failures
+}
+
+#[cfg(test)]
+#[path = "../../tests-rs/test_audit_pipe_sinks.rs"]
+mod tests;

--- a/src/pane/staging.rs
+++ b/src/pane/staging.rs
@@ -1,0 +1,80 @@
+//! Lossless PTY output staging. Only the reader waits for capacity; snapshots,
+//! the parser, and the server event loop never wait on a full output queue.
+
+use std::collections::VecDeque;
+use std::sync::{Condvar, Mutex};
+
+pub(super) const OUTPUT_BYTE_LIMIT: usize = 1024 * 1024;
+pub(super) const PARSE_BATCH_LIMIT: usize = 64 * 1024;
+
+struct State {
+    bytes: VecDeque<u8>,
+    reader_done: bool,
+    parser_done: bool,
+}
+
+pub(super) struct Staging {
+    state: Mutex<State>,
+    changed: Condvar,
+    limit: usize,
+}
+
+impl Staging {
+    pub(super) fn new(limit: usize) -> Self {
+        assert!(limit > 0);
+        Self {
+            state: Mutex::new(State { bytes: VecDeque::with_capacity(limit), reader_done: false, parser_done: false }),
+            changed: Condvar::new(),
+            limit,
+        }
+    }
+
+    pub(super) fn push(&self, mut bytes: &[u8]) -> bool {
+        let mut state = self.state.lock().unwrap_or_else(|e| e.into_inner());
+        while !bytes.is_empty() {
+            while state.bytes.len() == self.limit && !state.parser_done {
+                state = self.changed.wait(state).unwrap_or_else(|e| e.into_inner());
+            }
+            if state.parser_done { return false; }
+            let n = bytes.len().min(self.limit - state.bytes.len());
+            state.bytes.extend(&bytes[..n]);
+            bytes = &bytes[n..];
+            self.changed.notify_all();
+        }
+        true
+    }
+
+    pub(super) fn wait_for_data(&self) -> bool {
+        let mut state = self.state.lock().unwrap_or_else(|e| e.into_inner());
+        while state.bytes.is_empty() && !state.reader_done {
+            state = self.changed.wait(state).unwrap_or_else(|e| e.into_inner());
+        }
+        !state.bytes.is_empty()
+    }
+
+    pub(super) fn len(&self) -> usize {
+        self.state.lock().unwrap_or_else(|e| e.into_inner()).bytes.len()
+    }
+
+    pub(super) fn take(&self, max: usize) -> Vec<u8> {
+        let mut state = self.state.lock().unwrap_or_else(|e| e.into_inner());
+        let n = max.min(state.bytes.len());
+        let bytes = state.bytes.drain(..n).collect();
+        self.changed.notify_all();
+        bytes
+    }
+
+    pub(super) fn finish_reader(&self) {
+        self.state.lock().unwrap_or_else(|e| e.into_inner()).reader_done = true;
+        self.changed.notify_all();
+    }
+
+    pub(super) fn finish_parser(&self) {
+        self.state.lock().unwrap_or_else(|e| e.into_inner()).parser_done = true;
+        self.changed.notify_all();
+    }
+}
+
+#[cfg(test)]
+#[path = "../../tests-rs/test_audit_output_staging.rs"]
+mod tests;

--- a/src/pane/warm.rs
+++ b/src/pane/warm.rs
@@ -1,0 +1,130 @@
+//! A single asynchronous warm-pane refill, with a configuration snapshot.
+//! No worker holds AppState and no stale result is installed after settings,
+//! identity, environment, or terminal dimensions have changed.
+
+use std::collections::HashMap;
+use std::io;
+use std::sync::mpsc;
+
+use super::{AppState, MIN_PANE_DIM};
+use crate::types::{HostColors, WarmPane};
+
+#[derive(Clone, PartialEq)]
+pub(super) struct WarmPaneConfig {
+    pub rows: u16,
+    pub cols: u16,
+    pub shell: String,
+    pub env_shim: bool,
+    pub allow_predictions: bool,
+    pub control_port: Option<u16>,
+    pub socket_name: Option<String>,
+    pub session_name: String,
+    pub fix_tty: bool,
+    pub force_interactive: bool,
+    pub host_colors: Option<HostColors>,
+    pub environment: HashMap<String, String>,
+    pub history_limit: usize,
+    pub allow_alternate_screen: bool,
+}
+
+impl WarmPaneConfig {
+    pub(super) fn capture(app: &AppState) -> Self {
+        let area = app.client_area;
+        Self {
+            rows: if area.height > 1 { area.height } else { 30 }.max(MIN_PANE_DIM),
+            cols: if area.width > 1 { area.width } else { 120 }.max(MIN_PANE_DIM),
+            shell: crate::format::expand_format(&app.default_shell, app),
+            env_shim: app.env_shim,
+            allow_predictions: app.allow_predictions,
+            control_port: app.control_port,
+            socket_name: app.socket_name.clone(),
+            session_name: app.session_name.clone(),
+            fix_tty: app.claude_code_fix_tty,
+            force_interactive: app.claude_code_force_interactive,
+            host_colors: app.host_colors.clone(),
+            environment: app.environment.clone(),
+            history_limit: app.history_limit,
+            allow_alternate_screen: app.allow_alternate_screen,
+        }
+    }
+}
+
+struct OwnedWarmPane(Option<WarmPane>);
+impl Drop for OwnedWarmPane {
+    fn drop(&mut self) {
+        if let Some(pane) = self.0.take() {
+            // Receiver abandonment/stale results must kill the owned shell,
+            // not leave an unreferenced prewarmed child process running.
+            retire_warm_pane(pane);
+        }
+    }
+}
+
+/// Closing ConPTY can wait for its output drain, so retire outside the control
+/// loop. If the OS refuses a worker thread, still kill the owned child rather
+/// than dropping a process handle and silently leaving the child alive.
+pub fn retire_warm_pane(pane: WarmPane) {
+    let owned = std::sync::Arc::new(std::sync::Mutex::new(Some(pane)));
+    let worker_owned = owned.clone();
+    let spawned = std::thread::Builder::new().name("warm-pane-retire".into()).spawn(move || {
+        if let Some(mut pane) = worker_owned.lock().unwrap_or_else(|e| e.into_inner()).take() {
+            let _ = pane.child.kill();
+            drop(pane);
+        }
+    });
+    if spawned.is_err() {
+        if let Some(mut pane) = owned.lock().unwrap_or_else(|e| e.into_inner()).take() {
+            let _ = pane.child.kill();
+            drop(pane);
+        }
+    }
+}
+
+pub struct WarmPaneTask {
+    config: WarmPaneConfig,
+    result: mpsc::Receiver<io::Result<OwnedWarmPane>>,
+    invalidated: bool,
+}
+
+impl WarmPaneTask {
+    pub fn start(app: &mut AppState) -> io::Result<Self> {
+        if !app.warm_enabled {
+            return Err(io::Error::other("warm panes disabled"));
+        }
+        let config = WarmPaneConfig::capture(app);
+        let worker_config = config.clone();
+        let pane_id = app.next_pane_id;
+        app.next_pane_id = app.next_pane_id.checked_add(1)
+            .ok_or_else(|| io::Error::other("pane ID space exhausted"))?;
+        let (tx, result) = mpsc::sync_channel(1);
+        std::thread::Builder::new().name("warm-pane-spawn".into()).spawn(move || {
+            let pty_system = portable_pty::native_pty_system();
+            let spawned = super::spawn_warm_pane_config(&*pty_system, worker_config, pane_id)
+                .map(|pane| OwnedWarmPane(Some(pane)));
+            // Failed delivery drops the ownership guard and retires the shell.
+            let _ = tx.send(spawned);
+        })?;
+        Ok(Self { config, result, invalidated: false })
+    }
+
+    pub fn invalidate(&mut self) { self.invalidated = true; }
+
+    /// true means the task is terminal and its caller can clear the slot.
+    pub fn poll(&mut self, app: &mut AppState) -> bool {
+        match self.result.try_recv() {
+            Ok(Ok(mut owned)) => {
+                if !self.invalidated && app.warm_enabled && app.warm_pane.is_none()
+                    && self.config == WarmPaneConfig::capture(app) {
+                    app.warm_pane = owned.0.take();
+                }
+                true
+            }
+            Ok(Err(error)) => {
+                crate::debug_log::server_log("warm", &format!("warm pane spawn failed: {}", error));
+                true
+            }
+            Err(mpsc::TryRecvError::Empty) => false,
+            Err(mpsc::TryRecvError::Disconnected) => true,
+        }
+    }
+}

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -116,7 +116,107 @@ pub fn psmux_dir() -> String {
 /// folded, because Windows treats `C:/Foo` and `c:\foo` as one directory and
 /// anything keyed on the root must treat them as one too.
 fn normalized_data_root() -> String {
-    psmux_dir().replace('/', "\\").to_lowercase()
+    let root = psmux_dir();
+    // Resolve junctions and dot components before naming a kernel lock. Two
+    // spellings of the same registry must never acquire different locks.
+    std::fs::canonicalize(&root).unwrap_or_else(|_| root.into())
+        .to_string_lossy().trim_start_matches(r"\\?\").replace('/', "\\").to_lowercase()
+}
+
+const ENCODED_BASE: &str = "~psmux~";
+
+fn plain_component(value: &str) -> bool {
+    let lower = value.to_ascii_lowercase();
+    let reserved_device = matches!(lower.as_str(), "con" | "prn" | "aux" | "nul")
+        || (lower.len() == 4 && (lower.starts_with("com") || lower.starts_with("lpt"))
+            && matches!(lower.as_bytes()[3], b'1'..=b'9'));
+    !value.is_empty() && !value.contains("__") && !value.starts_with(ENCODED_BASE)
+        && !value.starts_with('_') && !value.ends_with('_')
+        && !reserved_device
+        && value.bytes().all(|b| b.is_ascii_alphanumeric() || b == b'-' || b == b'_')
+}
+
+fn hex_name(value: &str) -> String {
+    value.as_bytes().iter().map(|b| format!("{b:02x}")).collect()
+}
+
+fn unhex_name(value: &str) -> Option<String> {
+    if value.len() % 2 != 0 || !value.is_ascii() { return None; }
+    let bytes = (0..value.len()).step_by(2)
+        .map(|i| u8::from_str_radix(&value[i..i+2], 16).ok())
+        .collect::<Option<Vec<_>>>()?;
+    String::from_utf8(bytes).ok()
+}
+
+/// An injective filename encoding for newly created registry entries. Preserve
+/// ordinary legacy names; delimiters and path characters are encoded together
+/// with an explicit default/named-namespace tag.
+pub fn storage_base(namespace: Option<&str>, name: &str) -> String {
+    let ordinary_name = plain_component(name) || name == "__warm__";
+    if ordinary_name && namespace.map_or(true, plain_component) {
+        return namespace.map_or_else(|| name.to_string(), |ns| format!("{ns}__{name}"));
+    }
+    match namespace {
+        None => format!("{ENCODED_BASE}d~{}", hex_name(name)),
+        Some(ns) => format!("{ENCODED_BASE}n~{}~{}", hex_name(ns), hex_name(name)),
+    }
+}
+
+pub fn session_base(namespace: Option<&str>, name: &str) -> String {
+    storage_base(namespace, name)
+}
+
+fn decode_base(base: &str) -> Option<(Option<String>, String)> {
+    let encoded = base.strip_prefix(ENCODED_BASE)?;
+    if let Some(name) = encoded.strip_prefix("d~") {
+        return Some((None, unhex_name(name)?));
+    }
+    let (ns, name) = encoded.strip_prefix("n~")?.split_once('~')?;
+    Some((Some(unhex_name(ns)?), unhex_name(name)?))
+}
+
+pub fn registry_namespace(base: &str) -> Option<String> {
+    if let Some((ns, _)) = decode_base(base) { return ns; }
+    if base == "__warm__" { return None; }
+    base.split_once("__").map(|(ns, _)| ns.to_string())
+}
+
+pub fn registry_session_name(base: &str) -> String {
+    if let Some((_, name)) = decode_base(base) { return name; }
+    if base == "__warm__" { return base.to_string(); }
+    base.split_once("__").map_or(base, |(_, name)| name).to_string()
+}
+
+pub fn registry_visible_from(base: &str, namespace: Option<&str>) -> bool {
+    registry_namespace(base).as_deref() == namespace
+}
+
+/// Keep an encoded registry component within Windows' 255-character limit and
+/// prevent protocol delimiters from entering command/session identifiers.
+pub fn validate_session_name(name: &str) -> std::io::Result<()> {
+    if name.is_empty() || name.chars().any(char::is_control) || name.contains(':') || name.len() > 100 {
+        return Err(std::io::Error::new(std::io::ErrorKind::InvalidInput,
+            "session name must be 1–100 UTF-8 bytes, without control characters or ':'"));
+    }
+    Ok(())
+}
+
+pub fn validate_namespace(namespace: &str) -> std::io::Result<()> {
+    if namespace.is_empty() || namespace.chars().any(char::is_control) || namespace.len() > 100 {
+        return Err(std::io::Error::new(std::io::ErrorKind::InvalidInput,
+            "namespace must be 1–100 UTF-8 bytes without control characters"));
+    }
+    Ok(())
+}
+
+pub fn validate_registry_base(namespace: Option<&str>, name: &str) -> std::io::Result<()> {
+    validate_session_name(name)?;
+    if let Some(ns) = namespace { validate_namespace(ns)?; }
+    if storage_base(namespace, name).len() > 235 {
+        return Err(std::io::Error::new(std::io::ErrorKind::InvalidInput,
+            "combined namespace and session name are too long for the registry"));
+    }
+    Ok(())
 }
 
 /// Stable per-data-root tag for names that live in the machine-wide kernel
@@ -297,3 +397,42 @@ mod tests_issue474_home_resolution;
 #[cfg(test)]
 #[path = "../tests-rs/test_data_dir_override.rs"]
 mod tests_data_dir_override;
+
+#[cfg(test)]
+mod registry_encoding_tests {
+    use super::*;
+
+    #[test]
+    fn identities_round_trip_without_delimiter_or_path_collisions() {
+        let namespaces = [None, Some("a"), Some("a__b"), Some("a_"), Some("a/b"), Some("a\\b")];
+        let names = ["dev", "build__dev", "b__c", "_b", "__warm__", "~psmux~d~61", "a/b", "é", "CON", "nul", "COM1"];
+        let mut bases = std::collections::HashSet::new();
+        for namespace in namespaces {
+            for name in names {
+                let base = storage_base(namespace, name);
+                assert!(bases.insert(base.clone()), "duplicate encoding: {base}");
+                assert_eq!(registry_namespace(&base).as_deref(), namespace);
+                assert_eq!(registry_session_name(&base), name);
+                assert!(registry_visible_from(&base, namespace));
+                assert!(!base.contains(['/', '\\', ':']));
+            }
+        }
+    }
+
+    #[test]
+    fn ordinary_legacy_entries_remain_readable() {
+        assert_eq!(storage_base(Some("work"), "dev"), "work__dev");
+        assert_eq!(storage_base(None, "dev"), "dev");
+        assert_eq!(registry_namespace("work____warm__"), Some("work".into()));
+        assert_eq!(registry_session_name("work____warm__"), "__warm__");
+        assert_eq!(registry_namespace("work__build__dev"), Some("work".into()));
+        assert_eq!(registry_session_name("work__build__dev"), "build__dev");
+    }
+
+    #[test]
+    fn unsafe_or_oversized_protocol_names_fail_explicitly() {
+        for name in ["", "bad\nname", "a:b", "a\0b"] { assert!(validate_registry_base(None, name).is_err()); }
+        assert!(validate_registry_base(Some(&"n".repeat(100)), &"_".repeat(100)).is_err());
+        assert!(validate_registry_base(Some("a__b"), "c__d").is_ok());
+    }
+}

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -343,18 +343,15 @@ impl Drop for SessionMutex {
 /// logon session, matching the per-user scope of the data directory.
 #[cfg(windows)]
 pub fn session_mutex_name(base: &str) -> String {
-    let sanitized: String = base.chars().map(|c| if c == '\\' || c == '/' { '_' } else { c }).collect();
+    let sanitized: String = base.to_lowercase().chars().map(|c| if c == '\\' || c == '/' { '_' } else { c }).collect();
     format!("Local\\psmux-session-{}-{}", crate::paths::data_root_tag(), sanitized)
 }
 
-/// Acquire the single-server lock for session `name` (P0: kill the duplicate-
-/// same-name-server race). Returns `Some(guard)` when this process MAY run as
-/// the server — because it now owns the mutex, or a previous owner died and left
-/// it abandoned, or the FFI was unavailable (**fail-open**, so a legitimate start
-/// is never blocked). Returns `None` ONLY when another LIVE process already owns
-/// the name, i.e. this is a duplicate cold-spawn that must exit.
+/// Acquire the single-server lock for this data root and session storage name.
+/// Some means ownership was acquired (including an abandoned mutex); None means
+/// another owner holds it. OS errors are returned, never treated as ownership.
 #[cfg(windows)]
-pub fn acquire_session_mutex(name: &str) -> Option<SessionMutex> {
+pub fn acquire_session_mutex_strict(name: &str) -> std::io::Result<Option<SessionMutex>> {
     #[link(name = "kernel32")]
     extern "system" {
         fn CreateMutexW(attrs: *const std::ffi::c_void, initial_owner: i32, name: *const u16) -> *mut std::ffi::c_void;
@@ -369,14 +366,23 @@ pub fn acquire_session_mutex(name: &str) -> Option<SessionMutex> {
     unsafe {
         let h = CreateMutexW(std::ptr::null(), 0, wide.as_ptr());
         if h.is_null() {
-            return Some(SessionMutex { handle: std::ptr::null_mut() }); // fail-open
+            return Err(std::io::Error::last_os_error());
         }
         match WaitForSingleObject(h, 0) {
-            WAIT_OBJECT_0 | WAIT_ABANDONED => Some(SessionMutex { handle: h }),
-            WAIT_TIMEOUT => { CloseHandle(h as isize); None }
-            _ => Some(SessionMutex { handle: h }), // unknown -> fail-open
+            WAIT_OBJECT_0 | WAIT_ABANDONED => Ok(Some(SessionMutex { handle: h })),
+            WAIT_TIMEOUT => { CloseHandle(h as isize); Ok(None) }
+            _ => {
+                let error = std::io::Error::last_os_error();
+                CloseHandle(h as isize);
+                Err(error)
+            }
         }
     }
+}
+
+#[cfg(windows)]
+pub fn acquire_session_mutex(name: &str) -> Option<SessionMutex> {
+    acquire_session_mutex_strict(name).ok().flatten()
 }
 
 #[cfg(not(windows))]
@@ -385,6 +391,9 @@ pub struct SessionMutex;
 /// legitimate start). psmux's duplicate-server race is a Windows-only concern.
 #[cfg(not(windows))]
 pub fn acquire_session_mutex(_name: &str) -> Option<SessionMutex> { Some(SessionMutex) }
+
+#[cfg(not(windows))]
+pub fn acquire_session_mutex_strict(_name: &str) -> std::io::Result<Option<SessionMutex>> { Ok(Some(SessionMutex)) }
 
 /// Enable virtual terminal processing on Windows Console Host.
 /// This is required for ANSI color codes to work in conhost.exe (legacy console).
@@ -2429,6 +2438,67 @@ pub mod mouse_inject {
 
 #[cfg(windows)]
 pub mod process_kill {
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub enum ProcessIdentity { Alive(u64), Exited, Unknown }
+
+    /// Read identity and liveness on the SAME handle. Access denial or query
+    /// failure is uncertainty, never evidence of process death.
+    pub fn process_identity(pid: u32) -> ProcessIdentity {
+        #[link(name = "kernel32")]
+        extern "system" {
+            fn WaitForSingleObject(handle: *mut std::ffi::c_void, timeout: u32) -> u32;
+            fn GetLastError() -> u32;
+        }
+        unsafe {
+            let handle = OpenProcess(0x1000 | 0x0010_0000, 0, pid);
+            if handle == 0 || handle == INVALID_HANDLE {
+                return if pid != 0 && GetLastError() == 87 { ProcessIdentity::Exited } else { ProcessIdentity::Unknown };
+            }
+            let state = match WaitForSingleObject(handle as *mut _, 0) {
+                0 => ProcessIdentity::Exited,
+                258 => {
+                    let mut creation: FILETIME = std::mem::zeroed();
+                    let mut exit: FILETIME = std::mem::zeroed();
+                    let mut kernel: FILETIME = std::mem::zeroed();
+                    let mut user: FILETIME = std::mem::zeroed();
+                    if GetProcessTimes(handle, &mut creation, &mut exit, &mut kernel, &mut user) != 0 {
+                        ProcessIdentity::Alive(filetime_to_u64(creation))
+                    } else { ProcessIdentity::Unknown }
+                }
+                _ => ProcessIdentity::Unknown,
+            };
+            CloseHandle(handle);
+            state
+        }
+    }
+
+    pub fn verified_process_dead(pid: u32, creation: u64) -> bool {
+        match process_identity(pid) {
+            ProcessIdentity::Exited => true,
+            ProcessIdentity::Alive(actual) => creation != 0 && actual != creation,
+            ProcessIdentity::Unknown => false,
+        }
+    }
+
+    /// Explicit user-requested termination, pinned to one process generation.
+    /// Validate and terminate using one retained handle so PID reuse cannot
+    /// redirect a previously authorized kill to a replacement process.
+    pub fn terminate_server_pid_exact(pid: u32, expected_creation: u64) -> bool {
+        if expected_creation == 0 { return false; }
+        unsafe {
+            let handle = OpenProcess(0x1000 | PROCESS_TERMINATE, 0, pid);
+            if handle == 0 || handle == INVALID_HANDLE { return false; }
+            let mut creation: FILETIME = std::mem::zeroed();
+            let mut exit: FILETIME = std::mem::zeroed();
+            let mut kernel: FILETIME = std::mem::zeroed();
+            let mut user: FILETIME = std::mem::zeroed();
+            let matched = GetProcessTimes(handle, &mut creation, &mut exit, &mut kernel, &mut user) != 0
+                && filetime_to_u64(creation) == expected_creation;
+            let result = matched && TerminateProcess(handle, 0) != 0;
+            CloseHandle(handle);
+            result
+        }
+    }
     const TH32CS_SNAPPROCESS: u32 = 0x00000002;
     const PROCESS_TERMINATE: u32 = 0x0001;
     const PROCESS_QUERY_INFORMATION: u32 = 0x0400;
@@ -2997,6 +3067,11 @@ pub mod process_kill {
 
 #[cfg(not(windows))]
 pub mod process_kill {
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub enum ProcessIdentity { Alive(u64), Exited, Unknown }
+    pub fn process_identity(_pid: u32) -> ProcessIdentity { ProcessIdentity::Unknown }
+    pub fn verified_process_dead(_pid: u32, _creation: u64) -> bool { false }
+    pub fn terminate_server_pid_exact(_pid: u32, _creation: u64) -> bool { false }
     /// On non-Windows, fall back to simple kill (no wait — let the reaper handle it).
     pub fn kill_process_tree(child: &mut Box<dyn portable_pty::Child>) {
         let _ = child.kill();

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -1,0 +1,303 @@
+//! Coherent session registration. Only the server holding the session-name
+//! mutex may publish; cleanup additionally checks the immutable generation.
+use std::io::{self, Read, Write};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+pub struct RegistryManifest {
+    pub pid: u32,
+    pub creation_time: u64,
+    pub generation: String,
+    pub port: u16,
+    pub key: String,
+    pub sid: u64,
+}
+
+#[derive(Clone, Debug)]
+pub struct RegistryOwner {
+    pid: u32,
+    creation_time: u64,
+    generation: String,
+}
+
+pub fn manifest_path(base: &str) -> PathBuf {
+    PathBuf::from(crate::paths::psmux_dir_file(format!("{}.registry.json", base)))
+}
+
+pub fn read_manifest(base: &str) -> io::Result<Option<RegistryManifest>> {
+    read_manifest_at(&manifest_path(base))
+}
+
+fn read_manifest_at(path: &Path) -> io::Result<Option<RegistryManifest>> {
+    let file = match std::fs::File::open(path) {
+        Ok(file) => file,
+        Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(None),
+        Err(e) => return Err(e),
+    };
+    let mut bytes = Vec::new();
+    file.take(16385).read_to_end(&mut bytes)?;
+    if bytes.len() > 16384 { return Err(io::Error::other("oversized session manifest")); }
+    let manifest: RegistryManifest = serde_json::from_slice(&bytes).map_err(io::Error::other)?;
+    if manifest.pid == 0 || manifest.creation_time == 0 || manifest.port == 0
+        || manifest.key.is_empty() || manifest.generation.is_empty() {
+        return Err(io::Error::other("invalid session manifest"));
+    }
+    Ok(Some(manifest))
+}
+
+/// Same-directory replace: readers see either the complete old file or the
+/// complete new file. In particular Windows rename must replace an existing
+/// destination without deleting it first.
+pub fn atomic_write(path: &Path, bytes: &[u8]) -> io::Result<()> {
+    static NEXT: AtomicU64 = AtomicU64::new(0);
+    let n = NEXT.fetch_add(1, Ordering::Relaxed);
+    let temp = path.with_extension(format!("tmp-{}-{}", std::process::id(), n));
+    // A leftover file may belong to an earlier process with the same PID. Do
+    // not remove it when create_new fails; cleanup is only for our own file.
+    let mut file = std::fs::OpenOptions::new().create_new(true).write(true).open(&temp)?;
+    let result = (|| {
+        file.write_all(bytes)?;
+        file.sync_all()?;
+        drop(file);
+        #[cfg(windows)]
+        {
+            use std::os::windows::ffi::OsStrExt;
+            let from: Vec<u16> = temp.as_os_str().encode_wide().chain(Some(0)).collect();
+            let to: Vec<u16> = path.as_os_str().encode_wide().chain(Some(0)).collect();
+            let ok = unsafe { windows_sys::Win32::Storage::FileSystem::MoveFileExW(
+                from.as_ptr(), to.as_ptr(),
+                windows_sys::Win32::Storage::FileSystem::MOVEFILE_REPLACE_EXISTING
+                    | windows_sys::Win32::Storage::FileSystem::MOVEFILE_WRITE_THROUGH,
+            ) };
+            if ok == 0 { return Err(io::Error::last_os_error()); }
+        }
+        #[cfg(not(windows))]
+        std::fs::rename(&temp, path)?;
+        Ok(())
+    })();
+    if result.is_err() { let _ = std::fs::remove_file(&temp); }
+    result
+}
+
+impl RegistryOwner {
+    pub fn current() -> io::Result<Self> {
+        let pid = std::process::id();
+        let creation_time = crate::platform::process_kill::process_creation_time(pid)
+            .filter(|t| *t != 0).ok_or_else(|| io::Error::other("cannot establish server process identity"))?;
+        let generation = format!("{}-{}-{}", pid, creation_time,
+            std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap_or_default().as_nanos());
+        Ok(Self { pid, creation_time, generation })
+    }
+
+    fn owns(&self, m: &RegistryManifest) -> bool {
+        self.pid == m.pid && self.creation_time == m.creation_time && self.generation == m.generation
+    }
+
+    pub fn publish(&self, base: &str, port: u16, key: &str, sid: u64) -> io::Result<()> {
+        self.publish_at(&PathBuf::from(crate::paths::psmux_dir()), base, port, key, sid)
+    }
+
+    fn publish_at(&self, dir: &Path, base: &str, port: u16, key: &str, sid: u64) -> io::Result<()> {
+        self.publish_at_with(dir, base, port, key, sid, atomic_write)
+    }
+
+    fn publish_at_with(&self, dir: &Path, base: &str, port: u16, key: &str, sid: u64,
+        mut write_record: impl FnMut(&Path, &[u8]) -> io::Result<()>) -> io::Result<()> {
+        std::fs::create_dir_all(dir)?;
+        let manifest = RegistryManifest { pid: self.pid, creation_time: self.creation_time,
+            generation: self.generation.clone(), port, key: key.to_string(), sid };
+        let mp = dir.join(format!("{}.registry.json", base));
+        if let Some(previous) = read_manifest_at(&mp)? {
+            if !self.owns(&previous)
+                && !crate::platform::process_kill::verified_process_dead(previous.pid, previous.creation_time) {
+                return Err(io::Error::new(io::ErrorKind::AlreadyExists, "session registry belongs to another server"));
+            }
+        }
+        if read_manifest_at(&mp)?.is_none() {
+            let pid_path = dir.join(format!("{}.pid", base));
+            match std::fs::read_to_string(pid_path) {
+                Ok(value) => {
+                    let Some((pid, Some(creation))) = crate::session::parse_pid_file_contents(&value) else {
+                        return Err(io::Error::new(io::ErrorKind::AlreadyExists, "legacy session identity is uncertain"));
+                    };
+                    if (pid != self.pid || creation != self.creation_time)
+                        && !crate::platform::process_kill::verified_process_dead(pid, creation) {
+                        return Err(io::Error::new(io::ErrorKind::AlreadyExists, "legacy session belongs to a live server"));
+                    }
+                }
+                Err(error) if error.kind() == io::ErrorKind::NotFound => {
+                    if dir.join(format!("{}.port", base)).exists() {
+                        return Err(io::Error::new(io::ErrorKind::AlreadyExists,
+                            "existing session endpoint has no verifiable process identity"));
+                    }
+                },
+                Err(error) => return Err(error),
+            }
+        }
+        // Snapshot first: a failed destination publication must leave the old
+        // records intact, including stale legacy records that are not ours.
+        let files = vec![
+            (dir.join(format!("{}.pid", base)), format!("{}:{}", self.pid, self.creation_time).into_bytes()),
+            (dir.join(format!("{}.key", base)), key.as_bytes().to_vec()),
+            (dir.join(format!("{}.sid", base)), sid.to_string().into_bytes()),
+            (mp, serde_json::to_vec(&manifest).map_err(io::Error::other)?),
+            (dir.join(format!("{}.port", base)), port.to_string().into_bytes()),
+        ];
+        let mut previous = Vec::new();
+        for (path, _) in &files {
+            previous.push(match std::fs::read(path) {
+                Ok(value) => Some(value),
+                Err(e) if e.kind() == io::ErrorKind::NotFound => None,
+                Err(e) => return Err(e),
+            });
+        }
+        for (i, (path, contents)) in files.iter().enumerate() {
+            if previous[i].as_deref() == Some(contents.as_slice()) { continue; }
+            if let Err(error) = write_record(path, contents) {
+                for j in (0..i).rev() {
+                    // Never roll back data that changed after our write.
+                    if std::fs::read(&files[j].0).ok().as_deref() != Some(files[j].1.as_slice()) { continue; }
+                    if let Some(old) = &previous[j] { let _ = atomic_write(&files[j].0, old); }
+                    else { let _ = std::fs::remove_file(&files[j].0); }
+                }
+                return Err(error);
+            }
+        }
+        Ok(())
+    }
+
+    pub fn remove_owned(&self, base: &str) -> io::Result<bool> {
+        self.remove_owned_at(&PathBuf::from(crate::paths::psmux_dir()), base)
+    }
+
+    fn remove_owned_at(&self, dir: &Path, base: &str) -> io::Result<bool> {
+        let mp = dir.join(format!("{}.registry.json", base));
+        let Some(m) = read_manifest_at(&mp)? else { return Ok(false); };
+        if !self.owns(&m) { return Ok(false); }
+        // An older binary may ignore the manifest. Do not delete records it
+        // replaced even when it left this generation's manifest behind.
+        let expected = [
+            ("port", m.port.to_string()), ("key", m.key),
+            ("sid", m.sid.to_string()), ("pid", format!("{}:{}", m.pid, m.creation_time)),
+        ];
+        for (extension, value) in &expected {
+            match std::fs::read_to_string(dir.join(format!("{}.{}", base, extension))) {
+                Ok(contents) if contents.trim() != value => return Ok(false),
+                Ok(_) => {},
+                Err(error) if error.kind() == io::ErrorKind::NotFound => {},
+                Err(error) => return Err(error),
+            }
+        }
+        // Remove readiness first. Failure here leaves the old name fully
+        // discoverable and allows a rename to roll its destination back.
+        match std::fs::remove_file(dir.join(format!("{}.port", base))) {
+            Ok(()) => {},
+            Err(e) if e.kind() == io::ErrorKind::NotFound => {},
+            Err(e) => return Err(e),
+        }
+        // New clients discover the coherent manifest itself. Remove it before
+        // treating cleanup as committed. If that fails, restore the legacy
+        // beacon so a rename can safely withdraw its tentative destination.
+        if let Err(error) = std::fs::remove_file(&mp) {
+            if error.kind() != io::ErrorKind::NotFound {
+                let _ = atomic_write(&dir.join(format!("{}.port", base)), m.port.to_string().as_bytes());
+                return Err(error);
+            }
+        }
+        // Satellites no longer advertise an endpoint; failures are harmless
+        // debris and cannot justify rolling back the successful rename.
+        for extension in ["key", "sid", "pid", "act"] {
+            match std::fs::remove_file(dir.join(format!("{}.{}", base, extension))) {
+                Ok(()) => {},
+                Err(e) if e.kind() == io::ErrorKind::NotFound => {},
+                Err(_) => {},
+            }
+        }
+        Ok(true)
+    }
+}
+
+/// Cleans startup/normal-return failures, but never reacts to an unrelated
+/// worker panic. Explicit process::exit sites also call remove_owned.
+pub struct RegistrationLease {
+    pub owner: RegistryOwner,
+    pub base: String,
+}
+impl Drop for RegistrationLease {
+    fn drop(&mut self) { let _ = self.owner.remove_owned(&self.base); }
+}
+
+#[cfg(test)]
+mod reliability_registry_tests {
+    use super::*;
+    fn temp() -> PathBuf {
+        let p = std::env::temp_dir().join(format!("psmux-registry-unit-{}-{}", std::process::id(),
+            std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_nanos()));
+        std::fs::create_dir_all(&p).unwrap(); p
+    }
+    fn owner(generation: &str) -> RegistryOwner { RegistryOwner { pid: std::process::id(),
+        creation_time: crate::platform::process_kill::process_creation_time(std::process::id()).unwrap(), generation: generation.into() } }
+    #[test]
+    fn ownership_prevents_old_generation_cleanup() {
+        let d = temp(); let first = owner("first"); let second = owner("second");
+        first.publish_at(&d, "s", 1234, "key", 1).unwrap();
+        assert!(!second.remove_owned_at(&d, "s").unwrap());
+        assert!(d.join("s.port").exists());
+        assert!(second.publish_at(&d, "s", 2345, "replacement", 2).is_err());
+        assert_eq!(read_manifest_at(&d.join("s.registry.json")).unwrap().unwrap().port, 1234);
+        assert!(first.remove_owned_at(&d, "s").unwrap()); std::fs::remove_dir_all(d).unwrap();
+    }
+    #[test]
+    fn failed_publication_rolls_back_only_written_records() {
+        let d = temp(); let o = owner("first");
+        std::fs::write(d.join("s.key"), b"old-key").unwrap();
+        std::fs::create_dir(d.join("s.port")).unwrap();
+        assert!(o.publish_at(&d, "s", 1234, "key", 1).is_err());
+        assert_eq!(std::fs::read(d.join("s.key")).unwrap(), b"old-key");
+        assert!(!d.join("s.pid").exists()); std::fs::remove_dir_all(d).unwrap();
+    }
+    #[test]
+    fn atomic_replace_never_truncates_existing_file() {
+        let d = temp(); let p = d.join("record");
+        atomic_write(&p, b"first").unwrap(); atomic_write(&p, b"second").unwrap();
+        assert_eq!(std::fs::read(&p).unwrap(), b"second"); std::fs::remove_dir_all(d).unwrap();
+    }
+    #[test]
+    fn late_write_failure_restores_entire_generation() {
+        let d = temp(); let o = owner("first");
+        o.publish_at(&d, "s", 1234, "old-key", 1).unwrap();
+        let result = o.publish_at_with(&d, "s", 2345, "new-key", 2, |path, data| {
+            if path.extension().and_then(|ext| ext.to_str()) == Some("port") {
+                Err(io::Error::other("injected beacon write failure"))
+            } else { atomic_write(path, data) }
+        });
+        assert!(result.is_err());
+        let m = read_manifest_at(&d.join("s.registry.json")).unwrap().unwrap();
+        assert_eq!((m.port, m.key.as_str(), m.sid), (1234, "old-key", 1));
+        assert_eq!(std::fs::read_to_string(d.join("s.key")).unwrap(), "old-key");
+        assert_eq!(std::fs::read_to_string(d.join("s.sid")).unwrap(), "1");
+        assert_eq!(std::fs::read_to_string(d.join("s.port")).unwrap(), "1234");
+        std::fs::remove_dir_all(d).unwrap();
+    }
+    #[test]
+    fn older_binary_replacement_is_not_removed() {
+        let d = temp(); let o = owner("first");
+        o.publish_at(&d, "s", 1234, "old-key", 1).unwrap();
+        std::fs::write(d.join("s.key"), "foreign-key").unwrap();
+        assert!(!o.remove_owned_at(&d, "s").unwrap());
+        assert!(d.join("s.port").exists());
+        std::fs::remove_dir_all(d).unwrap();
+    }
+    #[test]
+    fn unreadable_legacy_record_prevents_cleanup() {
+        let d = temp(); let o = owner("first");
+        o.publish_at(&d, "s", 1234, "key", 1).unwrap();
+        std::fs::remove_file(d.join("s.key")).unwrap();
+        std::fs::create_dir(d.join("s.key")).unwrap();
+        assert!(o.remove_owned_at(&d, "s").is_err());
+        assert!(d.join("s.port").exists());
+        assert!(d.join("s.registry.json").exists());
+        std::fs::remove_dir_all(d).unwrap();
+    }
+}

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -29,6 +29,22 @@ pub fn read_manifest(base: &str) -> io::Result<Option<RegistryManifest>> {
     read_manifest_at(&manifest_path(base))
 }
 
+/// Warm claims must run on a server with the current registration protocol.
+/// A legacy standby remains untouched; callers can cold-start the new binary.
+/// Named-session connections still use the legacy-compatible endpoint reader.
+pub fn read_warm_claim_endpoint(base: &str) -> io::Result<Option<(u16, String)>> {
+    read_warm_claim_endpoint_at(&manifest_path(base))
+}
+
+fn read_warm_claim_endpoint_at(path: &Path) -> io::Result<Option<(u16, String)>> {
+    let Some(manifest) = read_manifest_at(path)? else { return Ok(None); };
+    if crate::session::validate_auth_key(&manifest.key).is_none() {
+        return Err(io::Error::new(io::ErrorKind::InvalidData, "invalid warm session authentication key"));
+    }
+    // Read both endpoint fields from one generation, never legacy satellites.
+    Ok(Some((manifest.port, manifest.key)))
+}
+
 fn read_manifest_at(path: &Path) -> io::Result<Option<RegistryManifest>> {
     let file = match std::fs::File::open(path) {
         Ok(file) => file,
@@ -238,6 +254,46 @@ mod reliability_registry_tests {
     }
     fn owner(generation: &str) -> RegistryOwner { RegistryOwner { pid: std::process::id(),
         creation_time: crate::platform::process_kill::process_creation_time(std::process::id()).unwrap(), generation: generation.into() } }
+    #[test]
+    fn warm_claim_compatibility_preserves_legacy_standby() {
+        let d = temp();
+        let port = d.join("__warm__.port"); let key = d.join("__warm__.key");
+        std::fs::write(&port, "1234").unwrap();
+        std::fs::write(&key, "legacy-key").unwrap();
+        assert_eq!(read_warm_claim_endpoint_at(&d.join("__warm__.registry.json")).unwrap(), None);
+        assert_eq!(std::fs::read_to_string(port).unwrap(), "1234");
+        assert_eq!(std::fs::read_to_string(key).unwrap(), "legacy-key");
+        std::fs::remove_dir_all(d).unwrap();
+    }
+    #[test]
+    fn warm_claim_compatibility_accepts_matching_manifest() {
+        let d = temp(); let o = owner("warm-generation");
+        o.publish_at(&d, "__warm__", 2345, "manifest-key", 1).unwrap();
+        assert_eq!(read_warm_claim_endpoint_at(&d.join("__warm__.registry.json")).unwrap(),
+            Some((2345, "manifest-key".into())));
+        std::fs::remove_dir_all(d).unwrap();
+    }
+    #[test]
+    fn warm_claim_compatibility_uses_one_generation() {
+        let d = temp(); let o = owner("warm-generation");
+        o.publish_at(&d, "__warm__", 2345, "manifest-key", 1).unwrap();
+        std::fs::write(d.join("__warm__.port"), "3456").unwrap();
+        std::fs::write(d.join("__warm__.key"), "other-generation").unwrap();
+        assert_eq!(read_warm_claim_endpoint_at(&d.join("__warm__.registry.json")).unwrap(),
+            Some((2345, "manifest-key".into())));
+        std::fs::remove_dir_all(d).unwrap();
+    }
+    #[test]
+    fn warm_claim_compatibility_rejects_invalid_manifest() {
+        let d = temp(); let path = d.join("__warm__.registry.json");
+        std::fs::write(&path, b"{\"pid\":").unwrap();
+        assert!(read_warm_claim_endpoint_at(&path).is_err());
+        let manifest = RegistryManifest { pid: 1, creation_time: 1, generation: "generation".into(),
+            port: 1234, key: "invalid\nkey".into(), sid: 1 };
+        std::fs::write(&path, serde_json::to_vec(&manifest).unwrap()).unwrap();
+        assert!(read_warm_claim_endpoint_at(&path).is_err());
+        std::fs::remove_dir_all(d).unwrap();
+    }
     #[test]
     fn ownership_prevents_old_generation_cleanup() {
         let d = temp(); let first = owner("first"); let second = owner("second");

--- a/src/request_queue.rs
+++ b/src/request_queue.rs
@@ -1,0 +1,340 @@
+//! Nonblocking admission with both count and allocated-byte limits. A full
+//! queue is a rejected command, never an invitation to block the server loop.
+use std::sync::{Arc, atomic::{AtomicUsize, Ordering}, mpsc};
+use std::time::Duration;
+use super::{CtrlReq, LayoutKind, Menu, MenuItem, WaitForOp, WindowDumpFormat};
+
+const MAX_REQUESTS: usize = 256;
+const MAX_BYTES: usize = 4 * 1024 * 1024;
+const MAX_REQUEST_BYTES: usize = 1024 * 1024;
+
+impl CtrlReq {
+    pub fn queued_bytes(&self) -> usize { std::mem::size_of::<Self>().saturating_add(self.heap_bytes()) }
+}
+
+struct Envelope {
+    request: Option<CtrlReq>,
+    bytes: usize,
+    budget: Arc<AtomicUsize>,
+}
+impl Drop for Envelope {
+    fn drop(&mut self) { self.budget.fetch_sub(self.bytes, Ordering::AcqRel); }
+}
+
+#[derive(Clone)]
+pub struct ControlSender { tx: mpsc::SyncSender<Envelope>, budget: Arc<AtomicUsize> }
+pub struct ControlReceiver { rx: mpsc::Receiver<Envelope> }
+
+pub fn control_channel() -> (ControlSender, ControlReceiver) {
+    let (tx, rx) = mpsc::sync_channel(MAX_REQUESTS);
+    let budget = Arc::new(AtomicUsize::new(0));
+    (ControlSender { tx, budget }, ControlReceiver { rx })
+}
+
+impl ControlSender {
+    pub fn send(&self, request: CtrlReq) -> Result<(), mpsc::SendError<CtrlReq>> {
+        let bytes = request.queued_bytes();
+        if bytes > MAX_REQUEST_BYTES || self.budget.fetch_update(Ordering::AcqRel, Ordering::Acquire,
+            |used| used.checked_add(bytes).filter(|total| *total <= MAX_BYTES)).is_err() {
+            return Err(mpsc::SendError(request));
+        }
+        let envelope = Envelope { request: Some(request), bytes, budget: self.budget.clone() };
+        self.tx.try_send(envelope).map_err(|error| {
+            let mut envelope = match error { mpsc::TrySendError::Full(e) | mpsc::TrySendError::Disconnected(e) => e };
+            mpsc::SendError(envelope.request.take().unwrap())
+        })
+    }
+}
+
+impl ControlReceiver {
+    pub fn try_recv(&self) -> Result<CtrlReq, mpsc::TryRecvError> {
+        self.rx.try_recv().map(|mut envelope| envelope.request.take().unwrap())
+    }
+    pub fn recv_timeout(&self, timeout: Duration) -> Result<CtrlReq, mpsc::RecvTimeoutError> {
+        self.rx.recv_timeout(timeout).map(|mut envelope| envelope.request.take().unwrap())
+    }
+    pub fn recv(&self) -> Result<CtrlReq, mpsc::RecvError> {
+        self.rx.recv().map(|mut envelope| envelope.request.take().unwrap())
+    }
+}
+
+trait HeapBytes { fn heap_bytes(&self) -> usize; }
+impl HeapBytes for String { fn heap_bytes(&self) -> usize { self.capacity() } }
+impl<T: HeapBytes> HeapBytes for Vec<T> {
+    fn heap_bytes(&self) -> usize { self.capacity().saturating_mul(std::mem::size_of::<T>())
+        .saturating_add(self.iter().map(HeapBytes::heap_bytes).sum::<usize>()) }
+}
+impl<T: HeapBytes> HeapBytes for Option<T> { fn heap_bytes(&self) -> usize { self.as_ref().map_or(0, HeapBytes::heap_bytes) } }
+impl<T: HeapBytes> HeapBytes for Box<T> { fn heap_bytes(&self) -> usize { std::mem::size_of::<T>() + (**self).heap_bytes() } }
+impl<A: HeapBytes, B: HeapBytes> HeapBytes for (A, B) { fn heap_bytes(&self) -> usize { self.0.heap_bytes() + self.1.heap_bytes() } }
+impl<T> HeapBytes for mpsc::Sender<T> { fn heap_bytes(&self) -> usize { 0 } }
+impl<T> HeapBytes for mpsc::SyncSender<T> { fn heap_bytes(&self) -> usize { 0 } }
+macro_rules! no_heap { ($($t:ty),*) => { $(impl HeapBytes for $t { fn heap_bytes(&self) -> usize { 0 } })* }; }
+no_heap!(bool, u8, u16, u32, u64, usize, i16, i32, char, LayoutKind, WaitForOp, WindowDumpFormat);
+impl HeapBytes for MenuItem { fn heap_bytes(&self) -> usize { self.name.heap_bytes() + self.command.heap_bytes() } }
+impl HeapBytes for Menu { fn heap_bytes(&self) -> usize { self.title.heap_bytes() + self.items.heap_bytes() } }
+impl HeapBytes for crate::resize_window::ResizeWindowRequest {
+    fn heap_bytes(&self) -> usize {
+        if let crate::resize_window::WindowTarget::Name(name) = &self.target { name.heap_bytes() } else { 0 }
+    }
+}
+
+// Exhaustive per-variant accounting is below: adding a request with owned
+// payload must update its admission accounting at compile time.
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn full_queue_rejects_without_waiting_and_preserves_fifo() {
+        let (tx, rx) = control_channel();
+        for i in 0..MAX_REQUESTS { assert!(tx.send(CtrlReq::FocusWindow(i)).is_ok()); }
+        assert!(tx.send(CtrlReq::FocusWindow(999)).is_err());
+        for i in 0..MAX_REQUESTS {
+            assert!(matches!(rx.try_recv(), Ok(CtrlReq::FocusWindow(value)) if value == i));
+        }
+        assert_eq!(tx.budget.load(Ordering::Acquire), 0);
+        assert!(tx.send(CtrlReq::KillPane).is_ok());
+    }
+
+    #[test]
+    fn allocated_capacity_and_wrapped_payload_share_byte_limit() {
+        let (tx, rx) = control_channel();
+        let oversized = String::with_capacity(MAX_REQUEST_BYTES + 1);
+        assert!(tx.send(CtrlReq::SendText(oversized)).is_err());
+        assert_eq!(tx.budget.load(Ordering::Acquire), 0);
+        let mut count = 0;
+        loop {
+            let (ack, _) = mpsc::channel();
+            let req = CtrlReq::CommandRequest(Box::new(CtrlReq::SendText("x".repeat(700_000))), ack);
+            if tx.send(req).is_err() { break; }
+            count += 1;
+        }
+        assert!(count > 1 && count < 8);
+        assert!(tx.budget.load(Ordering::Acquire) <= MAX_BYTES);
+        drop(rx);
+        assert_eq!(tx.budget.load(Ordering::Acquire), 0);
+        assert!(tx.send(CtrlReq::KillPane).is_err());
+        assert_eq!(tx.budget.load(Ordering::Acquire), 0);
+    }
+}
+
+impl HeapBytes for CtrlReq {
+    fn heap_bytes(&self) -> usize {
+        match self {
+            CtrlReq::CommandRequest(v0, v1) => v0.heap_bytes() + v1.heap_bytes(),
+            CtrlReq::NewWindow(v0, v1, v2, v3, v4, v5, v6) => v0.heap_bytes() + v1.heap_bytes() + v2.heap_bytes() + v3.heap_bytes() + v4.heap_bytes() + v5.heap_bytes() + v6.heap_bytes(),
+            CtrlReq::NewWindowPrint(v0, v1, v2, v3, v4, v5, v6, v7, v8) => v0.heap_bytes() + v1.heap_bytes() + v2.heap_bytes() + v3.heap_bytes() + v4.heap_bytes() + v5.heap_bytes() + v6.heap_bytes() + v7.heap_bytes() + v8.heap_bytes(),
+            CtrlReq::SplitWindow(v0, v1, v2, v3, v4, v5, v6, v7, v8) => v0.heap_bytes() + v1.heap_bytes() + v2.heap_bytes() + v3.heap_bytes() + v4.heap_bytes() + v5.heap_bytes() + v6.heap_bytes() + v7.heap_bytes() + v8.heap_bytes(),
+            CtrlReq::SplitWindowPrint(v0, v1, v2, v3, v4, v5, v6, v7, v8, v9) => v0.heap_bytes() + v1.heap_bytes() + v2.heap_bytes() + v3.heap_bytes() + v4.heap_bytes() + v5.heap_bytes() + v6.heap_bytes() + v7.heap_bytes() + v8.heap_bytes() + v9.heap_bytes(),
+            CtrlReq::NewFloat { command, x, y, w, h, border, title, start_dir, detached, empty, resp } => command.heap_bytes() + x.heap_bytes() + y.heap_bytes() + w.heap_bytes() + h.heap_bytes() + border.heap_bytes() + title.heap_bytes() + start_dir.heap_bytes() + detached.heap_bytes() + empty.heap_bytes() + resp.heap_bytes(),
+            CtrlReq::KillPane => 0,
+            CtrlReq::KillPaneById(v0) => v0.heap_bytes(),
+            CtrlReq::CapturePane(v0, v1, v2) => v0.heap_bytes() + v1.heap_bytes() + v2.heap_bytes(),
+            CtrlReq::CapturePaneStyled(v0, v1, v2, v3, v4) => v0.heap_bytes() + v1.heap_bytes() + v2.heap_bytes() + v3.heap_bytes() + v4.heap_bytes(),
+            CtrlReq::FocusWindow(v0) => v0.heap_bytes(),
+            CtrlReq::FocusWindowById(v0) => v0.heap_bytes(),
+            CtrlReq::FocusWindowByName(v0) => v0.heap_bytes(),
+            CtrlReq::FocusPane(v0) => v0.heap_bytes(),
+            CtrlReq::FocusPaneByIndex(v0) => v0.heap_bytes(),
+            CtrlReq::FocusTargetTemp { win, win_is_id, win_name, pane, pane_is_id, resp } => win.heap_bytes() + win_is_id.heap_bytes() + win_name.heap_bytes() + pane.heap_bytes() + pane_is_id.heap_bytes() + resp.heap_bytes(),
+            CtrlReq::SessionInfo(v0) => v0.heap_bytes(),
+            CtrlReq::SessionInfoFormat(v0, v1) => v0.heap_bytes() + v1.heap_bytes(),
+            CtrlReq::CapturePaneRange(v0, v1, v2, v3, v4) => v0.heap_bytes() + v1.heap_bytes() + v2.heap_bytes() + v3.heap_bytes() + v4.heap_bytes(),
+            CtrlReq::ClientAttach(v0) => v0.heap_bytes(),
+            CtrlReq::ClientDetach(v0) => v0.heap_bytes(),
+            CtrlReq::DumpLayout(v0) => v0.heap_bytes(),
+            CtrlReq::DumpState(v0, v1, v2) => v0.heap_bytes() + v1.heap_bytes() + v2.heap_bytes(),
+            CtrlReq::SendText(v0) => v0.heap_bytes(),
+            CtrlReq::SendKey(v0) => v0.heap_bytes(),
+            CtrlReq::SendPaste(v0) => v0.heap_bytes(),
+            CtrlReq::ZoomPane => 0,
+            CtrlReq::PrefixBegin => 0,
+            CtrlReq::PrefixEnd => 0,
+            CtrlReq::CopyEnter => 0,
+            CtrlReq::CopyEnterPageUp => 0,
+            CtrlReq::CopyMove(v0, v1) => v0.heap_bytes() + v1.heap_bytes(),
+            CtrlReq::CopyAnchor => 0,
+            CtrlReq::CopyYank => 0,
+            CtrlReq::CopyRectToggle => 0,
+            CtrlReq::ClientSize(v0, v1, v2) => v0.heap_bytes() + v1.heap_bytes() + v2.heap_bytes(),
+            CtrlReq::HostColors(v0) => v0.heap_bytes(),
+            CtrlReq::FocusPaneCmd(v0) => v0.heap_bytes(),
+            CtrlReq::FocusWindowCmd(v0) => v0.heap_bytes(),
+            CtrlReq::MouseDown(v0, v1, v2) => v0.heap_bytes() + v1.heap_bytes() + v2.heap_bytes(),
+            CtrlReq::MouseDownRight(v0, v1, v2) => v0.heap_bytes() + v1.heap_bytes() + v2.heap_bytes(),
+            CtrlReq::MouseDownMiddle(v0, v1, v2) => v0.heap_bytes() + v1.heap_bytes() + v2.heap_bytes(),
+            CtrlReq::MouseDrag(v0, v1, v2) => v0.heap_bytes() + v1.heap_bytes() + v2.heap_bytes(),
+            CtrlReq::MouseUp(v0, v1, v2) => v0.heap_bytes() + v1.heap_bytes() + v2.heap_bytes(),
+            CtrlReq::MouseUpRight(v0, v1, v2) => v0.heap_bytes() + v1.heap_bytes() + v2.heap_bytes(),
+            CtrlReq::MouseUpMiddle(v0, v1, v2) => v0.heap_bytes() + v1.heap_bytes() + v2.heap_bytes(),
+            CtrlReq::MouseMove(v0, v1, v2) => v0.heap_bytes() + v1.heap_bytes() + v2.heap_bytes(),
+            CtrlReq::ScrollUp(v0, v1, v2) => v0.heap_bytes() + v1.heap_bytes() + v2.heap_bytes(),
+            CtrlReq::ScrollDown(v0, v1, v2) => v0.heap_bytes() + v1.heap_bytes() + v2.heap_bytes(),
+            CtrlReq::PaneMouse(v0, v1, v2, v3, v4, v5) => v0.heap_bytes() + v1.heap_bytes() + v2.heap_bytes() + v3.heap_bytes() + v4.heap_bytes() + v5.heap_bytes(),
+            CtrlReq::PaneScroll(v0, v1, v2, v3) => v0.heap_bytes() + v1.heap_bytes() + v2.heap_bytes() + v3.heap_bytes(),
+            CtrlReq::CopyDragBegin(v0, v1, v2, v3, v4, v5, v6) => v0.heap_bytes() + v1.heap_bytes() + v2.heap_bytes() + v3.heap_bytes() + v4.heap_bytes() + v5.heap_bytes() + v6.heap_bytes(),
+            CtrlReq::SplitSetSizes(v0, v1, v2) => v0.heap_bytes() + v1.heap_bytes() + v2.heap_bytes(),
+            CtrlReq::SplitResizeDone(v0) => v0.heap_bytes(),
+            CtrlReq::NextWindow => 0,
+            CtrlReq::PrevWindow => 0,
+            CtrlReq::RenameWindow(v0) => v0.heap_bytes(),
+            CtrlReq::ListWindows(v0) => v0.heap_bytes(),
+            CtrlReq::ListWindowsTmux(v0) => v0.heap_bytes(),
+            CtrlReq::ListWindowsFormat(v0, v1) => v0.heap_bytes() + v1.heap_bytes(),
+            CtrlReq::ListTree(v0) => v0.heap_bytes(),
+            CtrlReq::WindowLayout(v0, v1) => v0.heap_bytes() + v1.heap_bytes(),
+            CtrlReq::WindowDump(v0, v1, v2) => v0.heap_bytes() + v1.heap_bytes() + v2.heap_bytes(),
+            CtrlReq::ToggleSync => 0,
+            CtrlReq::SetPaneTitle(v0) => v0.heap_bytes(),
+            CtrlReq::SetPaneStyle(v0) => v0.heap_bytes(),
+            CtrlReq::SetPaneAttrs { title, style } => title.heap_bytes() + style.heap_bytes(),
+            CtrlReq::SendKeys(v0, v1) => v0.heap_bytes() + v1.heap_bytes(),
+            CtrlReq::SendBytes(v0) => v0.heap_bytes(),
+            CtrlReq::SendKeysX(v0) => v0.heap_bytes(),
+            CtrlReq::SelectPane(v0, v1) => v0.heap_bytes() + v1.heap_bytes(),
+            CtrlReq::SelectWindow(v0) => v0.heap_bytes(),
+            CtrlReq::ListPanes(v0) => v0.heap_bytes(),
+            CtrlReq::ListPanesFormat(v0, v1) => v0.heap_bytes() + v1.heap_bytes(),
+            CtrlReq::ListAllPanes(v0) => v0.heap_bytes(),
+            CtrlReq::ListAllPanesFormat(v0, v1) => v0.heap_bytes() + v1.heap_bytes(),
+            CtrlReq::KillWindow => 0,
+            CtrlReq::KillWindowTarget { win, win_is_id, name, resp } => win.heap_bytes() + win_is_id.heap_bytes() + name.heap_bytes() + resp.heap_bytes(),
+            CtrlReq::KillSession => 0,
+            CtrlReq::HasSession(v0) => v0.heap_bytes(),
+            CtrlReq::RenameSession(v0) => v0.heap_bytes(),
+            CtrlReq::ClaimSession(v0, v1, v2, v3) => v0.heap_bytes() + v1.heap_bytes() + v2.heap_bytes() + v3.heap_bytes(),
+            CtrlReq::SwapPane(v0) => v0.heap_bytes(),
+            CtrlReq::SwapPaneTarget(v0, v1) => v0.heap_bytes() + v1.heap_bytes(),
+            CtrlReq::SwapPaneSrcDst { src, src_is_id, dst, dst_is_id, detach } => src.heap_bytes() + src_is_id.heap_bytes() + dst.heap_bytes() + dst_is_id.heap_bytes() + detach.heap_bytes(),
+            CtrlReq::SwapPanePosition(v0) => v0.heap_bytes(),
+            CtrlReq::ResizePane(v0, v1) => v0.heap_bytes() + v1.heap_bytes(),
+            CtrlReq::SetBuffer(v0) => v0.heap_bytes(),
+            CtrlReq::SetNamedBuffer(v0, v1) => v0.heap_bytes() + v1.heap_bytes(),
+            CtrlReq::ListBuffers(v0) => v0.heap_bytes(),
+            CtrlReq::ListBuffersFormat(v0, v1) => v0.heap_bytes() + v1.heap_bytes(),
+            CtrlReq::ShowBuffer(v0) => v0.heap_bytes(),
+            CtrlReq::ShowBufferAt(v0, v1) => v0.heap_bytes() + v1.heap_bytes(),
+            CtrlReq::ShowNamedBuffer(v0, v1) => v0.heap_bytes() + v1.heap_bytes(),
+            CtrlReq::DeleteBuffer => 0,
+            CtrlReq::DeleteBufferAt(v0) => v0.heap_bytes(),
+            CtrlReq::DeleteNamedBuffer(v0) => v0.heap_bytes(),
+            CtrlReq::PasteBufferAt(v0) => v0.heap_bytes(),
+            CtrlReq::DisplayMessage(v0, v1, v2, v3, v4) => v0.heap_bytes() + v1.heap_bytes() + v2.heap_bytes() + v3.heap_bytes() + v4.heap_bytes(),
+            CtrlReq::DisplayMessageById(v0, v1, v2, v3, v4) => v0.heap_bytes() + v1.heap_bytes() + v2.heap_bytes() + v3.heap_bytes() + v4.heap_bytes(),
+            CtrlReq::LastWindow => 0,
+            CtrlReq::LastPane => 0,
+            CtrlReq::RotateWindow(v0) => v0.heap_bytes(),
+            CtrlReq::DisplayPanes => 0,
+            CtrlReq::DisplayPaneSelect(v0) => v0.heap_bytes(),
+            CtrlReq::BreakPane => 0,
+            CtrlReq::JoinPane { src_win, src_pane, target_win, target_pane, horizontal } => src_win.heap_bytes() + src_pane.heap_bytes() + target_win.heap_bytes() + target_pane.heap_bytes() + horizontal.heap_bytes(),
+            CtrlReq::RespawnPane(v0, v1, v2, v3) => v0.heap_bytes() + v1.heap_bytes() + v2.heap_bytes() + v3.heap_bytes(),
+            CtrlReq::SetPaneOption(v0, v1, v2, v3) => v0.heap_bytes() + v1.heap_bytes() + v2.heap_bytes() + v3.heap_bytes(),
+            CtrlReq::ShowPaneOptions(v0, v1) => v0.heap_bytes() + v1.heap_bytes(),
+            CtrlReq::BindKey(v0, v1, v2, v3) => v0.heap_bytes() + v1.heap_bytes() + v2.heap_bytes() + v3.heap_bytes(),
+            CtrlReq::UnbindKey(v0, v1) => v0.heap_bytes() + v1.heap_bytes(),
+            CtrlReq::UnbindAll => 0,
+            CtrlReq::UnbindAllInTable(v0) => v0.heap_bytes(),
+            CtrlReq::ListKeys(v0) => v0.heap_bytes(),
+            CtrlReq::SetOption(v0, v1) => v0.heap_bytes() + v1.heap_bytes(),
+            CtrlReq::SetOptionQuiet(v0, v1, v2) => v0.heap_bytes() + v1.heap_bytes() + v2.heap_bytes(),
+            CtrlReq::SetOptionUnset(v0) => v0.heap_bytes(),
+            CtrlReq::SetOptionAppend(v0, v1) => v0.heap_bytes() + v1.heap_bytes(),
+            CtrlReq::SetOptionOnlyIfUnset(v0, v1, v2) => v0.heap_bytes() + v1.heap_bytes() + v2.heap_bytes(),
+            CtrlReq::SetOptionToggle(v0) => v0.heap_bytes(),
+            CtrlReq::SetWindowSize(v0) => v0.heap_bytes(),
+            CtrlReq::ShowOptions(v0) => v0.heap_bytes(),
+            CtrlReq::ShowWindowOptions(v0) => v0.heap_bytes(),
+            CtrlReq::SourceFile(v0) => v0.heap_bytes(),
+            CtrlReq::ExpandFormat(v0, v1) => v0.heap_bytes() + v1.heap_bytes(),
+            CtrlReq::MoveWindow { src, dst, detach, kill, renumber, after, before, resp } => src.heap_bytes() + dst.heap_bytes() + detach.heap_bytes() + kill.heap_bytes() + renumber.heap_bytes() + after.heap_bytes() + before.heap_bytes() + resp.heap_bytes(),
+            CtrlReq::SwapWindow { src, dst, detach, resp } => src.heap_bytes() + dst.heap_bytes() + detach.heap_bytes() + resp.heap_bytes(),
+            CtrlReq::LinkWindow(v0, v1) => v0.heap_bytes() + v1.heap_bytes(),
+            CtrlReq::UnlinkWindow => 0,
+            CtrlReq::SetSessionGroup(v0) => v0.heap_bytes(),
+            CtrlReq::FindWindow(v0, v1) => v0.heap_bytes() + v1.heap_bytes(),
+            CtrlReq::MovePane { src_win, src_pane, target_win, target_pane, horizontal } => src_win.heap_bytes() + src_pane.heap_bytes() + target_win.heap_bytes() + target_pane.heap_bytes() + horizontal.heap_bytes(),
+            CtrlReq::PaneForwardExtract(v0, v1, v2) => v0.heap_bytes() + v1.heap_bytes() + v2.heap_bytes(),
+            CtrlReq::PaneForwardInject { source_session, source_addr, source_key, forward_id, fwd_port, pid, title, rows, cols, screen_b64, target_win, target_pane, horizontal } => source_session.heap_bytes() + source_addr.heap_bytes() + source_key.heap_bytes() + forward_id.heap_bytes() + fwd_port.heap_bytes() + pid.heap_bytes() + title.heap_bytes() + rows.heap_bytes() + cols.heap_bytes() + screen_b64.heap_bytes() + target_win.heap_bytes() + target_pane.heap_bytes() + horizontal.heap_bytes(),
+            CtrlReq::PaneForwardResize(v0, v1, v2) => v0.heap_bytes() + v1.heap_bytes() + v2.heap_bytes(),
+            CtrlReq::PaneForwardStatus(v0, v1) => v0.heap_bytes() + v1.heap_bytes(),
+            CtrlReq::PaneForwardKill(v0) => v0.heap_bytes(),
+            CtrlReq::PipePane(v0, v1, v2, v3, v4) => v0.heap_bytes() + v1.heap_bytes() + v2.heap_bytes() + v3.heap_bytes() + v4.heap_bytes(),
+            CtrlReq::SelectLayout(v0) => v0.heap_bytes(),
+            CtrlReq::NextLayout => 0,
+            CtrlReq::ListClients(v0) => v0.heap_bytes(),
+            CtrlReq::ListClientsFormat(v0, v1) => v0.heap_bytes() + v1.heap_bytes(),
+            CtrlReq::ForceDetachClient(v0) => v0.heap_bytes(),
+            CtrlReq::ForceDetachClientByTty(v0, v1) => v0.heap_bytes() + v1.heap_bytes(),
+            CtrlReq::DetachAllOtherClients(v0, v1) => v0.heap_bytes() + v1.heap_bytes(),
+            CtrlReq::DetachAllClients(v0) => v0.heap_bytes(),
+            CtrlReq::SetClientLastSession(v0, v1) => v0.heap_bytes() + v1.heap_bytes(),
+            CtrlReq::SwitchClient(v0, v1, v2) => v0.heap_bytes() + v1.heap_bytes() + v2.heap_bytes(),
+            CtrlReq::SwitchClientTarget(v0, v1) => v0.heap_bytes() + v1.heap_bytes(),
+            CtrlReq::LockClient => 0,
+            CtrlReq::RefreshClient => 0,
+            CtrlReq::ControlSubscribe { client_id, name, target, format } => client_id.heap_bytes() + name.heap_bytes() + target.heap_bytes() + format.heap_bytes(),
+            CtrlReq::ControlUnsubscribe { client_id, name } => client_id.heap_bytes() + name.heap_bytes(),
+            CtrlReq::ControlSetPauseAfter { client_id, pause_after_secs } => client_id.heap_bytes() + pause_after_secs.heap_bytes(),
+            CtrlReq::ControlContinuePane { client_id, pane_id } => client_id.heap_bytes() + pane_id.heap_bytes(),
+            CtrlReq::SuspendClient => 0,
+            CtrlReq::CopyModePageUp => 0,
+            CtrlReq::ClearHistory => 0,
+            CtrlReq::SaveBuffer(v0) => v0.heap_bytes(),
+            CtrlReq::LoadBuffer(v0) => v0.heap_bytes(),
+            CtrlReq::SetEnvironment(v0, v1) => v0.heap_bytes() + v1.heap_bytes(),
+            CtrlReq::UnsetEnvironment(v0) => v0.heap_bytes(),
+            CtrlReq::ShowEnvironment(v0) => v0.heap_bytes(),
+            CtrlReq::SetHook(v0, v1) => v0.heap_bytes() + v1.heap_bytes(),
+            CtrlReq::AppendHook(v0, v1) => v0.heap_bytes() + v1.heap_bytes(),
+            CtrlReq::ShowHooks(v0) => v0.heap_bytes(),
+            CtrlReq::RemoveHook(v0) => v0.heap_bytes(),
+            CtrlReq::KillServer => 0,
+            CtrlReq::WaitFor(v0, v1) => v0.heap_bytes() + v1.heap_bytes(),
+            CtrlReq::DisplayMenu(v0, v1, v2) => v0.heap_bytes() + v1.heap_bytes() + v2.heap_bytes(),
+            CtrlReq::DisplayMenuDirect(v0) => v0.heap_bytes(),
+            CtrlReq::DisplayPopup(v0, v1, v2, v3, v4) => v0.heap_bytes() + v1.heap_bytes() + v2.heap_bytes() + v3.heap_bytes() + v4.heap_bytes(),
+            CtrlReq::ConfirmBefore(v0, v1) => v0.heap_bytes() + v1.heap_bytes(),
+            CtrlReq::ClockMode => 0,
+            CtrlReq::ResizePaneAbsolute(v0, v1) => v0.heap_bytes() + v1.heap_bytes(),
+            CtrlReq::ResizePanePercent(v0, v1) => v0.heap_bytes() + v1.heap_bytes(),
+            CtrlReq::ShowOptionValue(v0, v1) => v0.heap_bytes() + v1.heap_bytes(),
+            CtrlReq::ShowWindowOptionValue(v0, v1, v2) => v0.heap_bytes() + v1.heap_bytes() + v2.heap_bytes(),
+            CtrlReq::ChooseBuffer(v0) => v0.heap_bytes(),
+            CtrlReq::ServerInfo(v0) => v0.heap_bytes(),
+            CtrlReq::SendPrefix => 0,
+            CtrlReq::PrevLayout => 0,
+            CtrlReq::SwitchClientTable(v0) => v0.heap_bytes(),
+            CtrlReq::ListCommands(v0) => v0.heap_bytes(),
+            CtrlReq::ResizeWindow(v0, v1) => v0.heap_bytes() + v1.heap_bytes(),
+            CtrlReq::ControlClientResize { client_id, window_id, size } => client_id.heap_bytes() + window_id.heap_bytes() + size.heap_bytes(),
+            CtrlReq::RespawnWindow(v0, v1, v2) => v0.heap_bytes() + v1.heap_bytes() + v2.heap_bytes(),
+            CtrlReq::FocusIn => 0,
+            CtrlReq::FocusOut => 0,
+            CtrlReq::CommandPrompt(v0) => v0.heap_bytes(),
+            CtrlReq::ShowMessages(v0) => v0.heap_bytes(),
+            CtrlReq::PopupInput(v0) => v0.heap_bytes(),
+            CtrlReq::OverlayClose => 0,
+            CtrlReq::ConfirmRespond(v0) => v0.heap_bytes(),
+            CtrlReq::MenuSelect(v0) => v0.heap_bytes(),
+            CtrlReq::MenuNavigate(v0) => v0.heap_bytes(),
+            CtrlReq::ShowTextPopup(v0, v1) => v0.heap_bytes() + v1.heap_bytes(),
+            CtrlReq::StatusMessage(v0) => v0.heap_bytes(),
+            CtrlReq::ClearPromptHistory => 0,
+            CtrlReq::ShowPromptHistory(v0) => v0.heap_bytes(),
+            CtrlReq::ControlRegister { client_id, echo, notif_tx } => client_id.heap_bytes() + echo.heap_bytes() + notif_tx.heap_bytes(),
+            CtrlReq::ControlDeregister { client_id } => client_id.heap_bytes(),
+            CtrlReq::CustomizeMode => 0,
+            CtrlReq::CustomizeNavigate(v0) => v0.heap_bytes(),
+            CtrlReq::CustomizeEdit => 0,
+            CtrlReq::CustomizeEditUpdate(v0) => v0.heap_bytes(),
+            CtrlReq::CustomizeEditConfirm => 0,
+            CtrlReq::CustomizeEditCancel => 0,
+            CtrlReq::CustomizeResetDefault => 0,
+            CtrlReq::CustomizeFilter(v0) => v0.heap_bytes(),
+            CtrlReq::RunCommand(v0, v1) => v0.heap_bytes() + v1.heap_bytes(),
+        }
+    }
+}

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -7,6 +7,366 @@ use crate::types::{
     ControlNotification, CtrlReq, LayoutKind, WaitForOp, WindowDumpFormat,
 };
 
+const MAX_WIRE_LINE: usize = 1024 * 1024;
+
+const MAX_CONNECTIONS: usize = 128;
+static CONNECTIONS: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+pub(super) struct ConnectionPermit;
+impl ConnectionPermit {
+    pub(super) fn acquire() -> Option<Self> {
+        use std::sync::atomic::Ordering;
+        CONNECTIONS.fetch_update(Ordering::AcqRel, Ordering::Acquire,
+            |count| (count < MAX_CONNECTIONS).then_some(count + 1)).ok().map(|_| Self)
+    }
+}
+impl Drop for ConnectionPermit {
+    fn drop(&mut self) { CONNECTIONS.fetch_sub(1, std::sync::atomic::Ordering::AcqRel); }
+}
+
+/// Retain fragmented commands across socket timeouts without exposing a
+/// partial command to the dispatcher. Bound allocation before copying bytes.
+struct BoundedLines<R: io::Read> {
+    reader: io::BufReader<R>,
+    pending: Vec<u8>,
+    started: Option<std::time::Instant>,
+}
+impl<R: io::Read> BoundedLines<R> {
+    fn new(reader: R) -> Self { Self { reader: io::BufReader::new(reader), pending: Vec::new(), started: None } }
+    fn get_ref(&self) -> &R { self.reader.get_ref() }
+    fn read_line(&mut self, output: &mut String) -> io::Result<usize> {
+        loop {
+            if self.started.is_some_and(|start| start.elapsed() > Duration::from_secs(10)) {
+                return Err(io::Error::new(io::ErrorKind::InvalidData, "incomplete command exceeded deadline"));
+            }
+            let available = self.reader.fill_buf()?;
+            if available.is_empty() {
+                return if self.pending.is_empty() { Ok(0) } else {
+                    Err(io::Error::new(io::ErrorKind::UnexpectedEof, "incomplete command"))
+                };
+            }
+            let newline = available.iter().position(|b| *b == b'\n');
+            let count = newline.map_or(available.len(), |i| i + 1);
+            if self.pending.len().saturating_add(count) > MAX_WIRE_LINE {
+                return Err(io::Error::new(io::ErrorKind::InvalidData, "command exceeds 1 MiB limit"));
+            }
+            self.started.get_or_insert_with(std::time::Instant::now);
+            self.pending.extend_from_slice(&available[..count]);
+            self.reader.consume(count);
+            if newline.is_some() {
+                let line = std::str::from_utf8(&self.pending)
+                    .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "command is not UTF-8"))?;
+                output.push_str(line);
+                let count = self.pending.len();
+                self.pending.clear();
+                self.started = None;
+                return Ok(count);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod bounded_wire_tests {
+    use super::*;
+
+    #[test]
+    fn connection_admission_is_bounded_and_reusable() {
+        let mut permits = Vec::new();
+        for _ in 0..MAX_CONNECTIONS { permits.push(ConnectionPermit::acquire().unwrap()); }
+        assert!(ConnectionPermit::acquire().is_none());
+        permits.pop();
+        assert!(ConnectionPermit::acquire().is_some());
+        drop(permits);
+        assert_eq!(CONNECTIONS.load(std::sync::atomic::Ordering::Acquire), 0);
+    }
+
+    #[test]
+    fn oversized_and_truncated_commands_never_reach_dispatch() {
+        let mut reader = BoundedLines::new(io::Cursor::new(vec![b'x'; MAX_WIRE_LINE + 1]));
+        let mut line = String::new();
+        assert_eq!(reader.read_line(&mut line).unwrap_err().kind(), io::ErrorKind::InvalidData);
+        assert!(line.is_empty());
+        assert!(reader.pending.len() <= MAX_WIRE_LINE);
+        let mut reader = BoundedLines::new(io::Cursor::new(b"send-keys partial"));
+        assert_eq!(reader.read_line(&mut line).unwrap_err().kind(), io::ErrorKind::UnexpectedEof);
+        assert!(line.is_empty());
+    }
+
+    #[test]
+    fn complete_lines_are_separate_and_utf8_is_validated() {
+        let mut reader = BoundedLines::new(io::Cursor::new(b"first\nsecond\n"));
+        let mut line = String::new();
+        assert_eq!(reader.read_line(&mut line).unwrap(), 6);
+        assert_eq!(line, "first\n");
+        line.clear();
+        assert_eq!(reader.read_line(&mut line).unwrap(), 7);
+        assert_eq!(line, "second\n");
+        let mut reader = BoundedLines::new(io::Cursor::new([0xff, b'\n']));
+        line.clear();
+        assert!(reader.read_line(&mut line).is_err());
+        assert!(line.is_empty());
+    }
+
+    #[test]
+    fn socket_timeouts_preserve_partial_command() {
+        struct Fragmented { reads: usize }
+        impl io::Read for Fragmented {
+            fn read(&mut self, buffer: &mut [u8]) -> io::Result<usize> {
+                self.reads += 1;
+                let data = match self.reads {
+                    1 => b"send-".as_slice(),
+                    2 => return Err(io::ErrorKind::TimedOut.into()),
+                    3 => b"keys\n".as_slice(),
+                    _ => return Ok(0),
+                };
+                buffer[..data.len()].copy_from_slice(data);
+                Ok(data.len())
+            }
+        }
+        let mut reader = BoundedLines::new(Fragmented { reads: 0 });
+        let mut line = String::new();
+        assert_eq!(reader.read_line(&mut line).unwrap_err().kind(), io::ErrorKind::TimedOut);
+        assert!(line.is_empty());
+        assert_eq!(reader.read_line(&mut line).unwrap(), 10);
+        assert_eq!(line, "send-keys\n");
+    }
+}
+
+/// Every request has its own completion channel. Waiting on the submitting
+/// connection provides backpressure and keeps errors attached to that client;
+/// a global "last error" or a later unrelated barrier could steal an error.
+#[derive(Clone)]
+struct RequestSender {
+    inner: crate::types::ControlSender,
+    errors: std::sync::Arc<std::sync::Mutex<Vec<String>>>,
+    error_stream: std::sync::Arc<std::sync::Mutex<TcpStream>>,
+    control_mode: std::sync::Arc<std::sync::atomic::AtomicBool>,
+    persistent_mode: std::sync::Arc<std::sync::atomic::AtomicBool>,
+}
+trait RequestDispatch {
+    fn send(&self, request: CtrlReq) -> Result<(), String>;
+}
+
+/// The connection handler runs inside the server process, whose startup has
+/// resolved PSMUX_SOCKET_NAME. Keep logical names separate from registry bases.
+fn new_session_destination(
+    namespace: Option<&str>,
+    requested_name: Option<String>,
+    next_name: impl FnOnce(Option<&str>) -> String,
+) -> io::Result<(String, String)> {
+    let name = requested_name.unwrap_or_else(|| next_name(namespace));
+    crate::paths::validate_registry_base(namespace, &name)?;
+    Ok((name.clone(), crate::paths::storage_base(namespace, &name)))
+}
+
+fn spawned_session_manifest_matches(
+    manifest: &crate::registry::RegistryManifest,
+    spawned_pid: u32,
+    creation_time: u64,
+) -> bool {
+    creation_time != 0 && manifest.pid == spawned_pid && manifest.creation_time == creation_time
+}
+
+fn kill_session_target_base(
+    namespace: Option<&str>, target: &str,
+    resolve_id: impl FnOnce(usize) -> Option<String>,
+) -> io::Result<String> {
+    let target = crate::cli::strip_exact_match_prefix(target);
+    let session = target.split(':').next().unwrap_or("");
+    if session.is_empty() || session.starts_with('%') || session.starts_with('@') {
+        return Err(io::Error::new(io::ErrorKind::InvalidInput, "kill-session requires an explicit session name or ID"));
+    }
+    if let Some(id) = session.strip_prefix('$') {
+        let id = id.parse::<usize>().map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "invalid session ID"))?;
+        let base = resolve_id(id).ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "session ID not found"))?;
+        if !crate::paths::registry_visible_from(&base, namespace) {
+            return Err(io::Error::new(io::ErrorKind::NotFound, "session ID not found in current namespace"));
+        }
+        return Ok(base);
+    }
+    crate::paths::validate_registry_base(namespace, session)?;
+    Ok(crate::paths::storage_base(namespace, session))
+}
+
+/// An explicit target either resolves in this namespace or fails. It can
+/// never fall through to terminating the current session.
+fn route_kill_session(
+    tx: &impl RequestDispatch, target: Option<&str>, namespace: Option<&str>,
+    endpoint: impl FnOnce(&str) -> io::Result<(u16, String)>,
+    kill_endpoint: impl FnOnce(u16, &str) -> io::Result<()>,
+) -> io::Result<()> {
+    if let Some(target) = target {
+        let base = kill_session_target_base(namespace, target, crate::session::resolve_session_by_id)?;
+        let (port, key) = endpoint(&base).map_err(|error| io::Error::new(error.kind(),
+            format!("can't resolve session '{}': {}", target, error)))?;
+        kill_endpoint(port, &key)
+    } else {
+        tx.send(CtrlReq::KillSession).map_err(io::Error::other)
+    }
+}
+
+fn kill_session_request(tx: &impl RequestDispatch, target: Option<&str>) -> io::Result<()> {
+    let namespace = std::env::var("PSMUX_SOCKET_NAME").ok().filter(|value| !value.is_empty());
+    route_kill_session(tx, target, namespace.as_deref(), crate::session::read_session_endpoint,
+        |port, key| {
+            let response = crate::session::query_authed_line(&format!("127.0.0.1:{}", port), key,
+                b"kill-session\n", Duration::from_millis(500), Duration::from_secs(2))?;
+            if response == "OK" { Ok(()) }
+            else { Err(io::Error::new(io::ErrorKind::InvalidData, "session termination was not acknowledged")) }
+        })
+}
+
+fn has_session_request(tx: &impl RequestDispatch) -> io::Result<()> {
+    let (reply, receiver) = mpsc::channel();
+    tx.send(CtrlReq::HasSession(reply)).map_err(io::Error::other)?;
+    match receiver.recv_timeout(Duration::from_secs(5)) {
+        Ok(true) => Ok(()),
+        Ok(false) => Err(io::Error::new(io::ErrorKind::NotFound, "session not found")),
+        Err(_) => Err(io::Error::new(io::ErrorKind::TimedOut, "session existence was not confirmed")),
+    }
+}
+
+#[cfg(test)]
+mod session_command_routing_tests {
+    use super::*;
+
+    #[test]
+    fn explicit_kill_target_is_encoded_in_current_namespace() {
+        let (tx, rx) = mpsc::channel();
+        route_kill_session(&tx, Some("=worker__one"), Some("team"), |base| {
+            assert_eq!(base, crate::paths::storage_base(Some("team"), "worker__one"));
+            Ok((1234, "key".into()))
+        }, |port, key| { assert_eq!((port, key), (1234, "key")); Ok(()) }).unwrap();
+        assert!(matches!(rx.try_recv(), Err(mpsc::TryRecvError::Empty)));
+    }
+
+    #[test]
+    fn unresolved_explicit_kill_never_terminates_current_session() {
+        let (tx, rx) = mpsc::channel();
+        let result = route_kill_session(&tx, Some("missing"), Some("team"), |_| {
+            Err(io::ErrorKind::NotFound.into())
+        }, |_, _| panic!("unresolved endpoint must never be used"));
+        assert_eq!(result.unwrap_err().kind(), io::ErrorKind::NotFound);
+        assert!(matches!(rx.try_recv(), Err(mpsc::TryRecvError::Empty)));
+    }
+
+    #[test]
+    fn only_omitted_target_terminates_current_session() {
+        let (tx, rx) = mpsc::channel();
+        route_kill_session(&tx, None, Some("team"), |_| panic!("no lookup"), |_, _| panic!("no forwarding")).unwrap();
+        assert!(matches!(rx.try_recv().unwrap(), CtrlReq::KillSession));
+        assert!(kill_session_target_base(Some("team"), ":0", |_| None).is_err());
+        assert!(kill_session_target_base(Some("team"), "$999", |_| None).is_err());
+    }
+
+    #[test]
+    fn numeric_session_id_cannot_cross_namespace() {
+        let foreign = crate::paths::storage_base(None, "worker");
+        assert!(kill_session_target_base(Some("team"), "$4", |_| Some(foreign)).is_err());
+        let same = crate::paths::storage_base(Some("team"), "worker");
+        assert_eq!(kill_session_target_base(Some("team"), "$4", |_| Some(same.clone())).unwrap(), same);
+    }
+
+    #[test]
+    fn negative_has_session_is_a_request_error_not_process_exit() {
+        let (tx, rx) = mpsc::channel();
+        let worker = std::thread::spawn(move || match rx.recv().unwrap() {
+            CtrlReq::HasSession(reply) => reply.send(false).unwrap(),
+            _ => panic!("expected HasSession"),
+        });
+        assert_eq!(has_session_request(&tx).unwrap_err().kind(), io::ErrorKind::NotFound);
+        worker.join().unwrap();
+    }
+}
+
+#[cfg(test)]
+mod new_session_destination_tests {
+    use super::*;
+
+    #[test]
+    fn automatic_name_uses_the_inherited_namespace() {
+        let (name, base) = new_session_destination(Some("team__one"), None, |namespace| {
+            assert_eq!(namespace, Some("team__one"));
+            "4".into()
+        }).unwrap();
+        assert_eq!(name, "4");
+        assert_eq!(base, crate::paths::storage_base(Some("team__one"), "4"));
+        assert_ne!(base, crate::paths::storage_base(None, "4"));
+    }
+
+    #[test]
+    fn explicit_name_is_validated_and_encoded_without_allocating() {
+        let (name, base) = new_session_destination(Some("team"), Some("work__one".into()), |_| {
+            panic!("explicit name must not allocate a numeric name")
+        }).unwrap();
+        assert_eq!(name, "work__one");
+        assert_eq!(base, crate::paths::storage_base(Some("team"), "work__one"));
+        assert!(new_session_destination(Some("team"), Some("bad\nname".into()), |_| "0".into()).is_err());
+    }
+
+    #[test]
+    fn existing_or_recycled_pid_cannot_confirm_a_new_spawn() {
+        let manifest = crate::registry::RegistryManifest {
+            pid: 42, creation_time: 100, generation: "generation".into(),
+            port: 1234, key: "key".into(), sid: 1,
+        };
+        assert!(spawned_session_manifest_matches(&manifest, 42, 100));
+        assert!(!spawned_session_manifest_matches(&manifest, 43, 100));
+        assert!(!spawned_session_manifest_matches(&manifest, 42, 101));
+        assert!(!spawned_session_manifest_matches(&manifest, 42, 0));
+    }
+}
+impl RequestDispatch for RequestSender {
+    fn send(&self, request: CtrlReq) -> Result<(), String> { RequestSender::send(self, request) }
+}
+#[cfg(test)]
+impl RequestDispatch for mpsc::Sender<CtrlReq> {
+    fn send(&self, request: CtrlReq) -> Result<(), String> {
+        mpsc::Sender::send(self, request).map_err(|_| "test receiver closed".into())
+    }
+}
+#[cfg(test)]
+impl RequestDispatch for crate::types::ControlSender {
+    fn send(&self, request: CtrlReq) -> Result<(), String> {
+        crate::types::ControlSender::send(self, request).map_err(|_| "test queue unavailable".into())
+    }
+}
+impl RequestSender {
+    fn send(&self, req: CtrlReq) -> Result<(), String> {
+        let shutdown = matches!(req, CtrlReq::KillServer | CtrlReq::KillSession);
+        let (done, receiver) = mpsc::channel();
+        let result = if shutdown {
+            self.inner.send(req).map_err(|_| "server busy or unavailable; request was not accepted".to_string())
+        } else if self.inner.send(CtrlReq::CommandRequest(Box::new(req), done)).is_err() {
+            Err("server busy or unavailable; request was not accepted".to_string())
+        } else {
+            receiver.recv_timeout(Duration::from_secs(5))
+                .unwrap_or_else(|_| Err("server did not acknowledge request; outcome is unknown".to_string()))
+        };
+        if let Err(error) = &result {
+            if self.control_mode.load(std::sync::atomic::Ordering::Relaxed) {
+                if let Ok(mut errors) = self.errors.lock() { errors.push(error.clone()); }
+            } else if self.persistent_mode.load(std::sync::atomic::Ordering::Relaxed) {
+                // Frames have a dedicated socket writer. Never inject ERROR
+                // bytes through another clone in the middle of a JSON frame.
+                if self.inner.send(CtrlReq::StatusMessage(error.clone())).is_err() {
+                    if let Ok(stream) = self.error_stream.lock() {
+                        let _ = stream.shutdown(std::net::Shutdown::Both);
+                    }
+                }
+            } else if let Ok(mut stream) = self.error_stream.lock() {
+                let _ = writeln!(stream, "ERROR: {}", error.replace(['\r', '\n'], " "));
+                let _ = stream.flush();
+            }
+        }
+        result
+    }
+    fn take_error(&self) -> Option<String> {
+        let mut errors = self.errors.lock().ok()?;
+        if errors.is_empty() { None } else { Some(std::mem::take(&mut *errors).join("; ")) }
+    }
+}
+
 /// Clear HANDLE_FLAG_INHERIT on a connection socket (see the comment at the
 /// clone sites in `handle_connection`). No-op off Windows.
 #[cfg(windows)]
@@ -34,7 +394,7 @@ fn clear_inherit(_s: &TcpStream) {}
 /// server thread to expand it with the same CtrlReq the bind-key path uses.
 /// Without `-F`, or for an empty value, this is the identity.
 fn expand_set_option_value(
-    tx: &mpsc::Sender<CtrlReq>,
+    tx: &impl RequestDispatch,
     format_expand: bool,
     value: String,
 ) -> String {
@@ -412,7 +772,7 @@ fn parse_new_pane_args(args: &[&str]) -> ParsedNewPane {
 /// to the main server event loop via the `tx` channel.
 pub(crate) fn handle_connection(
     stream: TcpStream,
-    tx: mpsc::Sender<CtrlReq>,
+    tx: crate::types::ControlSender,
     session_key: &str,
     aliases: std::sync::Arc<std::sync::RwLock<std::collections::HashMap<String, String>>>,
 ) {
@@ -434,10 +794,16 @@ let mut write_stream = match stream.try_clone() {
 // each one where it is made.
 clear_inherit(&stream);
 clear_inherit(&write_stream);
+let error_stream = match write_stream.try_clone() { Ok(s) => s, Err(_) => return };
+clear_inherit(&error_stream);
+let _ = error_stream.set_write_timeout(Some(Duration::from_secs(5)));
+let tx = RequestSender { inner: tx, errors: Default::default(),
+    error_stream: std::sync::Arc::new(std::sync::Mutex::new(error_stream)),
+    control_mode: Default::default(), persistent_mode: Default::default() };
 
 // Set initial timeout for auth (reduced from 5s - client sends immediately)
 let _ = stream.set_read_timeout(Some(Duration::from_millis(2000)));
-let mut r = io::BufReader::new(stream);
+let mut r = BoundedLines::new(stream);
 
 // Read the authentication line
 let mut auth_line = String::new();
@@ -475,7 +841,7 @@ let _ = r.get_ref().set_read_timeout(Some(Duration::from_millis(2000)));
 
 // Check for PERSISTENT flag and optional TARGET line
 let mut persistent = false;
-let mut resp_tx_opt: Option<mpsc::Sender<mpsc::Receiver<String>>> = None;
+let mut resp_tx_opt: Option<mpsc::SyncSender<mpsc::Receiver<String>>> = None;
 let mut global_target_win: Option<usize> = None;
 let mut global_target_win_is_id = false;
 let mut global_target_win_name: Option<String> = None;
@@ -489,6 +855,7 @@ if r.read_line(&mut line).is_err() {
 // Check if client requests persistent connection mode
 if line.trim() == "PERSISTENT" {
     persistent = true;
+    tx.persistent_mode.store(true, std::sync::atomic::Ordering::Relaxed);
     // Enable TCP_NODELAY for low-latency persistent connections
     let _ = r.get_ref().set_nodelay(true);
     let _ = write_stream.set_nodelay(true);
@@ -511,7 +878,7 @@ if line.trim() == "PERSISTENT" {
     // timeout, a full socket causes write() to block forever, silently
     // freezing frame delivery. 5 s matches the command-response timeout.
     let _ = ws_bg.set_write_timeout(Some(Duration::from_secs(5)));
-    let (resp_tx, resp_rx) = mpsc::channel::<mpsc::Receiver<String>>();
+    let (resp_tx, resp_rx) = mpsc::sync_channel::<mpsc::Receiver<String>>(64);
 
     // Register a frame slot for server-pushed frames (event-driven rendering).
     // Slot holds at most one pending frame; push_frame() overwrites any
@@ -552,7 +919,7 @@ if line.trim() == "PERSISTENT" {
         // same `client_id` the second one is a harmless no-op. The client
         // reconnects under a *new* `client_id`, so reaping the old id here does
         // not remove the live reconnected client.
-        struct Guard { client_id: u64, shutdown: std::net::TcpStream, tx: mpsc::Sender<CtrlReq> }
+        struct Guard { client_id: u64, shutdown: std::net::TcpStream, tx: RequestSender }
         impl Drop for Guard {
             fn drop(&mut self) {
                 let _ = self.shutdown.shutdown(std::net::Shutdown::Both);
@@ -571,7 +938,8 @@ if line.trim() == "PERSISTENT" {
             // starve frame delivery.
 
             // 0. Drain queued directives (non-blocking).
-            while let Ok(directive) = directive_rx.try_recv() {
+            for _ in 0..16 {
+                let Ok(directive) = directive_rx.try_recv() else { break; };
                 if write!(ws_bg, "{}\n", directive).is_err() { return; }
                 if ws_bg.flush().is_err() { return; }
             }
@@ -591,7 +959,8 @@ if line.trim() == "PERSISTENT" {
                         }
                         Err(_) => return,
                     }
-                    while let Ok(rrx) = resp_rx.try_recv() {
+                    for _ in 0..16 {
+                        let Ok(rrx) = resp_rx.try_recv() else { break; };
                         match rrx.recv_timeout(Duration::from_secs(5)) {
                             Ok(text) => {
                                 if write!(ws_bg, "{}\n", text).is_err() { return; }
@@ -630,7 +999,7 @@ if control_echo || control_noecho {
     let ctrl_client_id = crate::types::next_client_id();
     crate::types::register_persistent_stream(ctrl_client_id, &write_stream);
 
-    let (notif_tx, notif_rx) = std::sync::mpsc::sync_channel::<ControlNotification>(4096);
+    let (notif_tx, notif_rx) = std::sync::mpsc::sync_channel::<ControlNotification>(128);
 
     // Wrap the write stream in a mutex so that the notification writer
     // thread and the command-response loop never interleave bytes on
@@ -703,6 +1072,7 @@ if control_echo || control_noecho {
     });
 
     // Control mode command loop: read lines, dispatch, wrap in %begin/%end/%error
+    tx.control_mode.store(true, std::sync::atomic::Ordering::Relaxed);
     let mut cmd_counter: u64 = 0;
     let tx_ctrl = tx.clone();
     let aliases_ctrl = aliases.clone();
@@ -864,7 +1234,7 @@ if control_echo || control_noecho {
         let skip_target_focus = matches!(cmd_name, "join-pane" | "joinp" | "move-pane" | "movep"
             | "move-window" | "movew" | "swap-window" | "swapw"
             | "switch-client" | "switchc" | "resize-window" | "resizew"
-            | "kill-window" | "killw" | "detach-client" | "detach");
+            | "kill-window" | "killw" | "detach-client" | "detach" | "kill-session" | "kill-ses");
         // capture-pane -t %N resolves the pane id inside the capture itself;
         // swap-pane resolves its own target and swaps it with the *current*
         // active pane (temp-focusing the target would make active == target
@@ -919,7 +1289,7 @@ if control_echo || control_noecho {
 
         // Dispatch command (use a oneshot for the response)
         let (resp_s, resp_r) = mpsc::channel::<String>();
-        let response_result = if let Some(err) = focus_err {
+        let mut response_result = if let Some(err) = focus_err {
             // Unresolvable -t target: skip dispatch entirely and surface
             // the diagnostic through the %error path (sentinel encoding,
             // same as dispatcher-signalled errors).
@@ -938,6 +1308,10 @@ if control_echo || control_noecho {
                 None
             }
         };
+
+        if let Some(error) = tx_ctrl.take_error() {
+            response_result = Some(Ok(format!("\u{0001}ERR\u{0001}{}", error)));
+        }
 
         // Acquire write lock for the ENTIRE %begin … %end sequence so
         // notifications from the notification thread never interleave
@@ -1172,7 +1546,7 @@ let is_focus_cmd = matches!(cmd, "select-window" | "selectw" | "select-pane" | "
 let skip_target_focus = matches!(cmd, "join-pane" | "joinp" | "move-pane" | "movep"
     | "move-window" | "movew" | "swap-window" | "swapw"
     | "switch-client" | "switchc" | "resize-window" | "resizew"
-    | "kill-window" | "killw" | "detach-client" | "detach");
+    | "kill-window" | "killw" | "detach-client" | "detach" | "kill-session" | "kill-ses");
 let targeted_kill_pane_id = if matches!(cmd, "kill-pane" | "killp") && pane_is_id {
     target_pane
 } else {
@@ -1411,7 +1785,10 @@ match cmd {
         if let Some(ref rtx_bg) = resp_tx_opt {
             // Persistent mode: hand off to writer thread (non-blocking).
             // This lets the read loop keep processing keys immediately.
-            let _ = rtx_bg.send(rrx);
+            if rtx_bg.try_send(rrx).is_err() {
+                crate::types::shutdown_client_stream(client_id);
+                return;
+            }
         } else {
             // One-shot mode: block and respond inline
             if let Ok(text) = rrx.recv() { 
@@ -1889,43 +2266,20 @@ match cmd {
         }
     }
     "kill-session" | "kill-ses" => {
-        // If -t <target> is given, kill that session instead of self.
-        // The target may be specified without the -L socket-name namespace
-        // prefix (e.g. "worker1" instead of "ns1__worker1"), so if the raw
-        // path is missing we ask our own server for its session name and
-        // fall through to KillSession when raw_target matches us.
-        if let Some(ref tgt) = raw_target {
-            let port_path = crate::paths::port_file(tgt);
-            let mut handled = false;
-            if let Ok(port_str) = std::fs::read_to_string(&port_path) {
-                if let Ok(port) = port_str.trim().parse::<u16>() {
-                    let key = crate::session::read_session_key(tgt).unwrap_or_default();
-                    let _ = crate::session::send_control_to_port(port, "kill-session\n", &key);
-                    handled = true;
-                }
-            }
-            if !handled {
-                // Query our own session name. If it matches the target
-                // (in-namespace name), kill self. Otherwise the target
-                // simply does not exist on this server.
-                let (rtx, rrx) = mpsc::channel::<String>();
-                let _ = tx.send(CtrlReq::SessionInfo(rtx));
-                if let Ok(line) = rrx.recv() {
-                    let self_name = line.split(':').next().unwrap_or("").trim();
-                    if !self_name.is_empty() && self_name == tgt {
-                        let _ = tx.send(CtrlReq::KillSession);
-                    }
-                }
-            }
-        } else {
-            let _ = tx.send(CtrlReq::KillSession);
+        match kill_session_request(&tx, raw_target.as_deref()) {
+            Ok(()) if !persistent => { let _ = writeln!(write_stream, "OK"); let _ = write_stream.flush(); }
+            Ok(()) => {},
+            Err(error) if persistent => { let _ = tx.send(CtrlReq::StatusMessage(error.to_string())); }
+            Err(error) => { let _ = writeln!(write_stream, "ERROR: {}", error); let _ = write_stream.flush(); }
         }
+        if !persistent { break; }
     }
     "has-session" => {
-        let (rtx, rrx) = mpsc::channel::<bool>();
-        let _ = tx.send(CtrlReq::HasSession(rtx));
-        if let Ok(exists) = rrx.recv() {
-            if !exists { std::process::exit(1); }
+        match has_session_request(&tx) {
+            Ok(()) if !persistent => { let _ = writeln!(write_stream, "OK"); let _ = write_stream.flush(); }
+            Ok(()) => {},
+            Err(error) if persistent => { let _ = tx.send(CtrlReq::StatusMessage(error.to_string())); }
+            Err(error) => { let _ = writeln!(write_stream, "ERROR: {}", error); let _ = write_stream.flush(); }
         }
     }
     "rename-session" | "rename" => {
@@ -3039,24 +3393,21 @@ match cmd {
         } else {
             (stdin_flag, stdout_flag)
         };
-        // Same reply shape as #559/#566: a direct file sink that cannot be
-        // opened must reach the caller as a non-zero exit, not a silent
-        // rc-0 no-op. The handler answers "" on acceptance; only an
-        // "ERROR: ..." reply is forwarded.
+        // Even an empty success needs a complete frame. EOF immediately after
+        // AUTH cannot distinguish acceptance from a server that crashed.
         let (rtx, rrx) = mpsc::channel::<String>();
         let _ = tx.send(CtrlReq::PipePane(cmd, stdin, stdout, toggle, Some(rtx)));
-        let resp = rrx.recv_timeout(Duration::from_millis(2000)).unwrap_or_default();
+        let resp = rrx.recv_timeout(Duration::from_millis(2000))
+            .unwrap_or_else(|_| "ERROR: pipe-pane did not return an outcome".to_string());
         if !persistent {
-            if !resp.is_empty() {
-                let _ = write!(write_stream, "{}\n", resp);
-                let _ = write_stream.flush();
-            }
+            let _ = writeln!(write_stream, "{}", resp);
+            let _ = write_stream.flush();
             // pipe-pane can sit in the middle of a chained line
             // (`pipe-pane -o ... \; display-message ...`); breaking with
             // queued sub-commands would silently drop the rest of the
             // chain. With no chain pending, the client's half-close ends
             // the loop on the next read anyway.
-            if pending_chain.is_empty() { break; }
+            // Also read any subsequent completion barrier sent on this socket.
         }
     }
     "select-layout" | "selectl" => {
@@ -3750,7 +4101,7 @@ match cmd {
             }
 
             if let Some(ref err) = env_parse_err {
-                let msg = format!("psmux: {}\n", err);
+                let msg = format!("ERROR: {}\n", err);
                 if persistent {
                     let _ = tx.send(CtrlReq::StatusMessage(msg.trim().to_string()));
                 } else {
@@ -3760,37 +4111,31 @@ match cmd {
                 if !persistent { break; }
             } else {
 
-            // Note: socket_name (from -L flag) is not directly available here;
-            // the client-side handler in commands.rs has it via app.socket_name.
-            let name = sess_name.unwrap_or_else(|| crate::session::next_session_name(None));
-
-            let port_file_base = name.clone();
-
-            let port_path = crate::paths::port_file(&port_file_base);
-
-            // Check if session already exists
-            let already_exists = if std::path::Path::new(&port_path).exists() {
-                if let Ok(port_str) = std::fs::read_to_string(&port_path) {
-                    if let Ok(port) = port_str.trim().parse::<u16>() {
-                        let addr: std::net::SocketAddr = format!("127.0.0.1:{}", port).parse().unwrap();
-                        std::net::TcpStream::connect_timeout(&addr, std::time::Duration::from_millis(100)).is_ok()
-                    } else { false }
-                } else { false }
-            } else { false };
-
-            if already_exists {
-                if persistent {
-                    let _ = tx.send(CtrlReq::StatusMessage(format!("session '{}' already exists", name)));
-                } else {
-                    let _ = write!(write_stream, "session '{}' already exists\n", name);
-                    let _ = write_stream.flush();
-                    break;
+            let namespace = std::env::var("PSMUX_SOCKET_NAME").ok().filter(|value| !value.is_empty());
+            let create_result = (|| -> io::Result<String> {
+                let (name, port_file_base) = new_session_destination(
+                    namespace.as_deref(), sess_name, crate::session::next_session_name)?;
+                let has_registration = crate::registry::manifest_path(&port_file_base).exists()
+                    || std::path::Path::new(&crate::paths::port_file(&port_file_base)).exists()
+                    || std::path::Path::new(&crate::paths::pid_file(&port_file_base)).exists();
+                if has_registration {
+                    match crate::session::existing_session_state(&port_file_base) {
+                        crate::session::SessionLiveness::Dead => {},
+                        crate::session::SessionLiveness::Alive(_) => return Err(io::Error::new(
+                            io::ErrorKind::AlreadyExists, format!("session '{}' already exists", name))),
+                        _ => return Err(io::Error::new(io::ErrorKind::WouldBlock,
+                            format!("session '{}' is registered but not responding; registration preserved", name))),
+                    }
                 }
-            } else {
-                // Spawn new server
-                let exe = std::env::current_exe().unwrap_or_else(|_| std::path::PathBuf::from("psmux"));
+                // The child reserves the name before publication. If another
+                // creator wins this race, its manifest must never count as our
+                // successful spawn below.
+                let exe = std::env::current_exe()?;
                 let mut server_args: Vec<String> = vec!["server".into(), "-s".into(), name.clone()];
-
+                if let Some(namespace) = namespace.as_ref() {
+                    server_args.push("-L".into());
+                    server_args.push(namespace.clone());
+                }
                 if let Some(ref dir) = start_dir {
                     server_args.push("-d".into());
                     server_args.push(dir.clone());
@@ -3819,41 +4164,69 @@ match cmd {
                     server_args.push(format!("{}={}", k, v));
                 }
                 #[cfg(windows)]
-                { let _ = crate::platform::spawn_server_hidden(&exe, &server_args); }
+                let spawned_pid = crate::platform::spawn_server_hidden(&exe, &server_args)?;
                 #[cfg(not(windows))]
-                {
-                    let mut cmd_proc = std::process::Command::new(&exe);
-                    for a in &server_args { cmd_proc.arg(a); }
-                    cmd_proc.stdin(std::process::Stdio::null());
-                    cmd_proc.stdout(std::process::Stdio::null());
-                    cmd_proc.stderr(std::process::Stdio::null());
-                    let _ = cmd_proc.spawn();
-                }
-
-                // Wait for port file
-                for _ in 0..500 {
-                    if std::path::Path::new(&port_path).exists() { break; }
-                    std::thread::sleep(std::time::Duration::from_millis(10));
-                }
-
-                if std::path::Path::new(&port_path).exists() {
-                    if !detached {
-                        // In-process follow-up to a new-session: nobody is waiting
-                        // on a switch result here, the reply for this command has
-                        // already been decided below.
-                        let _ = tx.send(CtrlReq::SwitchClient(name.clone(), 't', None));
+                let spawned_pid = {
+                    let mut command = std::process::Command::new(&exe);
+                    command.args(&server_args).stdin(std::process::Stdio::null())
+                        .stdout(std::process::Stdio::null()).stderr(std::process::Stdio::null());
+                    command.spawn()?.id()
+                };
+                let creation_time = crate::platform::process_kill::process_creation_time(spawned_pid)
+                    .filter(|created| *created != 0).ok_or_else(|| io::Error::other(
+                        format!("cannot verify newly spawned session '{}'; outcome is unknown", name)))?;
+                let deadline = std::time::Instant::now() + Duration::from_secs(15);
+                loop {
+                    if crate::platform::process_kill::verified_process_dead(spawned_pid, creation_time) {
+                        return Err(io::Error::other(format!("new session '{}' exited before becoming ready", name)));
                     }
+                    let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+                    if remaining.is_zero() {
+                        return Err(io::Error::new(io::ErrorKind::TimedOut,
+                            format!("new session '{}' did not become ready; outcome is unknown, registration preserved", name)));
+                    }
+                    if let Some(manifest) = crate::registry::read_manifest(&port_file_base)? {
+                        if spawned_session_manifest_matches(&manifest, spawned_pid, creation_time) {
+                            let address = format!("127.0.0.1:{}", manifest.port);
+                            // AUTH alone only confirms the early listener. Require a
+                            // real initial window, answered by the initialized loop.
+                            if let Ok(windows) = crate::session::query_authed_all(
+                                &address, &manifest.key, b"list-windows\n",
+                                remaining.min(Duration::from_millis(200)),
+                                remaining.min(Duration::from_millis(500))) {
+                                if crate::detached_list_windows_ready(&windows) { break; }
+                            }
+                        } else if !crate::platform::process_kill::verified_process_dead(
+                            manifest.pid, manifest.creation_time) {
+                            return Err(io::Error::new(io::ErrorKind::AlreadyExists,
+                                format!("session '{}' belongs to another server", name)));
+                        }
+                        // Positively dead records may still be present before
+                        // this child's first atomic publication. Wait for it;
+                        // never query the old endpoint or delete its records.
+                    }
+                    std::thread::sleep(Duration::from_millis(20).min(
+                        deadline.saturating_duration_since(std::time::Instant::now())));
+                }
+                if !detached {
+                    tx.send(CtrlReq::SwitchClient(name.clone(), 't', None)).map_err(io::Error::other)?;
+                }
+                Ok(name)
+            })();
+            match create_result {
+                Ok(name) => {
                     if persistent {
                         let _ = tx.send(CtrlReq::StatusMessage(format!("created session '{}'", name)));
                     } else {
-                        let _ = write!(write_stream, "OK\n");
+                        let _ = writeln!(write_stream, "OK");
                         let _ = write_stream.flush();
                     }
-                } else {
+                }
+                Err(error) => {
                     if persistent {
-                        let _ = tx.send(CtrlReq::StatusMessage(format!("failed to create session '{}'", name)));
+                        let _ = tx.send(CtrlReq::StatusMessage(error.to_string()));
                     } else {
-                        let _ = write!(write_stream, "failed to create session '{}'\n", name);
+                        let _ = writeln!(write_stream, "ERROR: {}", error);
                         let _ = write_stream.flush();
                     }
                 }
@@ -3944,7 +4317,7 @@ match cmd {
             .filter(|s| !s.is_empty())
             .or_else(|| respawn_positional_command(&args));
         let workdir = args.windows(2).find(|w| w[0] == "-c").map(|w| w[1].to_string());
-        let _ = tx.send(CtrlReq::RespawnWindow(workdir, command));
+        let _ = tx.send(CtrlReq::RespawnWindow(workdir, args.contains(&"-k"), command));
     }
     "lock-server" | "lock-session" | "lock" | "locks" => {
         // Lock is a no-op on Windows (no terminal locking concept)
@@ -4031,7 +4404,7 @@ match cmd {
 fn dispatch_control_command(
     cmd: &str,
     args: &[&str],
-    tx: &mpsc::Sender<CtrlReq>,
+    tx: &impl RequestDispatch,
     resp_tx: mpsc::Sender<String>,
     target_pane: Option<usize>,
     pane_is_id: bool,
@@ -4592,11 +4965,11 @@ fn dispatch_control_command(
             true
         }
         "has-session" | "has" => {
-            let (rtx, rrx) = mpsc::channel::<bool>();
-            let _ = tx.send(CtrlReq::HasSession(rtx));
-            if let Ok(exists) = rrx.recv_timeout(Duration::from_secs(5)) {
-                let _ = resp_tx.send(if exists { String::new() } else { "session not found".to_string() });
-            }
+            let response = match has_session_request(tx) {
+                Ok(()) => String::new(),
+                Err(error) => format!("\u{0001}ERR\u{0001}{}", error),
+            };
+            let _ = resp_tx.send(response);
             true
         }
         "list-clients" | "lsc" => {
@@ -4642,8 +5015,11 @@ fn dispatch_control_command(
             true
         }
         "kill-session" => {
-            let _ = tx.send(CtrlReq::KillSession);
-            let _ = resp_tx.send(String::new());
+            let response = match kill_session_request(tx, raw_target) {
+                Ok(()) => String::new(),
+                Err(error) => format!("\u{0001}ERR\u{0001}{}", error),
+            };
+            let _ = resp_tx.send(response);
             true
         }
         "kill-server" => {

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -102,80 +102,13 @@ fn should_spawn_warm_server(app: &AppState) -> bool {
     app.warm_enabled && app.session_name != "__warm__" && !app.destroy_unattached
 }
 
-fn ensure_session_registry_files(app: &AppState) {
-    let Some(port) = app.control_port else { return; };
-    let dir = crate::paths::psmux_dir();
-    let _ = std::fs::create_dir_all(&dir);
-
-    let base = app.port_file_base();
-    let port_path = crate::paths::port_file(&base);
-    let key_path = crate::paths::key_file(&base);
-    let sid_path = crate::paths::sid_file(&base);
-    let port_value = port.to_string();
-    let sid_value = app.session_id.to_string();
-
-    // Write the .key (and .sid) BEFORE the .port file: the .port file is the
-    // readiness beacon clients poll for, so every credential they will read
-    // next must already be on disk when it appears. Writing .port first opened
-    // a window where a cold-start attach read an empty .key and failed AUTH
-    // with "psmux: auth failed" (issue #496).
-    if std::fs::read_to_string(&key_path)
-        .map(|s| s.trim() != app.session_key)
-        .unwrap_or(true)
-    {
-        let _ = std::fs::write(&key_path, &app.session_key);
-    }
-
-    if std::fs::read_to_string(&sid_path)
-        .map(|s| s.trim() != sid_value)
-        .unwrap_or(true)
-    {
-        let _ = std::fs::write(&sid_path, &sid_value);
-    }
-
-    // Record this server's OS process ID (issue #448). Written together with
-    // port/key/sid so a live server is never listening without a PID anchor, and
-    // re-ensured periodically so the entry self-heals after rename/claim. This is
-    // what lets startup reap live-but-orphaned duplicate servers by identity.
-    //
-    // The body is `pid:creation_filetime`: the creation time lets kill-server's
-    // force-kill fallback confirm identity (exact match) before terminating, so a
-    // recycled pid is never killed. Readers tolerate a bare pid too.
-    let pid_path = crate::paths::pid_file(&base);
+fn ensure_session_registry_files(app: &AppState, owner: &crate::registry::RegistryOwner) -> io::Result<()> {
+    let port = app.control_port.ok_or_else(|| io::Error::other("server has no listener"))?;
+    owner.publish(&app.port_file_base(), port, &app.session_key, app.session_id as u64)?;
     let self_pid = std::process::id();
-    let pid_value = crate::session::format_pid_file_contents(
-        self_pid,
-        crate::platform::process_kill::process_creation_time(self_pid).unwrap_or(0),
-    );
-    if std::fs::read_to_string(&pid_path)
-        .map(|s| s.trim() != pid_value)
-        .unwrap_or(true)
-    {
-        let _ = std::fs::write(&pid_path, &pid_value);
-    }
-
-    // Establish the namespace's stable identity (issue #509) before the .port
-    // beacon, so a client that sees a ready server can immediately query
-    // `#{server_instance}` and get a value. Minted by the namespace's first
-    // server and left alone by every later one; re-ensured here so it self-heals
-    // if the file is lost while the namespace is still up.
     let _ = crate::session::ensure_namespace_instance(app.socket_name.as_deref(), self_pid);
-
-    // Claim this process for this data dir (issue #510). Keyed by PID and kept
-    // outside the per-session registry on purpose: the `.pid` entry above is
-    // removed with its session, but the reaper still needs to recognise a
-    // server as its own AFTER that happens - a spawn-race duplicate, or a
-    // registry wipe, is exactly the case it must clean up. Re-ensured here so
-    // the claim self-heals if the file is deleted underneath a live server.
     crate::session::write_server_marker(self_pid);
-
-    // .port goes LAST: it is the readiness beacon (see comment above).
-    if std::fs::read_to_string(&port_path)
-        .map(|s| s.trim() != port_value)
-        .unwrap_or(true)
-    {
-        let _ = std::fs::write(&port_path, &port_value);
-    }
+    Ok(())
 }
 
 /// Diagnostic-only logging for warm-server lifecycle races. Gated behind
@@ -218,33 +151,39 @@ fn is_active_pane_squelched(app: &AppState) -> bool {
 
 /// RAII guard for the warm-spawn lock file. Removing the file on drop lets a
 /// later warm spawn proceed.
-struct WarmSpawnLock(std::path::PathBuf);
+struct WarmSpawnLock(std::path::PathBuf, String);
 impl Drop for WarmSpawnLock {
     fn drop(&mut self) {
-        let _ = std::fs::remove_file(&self.0);
+        if std::fs::read_to_string(&self.0).ok().as_deref() == Some(self.1.as_str()) {
+            let _ = std::fs::remove_file(&self.0);
+        }
     }
 }
 
 /// Acquire the warm-spawn lock guarding the check->spawn window in
 /// `spawn_warm_server`. Returns `Some(guard)` when this caller owns the lock and
 /// may proceed to spawn, or `None` when another spawn is already in progress (in
-/// which case the caller must NOT spawn). A lock file older than 20s is treated
-/// as abandoned (its owner died mid-spawn) and stolen.
+/// which case the caller must NOT spawn). Age never proves abandonment;
+/// reclamation requires the exact owner process to have exited.
 fn acquire_warm_spawn_lock(lock_path: &str) -> Option<WarmSpawnLock> {
     use std::io::Write as _;
     let path = std::path::PathBuf::from(lock_path);
+    let creation = crate::platform::process_kill::process_creation_time(std::process::id())?;
+    let token = format!("{}:{}", std::process::id(), creation);
     for _ in 0..2 {
         match std::fs::OpenOptions::new().write(true).create_new(true).open(&path) {
             Ok(mut f) => {
-                let _ = write!(f, "{}", std::process::id());
-                return Some(WarmSpawnLock(path));
+                if f.write_all(token.as_bytes()).is_err() {
+                    let _ = std::fs::remove_file(&path);
+                    return None;
+                }
+                return Some(WarmSpawnLock(path, token));
             }
             Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
-                let stale = std::fs::metadata(&path)
-                    .and_then(|m| m.modified())
-                    .ok()
-                    .and_then(|t| std::time::SystemTime::now().duration_since(t).ok())
-                    .map(|age| age > std::time::Duration::from_secs(20))
+                let stale = std::fs::read_to_string(&path).ok()
+                    .and_then(|value| crate::session::parse_pid_file_contents(&value))
+                    .and_then(|(pid, creation)| creation.map(|creation| (pid, creation)))
+                    .map(|(pid, creation)| crate::platform::process_kill::verified_process_dead(pid, creation))
                     .unwrap_or(false);
                 if stale {
                     let _ = std::fs::remove_file(&path);
@@ -269,12 +208,16 @@ fn spawn_warm_server(app: &AppState) {
     if !should_spawn_warm_server(app) {
         return;
     }
+    let socket_name = app.socket_name.clone();
+    let area = app.client_area;
+    static SPAWNING: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+    if SPAWNING.swap(true, std::sync::atomic::Ordering::AcqRel) { return; }
+    let spawned = std::thread::Builder::new().name("psmux-warm-spawn".into()).spawn(move || {
+    struct Reset;
+    impl Drop for Reset { fn drop(&mut self) { SPAWNING.store(false, std::sync::atomic::Ordering::Release); } }
+    let _reset = Reset;
     // Skip if a warm server already exists
-    let warm_base = if let Some(ref sn) = app.socket_name {
-        format!("{}____warm__", sn)
-    } else {
-        "__warm__".to_string()
-    };
+    let warm_base = crate::paths::session_base(socket_name.as_deref(), "__warm__");
     let warm_port_path = crate::paths::port_file(&warm_base);
     warm_debug(&format!("spawn_warm_server entry base={} port_exists={}", warm_base, std::path::Path::new(&warm_port_path).exists()));
     // Serialize the check->spawn window: without this, two callers can both see
@@ -285,73 +228,20 @@ fn spawn_warm_server(app: &AppState) {
         Some(g) => g,
         None => { warm_debug("another warm spawn in progress -- skipping"); return; }
     };
-    if std::path::Path::new(&warm_port_path).exists() {
-        // Check if it's actually a live, unclaimed warm server.
-        // TCP reachability alone is not sufficient: OS ephemeral-port reuse or
-        // duplicated-warm churn can leave __warm__.port pointing at a real
-        // claimed session.  That server answers TCP connects but is NOT warm,
-        // so returning early here means warm never re-establishes and every
-        // subsequent open stays cold (~1-5s) until the pointer is manually removed.
-        let mut is_genuine_warm = false;
-        if let Ok(port_str) = std::fs::read_to_string(&warm_port_path) {
-            if let Ok(port) = port_str.trim().parse::<u16>() {
-                let addr = format!("127.0.0.1:{}", port);
-                if std::net::TcpStream::connect_timeout(
-                    &addr.parse().unwrap(),
-                    Duration::from_millis(100),
-                ).is_ok() {
-                    // TCP is up — verify the session name via AUTH.
-                    let warm_key_path = crate::paths::key_file(&warm_base);
-                    if let Ok(key) = std::fs::read_to_string(&warm_key_path) {
-                        let key = key.trim().to_string();
-                        if !key.is_empty() {
-                            // Ask the server what its session name is.
-                            // Response is the name followed by a newline.
-                            // Timeout is capped at 500ms inside send_auth_cmd_response.
-                            match crate::session::send_auth_cmd_response(
-                                &addr, &key,
-                                b"display-message -p '#{session_name}'\n",
-                            ) {
-                                Ok(resp) if resp.trim() == "__warm__" => {
-                                    warm_debug("early-return: existing warm verified alive");
-                                    is_genuine_warm = true;
-                                }
-                                Ok(resp) => {
-                                    warm_debug(&format!(
-                                        "warm port reachable but session='{}' (not __warm__) — treating as stale",
-                                        resp.trim()
-                                    ));
-                                }
-                                Err(_) => {
-                                    warm_debug("warm port reachable but auth/query failed — treating as stale");
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-        if is_genuine_warm {
-            return;
-        }
-        // Stale or wrong-server port file — remove it (and matching key/sid files)
-        warm_debug("removing STALE warm port/key/sid (unreachable or not a warm server)");
-        let _ = std::fs::remove_file(&warm_port_path);
-        let warm_key_path = crate::paths::key_file(&warm_base);
-        let _ = std::fs::remove_file(&warm_key_path);
-        let warm_sid_path = crate::paths::sid_file(&warm_base);
-        let _ = std::fs::remove_file(&warm_sid_path);
+    if std::path::Path::new(&warm_port_path).exists()
+        && crate::session::registry_pid_anchor_alive(&warm_base) != Some(false) {
+        warm_debug("existing warm registration retained (alive or uncertain)");
+        return;
     }
     warm_debug("SPAWNING new warm server");
     let exe = std::env::current_exe().unwrap_or_else(|_| std::path::PathBuf::from("psmux"));
     let mut args: Vec<String> = vec!["server".into(), "-s".into(), "__warm__".into()];
-    if let Some(ref sn) = app.socket_name {
+    if let Some(ref sn) = socket_name {
         args.push("-L".into());
         args.push(sn.clone());
     }
     // Pass current terminal dimensions so the warm server's first window
     // and warm pane are spawned at the right size.
-    let area = app.client_area;
     if area.width > 1 && area.height > 1 {
         args.push("-x".into());
         args.push(area.width.to_string());
@@ -387,6 +277,8 @@ fn spawn_warm_server(app: &AppState) {
         let _ = cmd.spawn();
         drop(spawn_lock);
     }
+    });
+    if spawned.is_err() { SPAWNING.store(false, std::sync::atomic::Ordering::Release); }
 }
 
 /// Parse a popup dimension spec: "80" (absolute) or "95%" (percentage of term_dim).
@@ -401,6 +293,7 @@ fn parse_popup_dim(spec: &str, term_dim: u16, default: u16) -> u16 {
     } else {
         spec.parse().unwrap_or(default)
     }
+
 }
 
 /// Process a single CtrlReq during the post-config plugin drain loop.
@@ -411,6 +304,11 @@ fn drain_plugin_req(
     req: CtrlReq,
     shared_aliases: &std::sync::Arc<std::sync::RwLock<std::collections::HashMap<String, String>>>,
 ) {
+    let (req, completion) = match req {
+        CtrlReq::CommandRequest(req, completion) => (*req, Some(completion)),
+        req => (req, None),
+    };
+    let mut outcome = Ok(());
     match req {
         CtrlReq::SetOption(option, value) => {
             if apply_set_option(app, &option, &value, false).is_ok() {
@@ -571,9 +469,11 @@ fn drain_plugin_req(
                 }
             }
         }
-        // Ignore other request types during plugin drain
-        _ => {}
+        // Startup has not created the session's panes yet. Refuse requests
+        // outside this subset explicitly so clients can retry readiness.
+        _ => outcome = Err("server is still initializing".to_string()),
     }
+    if let Some(completion) = completion { let _ = completion.send(outcome); }
 }
 
 /// Persist a server-startup failure to `~/.psmux/server-startup.log`.
@@ -848,41 +748,80 @@ fn move_window_request(
     app.move_window(src, dst, detach, renumber, after, before)
 }
 
-fn rekey_session_guard(guard: &mut Option<crate::platform::SessionMutex>, new_base: &str) {
-    *guard = None; // drop releases + closes the old name's mutex
-    *guard = crate::platform::acquire_session_mutex(new_base);
-    if guard.is_none() {
-        warm_debug(&format!("session guard: '{}' already owned by a live server — running unguarded", new_base));
+fn reserve_session_guard(new_base: &str) -> io::Result<crate::platform::SessionMutex> {
+    crate::platform::acquire_session_mutex_strict(new_base)?
+        .ok_or_else(|| io::Error::new(io::ErrorKind::AlreadyExists, format!("session already exists: {}", new_base)))
+}
+
+#[cfg(test)]
+fn rekey_session_guard(guard: &mut Option<crate::platform::SessionMutex>, new_base: &str) -> io::Result<()> {
+    let next = reserve_session_guard(new_base)?;
+    *guard = Some(next);
+    Ok(())
+}
+
+/// Reserve before publishing; retain both guards until the new name is ready.
+fn rename_registered_session(
+    app: &mut AppState,
+    guard: &mut Option<crate::platform::SessionMutex>,
+    registration: &mut crate::registry::RegistrationLease,
+    name: String,
+    panic_name: &std::sync::Arc<std::sync::Mutex<String>>,
+) -> io::Result<()> {
+    crate::paths::validate_registry_base(app.socket_name.as_deref(), &name)?;
+    if app.session_name == name { return Ok(()); }
+    let new_base = crate::paths::session_base(app.socket_name.as_deref(), &name);
+    // Windows registry paths are case-insensitive. A case-only rename must
+    // never publish and then remove the same files through the old spelling.
+    if new_base.eq_ignore_ascii_case(&registration.base) {
+        app.session_name = name;
+        if let Ok(mut current) = panic_name.lock() { *current = app.port_file_base(); }
+        env::set_var("PSMUX_TARGET_SESSION", app.port_file_base());
+        return Ok(());
     }
+    let next_guard = reserve_session_guard(&new_base)?;
+    let port = app.control_port.ok_or_else(|| io::Error::other("server has no listener"))?;
+    registration.owner.publish(&new_base, port, &app.session_key, app.session_id as u64)?;
+    // Publication succeeded. Old cleanup is ownership-checked while its guard
+    // is still held. A cleanup failure must not leave two discoverable names.
+    if let Err(error) = registration.owner.remove_owned(&registration.base) {
+        let _ = registration.owner.remove_owned(&new_base);
+        return Err(error);
+    }
+    registration.base = new_base;
+    app.session_name = name;
+    *guard = Some(next_guard);
+    if let Ok(mut current) = panic_name.lock() { *current = app.port_file_base(); }
+    env::set_var("PSMUX_TARGET_SESSION", app.port_file_base());
+    Ok(())
+}
+
+fn install_panic_logger(current_panic_name: std::sync::Arc<std::sync::Mutex<String>>, path: String) {
+    std::panic::set_hook(Box::new(move |info| {
+        let bt = std::backtrace::Backtrace::force_capture();
+        let name = current_panic_name.try_lock().map(|n| n.clone()).unwrap_or_else(|_| "<identity busy>".into());
+        let timestamp = chrono::Utc::now().to_rfc3339();
+        if let Ok(mut file) = std::fs::OpenOptions::new().create(true).append(true).open(&path) {
+            let _ = writeln!(file, "\n{} pid={} session={} thread={:?}\n{}\nBacktrace:\n{}",
+                timestamp, std::process::id(), name, std::thread::current().name(), info, bt);
+        }
+    }));
 }
 
 pub fn run_server(session_name: String, socket_name: Option<String>, initial_command: Option<String>, raw_command: Option<Vec<String>>, start_dir: Option<String>, window_name: Option<String>, init_size: Option<(u16, u16)>, group_target: Option<String>, env_vars: Vec<(String, String)>) -> io::Result<()> {
-    // Write crash info to a log file when stderr is unavailable (detached server)
-    // and clean up port/key files so stale entries do not linger (issue #204).
-    let panic_session_name = session_name.clone();
-    let panic_socket_name = socket_name.clone();
-    std::panic::set_hook(Box::new(move |info| {
-        let path = crate::paths::psmux_dir_file("crash.log");
-        let bt = std::backtrace::Backtrace::force_capture();
-        let _ = std::fs::write(&path, format!("{info}\n\nBacktrace:\n{bt}"));
-        // Remove port/key files to prevent stale entries after a panic
-        let base = if let Some(ref sn) = panic_socket_name {
-            format!("{}__{}", sn, panic_session_name)
-        } else {
-            panic_session_name.clone()
-        };
-        let _ = std::fs::remove_file(crate::paths::port_file(&base));
-        let _ = std::fs::remove_file(crate::paths::key_file(&base));
-        let _ = std::fs::remove_file(crate::paths::sid_file(&base));
-        let _ = std::fs::remove_file(crate::paths::pid_file(&base));
-        let _ = std::fs::remove_file(crate::paths::activity_file(&base));
-    }));
+    // Panic hooks run for *every thread*, including recoverable worker
+    // failures. Logging is observational: never delete any registration here.
+    let panic_name = std::sync::Arc::new(std::sync::Mutex::new(
+        crate::paths::session_base(socket_name.as_deref(), &session_name)));
+    install_panic_logger(panic_name.clone(), crate::paths::psmux_dir_file("crash.log"));
     // Install console control handler to prevent termination on client detach
     install_console_ctrl_handler();
 
+    crate::paths::validate_registry_base(socket_name.as_deref(), &session_name)?;
     let pty_system = native_pty_system();
 
     let mut app = AppState::new(session_name);
+    app.session_id = crate::session::allocate_session_id()?;
     // Claim a scheduling class before anything else runs (#608). A windowless
     // server never receives the foreground boost Windows reserves for the
     // process owning the active window, so on an oversubscribed box its reader
@@ -918,11 +857,11 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
     let mut session_guard = {
         let base = app.port_file_base();
         {
-            match crate::platform::acquire_session_mutex(&base) {
+            match crate::platform::acquire_session_mutex_strict(&base)? {
                 Some(g) => Some(g),
                 None => {
                     warm_debug(&format!("server STARTUP: session '{}' already owned by a live server — exiting duplicate", base));
-                    return Ok(()); // do NOT touch the winner's .port/.key/.sid
+                    return Err(io::Error::new(io::ErrorKind::AlreadyExists, "session already exists"));
                 }
             }
         }
@@ -930,7 +869,7 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
 
     // Bind the control listener BEFORE loading config so that run-shell
     // commands spawned by load_config can connect back to the server.
-    let (tx, rx) = mpsc::channel::<CtrlReq>();
+    let (tx, rx) = crate::types::control_channel();
     app.control_rx = Some(rx);
     // Keep a sender in AppState so loop-resident code can queue follow-up work
     // (see the field's doc comment — copy-mode key tables need this).
@@ -960,23 +899,9 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
 
     app.session_key = session_key.clone();
 
-    // Write the key file up front (user-only visibility on Windows comes from
-    // the profile directory ACLs). This MUST happen before
-    // ensure_session_registry_files writes the .port readiness beacon: a
-    // truncate+rewrite of the .key after .port is visible gave attaching
-    // clients a window to read an EMPTY key and fail with "psmux: auth
-    // failed" on cold start (issue #496). ensure_session_registry_files sees
-    // the matching content below and never rewrites it.
-    {
-        let keypath = crate::paths::key_file(&app.port_file_base());
-        let _ = std::fs::OpenOptions::new()
-            .write(true)
-            .create(true)
-            .truncate(true)
-            .open(&keypath)
-            .map(|mut f| std::io::Write::write_all(&mut f, session_key.as_bytes()));
-    }
-
+    let mut registration = crate::registry::RegistrationLease {
+        owner: crate::registry::RegistryOwner::current()?, base: app.port_file_base(),
+    };
     // TEST-ONLY fault injection — compiled out of release builds entirely
     // (gated on debug_assertions); inert in debug unless the env var is set.
     // Delays the .port file write (which happens inside
@@ -993,7 +918,11 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
         }
     }
 
-    ensure_session_registry_files(&app);
+    if let Err(error) = ensure_session_registry_files(&app, &registration.owner) {
+        #[cfg(windows)]
+        write_startup_error_log(&error);
+        return Err(error);
+    }
 
     // TEST-ONLY fault injection — compiled out of release builds entirely.
     // Simulates the server dying AFTER writing its .port file but WITHOUT the
@@ -1007,8 +936,6 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
         }
     }
 
-    let regpath = crate::paths::port_file(&app.port_file_base());
-    let keypath = crate::paths::key_file(&app.port_file_base());
 
     // Expose the server identity via env var so that child processes spawned
     // by run-shell (from hooks, keybindings, etc.) can find this server when
@@ -1031,6 +958,12 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
     thread::spawn(move || {
         for conn in listener.incoming() {
             if let Ok(stream) = conn {
+                let Some(permit) = connection::ConnectionPermit::acquire() else {
+                    let mut stream = stream;
+                    let _ = stream.set_write_timeout(Some(Duration::from_millis(50)));
+                    let _ = writeln!(stream, "ERROR: server busy (connection limit reached)");
+                    continue;
+                };
                 // Accepted control sockets must NOT be inheritable: the server
                 // spawns children with bInheritHandles=TRUE (pane shells via
                 // ConPTY, pipe-pane sinks, run-shell), and a long-lived child
@@ -1052,7 +985,8 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                 let tx = tx.clone();
                 let session_key_clone = session_key.clone();
                 let aliases = shared_aliases.clone();
-                thread::spawn(move || {
+                let _ = thread::Builder::new().name("control-client".into()).spawn(move || {
+                    let _permit = permit;
                     connection::handle_connection(stream, tx, &session_key_clone, aliases);
                 }); // end per-connection thread
             }
@@ -1211,9 +1145,7 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
         write_startup_error_log(&e);
         // Clean up port and key files so stale entries are not left
         // behind when the pane command fails to spawn (issue #204).
-        let _ = std::fs::remove_file(&regpath);
-        let _ = std::fs::remove_file(&keypath);
-        crate::session::remove_session_id_file(&app.port_file_base());
+        let _ = registration.owner.remove_owned(&registration.base);
         // Kill warm pane if one was pre-spawned
         if let Some(mut wp) = app.warm_pane.take() { wp.child.kill().ok(); }
         return Err(e);
@@ -1228,14 +1160,8 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
     if let Some(n) = window_name {
         app.windows.last_mut().map(|w| { w.name = n; w.manual_rename = true; });
     }
-    // Replenish: spawn a warm pane for the NEXT new-window / split.
-    // Always replenish when no warm pane is available.
-    if app.warm_pane.is_none() {
-        match spawn_warm_pane(&*pty_system, &mut app) {
-            Ok(wp) => { app.warm_pane = Some(wp); }
-            Err(e) => { eprintln!("psmux: warm pane pre-spawn failed: {e}"); }
-        }
-    }
+    // The first user pane is ready. Refill the warm pool asynchronously from
+    // the loop below so a slow second spawn cannot delay initial discovery.
     // Fire client-attached and session-created hooks once at startup so plugins
     // populate initial data (e.g. CPU/battery) even for detached sessions
     // (tppanel previews). Skip the warm server: firing here would double-fire
@@ -1312,25 +1238,43 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
     // FocusWindowTemp/FocusPaneByIndexTemp in one batch plus the actual
     // command (e.g. CapturePane) in the next batch still works correctly.
     let mut temp_focus_restore: Option<(usize, usize)> = None;
+    let mut warm_task: Option<crate::pane::WarmPaneTask> = None;
+    let mut last_warm_attempt = Instant::now() - Duration::from_secs(1);
 
     loop {
-        // Tier 3 — keep warm-pane spawning OFF the command path. A warm pane is a
-        // fresh shell + ConPTY; spawning one can block the single event loop for
-        // 100ms–seconds under load. Doing it inline after every new-window/split
-        // stalled *other* clients' commands, surfacing as the intermittent
-        // `os error 10060` timeouts. Instead replenish only during a quiet gap
-        // (no command processed in the last 20ms), so window-create bursts
-        // transplant the ready pane instantly and the blocking spawn lands in idle
-        // time. If no warm pane is ready when a new-window arrives, create_window
-        // still spawns one synchronously — correctness is unchanged.
-        if app.warm_pane.is_none() && last_client_activity.elapsed() >= Duration::from_millis(20) {
-            if let Ok(wp) = spawn_warm_pane(&*pty_system, &mut app) {
-                app.warm_pane = Some(wp);
-            }
+        if crate::types::CONTROL_OUTPUT_LOST.swap(false, std::sync::atomic::Ordering::AcqRel) {
+            for id in app.control_clients.keys() { crate::types::shutdown_client_stream(*id); }
+            app.status_message = Some(("control client disconnected: output queue overflow".into(), Instant::now(), None));
+        }
+        for (pane_id, error) in crate::pane::take_input_failures(&mut app) {
+            let message = format!("pane %{} input failed: {}", pane_id, error);
+            crate::debug_log::server_log("input", &message);
+            app.status_message = Some((message, Instant::now(), None));
+        }
+        for (pane_id, error) in crate::pane::pipe::take_failures() {
+            app.pipe_panes.retain_mut(|pipe| {
+                if pipe.pane_id != pane_id { return true; }
+                if let Some(child) = pipe.process.as_mut() { let _ = child.kill(); }
+                false
+            });
+            app.status_message = Some((format!("pipe-pane %{}: {}", pane_id, error), Instant::now(), None));
+        }
+        // At most one refill runs in a worker. An idle gap is not permission
+        // to block the event loop: a client can arrive while CreateProcess is
+        // stalled. Snapshot validation prevents installing stale warm state.
+        if warm_task.as_mut().map(|task| task.poll(&mut app)).unwrap_or(false) {
+            warm_task = None;
+        }
+        if app.warm_enabled && app.warm_pane.is_none() && warm_task.is_none()
+            && last_warm_attempt.elapsed() >= Duration::from_secs(1) {
+            last_warm_attempt = Instant::now();
+            warm_task = crate::pane::WarmPaneTask::start(&mut app).ok();
         }
         if last_registry_check.elapsed() >= Duration::from_secs(5) {
             last_registry_check = Instant::now();
-            ensure_session_registry_files(&app);
+            if let Err(error) = ensure_session_registry_files(&app, &registration.owner) {
+                app.status_message = Some((format!("session registration failed: {}", error), Instant::now(), None));
+            }
         }
 
         // Adaptive timeout: ramps from 1ms (active typing/echo) through
@@ -1362,7 +1306,9 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                     crate::tree::for_each_pane(&win.root, &mut |pane: &crate::types::Pane| {
                         if let Ok(mut ring) = pane.output_ring.lock() {
                             if !ring.is_empty() {
-                                let bytes: Vec<u8> = ring.drain(..).collect();
+                                let count = ring.len().min(64 * 1024);
+                                let bytes: Vec<u8> = ring.drain(..count).collect();
+                                if !ring.is_empty() { crate::types::PTY_DATA_READY.store(true, std::sync::atomic::Ordering::Release); }
                                 let data = String::from_utf8_lossy(&bytes).to_string();
                                 pane_outputs.push((pane.id, data));
                             }
@@ -1388,14 +1334,14 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                             if age.as_secs() >= pause_secs {
                                 // Client fell behind: pause this pane
                                 client.output_paused_panes.insert(*pane_id);
-                                let _ = client.notification_tx.try_send(
+                                crate::control::send_notification_checked(client.client_id, &client.notification_tx,
                                     crate::types::ControlNotification::Pause { pane_id: *pane_id }
                                 );
                                 continue;
                             }
                             // Send as extended-output with age
                             let age_ms = age.as_millis() as u64;
-                            let _ = client.notification_tx.try_send(
+                            crate::control::send_notification_checked(client.client_id, &client.notification_tx,
                                 crate::types::ControlNotification::ExtendedOutput {
                                     pane_id: *pane_id,
                                     age_ms,
@@ -1404,7 +1350,7 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                             );
                         } else {
                             // No pause-after: send normal %output
-                            let _ = client.notification_tx.try_send(
+                            crate::control::send_notification_checked(client.client_id, &client.notification_tx,
                                 crate::types::ControlNotification::Output {
                                     pane_id: *pane_id,
                                     data: data.clone(),
@@ -1521,9 +1467,13 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
         if let Some(rx) = app.control_rx.as_ref() {
             if let Ok(req) = rx.recv_timeout(Duration::from_millis(timeout_ms)) {
                 last_client_activity = Instant::now();
+                let mut pending_bytes = req.queued_bytes();
                 let mut pending = vec![req];
-                // Drain any additional queued messages without blocking
-                while let Ok(r) = rx.try_recv() {
+                // Reserve room for the maximum (1 MiB) next request. Requests
+                // removed from the queue are still resident in this batch.
+                while pending.len() < 128 && pending_bytes <= 3 * 1024 * 1024 {
+                    let Ok(r) = rx.try_recv() else { break; };
+                    pending_bytes = pending_bytes.saturating_add(r.queued_bytes());
                     pending.push(r);
                 }
                 // Also check if fresh PTY output arrived while we were
@@ -1532,15 +1482,7 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                 if crate::types::PTY_DATA_READY.swap(false, std::sync::atomic::Ordering::AcqRel) {
                     state_dirty = true;
                 }
-                // Process key/command inputs BEFORE dump-state requests.
-                // This ensures ConPTY receives keystrokes before we serialize
-                // the screen, reducing stale-frame responses.
-                pending.sort_by_key(|r| match r {
-                    CtrlReq::DumpState(..) => 1,
-                    CtrlReq::DumpLayout(_) => 1,
-                    CtrlReq::WindowDump(..) => 1,
-                    _ => 0,
-                });
+                // Keep FIFO order, including command completion barriers.
                 // Track temporary -t focus: save (active_idx, pane_id) when
                 // FocusWindowTemp/FocusPaneTemp is seen, restore after next
                 // non-temp command so the user's view doesn't jump.
@@ -1551,6 +1493,11 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                 // FocusWindowTemp and the actual command land in different
                 // batches).
                 for req in pending {
+                    let (req, completion) = match req {
+                        CtrlReq::CommandRequest(req, completion) => (*req, Some(completion)),
+                        req => (req, None),
+                    };
+
                     let mutates_state = !matches!(&req,
                         CtrlReq::DumpState(..)
                         | CtrlReq::SendText(_)
@@ -1593,7 +1540,9 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                         CtrlReq::SwapWindow { .. } => "SwapWindow",
                         _ => "",
                     };
+                    let command_result = (|| -> io::Result<()> {
                     match req {
+                CtrlReq::CommandRequest(_, _) => return Err(io::Error::other("nested command request")),
                 CtrlReq::NewWindow(cmd, name, detached, start_dir, title, empty, env_sets) => {
                     if let Some(cmds) = app.hooks.get("before-new-window") { let cmds = cmds.clone(); for cmd in &cmds { let _ = execute_command_string(&mut app, cmd); } }
                     let prev_idx = app.active_idx;
@@ -1613,9 +1562,7 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                     // pane.rs, usable_start_dir), and a warm transplant gets it through
                     // pane::silent_rehome(). A shell releases the directory as soon as
                     // it cd's elsewhere, which is the tmux behaviour.
-                    if let Err(e) = create_window_with_env(&*pty_system, &mut app, cmd.as_deref(), start_dir.as_deref(), empty, &env_sets) {
-                        eprintln!("psmux: new-window error: {e}");
-                    }
+                    create_window_with_env(&*pty_system, &mut app, cmd.as_deref(), start_dir.as_deref(), empty, &env_sets)?;
                     crate::resize_window::refresh_dynamic_window_sizes(&mut app);
                     if let Some(n) = name { app.windows.last_mut().map(|w| { w.name = n; w.manual_rename = true; }); }
                     // -T: set the new pane's title at creation (tmux new-window -T).
@@ -1642,9 +1589,7 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                     // No server chdir here: the pane's start directory is handed to the
                     // shell alone, never to the ConPTY host. See the #630 note on
                     // CtrlReq::NewWindow above.
-                    if let Err(e) = create_window_with_env(&*pty_system, &mut app, cmd.as_deref(), start_dir.as_deref(), empty, &env_sets) {
-                        eprintln!("psmux: new-window error: {e}");
-                    }
+                    create_window_with_env(&*pty_system, &mut app, cmd.as_deref(), start_dir.as_deref(), empty, &env_sets)?;
                     crate::resize_window::refresh_dynamic_window_sizes(&mut app);
                     if let Some(n) = name { app.windows.last_mut().map(|w| { w.name = n; w.manual_rename = true; }); }
                     if let Some(t) = title {
@@ -1710,8 +1655,8 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                         Err(e) => {
                             let msg = format!("split-window: {e}");
                             app.status_message = Some((msg.clone(), std::time::Instant::now(), None));
-                            let _ = resp.send(format!("psmux: {msg}"));
-                            false
+                            let _ = resp.send(format!("ERROR: {msg}"));
+                            return Err(e);
                         }
                         Ok(()) => {
                             let _ = resp.send(String::new());
@@ -1792,7 +1737,7 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                         Err(e) => {
                             app.status_message = Some((format!("split-window: {e}"), std::time::Instant::now(), None));
                             eprintln!("psmux: split-window error: {e}");
-                            false
+                            return Err(e);
                         }
                         Ok(()) => true,
                     };
@@ -2125,11 +2070,7 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                         }
                         hook_event = Some("client-detached");
                         if app.attached_clients == 0 && app.destroy_unattached {
-                            let regpath = crate::paths::port_file(&app.port_file_base());
-                            let keypath = crate::paths::key_file(&app.port_file_base());
-                            let _ = std::fs::remove_file(&regpath);
-                            let _ = std::fs::remove_file(&keypath);
-                            crate::session::remove_session_id_file(&app.port_file_base());
+                            let _ = registration.owner.remove_owned(&registration.base);
                             crate::types::shutdown_persistent_streams();
                             tree::kill_all_children_batch(&mut app.windows);
                             if let Some(mut wp) = app.warm_pane.take() {
@@ -2230,7 +2171,7 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                         && dump_state_seen_full.contains(&dump_client_id)
                     {
                         let _ = resp.send("NC".to_string());
-                        continue;
+                        return Ok(());
                     }
                     // Rebuild metadata cache if structural changes happened.
                     if meta_dirty {
@@ -3426,11 +3367,7 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                     if let Some(cmds) = app.hooks.get("session-closed") { let cmds = cmds.clone(); for cmd in &cmds { let _ = execute_command_string(&mut app, cmd); } }
                     // Remove port/key/sid files FIRST so clients see the session
                     // as gone immediately, then kill processes.
-                    let regpath = crate::paths::port_file(&app.port_file_base());
-                    let keypath = crate::paths::key_file(&app.port_file_base());
-                    let _ = std::fs::remove_file(&regpath);
-                    let _ = std::fs::remove_file(&keypath);
-                    crate::session::remove_session_id_file(&app.port_file_base());
+                    let _ = registration.owner.remove_owned(&registration.base);
                     crate::types::send_directive_to_all_clients("DETACH");
                     std::thread::sleep(Duration::from_millis(50));
                     crate::types::shutdown_persistent_streams();
@@ -3447,48 +3384,7 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                     let _ = resp.send(true);
                 }
                 CtrlReq::RenameSession(name) => {
-                    if let Some(cmds) = app.hooks.get("before-rename-session") { let cmds = cmds.clone(); for cmd in &cmds { let _ = execute_command_string(&mut app, cmd); } }
-                    let old_path = crate::paths::port_file(&app.port_file_base());
-                    let old_keypath = crate::paths::key_file(&app.port_file_base());
-                    // Compute new port file base with socket_name prefix
-                    let new_base = if let Some(ref sn) = app.socket_name {
-                        format!("{}__{}" , sn, name)
-                    } else {
-                        name.clone()
-                    };
-                    let new_path = crate::paths::port_file(&new_base);
-                    let new_keypath = crate::paths::key_file(&new_base);
-                    if let Some(port) = app.control_port {
-                        let _ = std::fs::remove_file(&old_path);
-                        // Write this server's OWN in-memory key, NOT a copy of the
-                        // old .key file. Under warm-server replenish churn the
-                        // __warm__.key file may have been overwritten by a LATER warm
-                        // server, so copying it would give the renamed/claimed session
-                        // a key that does not match this server (seen as "Invalid
-                        // session key" on a later command). app.session_key is correct.
-                        let _ = std::fs::remove_file(&old_keypath);
-                        let _ = std::fs::write(&new_keypath, &app.session_key);
-                        // The activity stamp follows the session across the rename
-                        // (issue #603); it must move BEFORE remove_session_id_file
-                        // drops the old base's stamp with its .sid/.pid.
-                        crate::session::carry_session_activity_file(&app.port_file_base(), &new_base);
-                        // Rename .sid file to match new session name
-                        crate::session::remove_session_id_file(&app.port_file_base());
-                        crate::session::write_session_id_file(&new_base, app.session_id);
-                        // Re-anchor the PID sentinel to the new base (issue #448):
-                        // remove_session_id_file above dropped the old .pid.
-                        crate::session::write_session_pid_file(&new_base, std::process::id());
-                        // The new .port file goes LAST: it is the readiness beacon an
-                        // attaching client polls for, so the .key/.sid/.pid it will
-                        // read next must already exist when it appears (issue #496).
-                        let _ = std::fs::write(&new_path, port.to_string());
-                    }
-                    app.session_name = name;
-                    // Move the single-server-per-name guard onto the new name, or the
-                    // old name stays locked forever and blocks re-creating it (#505).
-                    rekey_session_guard(&mut session_guard, &app.port_file_base());
-                    // Update env so run-shell/hooks from this server target the new name
-                    env::set_var("PSMUX_TARGET_SESSION", app.port_file_base());
+                    rename_registered_session(&mut app, &mut session_guard, &mut registration, name, &panic_name)?;
                     hook_event = Some("after-rename-session");
                 }
                 CtrlReq::ClaimSession(name, client_cwd, client_priority, resp) => {
@@ -3506,47 +3402,10 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                         let _ = resp.send("ERR: not a warm server (already claimed)\n".to_string());
                     } else {
                     warm_debug(&format!("CLAIM ACCEPT: __warm__ (port={:?}) -> '{}'", app.control_port, name));
-                    // Same as RenameSession but with a synchronous response
-                    // so the CLI knows the rename completed before attaching.
-                    let old_path = crate::paths::port_file(&app.port_file_base());
-                    let old_keypath = crate::paths::key_file(&app.port_file_base());
-                    let new_base = if let Some(ref sn) = app.socket_name {
-                        format!("{}__{}" , sn, name)
-                    } else {
-                        name.clone()
-                    };
-                    let new_path = crate::paths::port_file(&new_base);
-                    let new_keypath = crate::paths::key_file(&new_base);
-                    if let Some(port) = app.control_port {
-                        let _ = std::fs::remove_file(&old_path);
-                        // Write this server's OWN in-memory key, NOT a copy of the
-                        // old .key file. Under warm-server replenish churn the
-                        // __warm__.key file may have been overwritten by a LATER warm
-                        // server, so copying it would give the renamed/claimed session
-                        // a key that does not match this server (seen as "Invalid
-                        // session key" on a later command). app.session_key is correct.
-                        let _ = std::fs::remove_file(&old_keypath);
-                        let _ = std::fs::write(&new_keypath, &app.session_key);
-                        // The activity stamp follows the session across the rename
-                        // (issue #603); it must move BEFORE remove_session_id_file
-                        // drops the old base's stamp with its .sid/.pid.
-                        crate::session::carry_session_activity_file(&app.port_file_base(), &new_base);
-                        // Rename .sid file to match new session name
-                        crate::session::remove_session_id_file(&app.port_file_base());
-                        crate::session::write_session_id_file(&new_base, app.session_id);
-                        // Re-anchor the PID sentinel to the new base (issue #448):
-                        // remove_session_id_file above dropped the old .pid.
-                        crate::session::write_session_pid_file(&new_base, std::process::id());
-                        // The new .port file goes LAST: it is the readiness beacon an
-                        // attaching client polls for, so the .key/.sid/.pid it will
-                        // read next must already exist when it appears (issue #496).
-                        let _ = std::fs::write(&new_path, port.to_string());
+                    if let Err(error) = rename_registered_session(&mut app, &mut session_guard, &mut registration, name, &panic_name) {
+                        let _ = resp.send(format!("ERR: {}\n", error));
+                        return Err(error);
                     }
-                    app.session_name = name;
-                    // Move the guard from `__warm__` onto the claimed name (#505).
-                    // Releasing the warm name is what frees it for the replacement
-                    // warm spawned further below (issue #459).
-                    rekey_session_guard(&mut session_guard, &app.port_file_base());
                     // Warm server's created_at is the warm process start time, not the
                     // user's session-creation time — reset on claim or list-sessions /
                     // session_created / uptime would report the warm pool's age.
@@ -4688,7 +4547,7 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                     }
                     let _ = resp.send(output);
                 }
-                CtrlReq::PipePane(cmd, stdin, stdout, toggle, mut reply) => {
+                CtrlReq::PipePane(cmd, stdin, stdout, toggle, reply) => {
                     // The `-t` target (if any) was temp-focused by the connection
                     // layer before this request ran, so the active pane here IS the
                     // requested target pane (issue #440 defect 2). The pipe binds to
@@ -4717,27 +4576,14 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                         // shape). A pane_id match from another writer kind
                         // (cross-session tunnel) errs on keeping the entry,
                         // which is the pre-existing behavior.
-                        None => crate::types::PIPE_WRITERS
-                            .lock()
-                            .map(|w| w.iter().any(|(id, _)| *id == p.pane_id))
-                            .unwrap_or(true),
+                        None => crate::pane::pipe::is_registered(p.pane_id),
                     });
 
                     // Drop any writer this pane's reader thread was teeing to
                     // (issue #440). Dropping the ChildStdin closes the pipe so the
                     // child sees EOF; the count gate is kept in sync so idle panes
                     // pay nothing.
-                    let unregister_writer = |pid: usize| {
-                        if let Ok(mut writers) = crate::types::PIPE_WRITERS.lock() {
-                            let before = writers.len();
-                            writers.retain(|(id, _)| *id != pid);
-                            let removed = before - writers.len();
-                            if removed > 0 {
-                                crate::types::PIPE_PANE_COUNT
-                                    .fetch_sub(removed, std::sync::atomic::Ordering::Relaxed);
-                            }
-                        }
-                    };
+                    let unregister_writer = crate::pane::pipe::unregister;
 
                     // Drop the writers belonging to the sinks reaped above. The
                     // reader thread already drops a writer when a tee write
@@ -4815,32 +4661,9 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                                     path
                                 );
                             } else {
-                            let mut opts = std::fs::OpenOptions::new();
-                            opts.create(true).write(true);
-                            if append { opts.append(true); } else { opts.truncate(true); }
-                            match opts.open(&path) {
-                                Ok(file) => {
-                                    if let Ok(mut writers) = crate::types::PIPE_WRITERS.lock() {
-                                        writers.push((pane_id, Box::new(file)));
-                                        crate::types::PIPE_PANE_COUNT
-                                            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                                        app.pipe_panes.push(PipePaneState {
-                                            pane_id,
-                                            process: None,
-                                            stdin,
-                                            stdout,
-                                        });
-                                    } else {
-                                        // Poisoned registry: recording the pane as
-                                        // piped with no writer would be exactly the
-                                        // phantom pipe this change removes.
-                                        outcome =
-                                            "ERROR: pipe-pane: writer registry unavailable".to_string();
-                                    }
-                                }
-                                Err(e) => {
-                                    outcome = format!("ERROR: pipe-pane: can't open {}: {}", path, e);
-                                }
+                            match crate::pane::pipe::register_file(pane_id, path.clone(), append) {
+                                Ok(()) => app.pipe_panes.push(PipePaneState { pane_id, process: None, stdin, stdout }),
+                                Err(error) => outcome = format!("ERROR: pipe-pane: can't open {}: {}", path, error),
                             }
                             }
                             // The reply channel only reaches the one-shot CLI;
@@ -4856,16 +4679,7 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                                 ));
                             }
                         } else {
-                        // Start new pipe. Answer "accepted" BEFORE spawning:
-                        // CreateProcess can stall for seconds on a cold
-                        // antivirus scan of the shell image, and holding the
-                        // reply hostage to it turns a successful pipe-pane
-                        // into a client-side timeout error. A spawn failure
-                        // is still not recorded (no phantom pipe) and is
-                        // surfaced on the status bar below.
-                        if let Some(tx) = reply.take() {
-                            let _ = tx.send(String::new());
-                        }
+                        // A successful reply means the sink was actually started.
                         let (shell_prog, shell_args) = crate::commands::resolve_run_shell();
                         let spawn_result = {
                             let mut c = std::process::Command::new(&shell_prog);
@@ -4887,20 +4701,16 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                                 // input) is unchanged.
                                 if stdout {
                                     if let Some(stdin_handle) = child.stdin.take() {
-                                        if let Ok(mut writers) = crate::types::PIPE_WRITERS.lock() {
-                                            writers.push((pane_id, Box::new(stdin_handle)));
-                                            crate::types::PIPE_PANE_COUNT
-                                                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                                        if let Err(error) = crate::pane::pipe::register(pane_id, Box::new(stdin_handle)) {
+                                            let _ = child.kill();
+                                            outcome = format!("ERROR: pipe-pane: {}", error);
                                         }
                                     }
                                 }
 
-                                app.pipe_panes.push(PipePaneState {
-                                    pane_id,
-                                    process: Some(child),
-                                    stdin,
-                                    stdout,
-                                });
+                                if outcome.is_empty() {
+                                    app.pipe_panes.push(PipePaneState { pane_id, process: Some(child), stdin, stdout });
+                                }
                             }
                             Err(e) => {
                                 // A sink that never started must not be recorded:
@@ -4909,6 +4719,7 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                                 // (`spawn().ok()` swallowed the error). The reply
                                 // was already sent, so report where run-shell -b
                                 // reports its spawn failures: the status bar.
+                                outcome = format!("ERROR: pipe-pane: can't spawn sink: {}", e);
                                 app.status_message = Some((
                                     format!("pipe-pane: can't spawn sink: {}", e),
                                     std::time::Instant::now(),
@@ -5018,11 +4829,7 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                     });
                     hook_event = Some("client-detached");
                     if app.attached_clients == 0 && app.destroy_unattached {
-                        let regpath = crate::paths::port_file(&app.port_file_base());
-                        let keypath = crate::paths::key_file(&app.port_file_base());
-                        let _ = std::fs::remove_file(&regpath);
-                        let _ = std::fs::remove_file(&keypath);
-                        crate::session::remove_session_id_file(&app.port_file_base());
+                        let _ = registration.owner.remove_owned(&registration.base);
                         crate::types::shutdown_persistent_streams();
                         tree::kill_all_children_batch(&mut app.windows);
                         if let Some(mut wp) = app.warm_pane.take() {
@@ -5102,11 +4909,7 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                         hook_event = Some("client-detached");
                     }
                     if app.attached_clients == 0 && app.destroy_unattached {
-                        let regpath = crate::paths::port_file(&app.port_file_base());
-                        let keypath = crate::paths::key_file(&app.port_file_base());
-                        let _ = std::fs::remove_file(&regpath);
-                        let _ = std::fs::remove_file(&keypath);
-                        crate::session::remove_session_id_file(&app.port_file_base());
+                        let _ = registration.owner.remove_owned(&registration.base);
                         crate::types::shutdown_persistent_streams();
                         tree::kill_all_children_batch(&mut app.windows);
                         if let Some(mut wp) = app.warm_pane.take() {
@@ -5151,11 +4954,7 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                         hook_event = Some("client-detached");
                     }
                     if app.attached_clients == 0 && app.destroy_unattached {
-                        let regpath = crate::paths::port_file(&app.port_file_base());
-                        let keypath = crate::paths::key_file(&app.port_file_base());
-                        let _ = std::fs::remove_file(&regpath);
-                        let _ = std::fs::remove_file(&keypath);
-                        crate::session::remove_session_id_file(&app.port_file_base());
+                        let _ = registration.owner.remove_owned(&registration.base);
                         crate::types::shutdown_persistent_streams();
                         tree::kill_all_children_batch(&mut app.windows);
                         if let Some(mut wp) = app.warm_pane.take() {
@@ -5533,10 +5332,7 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                     }
                     // Remove port/key files FIRST so clients see the session
                     // as gone immediately, then kill processes.
-                    let regpath = crate::paths::port_file(&app.port_file_base());
-                    let keypath = crate::paths::key_file(&app.port_file_base());
-                    let _ = std::fs::remove_file(&regpath);
-                    let _ = std::fs::remove_file(&keypath);
+                    let _ = registration.owner.remove_owned(&registration.base);
                     crate::types::send_directive_to_all_clients("DETACH");
                     std::thread::sleep(Duration::from_millis(50));
                     crate::types::shutdown_persistent_streams();
@@ -5943,9 +5739,8 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                         }
                     }
                 }
-                CtrlReq::RespawnWindow(workdir, command) => {
-                    // Kill all panes in the active window and respawn
-                    respawn_active_pane(&mut app, Some(&*pty_system), workdir.as_deref(), true, command.as_deref(), false)?;
+                CtrlReq::RespawnWindow(workdir, kill, command) => {
+                    crate::window_ops::respawn_window(&mut app, &*pty_system, workdir.as_deref(), kill, command.as_deref())?;
                     state_dirty = true;
                 }
                 CtrlReq::PopupInput(data) => {
@@ -6076,6 +5871,7 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                     }
                 }
                 CtrlReq::ControlRegister { client_id, echo, notif_tx } => {
+                    crate::types::CONTROL_CLIENTS_ACTIVE.store(true, std::sync::atomic::Ordering::Release);
                     app.control_clients.insert(client_id, crate::types::ControlClient {
                         client_id,
                         cmd_counter: 0,
@@ -6137,7 +5933,7 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                 CtrlReq::ControlContinuePane { client_id, pane_id } => {
                     if let Some(cc) = app.control_clients.get_mut(&client_id) {
                         if cc.output_paused_panes.remove(&pane_id) {
-                            let _ = cc.notification_tx.try_send(
+                            crate::control::send_notification_checked(cc.client_id, &cc.notification_tx,
                                 crate::types::ControlNotification::Continue { pane_id }
                             );
                         }
@@ -6145,6 +5941,7 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                 }
                 CtrlReq::ControlDeregister { client_id } => {
                     app.control_clients.remove(&client_id);
+                    crate::types::CONTROL_CLIENTS_ACTIVE.store(!app.control_clients.is_empty(), std::sync::atomic::Ordering::Release);
                     // Idempotent reap keeps the counter in lock-step with the
                     // registry even if a control client is deregistered twice.
                     app.reap_client(client_id);
@@ -6307,6 +6104,15 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                     }
                 }
             }
+            Ok(())
+            })();
+            if let Err(error) = &command_result {
+                app.status_message = Some((error.to_string(), Instant::now(), None));
+                hook_event = None;
+            }
+            if let Some(completion) = completion {
+                let _ = completion.send(command_result.map_err(|e| e.to_string()));
+            }
             // Log any active_idx change for debugging window-switch issues
             if app.active_idx != _prev_active_idx && crate::debug_log::server_log_enabled() {
                 crate::debug_log::server_log("switch", &format!(
@@ -6465,8 +6271,8 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
             }
             // Rebuild metadata cache if structural changes happened.
             if meta_dirty {
-                cached_windows_json = list_windows_json_with_tabs(&app)?;
-                cached_tree_json = list_tree_json(&app)?;
+                cached_windows_json = match list_windows_json_with_tabs(&app) { Ok(value) => value, Err(error) => { app.status_message = Some((error.to_string(), Instant::now(), None)); continue; } };
+                cached_tree_json = match list_tree_json(&app) { Ok(value) => value, Err(error) => { app.status_message = Some((error.to_string(), Instant::now(), None)); continue; } };
                 cached_prefix_str = format_key_binding(&app.prefix_key);
                 cached_prefix2_str = app.prefix2_key.as_ref().map(|k| format_key_binding(k)).unwrap_or_default();
                 cached_base_index = app.window_base_index;
@@ -6475,7 +6281,7 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                 cached_bindings_json = serialize_bindings_json(&app);
                 meta_dirty = false;
             }
-            let layout_json = dump_layout_json_fast(&mut app)?;
+            let layout_json = match dump_layout_json_fast(&mut app) { Ok(value) => value, Err(error) => { app.status_message = Some((error.to_string(), Instant::now(), None)); continue; } };
             combined_buf.clear();
             // #372: style options must be format-expanded too (see persistent
             // path above). wsf/wscf stay raw: per-window formats the client
@@ -6715,7 +6521,7 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
             }
             for (cid, notif) in sub_notifs {
                 if let Some(cc) = app.control_clients.get(&cid) {
-                    let _ = cc.notification_tx.try_send(notif);
+                    crate::control::send_notification_checked(cc.client_id, &cc.notification_tx, notif);
                 }
             }
         }
@@ -6776,9 +6582,6 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                 .unwrap_or(false);
             if warm_dead {
                 if let Some(mut dead) = app.warm_pane.take() { dead.child.kill().ok(); }
-                if let Ok(nw) = spawn_warm_pane(&*pty_system, &mut app) {
-                    app.warm_pane = Some(nw);
-                }
             }
             // #450 (opt-in `@heal-crashed-panes`): a shell can FailFast on its
             // very first ConPTY read right after a warm-pane transplant (pwsh
@@ -6837,7 +6640,7 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                 Some(app.windows[app.active_idx].id)
             } else { None };
 
-            let (all_empty, any_pruned, any_newly_dead) = tree::reap_children(&mut app)?;
+            let (all_empty, any_pruned, any_newly_dead) = match tree::reap_children(&mut app) { Ok(state) => state, Err(error) => { app.status_message = Some((format!("child status unavailable: {}", error), Instant::now(), None)); (false, false, false) } };
             if any_pruned {
                 // A pane was removed from the tree - resize remaining panes to fill the space
                 resize_all_panes(&mut app);
@@ -6905,10 +6708,7 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                     // the DCS stream before we tear down the process.
                     std::thread::sleep(std::time::Duration::from_millis(80));
                 }
-                let regpath = crate::paths::port_file(&app.port_file_base());
-                let keypath = crate::paths::key_file(&app.port_file_base());
-                let _ = std::fs::remove_file(&regpath);
-                let _ = std::fs::remove_file(&keypath);
+                let _ = registration.owner.remove_owned(&registration.base);
                 crate::types::send_directive_to_all_clients("DETACH");
                 std::thread::sleep(Duration::from_millis(50));
                 crate::types::shutdown_persistent_streams();
@@ -6964,3 +6764,39 @@ mod test_issue370_startup_error_passthrough;
 #[cfg(test)]
 #[path = "../../tests-rs/test_issue459_warm_single_instance.rs"]
 mod test_issue459_warm_single_instance;
+
+#[cfg(test)]
+mod panic_registration_tests {
+    use super::*;
+    #[test]
+    fn worker_panic_logs_current_identity_without_touching_registration() {
+        let _lock = crate::util::lock_test_env();
+        let root = std::env::temp_dir().join(format!("psmux-panic-audit-{}-{}", std::process::id(),
+            std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_nanos()));
+        std::fs::create_dir_all(&root).unwrap();
+        let old = root.join("old.port");
+        let current = root.join("renamed.port");
+        let log = root.join("crash.log");
+        std::fs::write(&old, "replacement-owner").unwrap();
+        std::fs::write(&current, "current-owner").unwrap();
+        std::fs::write(&log, "prior diagnostic\n").unwrap();
+        let name = std::sync::Arc::new(std::sync::Mutex::new("old".to_string()));
+        let previous = std::panic::take_hook();
+        install_panic_logger(name.clone(), log.to_string_lossy().into_owned());
+        let outcome = std::panic::catch_unwind(|| {
+            *name.lock().unwrap() = "renamed".into();
+            std::thread::Builder::new().name("audit-panicking-worker".into())
+                .spawn(|| panic!("injected background failure")).unwrap().join().is_err()
+        });
+        std::panic::set_hook(previous);
+        assert!(outcome.unwrap());
+        assert_eq!(std::fs::read_to_string(&old).unwrap(), "replacement-owner");
+        assert_eq!(std::fs::read_to_string(&current).unwrap(), "current-owner");
+        let diagnostic = std::fs::read_to_string(&log).unwrap();
+        assert!(diagnostic.starts_with("prior diagnostic\n"));
+        assert!(diagnostic.contains("session=renamed"));
+        assert!(diagnostic.contains("audit-panicking-worker"));
+        assert!(diagnostic.contains("Backtrace:"));
+        std::fs::remove_dir_all(root).unwrap();
+    }
+}

--- a/src/server/options.rs
+++ b/src/server/options.rs
@@ -644,11 +644,7 @@ pub(crate) fn apply_set_option(
                     wp.child.kill().ok();
                 }
                 // Kill the background warm server process
-                let warm_base = if let Some(ref sn) = app.socket_name {
-                    format!("{}____warm__", sn)
-                } else {
-                    "__warm__".to_string()
-                };
+                let warm_base = crate::paths::storage_base(app.socket_name.as_deref(), "__warm__");
                 let warm_port_path = crate::paths::port_file(&warm_base);
                 if let Ok(port_str) = std::fs::read_to_string(&warm_port_path) {
                     if let Ok(port) = port_str.trim().parse::<u16>() {
@@ -662,9 +658,8 @@ pub(crate) fn apply_set_option(
                         );
                     }
                 }
-                let _ = std::fs::remove_file(&warm_port_path);
-                let warm_key_path = crate::paths::key_file(&warm_base);
-                let _ = std::fs::remove_file(&warm_key_path);
+                // The warm server removes its own registration on confirmed
+                // shutdown. A failed/slow command must not unpublish it.
             }
         }
         "claude-code-fix-tty" => {

--- a/src/session.rs
+++ b/src/session.rs
@@ -25,40 +25,24 @@ enum PortProbeResult {
 /// Returns true if this port-file base name belongs to a warm (standby) server.
 /// Warm sessions should be hidden from user-facing lists and never auto-attached.
 pub fn is_warm_session(base: &str) -> bool {
-    base == "__warm__" || base.ends_with("____warm__")
+    crate::paths::registry_session_name(base) == "__warm__"
 }
 
-/// The `-L` socket namespace a registry base name belongs to.
-///
-/// A namespaced session is stored as `<ns>__<name>`, so the namespace is the
-/// text before the first `__`. A bare name has none, and neither does the
-/// default namespace's own warm helper `__warm__` (its `__` is not a
-/// separator). Used to work out which server family a client belongs to from
-/// the full name it was attached with.
-pub fn session_namespace(full: &str) -> Option<&str> {
-    if is_warm_session(full) {
-        return None;
-    }
-    match full.split_once("__") {
-        Some((ns, _)) if !ns.is_empty() => Some(ns),
-        _ => None,
-    }
+pub fn session_namespace(full: &str) -> Option<String> {
+    crate::paths::registry_namespace(full)
 }
 
-/// Whether the registry base `base` is visible from namespace `ns`.
-///
-/// tmux parity: a `-L` socket is a separate server, and a client on one
-/// socket can never see sessions of another. psmux keeps every namespace in
-/// one registry directory, so listings that enumerate `.port` files must
-/// apply this rule. `ls`, `$N` resolution and the reaper already did; the
-/// interactive session and tree choosers did not, and a session from another
-/// namespace (`amx-6c9b6ad63d__main`) sorted itself between the default
-/// namespace's own sessions and shifted every `j`/`k` step in the picker.
 pub fn session_visible_from(base: &str, ns: Option<&str>) -> bool {
-    match ns {
-        Some(n) => base.starts_with(&format!("{}__", n)),
-        None => !base.contains("__"),
-    }
+    crate::paths::registry_visible_from(base, ns)
+}
+
+/// Resolve once for the entire invocation: explicit socket, inherited socket,
+/// then the current pane's registered endpoint, otherwise default namespace.
+pub fn effective_namespace(explicit: Option<&str>, inherited: Option<&str>, tmux: Option<&str>, dir: &Path) -> Option<String> {
+    explicit.or(inherited).map(str::to_string).or_else(|| {
+        tmux.and_then(|value| session_base_owning_tmux_port(value, dir))
+            .and_then(|base| session_namespace(&base))
+    })
 }
 
 /// Find the next available numeric session name (tmux-compatible).
@@ -77,18 +61,8 @@ pub fn next_session_name(ns_prefix: Option<&str>) -> String {
                 if let Some((base, ext)) = fname.rsplit_once('.') {
                     if ext != "port" { continue; }
                     if is_warm_session(base) { continue; }
-                    // Extract the session name part (after namespace prefix if any)
-                    let session_part = if let Some(pfx) = ns_prefix {
-                        let full_pfx = format!("{}__", pfx);
-                        if base.starts_with(&full_pfx) {
-                            &base[full_pfx.len()..]
-                        } else {
-                            continue; // different namespace
-                        }
-                    } else {
-                        if base.contains("__") { continue; } // namespaced session
-                        base
-                    };
+                    if !session_visible_from(base, ns_prefix) { continue; }
+                    let session_part = crate::paths::registry_session_name(base);
                     if let Ok(n) = session_part.parse::<u32>() {
                         used.insert(n);
                     }
@@ -109,69 +83,86 @@ pub fn next_session_name(ns_prefix: Option<&str>) -> String {
 /// either writes back, and hand out duplicate ids.
 static SESSION_ID_ALLOC: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
-/// Best-effort cross-process advisory lock backed by an atomically-created lock
-/// file. Separate psmux server processes share the same `next_session_id`
-/// counter, so the in-process mutex alone is not enough; this closes the
-/// read-modify-write gap across processes too. Released on drop. A lock left by
-/// a crashed process is taken over once it is clearly stale; the guarded
-/// critical section is sub-millisecond, so the staleness bound never steals a
-/// live lock.
-struct CounterLock {
-    path: String,
-}
-
+/// Compatibility lock for older executables, protected by a strict named
+/// mutex between current servers. Age alone never authorizes lock theft.
+struct CounterLock { path: String, identity: String }
 impl CounterLock {
-    const STALE_AFTER: Duration = Duration::from_secs(5);
-
-    fn acquire(path: String) -> Self {
-        for _ in 0..2000 {
+    fn acquire(path: String) -> io::Result<Self> {
+        let creation = crate::platform::process_kill::process_creation_time(std::process::id())
+            .ok_or_else(|| io::Error::other("cannot establish counter owner identity"))?;
+        let identity = format!("{}:{}", std::process::id(), creation);
+        let deadline = std::time::Instant::now() + Duration::from_secs(2);
+        loop {
             match std::fs::OpenOptions::new().write(true).create_new(true).open(&path) {
-                Ok(mut f) => {
-                    let _ = write!(f, "{}", std::process::id());
-                    return CounterLock { path };
-                }
-                Err(_) => {
-                    // Take over a stale lock left behind by a crashed holder.
-                    let stale = std::fs::metadata(&path)
-                        .and_then(|m| m.modified())
-                        .map(|t| t.elapsed().map(|d| d >= Self::STALE_AFTER).unwrap_or(false))
-                        .unwrap_or(false);
-                    if stale {
+                Ok(mut file) => {
+                    if let Err(error) = file.write_all(identity.as_bytes()) {
+                        drop(file);
                         let _ = std::fs::remove_file(&path);
-                        continue;
+                        return Err(error);
                     }
-                    std::thread::sleep(Duration::from_millis(1));
+                    return Ok(Self { path, identity });
                 }
+                Err(error) if error.kind() == ErrorKind::AlreadyExists => {
+                    if let Ok(record) = std::fs::read_to_string(&path) {
+                        if let Some((pid, creation)) = parse_pid_file_contents(&record) {
+                            use crate::platform::process_kill::{process_identity, ProcessIdentity};
+                            let dead = match process_identity(pid) {
+                                ProcessIdentity::Exited => true,
+                                ProcessIdentity::Alive(actual) => creation.is_some_and(|old| old != actual),
+                                ProcessIdentity::Unknown => false,
+                            };
+                            if dead && std::fs::read_to_string(&path).ok().as_deref() == Some(record.as_str()) {
+                                std::fs::remove_file(&path)?;
+                                continue;
+                            }
+                        }
+                    }
+                    if std::time::Instant::now() >= deadline {
+                        return Err(io::Error::new(ErrorKind::WouldBlock, "session ID counter lock is busy or its owner is uncertain"));
+                    }
+                    std::thread::sleep(Duration::from_millis(5));
+                }
+                Err(error) => return Err(error),
             }
         }
-        // Never observed in practice (the critical section is microseconds);
-        // proceed rather than hang session creation indefinitely.
-        CounterLock { path }
     }
 }
-
 impl Drop for CounterLock {
     fn drop(&mut self) {
-        let _ = std::fs::remove_file(&self.path);
+        if std::fs::read_to_string(&self.path).ok().as_deref() == Some(self.identity.as_str()) {
+            let _ = std::fs::remove_file(&self.path);
+        }
     }
 }
 
-/// Allocate a globally unique session ID by reading and incrementing
-/// the persistent counter file `.psmux/next_session_id`.
-///
-/// The read-modify-write is serialized within the process by `SESSION_ID_ALLOC`
-/// and across processes by an advisory lock file, so concurrent callers can
-/// never observe the same `current` and return duplicate ids.
-pub fn allocate_session_id() -> usize {
+fn increment_session_counter(path: &Path) -> io::Result<usize> {
+    let current = match std::fs::read_to_string(path) {
+        Ok(value) => value.trim().parse::<usize>()
+            .map_err(|_| io::Error::new(ErrorKind::InvalidData, "invalid session ID counter"))?,
+        Err(error) if error.kind() == ErrorKind::NotFound => 0,
+        Err(error) => return Err(error),
+    };
+    let next = current.checked_add(1).ok_or_else(|| io::Error::other("session ID counter exhausted"))?;
+    crate::registry::atomic_write(path, next.to_string().as_bytes())?;
+    Ok(current)
+}
+
+/// Reserve an ID only when starting a server; failed allocation aborts startup.
+/// Neither AppState construction nor read-only clients mutate this counter.
+pub fn allocate_session_id() -> io::Result<usize> {
     let _guard = SESSION_ID_ALLOC.lock().unwrap_or_else(|e| e.into_inner());
+    std::fs::create_dir_all(crate::paths::psmux_dir())?;
+    let deadline = std::time::Instant::now() + Duration::from_secs(2);
+    let _named = loop {
+        if let Some(guard) = crate::platform::acquire_session_mutex_strict("~psmux~counter~session")? { break guard; }
+        if std::time::Instant::now() >= deadline {
+            return Err(io::Error::new(ErrorKind::WouldBlock, "session ID allocator is busy"));
+        }
+        std::thread::sleep(Duration::from_millis(5));
+    };
     let counter_path = crate::paths::psmux_dir_file("next_session_id");
-    let _xlock = CounterLock::acquire(format!("{}.lock", counter_path));
-    let current = std::fs::read_to_string(&counter_path)
-        .ok()
-        .and_then(|s| s.trim().parse::<usize>().ok())
-        .unwrap_or(0);
-    let _ = std::fs::write(&counter_path, (current + 1).to_string());
-    current
+    let _compatibility = CounterLock::acquire(format!("{}.lock", counter_path))?;
+    increment_session_counter(Path::new(&counter_path))
 }
 
 /// Write a `.sid` file recording the session ID for this session.
@@ -704,39 +695,16 @@ struct ServerCandidate {
 /// `.port` file pointing at it, so it can never be selected even if its `.pid`
 /// file is missing (backward compatibility with servers started before #448).
 fn select_orphan_pids(
-    candidates: &[ServerCandidate],
-    tracked_ports: &std::collections::HashSet<u16>,
-    tracked_pids: &std::collections::HashSet<u32>,
-    owned_pids: &std::collections::HashMap<u32, Option<u64>>,
-    self_pid: u32,
-    age_cutoff_ft: u64,
+    _candidates: &[ServerCandidate],
+    _tracked_ports: &std::collections::HashSet<u16>,
+    _tracked_pids: &std::collections::HashSet<u32>,
+    _owned_pids: &std::collections::HashMap<u32, Option<u64>>,
+    _self_pid: u32,
+    _age_cutoff_ft: u64,
 ) -> Vec<u32> {
-    let mut out = Vec::new();
-    for c in candidates {
-        if c.pid == self_pid { continue; }
-        if tracked_pids.contains(&c.pid) { continue; }
-        if c.ports.iter().any(|p| tracked_ports.contains(p)) { continue; }
-        // Issue #510: reap only what this data dir can positively claim.
-        //
-        // The candidate list is machine-wide, so "no registry entry references
-        // it" covers two very different processes: an orphan we started, and a
-        // perfectly healthy server belonging to another USERPROFILE/HOME. The
-        // old rule could not tell them apart and killed both. An absent
-        // ownership marker now means "not ours, not our business" rather than
-        // "orphan" - unknown must never justify termination.
-        let Some(&recorded_creation) = owned_pids.get(&c.pid) else { continue; };
-        // Same identity gate force_kill_targets applies: without a recorded
-        // creation time there is nothing to distinguish this process from an
-        // unrelated one that inherited the PID, so it is not a candidate.
-        match recorded_creation {
-            Some(ft) if ft == c.creation_ft => {}
-            _ => continue,
-        }
-        // Only reap processes old enough to have finished registering.
-        if age_cutoff_ft != 0 && c.creation_ft > age_cutoff_ft { continue; }
-        out.push(c.pid);
-    }
-    out
+    // Missing metadata cannot establish that a live session is disposable.
+    // Process termination is restricted to explicit kill operations.
+    Vec::new()
 }
 
 /// Read the set of ports referenced by `.port` files and the set of PIDs
@@ -826,7 +794,7 @@ pub fn force_kill_targets(dir: &std::path::Path, ns_prefix: Option<&str>) -> Vec
         if path.extension().map(|e| e == "pid").unwrap_or(false) {
             if let Some(pfx) = ns_prefix {
                 let stem = path.file_stem().and_then(|s| s.to_str()).unwrap_or("");
-                if !stem.starts_with(pfx) { continue; }
+                if !session_visible_from(stem, pfx.strip_suffix("__")) { continue; }
             }
             if let Ok(contents) = std::fs::read_to_string(&path) {
                 // A recorded creation time is required: it is the identity gate.
@@ -838,6 +806,116 @@ pub fn force_kill_targets(dir: &std::path::Path, ns_prefix: Option<&str>) -> Vec
         }
     }
     targets
+}
+
+const SESSION_REGISTRY_EXTENSIONS: &[&str] = &["port", "key", "sid", "pid", "act", "registry.json"];
+
+struct KillRegistrySnapshot {
+    base: String,
+    dir: std::path::PathBuf,
+    identity: Option<PidTarget>,
+    files: Vec<Option<Vec<u8>>>,
+}
+
+fn snapshot_kill_registry(dir: &Path, base: &str) -> io::Result<KillRegistrySnapshot> {
+    use std::io::Read;
+    let mut files = Vec::new();
+    for ext in SESSION_REGISTRY_EXTENSIONS {
+        let path = dir.join(format!("{}.{}", base, ext));
+        let bytes = match std::fs::File::open(path) {
+            Ok(file) => {
+                let mut bytes = Vec::new();
+                file.take(16385).read_to_end(&mut bytes)?;
+                if bytes.len() > 16384 { return Err(io::Error::new(ErrorKind::InvalidData, "oversized registry file")); }
+                Some(bytes)
+            }
+            Err(e) if e.kind() == ErrorKind::NotFound => None,
+            Err(e) => return Err(e),
+        };
+        files.push(bytes);
+    }
+    let identity = if let Some(bytes) = files[5].as_ref() {
+        let m: crate::registry::RegistryManifest = serde_json::from_slice(bytes).map_err(io::Error::other)?;
+        Some(PidTarget { pid: m.pid, creation_time: m.creation_time })
+    } else {
+        files[3].as_deref().and_then(|bytes| std::str::from_utf8(bytes).ok())
+            .and_then(parse_pid_file_contents).and_then(|(pid, creation)| creation.map(|creation_time| PidTarget { pid, creation_time }))
+    };
+    Ok(KillRegistrySnapshot { base: base.to_string(), dir: dir.to_path_buf(), identity, files })
+}
+
+/// Only explicit kill uses this cleanup. Hold the destination name reservation,
+/// prove the snapshotted process generation exited, and compare every sibling
+/// before deleting anything. A new registration always wins this race.
+fn cleanup_killed_registry(snapshot: &KillRegistrySnapshot) -> io::Result<bool> {
+    let Some(identity) = snapshot.identity.as_ref() else { return Ok(false); };
+    if !crate::platform::process_kill::verified_process_dead(identity.pid, identity.creation_time) { return Ok(false); }
+    let Some(_guard) = crate::platform::acquire_session_mutex_strict(&snapshot.base)? else { return Ok(false); };
+    let current = snapshot_kill_registry(&snapshot.dir, &snapshot.base)?;
+    if current.files != snapshot.files { return Ok(false); }
+    if !crate::platform::process_kill::verified_process_dead(identity.pid, identity.creation_time) { return Ok(false); }
+    for (ext, bytes) in SESSION_REGISTRY_EXTENSIONS.iter().zip(&snapshot.files) {
+        if bytes.is_some() {
+            match std::fs::remove_file(snapshot.dir.join(format!("{}.{}", snapshot.base, ext))) {
+                Ok(()) => {},
+                Err(e) if e.kind() == ErrorKind::NotFound => {},
+                Err(e) => return Err(e),
+            }
+        }
+    }
+    Ok(true)
+}
+
+/// Explicit kill scoped to the effective namespace; no process-name searches,
+/// and no registry deletion on a failed connection or authentication attempt.
+pub fn kill_registered_servers(namespace: Option<&str>) -> io::Result<()> {
+    let dir = std::path::PathBuf::from(crate::paths::psmux_dir());
+    let mut bases = std::collections::BTreeSet::new();
+    if let Ok(entries) = std::fs::read_dir(&dir) {
+        for entry in entries.flatten() {
+            let name = entry.file_name();
+            let Some(name) = name.to_str() else { continue; };
+            let base = name.strip_suffix(".port").or_else(|| name.strip_suffix(".registry.json"))
+                .or_else(|| name.strip_suffix(".pid"));
+            if let Some(base) = base {
+                if namespace.is_none() || session_visible_from(base, namespace) { bases.insert(base.to_string()); }
+            }
+        }
+    }
+    let mut failures = Vec::new();
+    for base in bases {
+        let snapshot = match snapshot_kill_registry(&dir, &base) {
+            Ok(snapshot) => snapshot,
+            Err(error) => { failures.push(format!("{}: {}", crate::paths::registry_session_name(&base), error)); continue; }
+        };
+        if let Ok((port, key)) = read_session_endpoint(&base) {
+            if let Ok(mut response) = open_authed(&format!("127.0.0.1:{}", port), &key, b"kill-server\n",
+                Duration::from_millis(500), Duration::from_millis(2000)) {
+                let _ = response.read_all();
+            }
+        }
+        if let Some(identity) = snapshot.identity.as_ref() {
+            // Exact check and termination happen on the same OS handle.
+            if !crate::platform::process_kill::verified_process_dead(identity.pid, identity.creation_time) {
+                crate::platform::process_kill::terminate_server_pid_exact(identity.pid, identity.creation_time);
+            }
+            let deadline = std::time::Instant::now() + Duration::from_millis(1000);
+            while !crate::platform::process_kill::verified_process_dead(identity.pid, identity.creation_time)
+                && std::time::Instant::now() < deadline {
+                std::thread::sleep(Duration::from_millis(20));
+            }
+            if crate::platform::process_kill::verified_process_dead(identity.pid, identity.creation_time) {
+                cleanup_killed_registry(&snapshot)?;
+            } else { failures.push(format!("{}: server exit could not be confirmed", crate::paths::registry_session_name(&base))); }
+        } else if snapshot.files.iter().any(Option::is_some) {
+            // Old servers without a precise anchor can clean themselves. They
+            // do not grant permission for a PID-based force kill or file wipe.
+            if snapshot_kill_registry(&dir, &base)?.files.iter().any(Option::is_some) {
+                failures.push(format!("{}: server identity unavailable; registry preserved", crate::paths::registry_session_name(&base)));
+            }
+        }
+    }
+    if failures.is_empty() { Ok(()) } else { Err(io::Error::other(failures.join("; "))) }
 }
 
 /// The exact-match identity gate for the force-kill fallback: terminate only when
@@ -866,12 +944,7 @@ pub fn namespace_peer_pids(dir: &Path, ns: Option<&str>, self_pid: u32) -> Vec<P
             continue;
         }
         let Some(stem) = path.file_stem().and_then(|s| s.to_str()) else { continue };
-        let mine = match ns {
-            Some(n) => stem.starts_with(&format!("{}__", n)),
-            // A bare session name has no `__` separator; the default namespace's
-            // own warm helper is the one exception.
-            None => !stem.contains("__") || stem == "__warm__",
-        };
+        let mine = session_visible_from(stem, ns);
         if !mine {
             continue;
         }
@@ -1052,67 +1125,11 @@ pub fn read_namespace_instance(ns: Option<&str>) -> Option<String> {
 /// server) and reaps the process itself, bounding the process count regardless
 /// of how the duplicate arose.
 pub fn reap_orphaned_servers() {
-    let Some(psmux_dir) = crate::paths::psmux_dir_opt() else {
-        return;
-    };
-    reap_orphaned_servers_in(Path::new(&psmux_dir));
+    // Kept as a compatibility entry point. Live orphan cleanup is unsafe:
+    // a busy server can temporarily lose registry files and still own panes.
 }
 
-fn reap_orphaned_servers_in(psmux_dir: &Path) {
-    use crate::platform::process_kill;
-
-    // Issue #474: no registry, no reaping. When the data dir does not exist,
-    // this invocation cannot see the files that track live servers (an MSYS2
-    // login shell that unset USERPROFILE resolves home elsewhere, for
-    // example). Proceeding with an empty view would classify every live
-    // server on the machine as an orphan and terminate them all.
-    if !psmux_dir.is_dir() {
-        return;
-    }
-
-    let (tracked_ports, tracked_pids) = read_tracked_registry(psmux_dir);
-    let self_pid = std::process::id();
-
-    // Capture the reuse-guard cutoff BEFORE enumerating: any process we see now
-    // was created at or before this instant, so a PID reused afterwards is
-    // rejected by terminate_server_pid (#447 guard).
-    let now_ft = process_kill::now_process_filetime();
-    // 100ns ticks in the grace window; a process is "old enough" to reap only if
-    // its creation time is at or before now - grace.
-    let grace_ticks = (ORPHAN_REAP_MIN_AGE.as_nanos() / 100) as u64;
-    let age_cutoff_ft = now_ft.saturating_sub(grace_ticks);
-
-    // Group loopback listeners by PID, keeping only psmux-image server processes.
-    let mut by_pid: std::collections::HashMap<u32, Vec<u16>> = std::collections::HashMap::new();
-    for (pid, port) in process_kill::loopback_listener_pids() {
-        by_pid.entry(pid).or_default().push(port);
-    }
-    let mut candidates: Vec<ServerCandidate> = Vec::new();
-    for (pid, ports) in by_pid {
-        let is_psmux = crate::platform::process_info::get_process_name(pid)
-            .map(|n| {
-                let n = n.to_ascii_lowercase();
-                PSMUX_SERVER_IMAGE_NAMES.contains(&n.as_str())
-            })
-            .unwrap_or(false);
-        if !is_psmux { continue; }
-        let creation_ft = process_kill::process_creation_time(pid).unwrap_or(u64::MAX);
-        candidates.push(ServerCandidate { pid, ports, creation_ft });
-    }
-
-    let owned_pids = read_owned_server_pids(psmux_dir);
-    let orphans = select_orphan_pids(
-        &candidates, &tracked_ports, &tracked_pids, &owned_pids, self_pid, age_cutoff_ft);
-    for pid in orphans {
-        if crate::debug_log::session_log_enabled() {
-            crate::debug_log::session_log("reaper", &format!(
-                "terminating orphaned psmux server pid {} (this data dir claims it, no registry entry references it)", pid));
-        }
-        process_kill::terminate_server_pid(pid, Some(now_ft));
-    }
-
-    prune_stale_server_markers(psmux_dir, &owned_pids);
-}
+fn reap_orphaned_servers_in(_psmux_dir: &Path) {}
 
 /// Delete ownership markers whose process is gone or whose PID now belongs to
 /// something else, so the directory tracks live servers rather than growing
@@ -1188,21 +1205,20 @@ fn pid_anchor_verdict(port_path: &Path) -> Option<bool> {
     let pid_path = port_path.with_extension("pid");
     // Tolerate both `pid` and `pid:creation_filetime` bodies (the latter written
     // so kill-server can verify identity); the anchor only needs the pid.
-    let (pid, _creation) = parse_pid_file_contents(&std::fs::read_to_string(&pid_path).ok()?)?;
-    let name = match crate::platform::process_info::get_process_name(pid) {
-        // No such process (a same-user psmux server is always openable with
-        // QUERY_LIMITED_INFORMATION, so an unopenable PID is not our server).
-        None => return Some(false),
-        Some(n) => n.to_ascii_lowercase(),
+    let (pid, creation) = parse_pid_file_contents(&std::fs::read_to_string(&pid_path).ok()?)?;
+    use crate::platform::process_kill::{process_identity, ProcessIdentity};
+    let observed_creation = match process_identity(pid) {
+        ProcessIdentity::Alive(actual) => Some(actual),
+        ProcessIdentity::Exited => return Some(false),
+        ProcessIdentity::Unknown => return None,
     };
-    if !PSMUX_SERVER_IMAGE_NAMES.contains(&name.as_str()) {
-        // PID recycled by an unrelated application; our server is gone.
-        return Some(false);
+    if let Some(recorded) = creation {
+        return observed_creation.map(|actual| actual == recorded);
     }
     // PID-reuse guard (same idea as the #447 reaper guard): a psmux process
     // created well AFTER the .pid file was last written cannot be the server
     // that wrote it. When either timestamp is unavailable, err towards alive.
-    if let Some(created_ft) = crate::platform::process_kill::process_creation_time(pid) {
+    if let Some(created_ft) = observed_creation {
         if let Some(mtime_ft) = std::fs::metadata(&pid_path)
             .ok()
             .and_then(|m| m.modified().ok())
@@ -1213,7 +1229,9 @@ fn pid_anchor_verdict(port_path: &Path) -> Option<bool> {
             }
         }
     }
-    Some(true)
+    // Legacy bare PID records cannot establish ownership. A live process may
+    // have reused the PID; query the authenticated endpoint instead.
+    None
 }
 
 /// Resolve the session key stored alongside a `.port` file (the sibling
@@ -1263,88 +1281,14 @@ fn cleanup_stale_port_files_in_with<F>(psmux_dir: &Path, mut probe: F)
 where
     F: FnMut(&str, u16) -> PortProbeResult,
 {
-    let boot = system_boot_time();
+    // Legacy entry point is now observational. Registry reclamation requires
+    // an owned generation under the session reservation, not age or TCP state.
     if let Ok(entries) = std::fs::read_dir(psmux_dir) {
         for entry in entries.flatten() {
             let path = entry.path();
-            if path.extension().map(|e| e == "port").unwrap_or(false) {
-                // PID-anchor verdict FIRST (issue #448 sentinel): the process
-                // table answers liveness instantly and definitively, so a
-                // Some(true) verdict (recorded PID alive with matching
-                // creation time) vetoes every heuristic below, including the
-                // boot-time guard. File metadata must never be a death
-                // certificate for a live server (issue #546): a live server's
-                // registry mtimes are frozen at creation (the 5s self-heal
-                // rewrites only on content change), so a forward wall-clock
-                // step, VM save/restore, or mtime-preserving backup restore
-                // pushes the frozen .port mtime behind the derived boot time
-                // and the old guard-first ordering reaped the registry of a
-                // running session — after which the orphan reaper killed its
-                // server — on any psmux invocation at all, even `psmux -V`.
-                // The genuine reboot case still reaps: after a restart, any
-                // live process holding a recycled PID was created later than
-                // .pid mtime + PID_REUSE_MARGIN_TICKS, which yields
-                // Some(false).
-                let pid_verdict = pid_anchor_verdict(&path);
-                if pid_verdict == Some(true) {
-                    continue; // live server; nothing to clean
-                }
-                // Boot-time guard: a port file last modified before this boot
-                // belongs to a server that died when the machine restarted.
-                // No network round-trip, and immune to the old port being
-                // reused by another process this boot. Applies only when the
-                // PID anchor could not positively confirm liveness
-                // (Some(false) or, for pre-#448 registries, None).
-                if let Some(boot) = boot {
-                    if let Some(mtime) = entry.metadata().ok().and_then(|m| m.modified().ok()) {
-                        if is_pre_boot(mtime, boot, BOOT_TIME_MARGIN) {
-                            if crate::debug_log::session_log_enabled() {
-                                crate::debug_log::session_log("cleanup", &format!(
-                                    "reaping '{}': port file predates last boot (server died on restart)",
-                                    registry_base(&path)));
-                            }
-                            remove_session_registry_files(&path);
-                            continue;
-                        }
-                    }
-                }
-                // PID-anchor negative path: registry entries with a `.pid`
-                // sibling never pay a network probe. Dead-port probes are not
-                // just slow (they can burn the full connect timeout per
-                // attempt on Windows loopback) - they are also inconclusive,
-                // so stale files were never reaped and the probe tax repeated
-                // on every subsequent CLI invocation.
-                match pid_verdict {
-                    Some(false) => {
-                        if crate::debug_log::session_log_enabled() {
-                            crate::debug_log::session_log("cleanup", &format!(
-                                "reaping '{}': recorded server PID is dead or recycled",
-                                registry_base(&path)));
-                        }
-                        remove_session_registry_files(&path);
-                        continue;
-                    }
-                    _ => {} // no .pid anchor; fall through to the network probe
-                }
-                if let Ok(port_str) = std::fs::read_to_string(&path) {
-                    if let Ok(port) = port_str.trim().parse::<u16>() {
-                        let key = read_key_for_port_path(&path);
-                        if probe(&key, port) == PortProbeResult::Stale {
-                            if crate::debug_log::session_log_enabled() {
-                                crate::debug_log::session_log("cleanup", &format!(
-                                    "reaping '{}' (port {}): no psmux server authenticated as ours (stale)",
-                                    registry_base(&path), port));
-                            }
-                            remove_session_registry_files(&path);
-                        }
-                    } else {
-                        if crate::debug_log::session_log_enabled() {
-                            crate::debug_log::session_log("cleanup", &format!(
-                                "reaping '{}': unparseable port value {:?}",
-                                registry_base(&path), port_str.trim()));
-                        }
-                        remove_session_registry_files(&path);
-                    }
+            if path.extension().is_some_and(|ext| ext == "port") {
+                if let Ok(port) = std::fs::read_to_string(&path).unwrap_or_default().trim().parse::<u16>() {
+                    let _ = probe(&read_key_for_port_path(&path), port);
                 }
             }
         }
@@ -1461,50 +1405,9 @@ fn probe_auth_identity(addr: std::net::SocketAddr, key: &str) -> Result<AuthProb
 /// unparseable, still keeps the conservative `Inconclusive` verdict).
 fn probe_session_for_cleanup(key: &str, port: u16) -> PortProbeResult {
     let addr = std::net::SocketAddr::from(([127, 0, 0, 1], port));
-    let mut saw_refused = false;
-    let mut saw_timed_out = false;
-    let mut saw_inconclusive = false;
-
-    for attempt in 0..STALE_PORT_PROBE_ATTEMPTS {
-        match probe_auth_identity(addr, key) {
-            Ok(AuthProbe::Authenticated) => {
-                if crate::debug_log::session_log_enabled() {
-                    crate::debug_log::session_log("probe",
-                        &format!("port {}: AUTH accepted -> alive", port));
-                }
-                return PortProbeResult::Alive;
-            }
-            Ok(AuthProbe::Rejected) => {
-                if crate::debug_log::session_log_enabled() {
-                    crate::debug_log::session_log("probe", &format!(
-                        "port {}: AUTH rejected by a different server (reused port) -> stale", port));
-                }
-                return PortProbeResult::Stale;
-            }
-            Ok(AuthProbe::Unknown) => saw_inconclusive = true,
-            Err(ErrorKind::ConnectionRefused) => saw_refused = true,
-            Err(ErrorKind::TimedOut) => saw_timed_out = true,
-            Err(_) => saw_inconclusive = true,
-        }
-
-        if attempt + 1 < STALE_PORT_PROBE_ATTEMPTS {
-            std::thread::sleep(STALE_PORT_RETRY_DELAY);
-        }
-    }
-
-    if (saw_refused || saw_timed_out) && !saw_inconclusive {
-        if crate::debug_log::session_log_enabled() {
-            crate::debug_log::session_log("probe", &format!(
-                "port {}: refused/timed-out on every attempt (refused={}, timed_out={}) -> stale",
-                port, saw_refused, saw_timed_out));
-        }
-        PortProbeResult::Stale
-    } else {
-        if crate::debug_log::session_log_enabled() {
-            crate::debug_log::session_log("probe",
-                &format!("port {}: no definitive answer -> inconclusive (kept)", port));
-        }
-        PortProbeResult::Inconclusive
+    match probe_auth_identity(addr, key) {
+        Ok(AuthProbe::Authenticated) => PortProbeResult::Alive,
+        _ => PortProbeResult::Inconclusive,
     }
 }
 
@@ -1512,6 +1415,35 @@ fn probe_session_for_cleanup(key: &str, port: u16) -> PortProbeResult {
 pub fn read_session_key(session: &str) -> io::Result<String> {
     let keypath = crate::paths::key_file(session);
     std::fs::read_to_string(&keypath).map(|s| s.trim().to_string())
+}
+
+/// Read one coherent endpoint generation, preferring the atomic manifest.
+/// A malformed manifest is a real error; it must not fall back to mixed files.
+pub fn read_session_endpoint(base: &str) -> io::Result<(u16, String)> {
+    if let Some(manifest) = crate::registry::read_manifest(base)? {
+        if validate_auth_key(&manifest.key).is_none() {
+            return Err(io::Error::new(ErrorKind::InvalidData, "invalid session credentials"));
+        }
+        return Ok((manifest.port, manifest.key));
+    }
+    let port = std::fs::read_to_string(crate::paths::port_file(base))?
+        .trim().parse::<u16>()
+        .map_err(|_| io::Error::new(ErrorKind::InvalidData, "invalid session port"))?;
+    if port == 0 { return Err(io::Error::new(ErrorKind::InvalidData, "invalid session port")); }
+    let key = read_session_key(base)?;
+    if validate_auth_key(&key).is_none() {
+        return Err(io::Error::new(ErrorKind::InvalidData, "invalid session credentials"));
+    }
+    Ok((port, key))
+}
+
+pub fn existing_session_state(base: &str) -> SessionLiveness {
+    if registry_pid_anchor_alive(base) == Some(false) { return SessionLiveness::Dead; }
+    match read_session_endpoint(base) {
+        Ok((port, key)) => probe_session_liveness(&format!("127.0.0.1:{}", port), &key,
+            Duration::from_millis(500), Duration::from_millis(2000)),
+        Err(_) => SessionLiveness::Unresponsive,
+    }
 }
 
 /// Hard cap on a single response payload read from the server (256 KB).
@@ -1571,143 +1503,152 @@ pub fn send_auth_cmd(addr: &str, key: &str, cmd: &[u8]) -> io::Result<()> {
 /// callers; new code should prefer `fetch_authed_response` /
 /// `fetch_authed_response_multi`.
 pub fn send_auth_cmd_response(addr: &str, key: &str, cmd: &[u8]) -> io::Result<String> {
-    let key = match validate_auth_key(key) {
-        Some(k) => k,
-        None => return Err(io::Error::new(io::ErrorKind::InvalidInput, "invalid session key")),
-    };
-    let mut s = std::net::TcpStream::connect(addr)?;
-    let _ = s.set_nodelay(true);
-    let _ = s.set_read_timeout(Some(Duration::from_millis(500)));
-    let _ = write!(s, "AUTH {}\n", key);
-    let _ = std::io::Write::write_all(&mut s, cmd);
-    let _ = s.flush();
-    let mut br = std::io::BufReader::new(std::io::Read::take(&mut s, MAX_AUTHED_RESPONSE_BYTES));
-    let mut auth_line = String::new();
-    let _ = std::io::BufRead::read_line(&mut br, &mut auth_line);
-    let mut buf = String::new();
-    let _ = std::io::Read::read_to_string(&mut br, &mut buf);
-    Ok(buf)
+    query_authed_all(addr, key, cmd, Duration::from_millis(500), Duration::from_millis(2000))
 }
 
-/// Internal: open an authenticated connection and send a single command.
-///
-/// Returns a length-capped `BufReader` positioned right after the command
-/// write, ready for response parsing. Centralizes:
-///   - CRLF/NUL key validation (security)
-///   - connect timeout, read timeout, TCP_NODELAY
-///   - response size cap (`MAX_AUTHED_RESPONSE_BYTES`, DoS guard)
-///   - the AUTH + command write
-///
-/// The size cap is applied with `Read::take` BEFORE the `BufReader` so the
-/// resulting reader still exposes `BufRead`. Wrapping the other way around
-/// (`BufReader::take`) loses `BufRead` because `Take` is `Read`-only.
+/// A bounded protocol reader with a total wall-time budget, not merely an
+/// idle timeout. A peer sending one byte per timeout cannot keep the CLI hung.
+struct AuthedReader {
+    reader: std::io::BufReader<std::net::TcpStream>,
+    remaining: usize,
+    deadline: std::time::Instant,
+}
+
+impl AuthedReader {
+    fn arm_timeout(&self) -> io::Result<()> {
+        let remaining = self.deadline.checked_duration_since(std::time::Instant::now())
+            .filter(|d| !d.is_zero())
+            .ok_or_else(|| io::Error::new(ErrorKind::TimedOut, "server response deadline exceeded"))?;
+        self.reader.get_ref().set_read_timeout(Some(remaining))
+    }
+
+    fn read_line(&mut self) -> io::Result<String> {
+        use std::io::BufRead;
+        let mut line = Vec::new();
+        loop {
+            self.arm_timeout()?;
+            let buf = self.reader.fill_buf()?;
+            if buf.is_empty() {
+                return Err(io::Error::new(ErrorKind::UnexpectedEof, "server closed before a complete response line"));
+            }
+            let n = buf.iter().position(|b| *b == b'\n').map_or(buf.len(), |p| p + 1);
+            if n > self.remaining {
+                return Err(io::Error::new(ErrorKind::InvalidData, "server response exceeds size limit"));
+            }
+            let complete = buf[n - 1] == b'\n';
+            line.extend_from_slice(&buf[..n]);
+            self.reader.consume(n);
+            self.remaining -= n;
+            if complete {
+                line.pop();
+                if line.last() == Some(&b'\r') { line.pop(); }
+                return String::from_utf8(line).map_err(|_| io::Error::new(ErrorKind::InvalidData, "server response is not UTF-8"));
+            }
+        }
+    }
+
+    fn read_all(&mut self) -> io::Result<String> {
+        use std::io::BufRead;
+        let mut output = Vec::new();
+        loop {
+            self.arm_timeout()?;
+            let buf = self.reader.fill_buf()?;
+            if buf.is_empty() { break; }
+            if buf.len() > self.remaining {
+                return Err(io::Error::new(ErrorKind::InvalidData, "server response exceeds size limit"));
+            }
+            let n = buf.len();
+            output.extend_from_slice(buf);
+            self.reader.consume(n);
+            self.remaining -= n;
+        }
+        String::from_utf8(output).map_err(|_| io::Error::new(ErrorKind::InvalidData, "server response is not UTF-8"))
+    }
+}
+
+fn protocol_error(line: &str) -> Option<io::Error> {
+    if line.starts_with("ERROR:") || line == "ERR" || line.starts_with("ERR ") {
+        let kind = if line.contains("Authentication required") || line.contains("Invalid session key") {
+            ErrorKind::PermissionDenied
+        } else { ErrorKind::Other };
+        Some(io::Error::new(kind, line.to_string()))
+    } else { None }
+}
+
 fn open_authed(
     addr: &str,
     key: &str,
     cmd: &[u8],
     connect_timeout: Duration,
     read_timeout: Duration,
-) -> Option<std::io::BufReader<std::io::Take<std::net::TcpStream>>> {
-    let key = validate_auth_key(key)?;
-    let sock_addr: std::net::SocketAddr = addr.parse().ok()?;
-    let mut s = std::net::TcpStream::connect_timeout(&sock_addr, connect_timeout).ok()?;
-    s.set_read_timeout(Some(read_timeout)).ok()?;
+) -> io::Result<AuthedReader> {
+    let key = validate_auth_key(key)
+        .ok_or_else(|| io::Error::new(ErrorKind::InvalidInput, "missing or invalid session key"))?;
+    let sock_addr: std::net::SocketAddr = addr.parse()
+        .map_err(|_| io::Error::new(ErrorKind::InvalidInput, "invalid server address"))?;
+    let mut s = std::net::TcpStream::connect_timeout(&sock_addr, connect_timeout)?;
+    s.set_read_timeout(Some(read_timeout))?;
+    s.set_write_timeout(Some(read_timeout))?;
     let _ = s.set_nodelay(true);
-    write!(s, "AUTH {}\n", key).ok()?;
-    s.write_all(cmd).ok()?;
-    if !cmd.ends_with(b"\n") {
-        s.write_all(b"\n").ok()?;
+    write!(s, "AUTH {}\n", key)?;
+    s.write_all(cmd)?;
+    if !cmd.ends_with(b"\n") { s.write_all(b"\n")?; }
+    s.flush()?;
+    // Commands are complete; EOF makes multi-line response completion explicit.
+    // A fast peer can finish and close before this half-close reaches Winsock.
+    // The response parser still must prove completion; do not discard buffered
+    // valid replies merely because shutdown reports an already closed socket.
+    let _ = s.shutdown(std::net::Shutdown::Write);
+    let mut response = AuthedReader {
+        reader: std::io::BufReader::new(s),
+        remaining: MAX_AUTHED_RESPONSE_BYTES as usize,
+        deadline: std::time::Instant::now() + read_timeout,
+    };
+    let ack = response.read_line()?;
+    if let Some(error) = protocol_error(&ack) { return Err(error); }
+    if ack != "OK" {
+        return Err(io::Error::new(ErrorKind::InvalidData, "invalid authentication acknowledgement"));
     }
-    let _ = s.flush();
-    Some(std::io::BufReader::new(std::io::Read::take(s, MAX_AUTHED_RESPONSE_BYTES)))
+    Ok(response)
 }
 
-/// Read one response line from an authenticated stream, transparently
-/// skipping the `OK\n` AUTH ack regardless of when it arrives.
-///
-/// Returns `None` on timeout, EOF, empty payload, or `ERROR:` reply.
-/// Returns `Some(line)` on a valid payload (newline trimmed).
-fn read_authed_line<R: std::io::BufRead>(br: &mut R) -> Option<String> {
-    // First read: could be either the AUTH ack ("OK") or the payload
-    // (if the ack was already pipelined into the same packet).
-    let mut line = String::new();
-    if std::io::BufRead::read_line(br, &mut line).ok()? == 0 {
-        return None;
-    }
-    let trimmed = line.trim();
-    if trimmed == "OK" {
-        // First line WAS the ack. Read the real payload now.
-        line.clear();
-        if std::io::BufRead::read_line(br, &mut line).ok()? == 0 {
-            return None;
-        }
-    }
-    // Filter again in case the second line is also empty/error/OK.
-    let trimmed = line.trim();
-    if trimmed.is_empty() || trimmed == "OK" || trimmed.starts_with("ERROR:") {
-        None
-    } else {
-        Some(trimmed.to_string())
-    }
+/// Require exact AUTH acknowledgement and a complete newline-framed payload.
+/// A valid empty line is a result, whereas EOF, timeout and truncation are errors.
+pub fn query_authed_line(
+    addr: &str, key: &str, cmd: &[u8], connect_timeout: Duration, read_timeout: Duration,
+) -> io::Result<String> {
+    let mut response = open_authed(addr, key, cmd, connect_timeout, read_timeout)?;
+    let line = response.read_line()?;
+    if let Some(error) = protocol_error(&line) { return Err(error); }
+    Ok(line)
 }
 
-/// Read all remaining bytes from an authenticated stream, stripping a
-/// leading `OK\n` AUTH ack if present.
-///
-/// Returns `None` on no payload, error response, or read failure.
-/// Returns `Some(payload)` with the AUTH ack removed and trailing
-/// whitespace stripped. Total read is capped by the underlying `Take`.
-fn read_authed_all<R: std::io::Read>(rd: &mut R) -> Option<String> {
-    let mut buf = String::new();
-    std::io::Read::read_to_string(rd, &mut buf).ok()?;
-    let body = buf.strip_prefix("OK\n").or_else(|| buf.strip_prefix("OK\r\n")).unwrap_or(&buf);
-    let trimmed = body.trim();
-    if trimmed.is_empty() || trimmed.starts_with("ERROR:") {
-        None
-    } else {
-        Some(trimmed.to_string())
+/// Require exact AUTH acknowledgement and EOF for a complete bounded body.
+pub fn query_authed_all(
+    addr: &str, key: &str, cmd: &[u8], connect_timeout: Duration, read_timeout: Duration,
+) -> io::Result<String> {
+    let mut response = open_authed(addr, key, cmd, connect_timeout, read_timeout)?;
+    let body = response.read_all()?;
+    if body.is_empty() {
+        return Err(io::Error::new(ErrorKind::UnexpectedEof, "server closed without a command response"));
     }
+    if let Some(error) = protocol_error(body.trim_end()) { return Err(error); }
+    Ok(body)
 }
 
-/// Send an authenticated single-command request and return one response line.
-///
-/// Centralized AUTH + command + response helper used by all picker fetches.
-/// Handles every known framing race for the AUTH ack:
-///   - ack pipelined with payload (one packet, both lines arrive together)
-///   - ack arrives first, then payload
-///   - ack delayed past first read (issue #250 race)
-///   - server replies only `OK` and never sends payload
-///   - server replies `ERROR: ...`
-///   - server hangs / connection refused / bad address
-///
-/// All callers get the same robust behavior; they can no longer reinvent
-/// the parser per-site (which is how #250 happened).
+/// Compatibility wrappers for picker callers; transport errors remain unknown.
 pub fn fetch_authed_response(
-    addr: &str,
-    key: &str,
-    cmd: &[u8],
-    connect_timeout: Duration,
-    read_timeout: Duration,
+    addr: &str, key: &str, cmd: &[u8], connect_timeout: Duration, read_timeout: Duration,
 ) -> Option<String> {
-    let mut br = open_authed(addr, key, cmd, connect_timeout, read_timeout)?;
-    read_authed_line(&mut br)
+    query_authed_line(addr, key, cmd, connect_timeout, read_timeout).ok()
+        .filter(|s| !s.is_empty())
 }
 
-/// Like `fetch_authed_response` but returns the entire response body
-/// (multi-line payloads such as `list-tree` JSON arrays or `choose-buffer`
-/// listings). The leading AUTH ack line is stripped if present.
-///
-/// The total payload is bounded by `MAX_AUTHED_RESPONSE_BYTES` to prevent
-/// a malformed or hostile server from forcing unbounded client memory.
 pub fn fetch_authed_response_multi(
-    addr: &str,
-    key: &str,
-    cmd: &[u8],
-    connect_timeout: Duration,
-    read_timeout: Duration,
+    addr: &str, key: &str, cmd: &[u8], connect_timeout: Duration, read_timeout: Duration,
 ) -> Option<String> {
-    let mut br = open_authed(addr, key, cmd, connect_timeout, read_timeout)?;
-    read_authed_all(&mut br)
+    query_authed_all(addr, key, cmd, connect_timeout, read_timeout).ok()
+        .map(|s| s.trim_end().to_string()).filter(|s| !s.is_empty())
 }
 
 /// Fetch a one-line `session-info` response from a session server.
@@ -1738,125 +1679,39 @@ pub fn fetch_session_info(
 /// `classify_sessions_parallel`, which both lists and prunes in one pass.
 #[allow(dead_code)]
 pub fn fetch_session_infos_parallel<F>(
-    inputs: Vec<(String, String, String)>,
-    connect_timeout: Duration,
-    read_timeout: Duration,
-    fallback: F,
+    inputs: Vec<(String, String, String)>, connect_timeout: Duration, read_timeout: Duration, fallback: F,
 ) -> Vec<(String, String)>
-where
-    F: Fn(&str) -> String + Send + Sync,
+where F: Fn(&str) -> String + Send + Sync,
 {
-    if inputs.is_empty() {
-        return Vec::new();
-    }
-    // Single session: skip thread spawn overhead entirely.
-    if inputs.len() == 1 {
-        let (label, addr, key) = &inputs[0];
-        let info = fetch_session_info(addr, key, connect_timeout, read_timeout)
-            .unwrap_or_else(|| fallback(label));
-        return vec![(label.clone(), info)];
-    }
-    let results: Vec<(String, String)> = std::thread::scope(|scope| {
-        let fallback_ref = &fallback;
-        let handles: Vec<_> = inputs
-            .iter()
-            .map(|(label, addr, key)| {
-                let label = label.clone();
-                let addr = addr.clone();
-                let key = key.clone();
-                scope.spawn(move || {
-                    let info = fetch_session_info(&addr, &key, connect_timeout, read_timeout)
-                        .unwrap_or_else(|| fallback_ref(&label));
-                    (label, info)
-                })
-            })
-            .collect();
-        handles.into_iter().filter_map(|h| h.join().ok()).collect()
-    });
-    results
+    classify_sessions_parallel(inputs, connect_timeout, read_timeout).into_iter()
+        .map(|(label, state)| {
+            let info = match state { SessionLiveness::Alive(info) => info, _ => fallback(&label) };
+            (label, info)
+        }).collect()
 }
 
 /// Liveness verdict for one session, produced by a single bounded probe.
 #[derive(Clone, Debug, PartialEq)]
 pub enum SessionLiveness {
-    /// Server authenticated and returned its session-info line (the payload).
+    /// Server authenticated and returned a complete nonempty session-info line.
     Alive(String),
-    /// Definitively gone: the connection failed (refused / unreachable — on
-    /// loopback any connect failure means nothing is listening), an `ERROR`
-    /// auth rejection (a different server reused the port), or connected then
-    /// silent past the read timeout. Its registry files should be reaped. A
-    /// genuinely live server that was momentarily too slow self-heals: it
-    /// rewrites its `.port`/`.key`/`.sid` every 5s (see
-    /// `ensure_session_registry_files`).
+    /// A recorded process generation is positively known to have exited.
     Dead,
-    /// No usable AUTH key on disk, so identity cannot be verified at all.
-    /// Left in place and shown as `(not responding)` rather than deleted.
+    /// Communication or identity could not be verified. Never authorizes cleanup.
+    Unresponsive,
+    /// Credentials are unavailable. Retained for callers distinguishing this case.
     Unreachable,
 }
 
-/// Single bounded liveness probe: connect, AUTH with the session's own key,
-/// ask for `session-info`, and classify the reply. Never retries or blocks
-/// beyond `connect_timeout + read_timeout`.
+/// Network failure never proves a process died: a live server can be busy,
+/// lose its listener, or have inconsistent registry data. Discovery is read-only.
 fn probe_session_liveness(
-    addr: &str,
-    key: &str,
-    connect_timeout: Duration,
-    read_timeout: Duration,
+    addr: &str, key: &str, connect_timeout: Duration, read_timeout: Duration,
 ) -> SessionLiveness {
-    let sock: std::net::SocketAddr = match addr.parse() {
-        Ok(a) => a,
-        Err(_) => return SessionLiveness::Dead,
-    };
-    let key = match validate_auth_key(key) {
-        Some(k) => k,
-        None => return SessionLiveness::Unreachable,
-    };
-    // On loopback a live server always completes the TCP handshake (the kernel
-    // accepts into the listen backlog even before the app calls accept()), so
-    // ANY connect failure means nothing usable is listening -> Dead. We do not
-    // branch on the error kind: Windows does not always surface a clean
-    // `ConnectionRefused` for a free port.
-    let mut s = match std::net::TcpStream::connect_timeout(&sock, connect_timeout) {
-        Ok(s) => s,
-        Err(_) => return SessionLiveness::Dead,
-    };
-    let _ = s.set_read_timeout(Some(read_timeout));
-    let _ = s.set_nodelay(true);
-    if write!(s, "AUTH {}\n", key).is_err() || s.write_all(b"session-info\n").is_err() {
-        // Connection broke right after connect -> not a healthy server.
-        return SessionLiveness::Dead;
-    }
-    let _ = s.flush();
-    let mut br = std::io::BufReader::new(std::io::Read::take(s, MAX_AUTHED_RESPONSE_BYTES));
-    let mut line = String::new();
-    match std::io::BufRead::read_line(&mut br, &mut line) {
-        Ok(0) => SessionLiveness::Dead,
-        Ok(_) => {
-            let t = line.trim();
-            if t.starts_with("ERROR") {
-                return SessionLiveness::Dead;
-            }
-            if t == "OK" {
-                // Ack consumed; the next line is the real payload.
-                line.clear();
-                match std::io::BufRead::read_line(&mut br, &mut line) {
-                    Ok(0) => SessionLiveness::Dead,
-                    Ok(_) => {
-                        let t2 = line.trim();
-                        if t2.is_empty() || t2 == "OK" || t2.starts_with("ERROR") {
-                            SessionLiveness::Dead
-                        } else {
-                            SessionLiveness::Alive(t2.to_string())
-                        }
-                    }
-                    Err(_) => SessionLiveness::Dead,
-                }
-            } else {
-                // Ack pipelined with the payload in one line.
-                SessionLiveness::Alive(t.to_string())
-            }
-        }
-        Err(_) => SessionLiveness::Dead,
+    if validate_auth_key(key).is_none() { return SessionLiveness::Unreachable; }
+    match query_authed_line(addr, key, b"session-info\n", connect_timeout, read_timeout) {
+        Ok(info) if !info.is_empty() => SessionLiveness::Alive(info),
+        _ => SessionLiveness::Unresponsive,
     }
 }
 
@@ -1869,33 +1724,27 @@ fn probe_session_liveness(
 /// it replaces a sequential cleanup pass (O(N * timeout)) with one parallel
 /// round-trip that both lists and prunes.
 pub fn classify_sessions_parallel(
-    inputs: Vec<(String, String, String)>,
-    connect_timeout: Duration,
-    read_timeout: Duration,
+    inputs: Vec<(String, String, String)>, connect_timeout: Duration, read_timeout: Duration,
 ) -> Vec<(String, SessionLiveness)> {
-    if inputs.is_empty() {
-        return Vec::new();
+    // Bound thread/resource use for a registry with many entries. Failed worker
+    // creation cannot omit a row or turn unknown liveness into a death verdict.
+    const MAX_PROBE_WORKERS: usize = 16;
+    let mut results = Vec::with_capacity(inputs.len());
+    for chunk in inputs.chunks(MAX_PROBE_WORKERS) {
+        std::thread::scope(|scope| {
+            let handles: Vec<_> = chunk.iter().map(|(label, addr, key)| {
+                let worker = std::thread::Builder::new().spawn_scoped(scope, move || {
+                    probe_session_liveness(addr, key, connect_timeout, read_timeout)
+                });
+                (label, worker)
+            }).collect();
+            for (label, worker) in handles {
+                let state = worker.ok().and_then(|worker| worker.join().ok()).unwrap_or(SessionLiveness::Unresponsive);
+                results.push((label.clone(), state));
+            }
+        });
     }
-    if inputs.len() == 1 {
-        let (label, addr, key) = &inputs[0];
-        let v = probe_session_liveness(addr, key, connect_timeout, read_timeout);
-        return vec![(label.clone(), v)];
-    }
-    std::thread::scope(|scope| {
-        let handles: Vec<_> = inputs
-            .iter()
-            .map(|(label, addr, key)| {
-                let label = label.clone();
-                let addr = addr.clone();
-                let key = key.clone();
-                scope.spawn(move || {
-                    let v = probe_session_liveness(&addr, &key, connect_timeout, read_timeout);
-                    (label, v)
-                })
-            })
-            .collect();
-        handles.into_iter().filter_map(|h| h.join().ok()).collect()
-    })
+    results
 }
 
 /// PID-anchor liveness for the session registered under `base`, for
@@ -1903,8 +1752,21 @@ pub fn classify_sessions_parallel(
 /// TCP connect timeout per dead entry. Some(false) = definitively dead
 /// (reap + skip), Some(true) = live, None = no anchor (probe as usual).
 pub fn registry_pid_anchor_alive(base: &str) -> Option<bool> {
-    let port_path = crate::paths::port_file_opt(base)?;
-    pid_anchor_verdict(Path::new(&port_path))
+    match crate::registry::read_manifest(base) {
+        Ok(Some(manifest)) => {
+            use crate::platform::process_kill::{process_identity, ProcessIdentity};
+            match process_identity(manifest.pid) {
+                ProcessIdentity::Alive(actual) => Some(actual == manifest.creation_time),
+                ProcessIdentity::Exited => Some(false),
+                ProcessIdentity::Unknown => None,
+            }
+        }
+        Ok(None) => {
+            let port_path = crate::paths::port_file_opt(base)?;
+            pid_anchor_verdict(Path::new(&port_path))
+        }
+        Err(_) => None,
+    }
 }
 
 /// Reap a single session's registry files (`.port`/`.key`/`.sid`) by base name.
@@ -1918,166 +1780,151 @@ pub fn remove_session_registry(base: &str) {
     remove_session_registry_files(Path::new(&port_path));
 }
 
-pub fn send_control(line: String) -> io::Result<()> {
-    let mut target = env::var("PSMUX_TARGET_SESSION").ok().unwrap_or_else(|| "default".to_string());
-    if env::var("PSMUX_ROUTE_DEBUG").is_ok() {
-        eprintln!("[route] send_control target={:?} full={:?} argv={:?} line={:?}",
-            target, env::var("PSMUX_TARGET_FULL").ok(),
-            env::args().collect::<Vec<_>>(), line.trim());
-    }
-    // Never target a warm (standby) session — resolve to a real session instead
+fn control_target() -> io::Result<String> {
+    let target = env::var("PSMUX_TARGET_SESSION").unwrap_or_else(|_| "default".to_string());
     if is_warm_session(&target) {
-        // Extract namespace from warm session name (e.g. "foo____warm__" -> Some("foo"))
-        let ns = target.strip_suffix("____warm__").map(|s| s.to_string());
-        target = resolve_last_session_name_ns(ns.as_deref()).unwrap_or_else(|| "default".to_string());
-    }
-    let full_target = env::var("PSMUX_TARGET_FULL").ok();
-    let path = crate::paths::port_file(&target);
-    let port = std::fs::read_to_string(&path).ok().and_then(|s| s.trim().parse::<u16>().ok()).ok_or_else(|| io::Error::new(io::ErrorKind::Other, format!("no server running on session '{}'", target)))?.clone();
-    let session_key = read_session_key(&target).unwrap_or_default();
-    let addr: std::net::SocketAddr = format!("127.0.0.1:{}", port).parse().unwrap();
-    // 1s connect timeout: a busy-but-alive server must not be mistaken for a
-    // dead one. The old 100ms falsely tripped callers' stale-port cleanup,
-    // deleting the port file of a server that was merely slow to accept.
-    let mut stream = std::net::TcpStream::connect_timeout(&addr, Duration::from_millis(1000))?;
-    let _ = stream.set_nodelay(true);
-    let _ = stream.set_read_timeout(Some(Duration::from_millis(2000)));
-    let _ = write!(stream, "AUTH {}\n", session_key);
-    if let Some(ref ft) = full_target {
-        let _ = write!(stream, "TARGET {}\n", ft);
-    }
-    let _ = write!(stream, "{}", line);
-    // Tier 2 — confirmed EXECUTION (not just delivery): append a `session-info`
-    // barrier. It round-trips through the server's single FIFO event loop, so its
-    // reply proves the command above was actually applied, not merely enqueued.
-    // This makes send_control synchronous and closes races where a caller inspects
-    // the effect immediately after the CLI returns. For commands whose server
-    // handler tears down the connection first (e.g. kill-session), the barrier is
-    // simply never answered — that path is covered by the caller's verify-retry.
-    let _ = write!(stream, "session-info\n");
-    let _ = stream.flush();
-    // Half-close the write side so the server observes EOF *after* our bytes.
-    // TCP guarantees all sent data is delivered before the FIN, so the server's
-    // read_line always sees the full command before its loop ends — eliminating
-    // the RST-on-close race that used to silently drop fire-and-forget commands
-    // (the old 50ms "drain" read was only a partial mitigation).
-    let _ = stream.shutdown(std::net::Shutdown::Write);
-    // Read to EOF (bounded by the read timeout): blocks until the server has
-    // processed the barrier — i.e. the command has executed — or the connection
-    // closes / times out.
-    let mut buf = [0u8; 256];
-    loop {
-        match std::io::Read::read(&mut stream, &mut buf) {
-            Ok(0) => break,
-            Ok(_) => continue,
-            Err(_) => break,
+        resolve_last_session_name_ns(session_namespace(&target).as_deref())
+            .ok_or_else(|| io::Error::new(ErrorKind::NotFound, "no user session running"))
+    } else { Ok(target) }
+}
+
+fn targeted_command(line: &str) -> io::Result<Vec<u8>> {
+    let mut command = String::new();
+    if let Ok(full) = env::var("PSMUX_TARGET_FULL") {
+        if full.bytes().any(|b| b == b'\n' || b == b'\r' || b == 0) {
+            return Err(io::Error::new(ErrorKind::InvalidInput, "invalid target"));
         }
+        command.push_str(&format!("TARGET {}\n", full));
+    }
+    command.push_str(line);
+    if !command.ends_with('\n') { command.push('\n'); }
+    Ok(command.into_bytes())
+}
+
+pub fn send_control(line: String) -> io::Result<()> {
+    let target = control_target()?;
+    let (port, key) = read_session_endpoint(&target)?;
+    let mut command = targeted_command(&line)?;
+    command.extend_from_slice(b"session-info\n");
+    let mut response = open_authed(&format!("127.0.0.1:{}", port), &key, &command,
+        Duration::from_millis(1000), Duration::from_millis(3000))?;
+    let body = response.read_all()?;
+    for line in body.lines() {
+        if let Some(error) = protocol_error(line) { return Err(error); }
+    }
+    // A complete session-info reply proves the FIFO event loop passed the
+    // command. EOF after AUTH alone must never report a crashed command as OK.
+    if !body.lines().any(|line| line.contains(" windows (created ")) {
+        return Err(io::Error::new(ErrorKind::UnexpectedEof, "server closed before command completion was confirmed"));
     }
     Ok(())
 }
 
 pub fn send_control_with_response(line: String) -> io::Result<String> {
-    let mut target = env::var("PSMUX_TARGET_SESSION").ok().unwrap_or_else(|| "default".to_string());
-    if env::var("PSMUX_ROUTE_DEBUG").is_ok() {
-        eprintln!("[route] send_control_with_response target={:?} full={:?} argv={:?} line={:?}",
-            target, env::var("PSMUX_TARGET_FULL").ok(),
-            env::args().collect::<Vec<_>>(), line.trim());
+    let target = control_target()?;
+    let (port, key) = read_session_endpoint(&target)?;
+    let command = targeted_command(&line)?;
+    let mut response = open_authed(&format!("127.0.0.1:{}", port), &key, &command,
+        Duration::from_millis(1000), Duration::from_millis(3000))?;
+    // Pane captures and buffers can be much larger than picker information.
+    response.remaining = 16 * 1024 * 1024;
+    let body = response.read_all()?;
+    let verb = line.split_whitespace().next().unwrap_or("");
+    // These commands carry arbitrary user text, including literal ERROR lines.
+    let arbitrary_text = matches!(verb, "capture-pane" | "capturep" | "show-buffer" | "showb" | "save-buffer" | "saveb");
+    if !arbitrary_text {
+        if let Some(error) = protocol_error(body.trim_end()) { return Err(error); }
     }
-    // Never target a warm (standby) session — resolve to a real session instead
-    if is_warm_session(&target) {
-        let ns = target.strip_suffix("____warm__").map(|s| s.to_string());
-        target = resolve_last_session_name_ns(ns.as_deref()).unwrap_or_else(|| "default".to_string());
+    if body.is_empty() {
+        return Err(io::Error::new(ErrorKind::UnexpectedEof, "server closed without a command response"));
     }
-    let full_target = env::var("PSMUX_TARGET_FULL").ok();
-    let path = crate::paths::port_file(&target);
-    let port = std::fs::read_to_string(&path).ok().and_then(|s| s.trim().parse::<u16>().ok()).ok_or_else(|| io::Error::new(io::ErrorKind::Other, format!("no server running on session '{}'", target)))?.clone();
-    let session_key = read_session_key(&target).unwrap_or_default();
-    // Bounded connect: against a saturated listen backlog, a bare connect()
-    // fails only after the ~21s Windows SYN-retransmit and surfaces as the
-    // notorious `os error 10060`. A 1s timeout turns that into a fast, retryable
-    // error instead of a multi-second hang printed to the user.
-    let addr: std::net::SocketAddr = format!("127.0.0.1:{}", port).parse()
-        .map_err(|_| io::Error::new(io::ErrorKind::Other, "bad server address"))?;
-    let mut stream = std::net::TcpStream::connect_timeout(&addr, Duration::from_millis(1000))?;
-    let _ = stream.set_nodelay(true);
-    let _ = stream.set_read_timeout(Some(Duration::from_millis(3000)));
-    let _ = write!(stream, "AUTH {}\n", session_key);
-    if let Some(ref ft) = full_target {
-        let _ = write!(stream, "TARGET {}\n", ft);
+    Ok(body)
+}
+
+const MAX_INTERNAL_COMMAND_BYTES: usize = 128 * 1024;
+const MAX_INTERNAL_COMMANDS: usize = 32;
+
+struct QueuedControl {
+    port: u16,
+    command: String,
+    key: String,
+    notify: Option<crate::types::ControlSender>,
+}
+
+fn queue_control_request(queue: &std::sync::mpsc::SyncSender<QueuedControl>, port: u16, msg: &str,
+    key: &str, notify: Option<crate::types::ControlSender>) -> io::Result<()> {
+    if msg.len().saturating_add(key.len()) > MAX_INTERNAL_COMMAND_BYTES {
+        return Err(io::Error::new(ErrorKind::InvalidInput, "internal command exceeds 128 KiB limit"));
     }
-    let _ = write!(stream, "{}", line);
-    let _ = stream.flush();
-    // Half-close so the server sees EOF after our request and closes the socket
-    // once the reply is complete — giving a definitive Ok(0) end-of-response
-    // instead of relying on an idle-gap timeout to guess the reply is done.
-    let _ = stream.shutdown(std::net::Shutdown::Write);
-    let mut buf = Vec::new();
-    let mut temp = [0u8; 4096];
-    let mut timed_out = false;
-    loop {
-        match std::io::Read::read(&mut stream, &mut temp) {
-            Ok(0) => break,
-            Ok(n) => buf.extend_from_slice(&temp[..n]),
-            Err(e) if e.kind() == io::ErrorKind::WouldBlock || e.kind() == io::ErrorKind::TimedOut => { timed_out = true; break; }
-            Err(_) => break,
-        }
-    }
-    let result = String::from_utf8_lossy(&buf).to_string();
-    // Strip the "OK\n" AUTH response prefix if present. This is protocol
-    // framing, not payload — it must come off before the checks below, because
-    // the server writes it before it has even read the command (issue #561).
-    let result = if result.starts_with("OK\n") {
-        result[3..].to_string()
-    } else if result.starts_with("OK\r\n") {
-        result[4..].to_string()
-    } else {
-        result
-    };
-    // A connection-level refusal is not reply data. The server writes these
-    // INSTEAD of running the command (and without the OK ack), but every caller
-    // simply printed the reply, so `list-windows` put "ERROR: Authentication
-    // required" on STDOUT at exit 0 and a machine consumer ingested it as a
-    // window record (issue #561). Classified here, at the single chokepoint,
-    // rather than at the 22 call sites that print the reply.
-    //
-    // Matched as exact whole-payload strings on purpose, NOT as an "ERROR:"
-    // prefix: capture-pane and show-buffer return arbitrary pane content, which
-    // may legitimately begin with the word ERROR, and misreading that as a
-    // refusal would be a worse bug than the one being fixed.
-    let trimmed = result.trim();
-    if trimmed == "ERROR: Authentication required" || trimmed == "ERROR: Invalid session key" {
-        return Err(io::Error::new(
-            io::ErrorKind::PermissionDenied,
-            trimmed.trim_start_matches("ERROR:").trim().to_string(),
-        ));
-    }
-    // A read timeout means the reply is INCOMPLETE. The half-close above makes a
-    // complete reply end in a definitive server-side EOF (Ok(0)), so landing in
-    // the timeout branch at all means we did not get the whole answer, whatever
-    // is already in `buf`. The old guard also required `buf.is_empty()`, which
-    // the OK ack made permanently false on any authenticated connection, so a
-    // stall returned Ok("") and a truncation returned Ok(partial) at exit 0 —
-    // indistinguishable from an empty result set and from a complete one
-    // (issue #561, cases B and C).
-    if timed_out {
-        return Err(io::Error::new(io::ErrorKind::TimedOut, "no response from server (timed out)"));
-    }
-    Ok(result)
+    validate_auth_key(key).ok_or_else(|| io::Error::new(ErrorKind::InvalidInput, "invalid session key"))?;
+    queue.try_send(QueuedControl { port, command: msg.to_string(), key: key.to_string(), notify })
+        .map_err(|e| match e {
+            std::sync::mpsc::TrySendError::Full(_) => io::Error::new(ErrorKind::WouldBlock, "internal command queue is full"),
+            std::sync::mpsc::TrySendError::Disconnected(_) => io::Error::new(ErrorKind::BrokenPipe, "internal command worker stopped"),
+        })
+}
+
+/// Enqueue key bindings/hooks without connecting or waiting on the server's own
+/// event loop. One bounded worker preserves submission order, including across
+/// commands that need an execution acknowledgement before the next is sent.
+pub fn enqueue_control(app: &crate::types::AppState, port: u16, msg: &str) -> io::Result<()> {
+    static QUEUE: std::sync::OnceLock<Option<std::sync::mpsc::SyncSender<QueuedControl>>> = std::sync::OnceLock::new();
+    let queue = QUEUE.get_or_init(|| {
+        let (tx, rx) = std::sync::mpsc::sync_channel::<QueuedControl>(MAX_INTERNAL_COMMANDS);
+        let worker = std::thread::Builder::new().name("psmux-command-worker".into()).spawn(move || {
+            while let Ok(request) = rx.recv() {
+                let result = (|| {
+                    let mut command = request.command.clone();
+                    if !command.ends_with('\n') { command.push('\n'); }
+                    command.push_str("session-info\n");
+                    let mut response = open_authed(&format!("127.0.0.1:{}", request.port), &request.key,
+                        command.as_bytes(), Duration::from_millis(500), Duration::from_millis(3000))?;
+                    let body = response.read_all()?;
+                    for line in body.lines() {
+                        if let Some(error) = protocol_error(line) { return Err(error); }
+                    }
+                    if !body.lines().any(|line| line.contains(" windows (created ")) {
+                        return Err(io::Error::new(ErrorKind::UnexpectedEof, "internal command completion not confirmed"));
+                    }
+                    Ok(())
+                })();
+                if let Err(error) = result {
+                    let message = format!("command failed: {}", error);
+                    crate::debug_log::session_log("command", &message);
+                    if let Some(notify) = request.notify {
+                        // Retry a bounded number of times from the worker, never
+                        // from the event loop, so a busy queue can surface the error.
+                        for _ in 0..20 {
+                            if notify.send(crate::types::CtrlReq::StatusMessage(message.clone())).is_ok() { break; }
+                            std::thread::sleep(Duration::from_millis(25));
+                        }
+                    }
+                }
+            }
+        });
+        worker.ok().map(|_| tx)
+    }).as_ref().ok_or_else(|| io::Error::other("could not start internal command worker"))?;
+    queue_control_request(queue, port, msg, &app.session_key, app.control_tx.clone())
 }
 
 /// Send a control message to a specific port with authentication
 pub fn send_control_to_port(port: u16, msg: &str, session_key: &str) -> io::Result<()> {
-    let addr = format!("127.0.0.1:{}", port);
-    if let Ok(mut stream) = std::net::TcpStream::connect(&addr) {
-        let _ = stream.set_nodelay(true);
-        let _ = write!(stream, "AUTH {}\n", session_key);
-        let _ = stream.write_all(msg.as_bytes());
-        let _ = stream.flush();
-        // Drain the OK response to prevent RST
-        let mut buf = [0u8; 64];
-        let _ = stream.set_read_timeout(Some(Duration::from_millis(50)));
-        let _ = std::io::Read::read(&mut stream, &mut buf);
-    }
+    let key = validate_auth_key(session_key).ok_or_else(|| io::Error::new(ErrorKind::InvalidInput, "invalid session key"))?;
+    let address = std::net::SocketAddr::from(([127, 0, 0, 1], port));
+    let mut stream = std::net::TcpStream::connect_timeout(&address, Duration::from_millis(500))?;
+    stream.set_write_timeout(Some(Duration::from_millis(500)))?;
+    stream.set_read_timeout(Some(Duration::from_millis(500)))?;
+    let _ = stream.set_nodelay(true);
+    write!(stream, "AUTH {}\n", key)?;
+    stream.write_all(msg.as_bytes())?;
+    if !msg.ends_with('\n') { stream.write_all(b"\n")?; }
+    stream.flush()?;
+    let _ = stream.shutdown(std::net::Shutdown::Write);
+    let mut response = AuthedReader { reader: std::io::BufReader::new(stream),
+        remaining: 4096, deadline: std::time::Instant::now() + Duration::from_millis(500) };
+    let ack = response.read_line()?;
+    if let Some(error) = protocol_error(&ack) { return Err(error); }
+    if ack != "OK" { return Err(io::Error::new(ErrorKind::InvalidData, "invalid authentication acknowledgement")); }
     Ok(())
 }
 
@@ -2231,7 +2078,6 @@ pub fn resolve_last_session_name_ns_in(dir: &std::path::Path, ns: Option<&str>) 
         .ok()
         .map(|s| s.trim().to_string())
         .filter(|s| !s.is_empty());
-    let ns_prefix = ns.map(|n| format!("{}__", n));
 
     // (activity, is_last_session_hint, base): ranked in that order, newest and
     // then hinted first, with the name as a final deterministic tie-break.
@@ -2243,14 +2089,7 @@ pub fn resolve_last_session_name_ns_in(dir: &std::path::Path, ns: Option<&str>) 
         if ext != "port" || is_warm_session(base) {
             continue;
         }
-        // Filter by namespace: -L sessions have "ns__name" format.
-        let in_ns = match ns_prefix {
-            Some(ref prefix) => base.starts_with(prefix.as_str()),
-            None => !base.contains("__"),
-        };
-        if !in_ns {
-            continue;
-        }
+        if !session_visible_from(base, ns) { continue; }
         let activity = session_activity_in(dir, base, e.metadata().ok());
         let hinted = hint.as_deref() == Some(base);
         let better = match best {
@@ -2292,7 +2131,7 @@ pub fn resolve_routing_target(
     if let Some(tmux_val) = tmux_env {
         if let Some(base) = session_base_owning_tmux_port(tmux_val, psmux_dir) {
             let in_namespace = match l_socket_name {
-                Some(ns) => base.starts_with(&format!("{}__", ns)),
+                Some(ns) => session_visible_from(&base, Some(ns)),
                 None => true,
             };
             if in_namespace {
@@ -2306,7 +2145,7 @@ pub fn resolve_routing_target(
     }
     // else a namespaced `X__default` so `-L X` never leaks to the un-namespaced
     // `default` server. With no `-L`, stay unresolved (the caller keeps "default").
-    l_socket_name.map(|ns| format!("{}__default", ns))
+    l_socket_name.map(|ns| crate::paths::storage_base(Some(ns), "default"))
 }
 
 /// Find the session port-file base whose control port matches the one encoded
@@ -2358,30 +2197,22 @@ pub fn list_session_names() -> Vec<String> {
 /// Return session names filtered by namespace (same logic as resolve_last_session_name_ns).
 pub fn list_session_names_ns(ns: Option<&str>) -> Vec<String> {
     let dir = crate::paths::psmux_dir();
-    let mut names = Vec::new();
-    if let Ok(entries) = std::fs::read_dir(&dir) {
-        for e in entries.flatten() {
-            if let Some(fname) = e.file_name().to_str().map(|s| s.to_string()) {
-                if let Some((base, ext)) = fname.rsplit_once('.') {
-                    if ext == "port" {
-                        if is_warm_session(base) { continue; }
-                        // Filter by namespace
-                        match ns {
-                            Some(prefix) => {
-                                if !base.starts_with(&format!("{}__", prefix)) { continue; }
-                            }
-                            None => {
-                                if base.contains("__") { continue; }
-                            }
-                        }
-                        names.push(base.to_string());
-                    }
-                }
+    list_session_names_ns_in(Path::new(&dir), ns)
+}
+
+fn list_session_names_ns_in(dir: &Path, ns: Option<&str>) -> Vec<String> {
+    let mut names = std::collections::BTreeSet::new();
+    if let Ok(entries) = std::fs::read_dir(dir) {
+        for entry in entries.flatten() {
+            let file_name = entry.file_name();
+            let Some(name) = file_name.to_str() else { continue; };
+            let Some(base) = name.strip_suffix(".port").or_else(|| name.strip_suffix(".registry.json")) else { continue; };
+            if !is_warm_session(base) && session_visible_from(base, ns) {
+                names.insert(base.to_string());
             }
         }
     }
-    names.sort();
-    names
+    names.into_iter().collect()
 }
 
 /// A tree entry used by choose-tree: either a session header or a window under a session.
@@ -2416,7 +2247,7 @@ pub fn tree_chooser_sessions_in(
                     // Hide warm (standby) sessions from choose-tree
                     if is_warm_session(stem) { continue; }
                     // Another -L namespace is another server: never listed.
-                    if !session_visible_from(stem, ns) { continue; }
+                    if !session_visible_from(stem, ns.as_deref()) { continue; }
                     if let Ok(port_str) = std::fs::read_to_string(&path) {
                         if let Ok(port) = port_str.trim().parse::<u16>() {
                             let mtime = entry.metadata()
@@ -2549,3 +2380,7 @@ mod tests_issue603_bare_routing;
 #[cfg(test)]
 #[path = "../tests-rs/test_picker_namespace_filter.rs"]
 mod tests_picker_namespace_filter;
+
+#[cfg(test)]
+#[path = "../tests-rs/test_reliability_discovery.rs"]
+mod tests_reliability_discovery;

--- a/src/types.rs
+++ b/src/types.rs
@@ -756,7 +756,7 @@ pub struct AppState {
     pub key_tables: std::collections::HashMap<String, Vec<Bind>>,
     /// Current key table for switch-client -T (None = normal mode)
     pub current_key_table: Option<String>,
-    pub control_rx: Option<mpsc::Receiver<CtrlReq>>,
+    pub control_rx: Option<ControlReceiver>,
     /// Sender for the same channel `control_rx` receives on, so code already
     /// running ON the server loop can queue follow-up work for a later
     /// iteration instead of recursing.
@@ -768,7 +768,7 @@ pub struct AppState {
     /// routing back out through `execute_command_string` would make the server
     /// open a TCP connection to itself while the loop is blocked doing so —
     /// a deadlock. Queueing costs one loop iteration and cannot deadlock.
-    pub control_tx: Option<mpsc::Sender<CtrlReq>>,
+    pub control_tx: Option<ControlSender>,
     pub control_port: Option<u16>,
     pub session_key: String,
     /// Receiver for async run-shell results (title, output).
@@ -1630,7 +1630,9 @@ impl AppState {
             format_job_rx: None,
             format_job_tx: None,
             session_name,
-            session_id: crate::session::allocate_session_id(),
+            // Temporary in-memory identity; run_server assigns the persistent ID.
+            session_id: { static NEXT: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+                NEXT.fetch_add(1, std::sync::atomic::Ordering::Relaxed) },
             socket_name: None,
             attached_clients: 0,
             client_sizes: std::collections::HashMap::new(),
@@ -1758,11 +1760,7 @@ impl AppState {
     /// When socket_name is set (via -L flag), files are stored as `{socket_name}__{session_name}`.
     /// Otherwise, just the session_name is used.
     pub fn port_file_base(&self) -> String {
-        if let Some(ref sn) = self.socket_name {
-            format!("{}__{}", sn, self.session_name)
-        } else {
-            self.session_name.clone()
-        }
+        crate::paths::storage_base(self.socket_name.as_deref(), &self.session_name)
     }
 }
 
@@ -1861,7 +1859,13 @@ pub enum WindowDumpFormat {
     PreviewState,
 }
 
+#[path = "request_queue.rs"]
+mod request_queue;
+pub use request_queue::{control_channel, ControlReceiver, ControlSender};
+
 pub enum CtrlReq {
+    /// The acknowledgement belongs to this command and this connection only.
+    CommandRequest(Box<CtrlReq>, mpsc::Sender<Result<(), String>>),
     NewWindow(Option<String>, Option<String>, bool, Option<String>, Option<String>, bool, Vec<(String, String)>),  // cmd, name, detached, start_dir, title (-T), empty (-E), env (-e, #489)
     NewWindowPrint(Option<String>, Option<String>, bool, Option<String>, Option<String>, mpsc::Sender<String>, Option<String>, bool, Vec<(String, String)>),  // cmd, name, detached, start_dir, format, resp, title (-T), empty (-E), env (-e, #489)
     SplitWindow(LayoutKind, Option<String>, bool, Option<String>, Option<(u16, bool)>, mpsc::Sender<String>, Option<String>, Vec<(String, String)>, bool),  // kind, cmd, detached, start_dir, size (value, is_percent), error_resp, title (-T), env (-e, #489), zoom (-Z)
@@ -2337,7 +2341,7 @@ pub enum CtrlReq {
         window_id: Option<usize>,
         size: Option<(u16, u16)>,
     },
-    RespawnWindow(Option<String>, Option<String>),  // optional workdir (-c), optional shell-command operand
+    RespawnWindow(Option<String>, bool, Option<String>),  // workdir (-c), kill (-k), command
     FocusIn,
     FocusOut,
     CommandPrompt(String),
@@ -2396,6 +2400,9 @@ pub enum CtrlReq {
 /// Global flag set by PTY reader threads when new output arrives.
 /// The server loop checks this to use a shorter recv_timeout, reducing
 /// keystroke-to-display latency for nested shells (e.g. WSL inside pwsh).
+pub static CONTROL_CLIENTS_ACTIVE: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+pub static CONTROL_OUTPUT_LOST: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+
 pub static PTY_DATA_READY: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
 
 /// Set by the parser thread when any pane's `cpr_pending` flag is raised.
@@ -2569,24 +2576,6 @@ pub fn parse_x11_color(s: &str) -> Option<(u8, u8, u8)> {
     Some((out[0], out[1], out[2]))
 }
 
-/// Issue #440: `pipe-pane` output routing.
-///
-/// A pane's PTY reader thread tees every raw output chunk to any pipe writer
-/// registered under its `pane_id`, so `pipe-pane -o '<cmd>'` actually receives
-/// the pane transcript on the child's stdin (previously the child was spawned
-/// with a piped stdin that nothing ever wrote to, so it blocked on an empty
-/// pipe forever and the sink stayed 0 bytes).
-///
-/// `PIPE_PANE_COUNT` is a cheap gate: it lets every reader thread skip the mutex
-/// entirely in the overwhelmingly common case where no pipe is active, so panes
-/// that are not being piped pay nothing. The server handler (`CtrlReq::PipePane`)
-/// pushes/removes `(pane_id, child_stdin)` entries and keeps the count in sync.
-pub static PIPE_PANE_COUNT: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
-/// Writers are boxed so the same tee path serves both pipe-pane child stdins
-/// and cross-session forward tunnels (TcpStream) without a second reader
-/// competing for the ConPTY output pipe.
-pub static PIPE_WRITERS: Mutex<Vec<(usize, Box<dyn std::io::Write + Send>)>> = Mutex::new(Vec::new());
-
 /// Tracked persistent client TCP streams.
 /// Connection handlers register clones here so the server can explicitly
 /// `shutdown()` them before `process::exit(0)`.  Without this, Windows
@@ -2715,13 +2704,13 @@ pub fn deregister_frame_channel(client_id: u64) {
 /// Per-client directive channels (queued, not overwritten like frame slots).
 /// Used for sending commands/directives (e.g. SWITCH) to specific persistent clients
 /// without risk of being overwritten by frame pushes.
-static DIRECTIVE_CHANNELS: std::sync::Mutex<Vec<(u64, std::sync::mpsc::Sender<String>)>> =
+static DIRECTIVE_CHANNELS: std::sync::Mutex<Vec<(u64, std::sync::mpsc::SyncSender<String>)>> =
     std::sync::Mutex::new(Vec::new());
 
 /// Register a directive channel for a persistent client. Returns the receiver
 /// for the writer thread to poll.
 pub fn register_directive_channel(client_id: u64) -> std::sync::mpsc::Receiver<String> {
-    let (tx, rx) = std::sync::mpsc::channel::<String>();
+    let (tx, rx) = std::sync::mpsc::sync_channel::<String>(64);
     if let Ok(mut v) = DIRECTIVE_CHANNELS.lock() {
         v.push((client_id, tx));
     }
@@ -2730,23 +2719,22 @@ pub fn register_directive_channel(client_id: u64) -> std::sync::mpsc::Receiver<S
 
 /// Send a directive to a specific persistent client. Returns true if sent.
 pub fn send_directive_to_client(client_id: u64, directive: &str) -> bool {
-    if let Ok(channels) = DIRECTIVE_CHANNELS.lock() {
-        for (cid, tx) in channels.iter() {
-            if *cid == client_id {
-                return tx.send(directive.to_string()).is_ok();
-            }
-        }
-    }
-    false
+    let sent = DIRECTIVE_CHANNELS.lock().ok().and_then(|channels|
+        channels.iter().find(|(cid, _)| *cid == client_id)
+            .map(|(_, tx)| directive.len() <= 16 * 1024 && tx.try_send(directive.to_string()).is_ok()))
+        .unwrap_or(false);
+    // Do not discard an ordered SWITCH/DETACH directive. Disconnect a slow
+    // consumer so it cannot keep operating with a silently divergent state.
+    if !sent { shutdown_client_stream(client_id); }
+    sent
 }
 
 /// Send a directive to ALL persistent clients.
 pub fn send_directive_to_all_clients(directive: &str) {
-    if let Ok(channels) = DIRECTIVE_CHANNELS.lock() {
-        for (_, tx) in channels.iter() {
-            let _ = tx.send(directive.to_string());
-        }
-    }
+    let failed = DIRECTIVE_CHANNELS.lock().map(|channels| channels.iter()
+        .filter_map(|(id, tx)| (directive.len() > 16 * 1024 || tx.try_send(directive.to_string()).is_err()).then_some(*id))
+        .collect::<Vec<_>>()).unwrap_or_default();
+    for id in failed { shutdown_client_stream(id); }
 }
 
 /// Remove a client's directive channel (called on disconnect).

--- a/src/warm_pane_sync.rs
+++ b/src/warm_pane_sync.rs
@@ -257,27 +257,15 @@ fn apply_patch_to_existing_panes(app: &mut AppState, patch: &WarmPanePatch) {
     }
 }
 
-fn respawn(app: &mut AppState, pty_system: &dyn portable_pty::PtySystem) {
+fn respawn(app: &mut AppState, _pty_system: &dyn portable_pty::PtySystem) {
     // Always kill any existing warm pane first — there is no in-place
     // way to swap shell binaries or environment blocks.
-    if let Some(mut old) = app.warm_pane.take() {
-        old.child.kill().ok();
+    if let Some(old) = app.warm_pane.take() {
+        crate::pane::retire_warm_pane(old);
     }
-    // Honour warm_enabled: a config-disabled warm pane must not come
-    // back to life after a Respawn — the user opted out.
-    if !app.warm_enabled {
-        return;
-    }
-    match crate::pane::spawn_warm_pane(pty_system, app) {
-        Ok(wp) => {
-            app.warm_pane = Some(wp);
-        }
-        Err(_) => {
-            // Best-effort: if a respawn fails (e.g. transient PTY
-            // creation error) we leave warm_pane = None and the next
-            // consume path falls back to a synchronous cold spawn.
-        }
-    }
+    // The event loop owns one WarmPaneTask and replenishes from a fresh
+    // configuration snapshot. Never run OpenConsole/CreateProcess here: a
+    // resize or set-option must not block every pending control request.
 }
 
 /// Helper for warm-pane consume sites in `pane.rs`.  When a warm

--- a/src/window_ops.rs
+++ b/src/window_ops.rs
@@ -1839,7 +1839,10 @@ pub fn handle_pane_scroll(app: &mut AppState, pane_id: usize, up: bool, at: Opti
         mouse_log("  -> legacy pager (more.com), sending Enter x3");
         if let Some(pane) = active_pane_mut(&mut win.root, &win.active_path) {
             for _ in 0..3 {
-                crate::input::write_key_seq(pane, b"\r");
+                if let Err(error) = crate::input::write_key_seq(pane, b"\r") {
+                    app.status_message = Some((format!("pane input: {}", error), std::time::Instant::now(), None));
+                    return;
+                }
             }
             let _ = pane.writer.flush();
         }
@@ -2625,28 +2628,61 @@ pub fn break_pane_to_window(app: &mut AppState) {
     }
 }
 
+pub fn respawn_window(app: &mut AppState, pty_system: &dyn portable_pty::PtySystem, workdir: Option<&str>, kill: bool, command: Option<&str>) -> io::Result<()> {
+    let window = app.windows.get_mut(app.active_idx).ok_or_else(|| io::Error::other("window not found"))?;
+    let mut any_alive = window.floating.iter().any(|fp| !fp.pane.dead);
+    crate::tree::for_each_pane(&window.root, &mut |pane| any_alive |= !pane.dead);
+    if any_alive && !kill { return Err(io::Error::other("window still active")); }
+    let old_path = window.active_path.clone();
+    window.active_path = crate::tree::first_leaf_path(&window.root);
+    if let Err(error) = respawn_active_pane(app, Some(pty_system), workdir, kill, command, false) {
+        app.windows[app.active_idx].active_path = old_path;
+        return Err(error);
+    }
+    let window = &mut app.windows[app.active_idx];
+    let keep_id = crate::tree::get_active_pane_id(&window.root, &window.active_path)
+        .expect("successful respawn retained the first pane");
+    fn retain_respawned(node: Node, keep_id: usize) -> Option<Node> {
+        match node {
+            Node::Leaf(mut pane) => {
+                if pane.id == keep_id { return Some(Node::Leaf(pane)); }
+                crate::platform::process_kill::kill_process_tree(&mut pane.child);
+                None
+            }
+            Node::Split { children, .. } => {
+                let mut keep = None;
+                for child in children {
+                    if let Some(pane) = retain_respawned(child, keep_id) { keep = Some(pane); }
+                }
+                keep
+            }
+        }
+    }
+    let root = std::mem::replace(&mut window.root, Node::Split {
+        kind: LayoutKind::Horizontal, sizes: Vec::new(), children: Vec::new(),
+    });
+    window.root = retain_respawned(root, keep_id).expect("respawned pane belongs to its window");
+    for floating in &mut window.floating { crate::platform::process_kill::kill_process_tree(&mut floating.pane.child); }
+    window.floating.clear();
+    window.floating_focus = None;
+    window.active_path.clear();
+    window.pane_mru = vec![keep_id];
+    window.zoom_saved = None;
+    resize_all_panes(app);
+    Ok(())
+}
+
 pub fn respawn_active_pane(app: &mut AppState, pty_system_ref: Option<&dyn portable_pty::PtySystem>, workdir: Option<&str>, kill: bool, command: Option<&str>, empty: bool) -> io::Result<()> {
     // tmux semantics: without -k, respawn only works on dead panes.
     // With -k, kill the running process first and respawn.
     {
-        let win = &app.windows[app.active_idx];
+        let win = app.windows.get(app.active_idx).ok_or_else(|| io::Error::other("window not found"))?;
         if let Some(pane) = crate::tree::active_pane(&win.root, &win.active_path) {
             if !pane.dead && !kill {
                 return Err(io::Error::new(io::ErrorKind::Other, "pane still active"));
             }
         }
     }
-    // If -k and pane is alive, kill the child process first
-    if kill {
-        let win = &mut app.windows[app.active_idx];
-        if let Some(pane) = active_pane_mut(&mut win.root, &win.active_path) {
-            if !pane.dead {
-                crate::platform::process_kill::kill_process_tree(&mut pane.child);
-                pane.dead = true;
-            }
-        }
-    }
-
     // -E: respawn as an EMPTY pane (no command). Replace the pane in place with
     // a childless empty pane, keeping its id/title/size, and return.
     if empty {
@@ -2655,9 +2691,12 @@ pub fn respawn_active_pane(app: &mut AppState, pty_system_ref: Option<&dyn porta
             let (r, c, id, title) = (pane.last_rows, pane.last_cols, pane.id, pane.title.clone());
             if let Some(mut ep) = crate::popup::create_empty_pane(r.max(1), c.max(1), id) {
                 ep.title = title;
+                if !pane.dead { crate::platform::process_kill::kill_process_tree(&mut pane.child); }
                 *pane = ep;
+            } else {
+                return Err(io::Error::other("could not create empty pane"));
             }
-        }
+        } else { return Err(io::Error::other("pane not found")); }
         return Ok(());
     }
 
@@ -2674,7 +2713,7 @@ pub fn respawn_active_pane(app: &mut AppState, pty_system_ref: Option<&dyn porta
     let expanded_shell = crate::format::expand_format(&app.default_shell, &app);
 
     let win = &mut app.windows[app.active_idx];
-    let Some(pane) = active_pane_mut(&mut win.root, &win.active_path) else { return Ok(()); };
+    let Some(pane) = active_pane_mut(&mut win.root, &win.active_path) else { return Err(io::Error::other("pane not found")); };
     let pane_id = pane.id;
     // tmux spawn.c: a respawn with no command of its own reuses the arguments
     // already stored on the pane ("Replace the stored arguments if there are
@@ -2712,14 +2751,18 @@ pub fn respawn_active_pane(app: &mut AppState, pty_system_ref: Option<&dyn porta
             .unwrap_or_default();
         let expanded = dir.replace("~/", &format!("{}/", home))
             .replace("~\\", &format!("{}\\", home));
+        if !std::fs::metadata(&expanded)?.is_dir() {
+            return Err(io::Error::new(io::ErrorKind::InvalidInput, "respawn working directory is not a directory"));
+        }
         shell_cmd.cwd(std::path::Path::new(&expanded));
     }
+    let reader = pair.master.try_clone_reader().map_err(|e| io::Error::other(format!("clone reader error: {e}")))?;
+    let raw_writer = pair.master.take_writer().map_err(|e| io::Error::other(format!("take writer error: {e}")))?;
     let child = pair.slave.spawn_command(shell_cmd).map_err(|e| io::Error::new(io::ErrorKind::Other, format!("spawn shell error: {e}")))?;
     // Close the slave handle immediately – required for ConPTY.
     drop(pair.slave);
     let term: Arc<Mutex<vt100::Parser>> = Arc::new(Mutex::new(vt100::Parser::new(size.rows, size.cols, app.history_limit)));
     let term_reader = term.clone();
-    let reader = pair.master.try_clone_reader().map_err(|e| io::Error::new(io::ErrorKind::Other, format!("clone reader error: {e}")))?;
     
     let data_version = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
     let dv_writer = data_version.clone();
@@ -2738,9 +2781,12 @@ pub fn respawn_active_pane(app: &mut AppState, pty_system_ref: Option<&dyn porta
     crate::pane::spawn_reader_thread(reader, term_reader, dv_writer, cs_writer, bell_writer, cpr_writer, cq_writer, output_ring.clone(), pane_id, child_pid);
     pane.output_ring = output_ring;
 
-    let mut pty_writer = crate::pane::spawn_pane_write_queue(pair.master.take_writer().map_err(|e| io::Error::new(io::ErrorKind::Other, format!("take writer error: {e}")))?);
+    let mut pty_writer = crate::pane::spawn_pane_write_queue(raw_writer);
     crate::pane::conpty_preemptive_dsr_response(&mut *pty_writer);
 
+    // The replacement is now fully prepared. Until this point every failure
+    // leaves the original process, terminal and registration untouched.
+    if !pane.dead { crate::platform::process_kill::kill_process_tree(&mut pane.child); }
     pane.master = pair.master;
     pane.writer = pty_writer;
     pane.child = child;

--- a/tests-rs/test_audit_input_errors.rs
+++ b/tests-rs/test_audit_input_errors.rs
@@ -1,0 +1,208 @@
+// PTY-free admission/error propagation regressions; no processes or sessions.
+use super::*;
+
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicU8};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use crate::types::Node;
+
+const ROWS: u16 = 6;
+const COLS: u16 = 40;
+
+// ── PTY-free pane scaffolding ──────────────────────────────────────────────
+
+#[derive(Debug)]
+struct DummyChild;
+
+#[derive(Debug)]
+struct DummyWriter;
+
+struct DummyMaster;
+
+impl std::io::Write for DummyWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> { Ok(buf.len()) }
+    fn flush(&mut self) -> std::io::Result<()> { Ok(()) }
+}
+
+impl portable_pty::ChildKiller for DummyChild {
+    fn kill(&mut self) -> std::io::Result<()> { Ok(()) }
+    fn clone_killer(&self) -> Box<dyn portable_pty::ChildKiller + Send + Sync> {
+        Box::new(DummyChild)
+    }
+}
+
+impl portable_pty::Child for DummyChild {
+    fn try_wait(&mut self) -> std::io::Result<Option<portable_pty::ExitStatus>> {
+        Ok(Some(portable_pty::ExitStatus::with_exit_code(0)))
+    }
+    fn wait(&mut self) -> std::io::Result<portable_pty::ExitStatus> {
+        Ok(portable_pty::ExitStatus::with_exit_code(0))
+    }
+    fn process_id(&self) -> Option<u32> { None }
+    #[cfg(windows)]
+    fn as_raw_handle(&self) -> Option<std::os::windows::io::RawHandle> { None }
+}
+
+impl portable_pty::MasterPty for DummyMaster {
+    fn resize(&self, _size: portable_pty::PtySize) -> Result<(), anyhow::Error> { Ok(()) }
+    fn get_size(&self) -> Result<portable_pty::PtySize, anyhow::Error> {
+        Ok(portable_pty::PtySize { rows: ROWS, cols: COLS, pixel_width: 0, pixel_height: 0 })
+    }
+    fn try_clone_reader(&self) -> Result<Box<dyn std::io::Read + Send>, anyhow::Error> {
+        Ok(Box::new(std::io::empty()))
+    }
+    fn take_writer(&self) -> Result<Box<dyn std::io::Write + Send>, anyhow::Error> {
+        Ok(Box::new(DummyWriter))
+    }
+    #[cfg(unix)]
+    fn process_group_leader(&self) -> Option<i32> { None }
+    #[cfg(unix)]
+    fn as_raw_fd(&self) -> Option<std::os::unix::io::RawFd> { None }
+    #[cfg(unix)]
+    fn tty_name(&self) -> Option<std::path::PathBuf> { None }
+}
+
+fn make_pane(id: usize, rows: u16, cols: u16) -> crate::types::Pane {
+    let term = Arc::new(Mutex::new(vt100::Parser::new(rows, cols, 0)));
+    let epoch = Instant::now() - Duration::from_secs(2);
+    crate::types::Pane {
+        master: Box::new(DummyMaster),
+        writer: Box::new(DummyWriter),
+        child: Box::new(DummyChild),
+        term,
+        last_rows: rows,
+        last_cols: cols,
+        id,
+        title: format!("pane{id}"),
+        title_locked: false,
+        child_pid: None,
+        data_version: Arc::new(AtomicU64::new(0)),
+        last_title_check: epoch,
+        last_infer_title: epoch,
+        dead: false,
+        last_text_input: None,
+        last_special_key: None,
+        vt_bridge_cache: None,
+        vti_mode_cache: None,
+        mouse_input_cache: None, win32_input_latched: false,
+        scroll_fg_cache: None, mouse_proto_owner: None, wheel_auth: None,
+        cursor_shape: Arc::new(AtomicU8::new(0)),
+        bell_pending: Arc::new(AtomicBool::new(false)),
+        cpr_pending: Arc::new(AtomicBool::new(false)),
+        color_query_pending: Arc::new(std::sync::atomic::AtomicU32::new(0)),
+        copy_state: None,
+        pane_style: None, pane_options: Default::default(),
+        squelch_until: None,
+        output_ring: Arc::new(Mutex::new(std::collections::VecDeque::new())),
+        spawned_at: None,
+        start_command: String::new(),
+        cwd_hint: None,
+    }
+}
+
+fn make_window(id: usize) -> crate::types::Window {
+    crate::types::Window {
+        root: Node::Split { kind: crate::types::LayoutKind::Horizontal, sizes: vec![], children: vec![] },
+        active_path: vec![],
+        name: "w".to_string(),
+        id,
+        area: ratatui::layout::Rect::new(0, 0, 120, 30),
+        window_size: None,
+        activity_flag: false,
+        bell_flag: false,
+        silence_flag: false,
+        last_output_time: Instant::now(),
+        last_seen_version: 0,
+        manual_rename: false,
+        layout_index: 0,
+        pane_mru: vec![],
+        zoom_saved: None,
+        linked_from: None,
+        floating: Vec::new(),
+        floating_focus: None,
+    }
+}
+
+fn app_with_writer(writer: Box<dyn Write + Send>) -> AppState {
+    let mut app = AppState::new("input-error-unit".into());
+    let mut pane = make_pane(17, ROWS, COLS);
+    pane.writer = writer;
+    let mut window = make_window(0);
+    window.root = Node::Leaf(pane);
+    app.windows.push(window);
+    app.active_idx = 0;
+    app
+}
+
+struct Reject(io::ErrorKind);
+impl Write for Reject {
+    fn write(&mut self, _: &[u8]) -> io::Result<usize> { Err(self.0.into()) }
+    fn flush(&mut self) -> io::Result<()> { Err(self.0.into()) }
+}
+
+#[test]
+fn all_live_input_routes_return_backpressure_and_permanent_errors() {
+    for kind in [io::ErrorKind::WouldBlock, io::ErrorKind::BrokenPipe] {
+        let mut app = app_with_writer(Box::new(Reject(kind)));
+        assert_eq!(send_text_to_active(&mut app, "hello").unwrap_err().kind(), kind);
+        assert_eq!(send_bytes_to_active(&mut app, &[0xff]).unwrap_err().kind(), kind);
+        assert_eq!(send_key_to_active(&mut app, "enter").unwrap_err().kind(), kind);
+        assert_eq!(send_key_to_active(&mut app, "f3").unwrap_err().kind(), kind);
+        assert_eq!(send_key_to_active(&mut app, "C-/").unwrap_err().kind(), kind);
+        assert_eq!(send_paste_to_active(&mut app, "hello\nworld").unwrap_err().kind(), kind);
+        assert_eq!(forward_key_to_active(&mut app,
+            KeyEvent::new(KeyCode::Char('z'), KeyModifiers::NONE)).unwrap_err().kind(), kind);
+    }
+}
+
+#[test]
+fn synchronized_input_does_not_hide_failed_pane() {
+    let mut app = app_with_writer(Box::new(Reject(io::ErrorKind::WouldBlock)));
+    app.sync_input = true;
+    assert!(send_text_to_active(&mut app, "hello").is_err());
+    assert!(send_bytes_to_active(&mut app, &[0xff]).is_err());
+    assert!(send_key_to_active(&mut app, "up").is_err());
+    assert!(send_paste_to_active(&mut app, "paste").is_err());
+}
+
+#[test]
+fn paste_brackets_and_normalized_text_are_one_admission() {
+    struct Calls(Vec<Vec<u8>>);
+    impl Write for Calls {
+        fn write(&mut self, bytes: &[u8]) -> io::Result<usize> { self.0.push(bytes.to_vec()); Ok(bytes.len()) }
+        fn flush(&mut self) -> io::Result<()> { Ok(()) }
+    }
+    let mut writer = Calls(Vec::new());
+    write_paste_chunked(&mut writer, b"line1\r\nline2\n", true).unwrap();
+    assert_eq!(writer.0, vec![b"\x1b[200~line1\rline2\r\x1b[201~".to_vec()]);
+}
+
+#[test]
+fn rejected_paste_does_not_emit_an_unclosed_bracket() {
+    struct Budget { bytes: Vec<u8>, limit: usize }
+    impl Write for Budget {
+        fn write(&mut self, b: &[u8]) -> io::Result<usize> {
+            if self.bytes.len() + b.len() > self.limit { return Err(io::ErrorKind::WouldBlock.into()); }
+            self.bytes.extend_from_slice(b);
+            Ok(b.len())
+        }
+        fn flush(&mut self) -> io::Result<()> { Ok(()) }
+    }
+    let mut writer = Budget { bytes: Vec::new(), limit: 8 };
+    assert_eq!(write_paste_chunked(&mut writer, b"hello", true).unwrap_err().kind(), io::ErrorKind::WouldBlock);
+    assert!(writer.bytes.is_empty());
+}
+
+#[test]
+fn idle_input_failure_is_reported_once_and_recovers_after_replacement() {
+    let mut app = app_with_writer(Box::new(Reject(io::ErrorKind::BrokenPipe)));
+    let failures = crate::pane::take_input_failures(&mut app);
+    assert_eq!(failures.len(), 1);
+    assert_eq!(failures[0].0, 17);
+    assert!(crate::pane::take_input_failures(&mut app).is_empty());
+    crate::tree::active_pane_mut(&mut app.windows[0].root, &Vec::new()).unwrap().writer = Box::new(DummyWriter);
+    assert!(crate::pane::take_input_failures(&mut app).is_empty());
+    crate::tree::active_pane_mut(&mut app.windows[0].root, &Vec::new()).unwrap().writer = Box::new(Reject(io::ErrorKind::BrokenPipe));
+    assert_eq!(crate::pane::take_input_failures(&mut app).len(), 1);
+}

--- a/tests-rs/test_audit_io_queue.rs
+++ b/tests-rs/test_audit_io_queue.rs
@@ -1,0 +1,200 @@
+use super::*;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::mpsc;
+use std::time::Instant;
+
+fn until(mut condition: impl FnMut() -> bool) {
+    let deadline = Instant::now() + Duration::from_secs(3);
+    while !condition() {
+        assert!(Instant::now() < deadline, "worker did not reach expected state");
+        thread::sleep(Duration::from_millis(1));
+    }
+}
+
+struct Gated {
+    entered: mpsc::Sender<()>,
+    gate: mpsc::Receiver<()>,
+    bytes: Arc<Mutex<Vec<u8>>>,
+    largest: Arc<AtomicUsize>,
+    first: bool,
+}
+
+impl Write for Gated {
+    fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
+        self.largest.fetch_max(bytes.len(), Ordering::Relaxed);
+        if self.first {
+            self.first = false;
+            self.entered.send(()).unwrap();
+            self.gate.recv().unwrap();
+        }
+        self.bytes.lock().unwrap().extend_from_slice(bytes);
+        Ok(bytes.len())
+    }
+    fn flush(&mut self) -> io::Result<()> { Ok(()) }
+}
+
+#[test]
+fn input_budget_includes_blocked_inflight_bytes_and_rejects_atomically() {
+    let (entered_tx, entered_rx) = mpsc::channel();
+    let (gate_tx, gate_rx) = mpsc::channel();
+    let bytes = Arc::new(Mutex::new(Vec::new()));
+    let largest = Arc::new(AtomicUsize::new(0));
+    let inner = Gated { entered: entered_tx, gate: gate_rx, bytes: bytes.clone(), largest: largest.clone(), first: true };
+    let queue = ByteWriter::spawn("audit-input-budget", 12, true, move || Ok(Box::new(inner))).unwrap();
+    assert_eq!(queue.enqueue(b"first!").unwrap(), 6);
+    entered_rx.recv_timeout(Duration::from_secs(3)).unwrap();
+    assert_eq!(queue.outstanding(), 6);
+    assert_eq!(queue.enqueue(b"second").unwrap(), 6);
+    let now = Instant::now();
+    assert_eq!(queue.enqueue(b"never").unwrap_err().kind(), io::ErrorKind::WouldBlock);
+    assert!(now.elapsed() < Duration::from_millis(250));
+    assert_eq!(queue.outstanding(), 12);
+    gate_tx.send(()).unwrap();
+    until(|| queue.outstanding() == 0);
+    assert_eq!(&*bytes.lock().unwrap(), b"first!second");
+    assert!(largest.load(Ordering::Relaxed) <= WRITE_BATCH_LIMIT);
+}
+
+#[test]
+fn accepted_large_write_is_delivered_in_bounded_batches() {
+    struct Recorder(Arc<Mutex<Vec<u8>>>, Arc<AtomicUsize>);
+    impl Write for Recorder {
+        fn write(&mut self, b: &[u8]) -> io::Result<usize> {
+            self.1.fetch_max(b.len(), Ordering::Relaxed);
+            self.0.lock().unwrap().extend_from_slice(b);
+            Ok(b.len())
+        }
+        fn flush(&mut self) -> io::Result<()> { Ok(()) }
+    }
+    let output = Arc::new(Mutex::new(Vec::new()));
+    let largest = Arc::new(AtomicUsize::new(0));
+    let inner = Recorder(output.clone(), largest.clone());
+    let queue = ByteWriter::spawn("audit-input-batch", INPUT_BYTE_LIMIT, true, move || Ok(Box::new(inner))).unwrap();
+    let bytes: Vec<_> = (0..300_000).map(|i| (i % 251) as u8).collect();
+    queue.enqueue(&bytes).unwrap();
+    until(|| queue.outstanding() == 0);
+    assert_eq!(*output.lock().unwrap(), bytes);
+    assert!(largest.load(Ordering::Relaxed) <= WRITE_BATCH_LIMIT);
+}
+
+#[test]
+fn short_writes_and_transient_errors_preserve_unwritten_suffix() {
+    struct Short(usize, Arc<Mutex<Vec<u8>>>);
+    impl Write for Short {
+        fn write(&mut self, b: &[u8]) -> io::Result<usize> {
+            self.0 += 1;
+            if self.0 == 2 { return Err(io::ErrorKind::Interrupted.into()); }
+            if self.0 == 4 { return Err(io::ErrorKind::WouldBlock.into()); }
+            let n = b.len().min(2);
+            self.1.lock().unwrap().extend_from_slice(&b[..n]);
+            Ok(n)
+        }
+        fn flush(&mut self) -> io::Result<()> { Ok(()) }
+    }
+    let output = Arc::new(Mutex::new(Vec::new()));
+    let inner = Short(0, output.clone());
+    let queue = ByteWriter::spawn("audit-input-short", 20, true, move || Ok(Box::new(inner))).unwrap();
+    queue.enqueue(b"abcdefghijk").unwrap();
+    until(|| queue.outstanding() == 0);
+    assert_eq!(&*output.lock().unwrap(), b"abcdefghijk");
+}
+
+#[test]
+fn permanent_failure_is_visible_and_retains_pty_handle_and_bytes_until_drop() {
+    struct Broken(Arc<AtomicBool>);
+    impl Write for Broken {
+        fn write(&mut self, _: &[u8]) -> io::Result<usize> { Err(io::ErrorKind::BrokenPipe.into()) }
+        fn flush(&mut self) -> io::Result<()> { Ok(()) }
+    }
+    impl Drop for Broken { fn drop(&mut self) { self.0.store(true, Ordering::Release); } }
+    let dropped = Arc::new(AtomicBool::new(false));
+    let inner = Broken(dropped.clone());
+    let mut queue = ByteWriter::spawn("audit-input-failed", 100, true, move || Ok(Box::new(inner))).unwrap();
+    queue.enqueue(b"accepted").unwrap();
+    until(|| queue.failure().is_some());
+    assert_eq!(queue.flush().unwrap_err().kind(), io::ErrorKind::BrokenPipe);
+    assert_eq!(queue.enqueue(b"rejected").unwrap_err().kind(), io::ErrorKind::BrokenPipe);
+    assert_eq!(queue.outstanding(), 8);
+    assert!(!dropped.load(Ordering::Acquire));
+    drop(queue);
+    until(|| dropped.load(Ordering::Acquire));
+}
+
+#[test]
+fn flush_error_is_observable() {
+    struct FailsFlush;
+    impl Write for FailsFlush {
+        fn write(&mut self, b: &[u8]) -> io::Result<usize> { Ok(b.len()) }
+        fn flush(&mut self) -> io::Result<()> { Err(io::ErrorKind::PermissionDenied.into()) }
+    }
+    let queue = ByteWriter::spawn("audit-input-flush", 100, true, || Ok(Box::new(FailsFlush))).unwrap();
+    queue.enqueue(b"hello").unwrap();
+    until(|| queue.failure().is_some());
+    assert_eq!(queue.check().unwrap_err().kind(), io::ErrorKind::PermissionDenied);
+}
+
+#[test]
+fn normal_finish_drains_accepted_bytes() {
+    let (entered_tx, entered_rx) = mpsc::channel();
+    let (gate_tx, gate_rx) = mpsc::channel();
+    let bytes = Arc::new(Mutex::new(Vec::new()));
+    let inner = Gated { entered: entered_tx, gate: gate_rx, bytes: bytes.clone(), largest: Arc::default(), first: true };
+    let queue = ByteWriter::spawn("audit-sink-finish", 100, false, move || Ok(Box::new(inner))).unwrap();
+    queue.enqueue(b"before").unwrap();
+    entered_rx.recv_timeout(Duration::from_secs(3)).unwrap();
+    queue.enqueue(b"after").unwrap();
+    queue.finish();
+    gate_tx.send(()).unwrap();
+    until(|| queue.is_finished());
+    assert_eq!(&*bytes.lock().unwrap(), b"beforeafter");
+    assert!(queue.failure().is_none());
+}
+
+#[test]
+fn cancellation_does_not_wait_for_blocked_writer() {
+    let (entered_tx, entered_rx) = mpsc::channel();
+    let (gate_tx, gate_rx) = mpsc::channel();
+    let inner = Gated { entered: entered_tx, gate: gate_rx, bytes: Arc::default(), largest: Arc::default(), first: true };
+    let queue = ByteWriter::spawn("audit-sink-cancel", 100, false, move || Ok(Box::new(inner))).unwrap();
+    queue.enqueue(b"blocked").unwrap();
+    entered_rx.recv_timeout(Duration::from_secs(3)).unwrap();
+    let now = Instant::now();
+    queue.cancel();
+    assert!(now.elapsed() < Duration::from_millis(250));
+    // A synthetic Condvar/channel is not Windows I/O and cannot be cancelled
+    // with CancelSynchronousIo. Release it explicitly after proving promptness.
+    gate_tx.send(()).unwrap();
+}
+
+#[cfg(windows)]
+#[test]
+fn windows_cancellation_releases_a_real_blocked_pipe_without_a_reader() {
+    use std::os::windows::io::FromRawHandle;
+    #[link(name = "kernel32")]
+    unsafe extern "system" {
+        fn CreatePipe(read: *mut *mut std::ffi::c_void, write: *mut *mut std::ffi::c_void,
+            attributes: *mut std::ffi::c_void, size: u32) -> i32;
+    }
+    let mut read = std::ptr::null_mut();
+    let mut write = std::ptr::null_mut();
+    assert_ne!(unsafe { CreatePipe(&mut read, &mut write, std::ptr::null_mut(), 4096) }, 0);
+    // Keep the read endpoint open and never consume it. Cancellation, not EOF,
+    // must release WriteFile and the worker even if it races the write start.
+    let _reader = unsafe { std::fs::File::from_raw_handle(read) };
+    let file = unsafe { std::fs::File::from_raw_handle(write) };
+    let (tx, rx) = mpsc::channel();
+    let dropped = Arc::new(AtomicBool::new(false));
+    struct PipeWriter(std::fs::File, mpsc::Sender<()>, Arc<AtomicBool>);
+    impl Write for PipeWriter {
+        fn write(&mut self, b: &[u8]) -> io::Result<usize> { let _ = self.1.send(()); self.0.write(b) }
+        fn flush(&mut self) -> io::Result<()> { Ok(()) }
+    }
+    impl Drop for PipeWriter { fn drop(&mut self) { self.2.store(true, Ordering::Release); } }
+    let inner = PipeWriter(file, tx, dropped.clone());
+    let queue = ByteWriter::spawn("audit-real-blocked-pipe", INPUT_BYTE_LIMIT, false, move || Ok(Box::new(inner))).unwrap();
+    queue.enqueue(&vec![42; WRITE_BATCH_LIMIT]).unwrap();
+    rx.recv_timeout(Duration::from_secs(3)).unwrap();
+    assert!(!dropped.load(Ordering::Acquire));
+    queue.cancel();
+    until(|| dropped.load(Ordering::Acquire));
+}

--- a/tests-rs/test_audit_output_staging.rs
+++ b/tests-rs/test_audit_output_staging.rs
@@ -1,0 +1,61 @@
+use super::*;
+use std::sync::{Arc, mpsc};
+use std::thread;
+use std::time::Duration;
+
+#[test]
+fn staging_blocks_only_reader_at_capacity_and_preserves_order() {
+    let staging = Arc::new(Staging::new(8));
+    assert!(staging.push(b"12345678"));
+    let (tx, rx) = mpsc::channel();
+    let producer = staging.clone();
+    let worker = thread::spawn(move || { tx.send(producer.push(b"90ab")).unwrap(); producer.finish_reader(); });
+    assert!(rx.recv_timeout(Duration::from_millis(30)).is_err());
+    assert_eq!(staging.len(), 8);
+    assert_eq!(staging.take(4), b"1234");
+    assert!(rx.recv_timeout(Duration::from_secs(3)).unwrap());
+    assert_eq!(staging.len(), 8);
+    assert_eq!(staging.take(3), b"567");
+    assert_eq!(staging.take(99), b"890ab");
+    assert!(!staging.wait_for_data());
+    worker.join().unwrap();
+}
+
+#[test]
+fn parser_shutdown_wakes_backpressured_reader() {
+    let staging = Arc::new(Staging::new(1));
+    assert!(staging.push(b"a"));
+    let producer = staging.clone();
+    let worker = thread::spawn(move || producer.push(b"b"));
+    staging.finish_parser();
+    assert!(!worker.join().unwrap());
+    assert_eq!(staging.take(5), b"a");
+}
+
+#[test]
+fn eof_wakes_parser_and_drains_final_bytes() {
+    let staging = Staging::new(8);
+    staging.push(b"last");
+    staging.finish_reader();
+    assert!(staging.wait_for_data());
+    assert_eq!(staging.take(8), b"last");
+    assert!(!staging.wait_for_data());
+}
+
+#[test]
+fn large_stream_is_lossless_and_batches_are_bounded() {
+    let staging = Arc::new(Staging::new(16 * 1024));
+    let expected: Vec<_> = (0..300_000).map(|i| (i % 251) as u8).collect();
+    let input = expected.clone();
+    let producer = staging.clone();
+    let worker = thread::spawn(move || { assert!(producer.push(&input)); producer.finish_reader(); });
+    let mut result = Vec::new();
+    while staging.wait_for_data() {
+        assert!(staging.len() <= 16 * 1024);
+        let batch = staging.take(1024);
+        assert!(batch.len() <= 1024);
+        result.extend_from_slice(&batch);
+    }
+    worker.join().unwrap();
+    assert_eq!(result, expected);
+}

--- a/tests-rs/test_audit_pipe_sinks.rs
+++ b/tests-rs/test_audit_pipe_sinks.rs
@@ -1,0 +1,103 @@
+use super::*;
+use std::sync::{mpsc, atomic::AtomicBool};
+use std::time::{Duration, Instant};
+
+static TEST_LOCK: Mutex<()> = Mutex::new(());
+
+fn until(mut condition: impl FnMut() -> bool) {
+    let deadline = Instant::now() + Duration::from_secs(3);
+    while !condition() {
+        assert!(Instant::now() < deadline, "sink did not reach expected state");
+        std::thread::sleep(Duration::from_millis(1));
+    }
+}
+
+struct Blocked(mpsc::Sender<()>, mpsc::Receiver<()>);
+impl Write for Blocked {
+    fn write(&mut self, b: &[u8]) -> io::Result<usize> {
+        let _ = self.0.send(());
+        let _ = self.1.recv();
+        Ok(b.len())
+    }
+    fn flush(&mut self) -> io::Result<()> { Ok(()) }
+}
+
+struct Record(Arc<Mutex<Vec<u8>>>);
+impl Write for Record {
+    fn write(&mut self, b: &[u8]) -> io::Result<usize> { self.0.lock().unwrap().extend_from_slice(b); Ok(b.len()) }
+    fn flush(&mut self) -> io::Result<()> { Ok(()) }
+}
+
+#[test]
+fn blocked_sink_cannot_block_other_sink_or_unregister() {
+    let _test = TEST_LOCK.lock().unwrap();
+    let pane = usize::MAX - 101;
+    let other = pane - 1;
+    let (entered_tx, entered_rx) = mpsc::channel();
+    let (release_tx, release_rx) = mpsc::channel();
+    register(pane, Box::new(Blocked(entered_tx, release_rx))).unwrap();
+    tee(pane, b"blocked");
+    entered_rx.recv_timeout(Duration::from_secs(3)).unwrap();
+    let bytes = Arc::new(Mutex::new(Vec::new()));
+    register(other, Box::new(Record(bytes.clone()))).unwrap();
+    tee(other, b"unrelated output");
+    until(|| !bytes.lock().unwrap().is_empty());
+    assert_eq!(&*bytes.lock().unwrap(), b"unrelated output");
+    let now = Instant::now();
+    unregister(pane);
+    assert!(now.elapsed() < Duration::from_millis(250));
+    assert!(!is_registered(pane));
+    release_tx.send(()).unwrap();
+    unregister(other);
+}
+
+#[test]
+fn overflow_stops_sink_and_reports_it_once() {
+    let _test = TEST_LOCK.lock().unwrap();
+    let pane = usize::MAX - 103;
+    let (entered_tx, entered_rx) = mpsc::channel();
+    let (release_tx, release_rx) = mpsc::channel();
+    register(pane, Box::new(Blocked(entered_tx, release_rx))).unwrap();
+    tee(pane, b"first");
+    entered_rx.recv_timeout(Duration::from_secs(3)).unwrap();
+    tee(pane, &vec![b'x'; SINK_BYTE_LIMIT]);
+    let failures = take_failures();
+    assert_eq!(failures.len(), 1);
+    assert_eq!(failures[0].0, pane);
+    assert!(failures[0].1.contains("queue full"));
+    assert!(!is_registered(pane));
+    assert!(take_failures().is_empty());
+    release_tx.send(()).unwrap();
+}
+
+#[test]
+fn idle_sink_failure_is_reported_without_next_pty_chunk() {
+    let _test = TEST_LOCK.lock().unwrap();
+    let pane = usize::MAX - 104;
+    let failed = Arc::new(AtomicBool::new(false));
+    let failed_worker = failed.clone();
+    register_factory(pane, false, move || {
+        failed_worker.store(true, Ordering::Release);
+        Err(io::Error::new(io::ErrorKind::PermissionDenied, "open failed"))
+    }).unwrap();
+    until(|| failed.load(Ordering::Acquire));
+    let mut failures = Vec::new();
+    until(|| { failures = take_failures(); !failures.is_empty() });
+    assert_eq!(failures[0].0, pane);
+    assert!(failures[0].1.contains("open failed"));
+    assert!(!is_registered(pane));
+}
+
+#[test]
+fn normal_eof_delivers_queued_transcript() {
+    let _test = TEST_LOCK.lock().unwrap();
+    let pane = usize::MAX - 105;
+    let bytes = Arc::new(Mutex::new(Vec::new()));
+    register(pane, Box::new(Record(bytes.clone()))).unwrap();
+    tee(pane, b"final transcript");
+    finish_pane(pane);
+    until(|| bytes.lock().unwrap().len() == 16);
+    assert_eq!(&*bytes.lock().unwrap(), b"final transcript");
+    assert!(take_failures().is_empty());
+    unregister(pane);
+}

--- a/tests-rs/test_copy_mode_key_tables.rs
+++ b/tests-rs/test_copy_mode_key_tables.rs
@@ -95,7 +95,7 @@ fn modified_keys_resolve() {
 #[test]
 fn send_keys_x_bindings_are_queued_with_their_arguments_intact() {
     let mut a = app_vi();
-    let (tx, rx) = std::sync::mpsc::channel();
+    let (tx, rx) = crate::types::control_channel();
     a.control_tx = Some(tx);
     bind_copy_key(&mut a, "copy-mode-vi", "y", "send-keys -X copy-pipe-and-cancel \"clip.exe\"");
 
@@ -125,7 +125,7 @@ fn send_keys_x_bindings_are_queued_with_their_arguments_intact() {
 #[test]
 fn a_quoted_argument_with_spaces_survives() {
     let mut a = app_vi();
-    let (tx, rx) = std::sync::mpsc::channel();
+    let (tx, rx) = crate::types::control_channel();
     a.control_tx = Some(tx);
     bind_copy_key(
         &mut a,

--- a/tests-rs/test_issue250_root_cause.rs
+++ b/tests-rs/test_issue250_root_cause.rs
@@ -304,17 +304,7 @@ fn fetch_authed_response_caps_runaway_response() {
         Duration::from_millis(500),
     );
     let elapsed = start.elapsed();
-    // Either we get None (no newline ever found before EOF/cap) or we get
-    // a "valid" giant string of X's bounded by the cap. What we MUST NOT do
-    // is buffer past the cap or hang past the read timeout.
-    if let Some(payload) = info.as_ref() {
-        assert!(
-            payload.len() <= MAX_AUTHED_RESPONSE_BYTES as usize,
-            "payload {} bytes exceeded cap {}",
-            payload.len(),
-            MAX_AUTHED_RESPONSE_BYTES
-        );
-    }
+    assert!(info.is_none(), "a truncated line at the byte cap must never count as a valid response");
     assert!(
         elapsed < Duration::from_millis(1500),
         "should finish within ~1.5x read_timeout, took {:?}",

--- a/tests-rs/test_issue448_orphan_reaper.rs
+++ b/tests-rs/test_issue448_orphan_reaper.rs
@@ -1,3 +1,4 @@
+// Reliability policy: these historical scenarios now require preserving every live server.
 // Issue #448: harden server cleanup — reap live orphaned servers and store PID.
 //
 // These unit tests exercise the PURE decision logic that drives the reaper
@@ -51,12 +52,12 @@ fn owning_all(candidates: &[ServerCandidate]) -> HashMap<u32, Option<u64>> {
 // ── select_orphan_pids: core policy ──────────────────────────────────────
 
 #[test]
-fn orphan_with_no_registry_reference_is_reaped() {
+fn orphan_with_no_registry_reference_is_preserved() {
     // A live server of OURS on port 5000 that no .port file references -> orphan.
     let cands = vec![cand(1000, &[5000], 100)];
     let got = select_orphan_pids(
         &cands, &ports(&[]), &pids(&[]), &owning_all(&cands), 42, u64::MAX);
-    assert_eq!(got, vec![1000], "untracked live server must be selected for reaping");
+    assert!(got.is_empty(), "a live server must not be terminated merely because registry metadata is missing");
 }
 
 #[test]
@@ -96,12 +97,12 @@ fn young_process_is_skipped_by_grace_window() {
 }
 
 #[test]
-fn old_process_passes_grace_window() {
+fn old_process_is_not_disposable_based_on_age() {
     // creation_ft (100) is at/older than the cutoff (150) -> eligible.
     let cands = vec![cand(1000, &[5000], 100)];
     let got = select_orphan_pids(
         &cands, &ports(&[]), &pids(&[]), &owning_all(&cands), 42, 150);
-    assert_eq!(got, vec![1000], "a process older than the grace window must be reaped");
+    assert!(got.is_empty(), "a live server must not be terminated merely because registry metadata is missing");
 }
 
 #[test]
@@ -115,7 +116,7 @@ fn multi_port_server_kept_if_any_port_tracked() {
 }
 
 #[test]
-fn mixed_fleet_only_orphans_selected() {
+fn mixed_fleet_all_live_sessions_preserved() {
     let cands = vec![
         cand(10, &[6000], 100), // orphan (untracked, ours)
         cand(11, &[6001], 100), // legit (port tracked)
@@ -126,7 +127,7 @@ fn mixed_fleet_only_orphans_selected() {
     let mut got = select_orphan_pids(
         &cands, &ports(&[6001]), &pids(&[12]), &owning_all(&cands), 42, u64::MAX);
     got.sort();
-    assert_eq!(got, vec![10, 13], "exactly the untracked non-self servers must be selected");
+    assert!(got.is_empty(), "a live server must not be terminated merely because registry metadata is missing");
 }
 
 // ── read_tracked_registry: file -> (ports, pids) ─────────────────────────
@@ -179,6 +180,6 @@ fn end_to_end_selection_over_registry_files() {
     // shared .port/.pid entries with the winner's.
     let got = select_orphan_pids(
         &cands, &tp, &tpid, &owned(&[(500, 100), (501, 100)]), 1, u64::MAX);
-    assert_eq!(got, vec![501], "only the orphaned duplicate must be reaped");
+    assert!(got.is_empty(), "a live server must not be terminated merely because registry metadata is missing");
     let _ = std::fs::remove_dir_all(&dir);
 }

--- a/tests-rs/test_issue505_rename_session_guard.rs
+++ b/tests-rs/test_issue505_rename_session_guard.rs
@@ -185,7 +185,7 @@ fn claiming_a_warm_server_guards_the_claimed_name() {
 
 #[test]
 #[cfg(windows)]
-fn rekey_onto_a_name_owned_elsewhere_runs_unguarded_instead_of_dying() {
+fn rekey_collision_preserves_original_guard() {
     let old = key("busy-old");
     let busy = key("busy-target");
 
@@ -205,12 +205,10 @@ fn rekey_onto_a_name_owned_elsewhere_runs_unguarded_instead_of_dying() {
     let mut guard = crate::platform::acquire_session_mutex(&old);
     assert!(guard.is_some(), "setup: should have acquired '{}'", old);
 
-    rekey_session_guard(&mut guard, &busy);
-
-    // The rename already happened, so a refused acquire must degrade to running
-    // unguarded rather than take the session down.
-    assert!(guard.is_none(), "must not claim a name a live owner holds");
-    assert!(name_is_free(&old), "old name '{}' must still be released", old);
+    assert!(rekey_session_guard(&mut guard, &busy).is_err());
+    assert!(guard.is_some(), "collision must preserve the original guard");
+    assert!(!name_is_free(&old), "old name must remain guarded after collision");
+    assert!(!name_is_free(&busy), "destination must remain guarded by its owner");
 
     release_tx.send(()).unwrap();
     holder.join().unwrap();

--- a/tests-rs/test_issue510_reaper_attribution.rs
+++ b/tests-rs/test_issue510_reaper_attribution.rs
@@ -1,3 +1,4 @@
+// Reliability policy: these historical scenarios now require preserving every live server.
 // Issue #510: the startup reaper must never terminate a server it cannot
 // positively attribute to THIS data dir.
 //
@@ -75,7 +76,7 @@ fn foreign_servers_survive_a_populated_local_registry() {
 }
 
 #[test]
-fn only_the_claimed_orphan_is_reaped_among_foreign_servers() {
+fn claimed_orphan_and_foreign_servers_are_preserved() {
     // Both halves of the contract at once: our own orphan still dies, and the
     // servers we cannot account for still live.
     let cands = vec![
@@ -85,7 +86,7 @@ fn only_the_claimed_orphan_is_reaped_among_foreign_servers() {
     ];
     let got = select_orphan_pids(
         &cands, &ports(&[]), &pids(&[]), &owned(&[(1000, 100)]), 42, u64::MAX);
-    assert_eq!(got, vec![1000], "exactly the claimed orphan must be reaped");
+    assert!(got.is_empty(), "a live server must not be terminated merely because registry metadata is missing");
 }
 
 // ── The claim is identity-gated ──────────────────────────────────────────
@@ -226,7 +227,7 @@ fn harness_data_dir_does_not_reap_the_users_servers() {
 }
 
 #[test]
-fn wiped_registry_still_reaps_our_own_orphan() {
+fn wiped_registry_does_not_authorize_killing_our_server() {
     // run_all_tests.ps1 deletes ~/.psmux\*.port and *.key, which is one way a
     // live server of ours loses its registry entry. The marker dir is outside
     // that pattern, so the server is still identifiable as ours and #448's
@@ -243,6 +244,6 @@ fn wiped_registry_still_reaps_our_own_orphan() {
 
     let cands = vec![cand(1000, &[5000], 100)];
     let got = select_orphan_pids(&cands, &tp, &tpid, &owned_pids, 1, u64::MAX);
-    assert_eq!(got, vec![1000], "our own orphan must still be reaped after a registry wipe");
+    assert!(got.is_empty(), "a live server must not be terminated merely because registry metadata is missing");
     let _ = std::fs::remove_dir_all(&dir);
 }

--- a/tests-rs/test_pane_border_indicator_control.rs
+++ b/tests-rs/test_pane_border_indicator_control.rs
@@ -16,10 +16,24 @@ fn assert_indicator_request(request: CtrlReq, expected: &str) {
     }
 }
 
-fn simple_tcp_command(command: &str) -> (String, mpsc::Receiver<CtrlReq>) {
+fn simple_tcp_command(command: &str) -> (String, crate::types::ControlReceiver) {
     let listener = TcpListener::bind("127.0.0.1:0").unwrap();
     let address = listener.local_addr().unwrap();
-    let (request_tx, request_rx) = mpsc::channel();
+    let (request_tx, request_rx) = crate::types::control_channel();
+    let (observed_tx, observed_rx) = crate::types::control_channel();
+    // Fake the event-loop completion boundary without creating a psmux server.
+    let dispatch = std::thread::spawn(move || {
+        while let Ok(request) = request_rx.recv() {
+            let request = match request {
+                CtrlReq::CommandRequest(request, completion) => {
+                    completion.send(Ok(())).unwrap();
+                    *request
+                }
+                request => request,
+            };
+            observed_tx.send(request).unwrap();
+        }
+    });
     let handler = std::thread::spawn(move || {
         let (stream, _) = listener.accept().unwrap();
         handle_connection(
@@ -45,11 +59,12 @@ fn simple_tcp_command(command: &str) -> (String, mpsc::Receiver<CtrlReq>) {
     response.clear();
     reader.read_to_string(&mut response).unwrap();
     handler.join().unwrap();
-    (response, request_rx)
+    dispatch.join().unwrap();
+    (response, observed_rx)
 }
 
 fn rejected_control_command(command: &str, args: &[&str]) -> String {
-    let (request_tx, request_rx) = mpsc::channel();
+    let (request_tx, request_rx) = crate::types::control_channel();
     let (response_tx, response_rx) = mpsc::channel();
     assert!(dispatch_control_command(
         command,
@@ -344,7 +359,7 @@ fn persistent_control_accepts_global_window_forms() {
             "both",
         ),
     ] {
-        let (request_tx, request_rx) = mpsc::channel();
+        let (request_tx, request_rx) = crate::types::control_channel();
         let (response_tx, response_rx) = mpsc::channel();
         assert!(dispatch_control_command(
             command,

--- a/tests-rs/test_pane_writer_queue.rs
+++ b/tests-rs/test_pane_writer_queue.rs
@@ -6,7 +6,7 @@
 // wedging every session. The fix routes every pane write through
 // `spawn_pane_write_queue`: a per-pane queue drained by a dedicated thread,
 // mirroring tmux's libevent bufferevent contract — writes complete
-// immediately, stay ordered, and absorb backpressure in memory. The thread
+// immediately while below the byte limit, and stay ordered. The thread
 // exits cleanly when the queue side is dropped with the pane.
 //
 // These tests wrap a dummy writer (no PTY, no spawn) and observe the queue
@@ -175,7 +175,7 @@ fn pane_close_ends_writer_thread_cleanly() {
 
 /// A burst of writes with no reader must still complete immediately and
 /// deliver every byte once the inner writer catches up — the queue absorbs
-/// unbounded backpressure in memory, like tmux's event buffer.
+/// backpressure up to its documented byte budget.
 #[test]
 fn burst_writes_survive_backpressure_and_arrive_complete() {
     let state = Arc::new((Mutex::new(Vec::new()), Condvar::new()));

--- a/tests-rs/test_pane_writer_transient_error.rs
+++ b/tests-rs/test_pane_writer_transient_error.rs
@@ -91,13 +91,13 @@ fn transient_write_error_keeps_the_writer_alive() {
 
     // The first write hits the injected failure inside the writer thread.
     assert_eq!(queue.write(b"first").unwrap(), 5, "enqueue must still succeed");
-    // A later write is consumed by the still-alive thread.
-    assert_eq!(queue.write(b"second").unwrap(), 6);
+    // Later writes must report the asynchronous failure, while retaining the handle.
 
     assert!(
         wait_until("failing write attempted", || attempts.load(Ordering::SeqCst) >= 1, Duration::from_secs(5)),
         "the writer thread must attempt the queued write"
     );
+    assert_eq!(queue.write(b"second").unwrap_err().kind(), std::io::ErrorKind::BrokenPipe);
     // Exactly one attempt: the failure stops further writes instead of
     // starting a retry storm.
     std::thread::sleep(Duration::from_millis(200));
@@ -119,11 +119,10 @@ fn transient_write_error_keeps_the_writer_alive() {
     );
 }
 
-/// After a failure the thread stays alive but sheds further writes (the
-/// documented "a failed write only stops further writes" contract): no
-/// panic, no delivery, no release.
+/// After a failure the thread retains the PTY handle but rejects further
+/// writes with the observed error instead of silently consuming their bytes.
 #[test]
-fn writes_after_a_failure_are_consumed_without_delivery_or_release() {
+fn writes_after_a_failure_report_error_without_releasing_handle() {
     let attempts = Arc::new(AtomicUsize::new(0));
     let bytes = Arc::new(Mutex::new(Vec::new()));
     let dropped = Arc::new(AtomicBool::new(false));
@@ -136,12 +135,13 @@ fn writes_after_a_failure_are_consumed_without_delivery_or_release() {
 
     let mut queue = spawn_pane_write_queue(Box::new(inner));
     assert_eq!(queue.write(b"boom").unwrap(), 4); // fails inside the thread
-    assert_eq!(queue.write(b"after").unwrap(), 5); // consumed, not delivered
 
     assert!(
         wait_until("failure attempted", || attempts.load(Ordering::SeqCst) >= 1, Duration::from_secs(5))
     );
-    // Give the thread time to process the second write, then check state.
+    assert_eq!(queue.write(b"after").unwrap_err().kind(), std::io::ErrorKind::BrokenPipe);
+    assert!(queue.flush().is_err());
+    // Verify no retry storm and retain the PTY handle.
     std::thread::sleep(Duration::from_millis(300));
     assert_eq!(
         attempts.load(Ordering::SeqCst),
@@ -185,11 +185,11 @@ fn writes_before_the_failure_are_delivered() {
     );
 
     assert_eq!(queue.write(b"boom").unwrap(), 4); // fails inside the thread
-    assert_eq!(queue.write(b"after").unwrap(), 5); // consumed, not delivered
 
     assert!(
         wait_until("failure attempted", || attempts.load(Ordering::SeqCst) >= 2, Duration::from_secs(5))
     );
+    assert_eq!(queue.write(b"after").unwrap_err().kind(), std::io::ErrorKind::BrokenPipe);
     std::thread::sleep(Duration::from_millis(300));
     assert_eq!(
         attempts.load(Ordering::SeqCst),

--- a/tests-rs/test_picker_namespace_filter.rs
+++ b/tests-rs/test_picker_namespace_filter.rs
@@ -18,23 +18,23 @@ use super::*;
 
 #[test]
 fn namespace_of_a_bare_name_is_none() {
-    assert_eq!(session_namespace("a_issue259"), None);
-    assert_eq!(session_namespace("main"), None);
-    assert_eq!(session_namespace("0"), None);
+    assert_eq!(session_namespace("a_issue259").as_deref(), None);
+    assert_eq!(session_namespace("main").as_deref(), None);
+    assert_eq!(session_namespace("0").as_deref(), None);
 }
 
 #[test]
 fn namespace_of_a_prefixed_name_is_the_prefix() {
-    assert_eq!(session_namespace("amx-6c9b6ad63d__main"), Some("amx-6c9b6ad63d"));
-    assert_eq!(session_namespace("dev__work"), Some("dev"));
+    assert_eq!(session_namespace("amx-6c9b6ad63d__main").as_deref(), Some("amx-6c9b6ad63d"));
+    assert_eq!(session_namespace("dev__work").as_deref(), Some("dev"));
     // Only the first separator counts: the session part may itself hold `__`.
-    assert_eq!(session_namespace("ns__a__b"), Some("ns"));
+    assert_eq!(session_namespace("ns__a__b").as_deref(), Some("ns"));
 }
 
 #[test]
 fn warm_helpers_have_no_namespace() {
-    assert_eq!(session_namespace("__warm__"), None);
-    assert_eq!(session_namespace("dev____warm__"), None);
+    assert_eq!(session_namespace("__warm__").as_deref(), None);
+    assert_eq!(session_namespace("dev____warm__").as_deref(), Some("dev"));
 }
 
 #[test]

--- a/tests-rs/test_refresh_client_flags.rs
+++ b/tests-rs/test_refresh_client_flags.rs
@@ -24,7 +24,7 @@ use std::time::Duration;
 const TEST_KEY: &str = "unit-test-key";
 
 /// Serve one connection through the real one-shot handler.
-fn spawn_handler(listener: TcpListener, tx: mpsc::Sender<CtrlReq>) -> JoinHandle<()> {
+fn spawn_handler(listener: TcpListener, tx: crate::types::ControlSender) -> JoinHandle<()> {
     std::thread::spawn(move || {
         let (stream, _) = listener.accept().expect("handler: accept");
         handle_connection(
@@ -55,7 +55,7 @@ fn connect_authenticated(addr: std::net::SocketAddr) -> TcpStream {
 fn control_only_flags_are_rejected_with_the_tmux_error_text() {
     for flag in ["-C", "-B", "-A", "-f"] {
         let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
-        let (tx, _rx) = mpsc::channel::<CtrlReq>();
+        let (tx, _rx) = crate::types::control_channel();
         let handler = spawn_handler(listener.try_clone().unwrap(), tx);
 
         let mut client = connect_authenticated(listener.local_addr().unwrap());
@@ -79,21 +79,25 @@ fn control_only_flags_are_rejected_with_the_tmux_error_text() {
 #[test]
 fn flag_free_refresh_client_is_forwarded_to_the_server() {
     let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
-    let (tx, rx) = mpsc::channel::<CtrlReq>();
+    let (tx, rx) = crate::types::control_channel();
     let handler = spawn_handler(listener.try_clone().unwrap(), tx);
 
     let mut client = connect_authenticated(listener.local_addr().unwrap());
     write!(client, "refresh-client\n").unwrap();
     client.shutdown(Shutdown::Write).unwrap();
 
+    let request = match rx.recv_timeout(Duration::from_secs(2)).expect("request forwarded") {
+        CtrlReq::CommandRequest(request, completion) => {
+            completion.send(Ok(())).unwrap();
+            *request
+        }
+        _ => panic!("network requests must carry their own completion"),
+    };
     let mut resp = String::new();
     client.read_to_string(&mut resp).expect("read response");
     handler.join().expect("handler thread");
 
     assert_eq!(resp, "", "flag-free refresh-client must produce no error");
-    let request = rx
-        .recv_timeout(Duration::from_secs(2))
-        .expect("the request must reach the server loop");
     assert!(
         matches!(request, CtrlReq::RefreshClient),
         "flag-free refresh-client must be forwarded unchanged"
@@ -105,18 +109,24 @@ fn flag_free_refresh_client_is_forwarded_to_the_server() {
 #[test]
 fn non_control_flags_are_not_rejected() {
     let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
-    let (tx, rx) = mpsc::channel::<CtrlReq>();
+    let (tx, rx) = crate::types::control_channel();
     let handler = spawn_handler(listener.try_clone().unwrap(), tx);
 
     let mut client = connect_authenticated(listener.local_addr().unwrap());
     write!(client, "refresh-client -S\n").unwrap();
     client.shutdown(Shutdown::Write).unwrap();
 
+    let request = match rx.recv_timeout(Duration::from_secs(2)).expect("request forwarded") {
+        CtrlReq::CommandRequest(request, completion) => {
+            completion.send(Ok(())).unwrap();
+            *request
+        }
+        _ => panic!("network requests must carry their own completion"),
+    };
     let mut resp = String::new();
     client.read_to_string(&mut resp).expect("read response");
     handler.join().expect("handler thread");
 
     assert_eq!(resp, "", "-S must not be rejected as control-only");
-    let request = rx.recv_timeout(Duration::from_secs(2)).expect("request forwarded");
     assert!(matches!(request, CtrlReq::RefreshClient));
 }

--- a/tests-rs/test_reliability_discovery.rs
+++ b/tests-rs/test_reliability_discovery.rs
@@ -1,0 +1,223 @@
+//! Isolated reliability regressions. Fake loopback peers and unique scratch
+//! directories only; no psmux server processes or default registry writes.
+use super::*;
+use std::io::{Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::thread;
+
+fn scratch() -> std::path::PathBuf {
+    static NEXT: AtomicU64 = AtomicU64::new(0);
+    let path = std::env::temp_dir().join(format!("psmux-reliability-discovery-{}-{}-{}",
+        std::process::id(), SystemTime::now().duration_since(SystemTime::UNIX_EPOCH).unwrap().as_nanos(),
+        NEXT.fetch_add(1, Ordering::Relaxed)));
+    std::fs::create_dir_all(&path).unwrap();
+    path
+}
+
+fn peer(reply: impl FnOnce(TcpStream) + Send + 'static) -> (String, thread::JoinHandle<()>) {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let address = listener.local_addr().unwrap().to_string();
+    let handle = thread::spawn(move || {
+        let (mut stream, _) = listener.accept().unwrap();
+        stream.set_read_timeout(Some(Duration::from_secs(2))).unwrap();
+        let mut request = Vec::new();
+        // Production client half-closes its write side after the whole request.
+        stream.read_to_end(&mut request).unwrap();
+        reply(stream);
+    });
+    (address, handle)
+}
+
+fn line_reply(bytes: &'static [u8]) -> io::Result<String> {
+    let (address, handle) = peer(move |mut stream| { let _ = stream.write_all(bytes); });
+    let result = query_authed_line(&address, "key", b"list-sessions -F test\n",
+        Duration::from_millis(200), Duration::from_millis(300));
+    handle.join().unwrap();
+    result
+}
+
+#[test]
+fn exact_auth_and_complete_payload_are_required() {
+    for reply in [&b"session: 1 windows\n"[..], &b"OKAY\nvalue\n"[..], &b"OK \nvalue\n"[..]] {
+        assert_eq!(line_reply(reply).unwrap_err().kind(), ErrorKind::InvalidData);
+    }
+    for reply in [&b"OK\n"[..], &b"OK\npartial"[..], &b"OK"[..]] {
+        assert_eq!(line_reply(reply).unwrap_err().kind(), ErrorKind::UnexpectedEof);
+    }
+    for reply in [&b"ERROR: Invalid session key\n"[..], &b"ERROR: Authentication required\n"[..]] {
+        assert_eq!(line_reply(reply).unwrap_err().kind(), ErrorKind::PermissionDenied);
+    }
+}
+
+#[test]
+fn empty_formatted_payload_is_distinct_from_no_reply_and_preserves_spaces() {
+    assert_eq!(line_reply(b"OK\n\n").unwrap(), "");
+    assert_eq!(line_reply(b"OK\r\n  padded  \r\n").unwrap(), "  padded  ");
+    assert_eq!(line_reply(b"OK\nOK\n").unwrap(), "OK");
+}
+
+#[test]
+fn split_auth_and_payload_are_framed_independently() {
+    let (address, handle) = peer(|mut stream| {
+        for fragment in [b"O".as_slice(), b"K\nrow", b"\n"] {
+            stream.write_all(fragment).unwrap();
+            thread::sleep(Duration::from_millis(10));
+        }
+    });
+    assert_eq!(query_authed_line(&address, "key", b"session-info\n",
+        Duration::from_millis(200), Duration::from_millis(300)).unwrap(), "row");
+    handle.join().unwrap();
+}
+
+#[test]
+fn authenticated_slow_session_stays_unresponsive_and_registry_survives() {
+    let dir = scratch();
+    let base = "slow";
+    for (ext, bytes) in [("port", "1234"), ("key", "key"), ("pid", "123:456"), ("sid", "2")] {
+        std::fs::write(dir.join(format!("{}.{}", base, ext)), bytes).unwrap();
+    }
+    let before: Vec<_> = ["port", "key", "pid", "sid"].iter().map(|ext| std::fs::read(dir.join(format!("{}.{}", base, ext))).unwrap()).collect();
+    let (address, handle) = peer(|mut stream| {
+        stream.write_all(b"OK\n").unwrap();
+        thread::sleep(Duration::from_millis(150));
+        let _ = stream.write_all(b"slow: 1 windows (created now)\n");
+    });
+    assert_eq!(probe_session_liveness(&address, "key", Duration::from_millis(200), Duration::from_millis(50)), SessionLiveness::Unresponsive);
+    handle.join().unwrap();
+    cleanup_stale_port_files_in_with(&dir, |_, _| PortProbeResult::Inconclusive);
+    for (ext, original) in ["port", "key", "pid", "sid"].iter().zip(before) {
+        assert_eq!(std::fs::read(dir.join(format!("{}.{}", base, ext))).unwrap(), original);
+    }
+    let candidates = vec![ServerCandidate { pid: 123, creation_ft: 456, ports: vec![1234] }];
+    assert!(select_orphan_pids(&candidates, &Default::default(), &Default::default(),
+        &[(123, Some(456))].into_iter().collect(), 1, u64::MAX).is_empty());
+    std::fs::remove_dir_all(dir).unwrap();
+}
+
+#[test]
+fn response_limit_rejects_truncation_instead_of_accepting_take_eof() {
+    for newline in [false, true] {
+        let (address, handle) = peer(move |mut stream| {
+            let _ = stream.write_all(b"OK\n");
+            let mut data = vec![b'x'; MAX_AUTHED_RESPONSE_BYTES as usize];
+            if newline { data.push(b'\n'); }
+            let _ = stream.write_all(&data);
+        });
+        assert_eq!(query_authed_line(&address, "key", b"session-info\n",
+            Duration::from_millis(200), Duration::from_secs(1)).unwrap_err().kind(), ErrorKind::InvalidData);
+        handle.join().unwrap();
+    }
+}
+
+#[test]
+fn multiline_reply_requires_eof_and_obeys_total_size_limit() {
+    let (address, handle) = peer(|mut stream| {
+        let _ = stream.write_all(b"OK\nrow\n");
+        thread::sleep(Duration::from_millis(150));
+    });
+    let error = query_authed_all(&address, "key", b"list-windows\n", Duration::from_millis(200), Duration::from_millis(50)).unwrap_err();
+    assert!(matches!(error.kind(), ErrorKind::TimedOut | ErrorKind::WouldBlock));
+    handle.join().unwrap();
+    let (address, handle) = peer(|mut stream| {
+        let _ = stream.write_all(b"OK\n");
+        let _ = stream.write_all(&vec![b'x'; MAX_AUTHED_RESPONSE_BYTES as usize]);
+    });
+    assert_eq!(query_authed_all(&address, "key", b"list-windows\n", Duration::from_millis(200), Duration::from_secs(1)).unwrap_err().kind(), ErrorKind::InvalidData);
+    handle.join().unwrap();
+}
+
+#[test]
+fn byte_dribble_cannot_extend_total_response_deadline() {
+    let (address, handle) = peer(|mut stream| {
+        for _ in 0..30 {
+            if stream.write_all(b"O").is_err() { break; }
+            thread::sleep(Duration::from_millis(20));
+        }
+    });
+    let started = std::time::Instant::now();
+    let error = query_authed_line(&address, "key", b"session-info\n", Duration::from_millis(200), Duration::from_millis(80)).unwrap_err();
+    assert!(matches!(error.kind(), ErrorKind::TimedOut | ErrorKind::WouldBlock));
+    assert!(started.elapsed() < Duration::from_millis(500));
+    handle.join().unwrap();
+}
+
+#[test]
+fn effective_namespace_and_manifest_discovery_are_consistent() {
+    let dir = scratch();
+    let a = crate::paths::storage_base(Some("work"), "alpha");
+    std::fs::write(dir.join(format!("{}.port", a)), "34567").unwrap();
+    let ambiguous = crate::paths::storage_base(None, "build__dev");
+    std::fs::write(dir.join(format!("{}.registry.json", ambiguous)), "{}").unwrap();
+    let tmux = "ignored,34567,0";
+    assert_eq!(effective_namespace(None, None, Some(tmux), &dir).as_deref(), Some("work"));
+    assert_eq!(effective_namespace(Some("other"), Some("inherited"), Some(tmux), &dir).as_deref(), Some("other"));
+    assert_eq!(effective_namespace(None, Some("inherited"), Some(tmux), &dir).as_deref(), Some("inherited"));
+    assert_eq!(list_session_names_ns_in(&dir, Some("work")), vec![a]);
+    assert_eq!(list_session_names_ns_in(&dir, None), vec![ambiguous]);
+    std::fs::remove_dir_all(dir).unwrap();
+}
+
+#[test]
+fn namespace_delimiters_cannot_collide_or_cross_boundaries() {
+    let pairs = [(Some("a"), "b__c"), (Some("a__b"), "c"), (Some("a_"), "_b"), (Some("a"), "__b"), (None, "build__dev"), (Some("build"), "dev")];
+    let bases: std::collections::BTreeSet<_> = pairs.iter().map(|(ns, name)| crate::paths::storage_base(*ns, name)).collect();
+    assert_eq!(bases.len(), pairs.len());
+    for (namespace, name) in pairs {
+        let base = crate::paths::storage_base(namespace, name);
+        assert_eq!(crate::paths::registry_namespace(&base).as_deref(), namespace);
+        assert_eq!(crate::paths::registry_session_name(&base), name);
+        assert!(session_visible_from(&base, namespace));
+    }
+    assert!(!session_visible_from(&crate::paths::storage_base(Some("a__b"), "c"), Some("a")));
+}
+
+#[cfg(windows)]
+#[test]
+fn exact_pid_anchor_accepts_renamed_test_executable_and_rejects_reuse() {
+    let dir = scratch();
+    let port = dir.join("custom-name.port");
+    std::fs::write(&port, "12345").unwrap();
+    let created = crate::platform::process_kill::process_creation_time(std::process::id()).unwrap();
+    std::fs::write(port.with_extension("pid"), format_pid_file_contents(std::process::id(), created)).unwrap();
+    // Test executable's stem is psmux-<hash>, outside the old filename whitelist.
+    assert_eq!(pid_anchor_verdict(&port), Some(true));
+    std::fs::write(port.with_extension("pid"), format_pid_file_contents(std::process::id(), created + 1)).unwrap();
+    assert_eq!(pid_anchor_verdict(&port), Some(false));
+    std::fs::write(port.with_extension("pid"), std::process::id().to_string()).unwrap();
+    assert_eq!(pid_anchor_verdict(&port), None);
+    std::fs::remove_dir_all(dir).unwrap();
+}
+
+#[cfg(windows)]
+#[test]
+fn explicit_cleanup_preserves_replacement_registry_generation() {
+    let dir = scratch();
+    let base = format!("reliability-dead-{}", dir.file_name().unwrap().to_string_lossy());
+    let created = crate::platform::process_kill::process_creation_time(std::process::id()).unwrap();
+    std::fs::write(dir.join(format!("{}.pid", base)), format_pid_file_contents(std::process::id(), created + 1)).unwrap();
+    std::fs::write(dir.join(format!("{}.port", base)), "12345").unwrap();
+    let snapshot = snapshot_kill_registry(&dir, &base).unwrap();
+    std::fs::write(dir.join(format!("{}.key", base)), "replacement-key").unwrap();
+    assert!(!cleanup_killed_registry(&snapshot).unwrap());
+    assert!(dir.join(format!("{}.port", base)).exists());
+    assert_eq!(std::fs::read(dir.join(format!("{}.key", base))).unwrap(), b"replacement-key");
+    std::fs::remove_dir_all(dir).unwrap();
+}
+
+
+#[test]
+fn internal_command_queue_is_bounded_nonblocking_and_fifo() {
+    let (queue, receiver) = std::sync::mpsc::sync_channel(MAX_INTERNAL_COMMANDS);
+    let start = std::time::Instant::now();
+    for i in 0..MAX_INTERNAL_COMMANDS {
+        queue_control_request(&queue, 1234, &format!("display-message {}\n", i), "key", None).unwrap();
+    }
+    assert_eq!(queue_control_request(&queue, 1234, "overflow\n", "key", None).unwrap_err().kind(), ErrorKind::WouldBlock);
+    assert!(start.elapsed() < Duration::from_millis(250));
+    for i in 0..MAX_INTERNAL_COMMANDS {
+        assert_eq!(receiver.try_recv().unwrap().command, format!("display-message {}\n", i));
+    }
+    assert_eq!(queue_control_request(&queue, 1234, &"x".repeat(MAX_INTERNAL_COMMAND_BYTES), "key", None).unwrap_err().kind(), ErrorKind::InvalidInput);
+    assert!(receiver.try_recv().is_err());
+}

--- a/tests-rs/test_session.rs
+++ b/tests-rs/test_session.rs
@@ -208,28 +208,28 @@ fn auth_rejected_returns_none() {
 }
 
 #[test]
-fn stale_cleanup_removes_invalid_port_and_key() {
+fn stale_cleanup_preserves_invalid_registry_without_ownership() {
     let dir = temp_psmux_dir("stale_cleanup_invalid");
     let (port_path, key_path, sid_path) = write_registry_files(&dir, "bad", "not-a-port");
 
     cleanup_stale_port_files_in(&dir);
 
-    assert!(!port_path.exists(), "invalid .port file should be removed");
-    assert!(!key_path.exists(), "matching .key file should be removed");
-    assert!(!sid_path.exists(), "matching .sid file should be removed");
+    assert!(port_path.exists(), "unowned cleanup must preserve registry metadata");
+    assert!(key_path.exists(), "unowned cleanup must preserve registry metadata");
+    assert!(sid_path.exists(), "unowned cleanup must preserve registry metadata");
     let _ = fs::remove_dir_all(dir.parent().unwrap());
 }
 
 #[test]
-fn stale_cleanup_removes_registry_only_when_probe_confirms_stale() {
+fn stale_cleanup_preserves_registry_even_if_network_probe_says_stale() {
     let dir = temp_psmux_dir("stale_cleanup_confirmed");
     let (port_path, key_path, sid_path) = write_registry_files(&dir, "dead", "54321");
 
     cleanup_stale_port_files_in_with(&dir, |_, _| PortProbeResult::Stale);
 
-    assert!(!port_path.exists(), "confirmed-stale .port file should be removed");
-    assert!(!key_path.exists(), "matching .key file should be removed");
-    assert!(!sid_path.exists(), "matching .sid file should be removed");
+    assert!(port_path.exists(), "unowned cleanup must preserve registry metadata");
+    assert!(key_path.exists(), "unowned cleanup must preserve registry metadata");
+    assert!(sid_path.exists(), "unowned cleanup must preserve registry metadata");
     let _ = fs::remove_dir_all(dir.parent().unwrap());
 }
 
@@ -278,7 +278,7 @@ fn read_one_line(stream: &mut TcpStream) {
 }
 
 #[test]
-fn stale_cleanup_removes_session_when_port_reused_by_other_server() {
+fn stale_cleanup_preserves_session_when_credentials_are_rejected() {
     // After a crash/reboot the old port can be grabbed by a *different* live
     // psmux server, which rejects our key. A bare TCP connect would call this
     // "alive" and leave the dead session as a "(not responding)" zombie; the
@@ -294,9 +294,9 @@ fn stale_cleanup_removes_session_when_port_reused_by_other_server() {
 
     cleanup_stale_port_files_in(&dir);
 
-    assert!(!port_path.exists(), "key-rejected (reused) .port must be removed");
-    assert!(!key_path.exists(), "matching .key must be removed");
-    assert!(!sid_path.exists(), "matching .sid must be removed");
+    assert!(port_path.exists(), "unowned cleanup must preserve registry metadata");
+    assert!(key_path.exists(), "unowned cleanup must preserve registry metadata");
+    assert!(sid_path.exists(), "unowned cleanup must preserve registry metadata");
     let _ = done.recv_timeout(Duration::from_secs(2));
     let _ = fs::remove_dir_all(dir.parent().unwrap());
 }
@@ -368,7 +368,7 @@ fn liveness_authenticated_server_is_alive() {
 }
 
 #[test]
-fn liveness_auth_rejection_is_dead() {
+fn liveness_auth_rejection_is_unresponsive() {
     // The reboot/reused-port case: a different server rejects our key.
     let (addr, done) = spawn_fake_server(|mut s| {
         drain_client_request(&mut s);
@@ -383,12 +383,12 @@ fn liveness_auth_rejection_is_dead() {
         Duration::from_millis(400),
     );
 
-    assert_eq!(v, SessionLiveness::Dead, "auth rejection must be Dead");
+    assert_eq!(v, SessionLiveness::Unresponsive, "auth rejection is not evidence the process exited");
     let _ = done.recv_timeout(Duration::from_secs(2));
 }
 
 #[test]
-fn liveness_connection_refused_is_dead() {
+fn liveness_connection_refused_is_unresponsive() {
     // Bind then drop so the port is guaranteed free -> connect refused.
     let listener = TcpListener::bind("127.0.0.1:0").expect("bind to grab a port");
     let addr = listener.local_addr().unwrap().to_string();
@@ -401,11 +401,11 @@ fn liveness_connection_refused_is_dead() {
         Duration::from_millis(200),
     );
 
-    assert_eq!(v, SessionLiveness::Dead, "refused connect must be Dead");
+    assert_eq!(v, SessionLiveness::Unresponsive, "refused connection is not a process death certificate");
 }
 
 #[test]
-fn liveness_connected_but_silent_is_dead() {
+fn liveness_connected_but_silent_is_unresponsive() {
     // A listener that accepts (via backlog) but never speaks our protocol.
     // Bounded: we wait one read timeout, then declare it Dead (honors
     // "no response within the timeout -> kill"); a real server self-heals.
@@ -420,7 +420,7 @@ fn liveness_connected_but_silent_is_dead() {
         Duration::from_millis(150),
     );
 
-    assert_eq!(v, SessionLiveness::Dead, "silent peer must be Dead after timeout");
+    assert_eq!(v, SessionLiveness::Unresponsive, "silent peer must remain registered after timeout");
     assert!(start.elapsed() < Duration::from_secs(2), "probe must stay bounded, not hang");
     drop(listener);
 }

--- a/tests-rs/test_session_id_alloc_race.rs
+++ b/tests-rs/test_session_id_alloc_race.rs
@@ -13,6 +13,16 @@ use super::*;
 
 #[test]
 fn allocate_session_id_is_unique_under_concurrency() {
+    let _env_lock = crate::util::lock_test_env();
+    let scratch = std::env::temp_dir().join(format!("psmux-counter-test-{}-{}", std::process::id(),
+        std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_nanos()));
+    std::fs::create_dir_all(&scratch).unwrap();
+    struct Restore(Option<std::ffi::OsString>);
+    impl Drop for Restore {
+        fn drop(&mut self) { match &self.0 { Some(value) => std::env::set_var("PSMUX_DATA_DIR", value), None => std::env::remove_var("PSMUX_DATA_DIR") } }
+    }
+    let _restore = Restore(std::env::var_os("PSMUX_DATA_DIR"));
+    std::env::set_var("PSMUX_DATA_DIR", &scratch);
     const THREADS: usize = 16;
     const PER_THREAD: usize = 32;
 
@@ -25,7 +35,7 @@ fn allocate_session_id_is_unique_under_concurrency() {
             b.wait();
             let mut ids = Vec::with_capacity(PER_THREAD);
             for _ in 0..PER_THREAD {
-                ids.push(allocate_session_id());
+                ids.push(allocate_session_id().unwrap());
             }
             ids
         }));
@@ -47,4 +57,34 @@ fn allocate_session_id_is_unique_under_concurrency() {
         sorted.len(),
         total
     );
+    std::fs::remove_dir_all(&scratch).unwrap();
+}
+
+#[test]
+fn counter_failure_does_not_reset_or_wrap_ids() {
+    let scratch = std::env::temp_dir().join(format!("psmux-counter-invalid-{}-{}", std::process::id(),
+        std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_nanos()));
+    std::fs::create_dir_all(&scratch).unwrap();
+    let path = scratch.join("counter");
+    assert_eq!(increment_session_counter(&path).unwrap(), 0);
+    assert_eq!(increment_session_counter(&path).unwrap(), 1);
+    for value in ["broken".to_string(), usize::MAX.to_string()] {
+        std::fs::write(&path, &value).unwrap();
+        assert!(increment_session_counter(&path).is_err());
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), value);
+    }
+    std::fs::remove_dir_all(scratch).unwrap();
+}
+
+#[test]
+fn counter_drop_does_not_delete_replacement_lock() {
+    let scratch = std::env::temp_dir().join(format!("psmux-counter-lock-{}-{}", std::process::id(),
+        std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_nanos()));
+    std::fs::create_dir_all(&scratch).unwrap();
+    let path = scratch.join("counter.lock");
+    let guard = CounterLock::acquire(path.to_string_lossy().into_owned()).unwrap();
+    std::fs::write(&path, b"replacement").unwrap();
+    drop(guard);
+    assert_eq!(std::fs::read_to_string(&path).unwrap(), "replacement");
+    std::fs::remove_dir_all(scratch).unwrap();
 }

--- a/tests/audit_discovery_faults.ps1
+++ b/tests/audit_discovery_faults.ps1
@@ -1,0 +1,320 @@
+#requires -Version 7.2
+<#
+.SYNOPSIS
+Reproduce discovery defects against fake peers without creating psmux sessions.
+.DESCRIPTION
+Use ONLY a freshly built, reviewed upstream binary with the #510 reaper
+attribution fix. Never pass the older installed executable. The mandatory hash
+pins the reviewed build; this script does not establish its source provenance.
+
+All psmux invocations are bounded list-sessions commands against a new
+PSMUX_DATA_DIR below target/audit. Fake loopback peers run in owned PowerShell
+workers. No psmux server, kill command, wildcard cleanup, or real registry write
+is used. Scratch evidence is retained. All cases require the fixed behavior; exit 1 means a regression, harness failure,
+or real-state change requiring investigation.
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)][ValidateNotNullOrEmpty()][string]$PsmuxExe,
+    [Parameter(Mandatory)][ValidatePattern('^[0-9a-fA-F]{64}$')][string]$ExpectedSha256,
+    [ValidateRange(2, 30)][int]$CommandTimeoutSeconds = 8
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+$repoRoot = Split-Path -Parent $PSScriptRoot
+$allowedRoot = [IO.Path]::GetFullPath((Join-Path $repoRoot 'target/audit'))
+$runRoot = [IO.Path]::GetFullPath((Join-Path $allowedRoot ('discovery-' + [Guid]::NewGuid().ToString('N'))))
+if (-not $runRoot.StartsWith($allowedRoot + [IO.Path]::DirectorySeparatorChar, [StringComparison]::OrdinalIgnoreCase)) {
+    throw 'Scratch directory escaped target/audit.'
+}
+$exePath = (Resolve-Path -LiteralPath $PsmuxExe).Path
+$actualHash = (Get-FileHash -LiteralPath $exePath -Algorithm SHA256).Hash
+if ($actualHash -ne $ExpectedSha256) { throw 'Executable SHA-256 differs from the reviewed build.' }
+$pwshPath = (Get-Process -Id $PID).Path
+if ([IO.Path]::GetFileNameWithoutExtension($pwshPath) -ne 'pwsh') {
+    throw 'Run this audit from pwsh.exe, not an embedded PowerShell host.'
+}
+
+New-Item -ItemType Directory -Path $runRoot -Force | Out-Null
+$namespace = 'audit' + [Guid]::NewGuid().ToString('N')
+$realHome = if ($env:USERPROFILE) { $env:USERPROFILE } else { $env:HOME }
+$realRegistry = Join-Path $realHome '.psmux'
+$savedEnvironment = @{}
+$managedEnvironment = @('TMUX', 'TMUX_PANE', 'PSMUX_DATA_DIR', 'PSMUX_NO_WARM')
+$managedEnvironment += @(Get-ChildItem Env: | Where-Object Name -Like 'PSMUX_*' | ForEach-Object Name)
+$managedEnvironment = @($managedEnvironment | Sort-Object -Unique)
+foreach ($name in $managedEnvironment) {
+    $savedEnvironment[$name] = [Environment]::GetEnvironmentVariable($name, 'Process')
+}
+$children = [Collections.Generic.List[object]]::new()
+$results = [Collections.Generic.List[object]]::new()
+$failures = [Collections.Generic.List[string]]::new()
+
+function Get-RealSnapshot {
+    $files = [Collections.Generic.List[object]]::new()
+    if (Test-Path -LiteralPath $realRegistry -PathType Container) {
+        foreach ($entry in Get-ChildItem -LiteralPath $realRegistry -File -Force) {
+            if ($entry.Extension -notin @('.port', '.key', '.pid', '.sid', '.act')) { continue }
+            try {
+                $digest = (Get-FileHash -LiteralPath $entry.FullName -Algorithm SHA256).Hash
+                $files.Add([pscustomobject]@{
+                    Name = $entry.Name; Length = $entry.Length
+                    LastWriteUtc = $entry.LastWriteTimeUtc.ToString('o'); Sha256 = $digest
+                })
+            } catch {
+                $files.Add([pscustomobject]@{ Name = $entry.Name; ReadError = $_.Exception.Message })
+            }
+        }
+    }
+    $processes = @(Get-Process | Where-Object ProcessName -In @('psmux', 'tmux', 'pmux') |
+        ForEach-Object {
+            $started = try { $_.StartTime.ToUniversalTime().ToString('o') } catch { $null }
+            [pscustomobject]@{ Id = $_.Id; Name = $_.ProcessName; StartTimeUtc = $started }
+        } | Sort-Object Id)
+    [pscustomobject]@{
+        CapturedUtc = [DateTime]::UtcNow.ToString('o'); Registry = $realRegistry
+        Files = @($files | Sort-Object Name); Processes = $processes
+    }
+}
+
+function Start-OwnedProcess([string]$File, [string[]]$Arguments) {
+    $start = [Diagnostics.ProcessStartInfo]::new()
+    $start.FileName = $File
+    $start.UseShellExecute = $false
+    $start.CreateNoWindow = $true
+    $start.RedirectStandardOutput = $true
+    $start.RedirectStandardError = $true
+    $start.WorkingDirectory = $runRoot
+    foreach ($argValue in $Arguments) { $start.ArgumentList.Add($argValue) }
+    $process = [Diagnostics.Process]::new()
+    $process.StartInfo = $start
+    if (-not $process.Start()) { throw "Could not start owned child: $File" }
+    $owned = [pscustomobject]@{
+        Process = $process
+        Stdout = $process.StandardOutput.ReadToEndAsync()
+        Stderr = $process.StandardError.ReadToEndAsync()
+    }
+    $children.Add($owned)
+    return $owned
+}
+
+function Stop-OwnedProcess($Owned) {
+    if (-not $Owned.Process.HasExited) {
+        # Only the exact Process object started by this script is eligible.
+        $Owned.Process.Kill()
+        if (-not $Owned.Process.WaitForExit(3000)) { throw 'Owned child did not exit after termination.' }
+    }
+}
+
+function Invoke-Listing([string[]]$Arguments) {
+    $timer = [Diagnostics.Stopwatch]::StartNew()
+    $owned = Start-OwnedProcess $exePath $Arguments
+    if (-not $owned.Process.WaitForExit($CommandTimeoutSeconds * 1000)) {
+        Stop-OwnedProcess $owned
+        throw "Listing exceeded its $CommandTimeoutSeconds second deadline."
+    }
+    $timer.Stop()
+    [pscustomobject]@{
+        ExitCode = $owned.Process.ExitCode
+        Stdout = $owned.Stdout.GetAwaiter().GetResult()
+        Stderr = $owned.Stderr.GetAwaiter().GetResult()
+        ElapsedMs = $timer.ElapsedMilliseconds
+    }
+}
+
+$workerPath = Join-Path $runRoot 'fake-peer.ps1'
+$workerSource = @'
+#requires -Version 7.2
+param([string]$Mode, [string]$ReadyPath, [string]$TranscriptPath)
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+$events = [Collections.Generic.List[object]]::new()
+$listener = [Net.Sockets.TcpListener]::new([Net.IPAddress]::Loopback, 0)
+$client = $null
+try {
+    $listener.Start()
+    [IO.File]::WriteAllText($ReadyPath, $listener.LocalEndpoint.Port.ToString())
+    $deadline = [DateTime]::UtcNow.AddSeconds(15)
+    for ($index = 1; $index -le 1; $index++) {
+        while (-not $listener.Pending()) {
+            if ([DateTime]::UtcNow -gt $deadline) { throw 'Fake peer accept deadline exceeded.' }
+            Start-Sleep -Milliseconds 10
+        }
+        $client = $listener.AcceptTcpClient()
+        $client.NoDelay = $true
+        $stream = $client.GetStream()
+        $stream.ReadTimeout = 2000
+        $stream.WriteTimeout = 2000
+        $reader = [IO.StreamReader]::new($stream)
+        $writer = [IO.StreamWriter]::new($stream, [Text.UTF8Encoding]::new($false))
+        $writer.NewLine = "`n"
+        $writer.AutoFlush = $true
+        $auth = $reader.ReadLine()
+        if ($null -eq $auth -or -not $auth.StartsWith('AUTH ')) { throw 'Expected AUTH from audit client.' }
+        $command = $reader.ReadLine()
+        if ($command -ne 'session-info' -and -not $command.StartsWith('list-sessions -F ')) {
+            throw 'Unexpected command from listing client.'
+        }
+        $events.Add([pscustomobject]@{ Connection = $index; Stage = 'listing'; Command = $command; Mode = $Mode })
+        if ($Mode -eq 'InvalidAuth') {
+            $writer.WriteLine('ERROR: Invalid session key')
+        } else {
+            $writer.WriteLine('OK')
+            if ($Mode -eq 'SlowPayload') { Start-Sleep -Milliseconds 3000 }
+            try { $writer.WriteLine('audit-peer: 1 windows') } catch {
+                if ($Mode -ne 'SlowPayload') { throw }
+                $events.Add([pscustomobject]@{ Stage = 'late-write'; ClientAlreadyClosed = $true })
+            }
+        }
+        $client.Dispose()
+        $client = $null
+    }
+} catch {
+    $events.Add([pscustomobject]@{ Stage = 'worker-error'; Message = $_.Exception.Message })
+    [Console]::Error.WriteLine($_.Exception.Message)
+    exit 1
+} finally {
+    if ($null -ne $client) { $client.Dispose() }
+    $listener.Stop()
+    $events | ConvertTo-Json -Depth 5 | Set-Content -LiteralPath $TranscriptPath -Encoding utf8
+}
+'@
+[IO.File]::WriteAllText($workerPath, $workerSource, [Text.UTF8Encoding]::new($false))
+
+function Invoke-PeerCase([string]$Case, [string]$Mode, [bool]$Formatted) {
+    $dataDir = Join-Path $runRoot $Case
+    New-Item -ItemType Directory -Path $dataDir | Out-Null
+    [Environment]::SetEnvironmentVariable('PSMUX_DATA_DIR', $dataDir, 'Process')
+    $readyPath = Join-Path $dataDir 'listener.ready'
+    $transcriptPath = Join-Path $dataDir 'peer.json'
+    $worker = Start-OwnedProcess $pwshPath @(
+        '-NoLogo', '-NoProfile', '-NonInteractive', '-ExecutionPolicy', 'Bypass', '-File', $workerPath,
+        '-Mode', $Mode, '-ReadyPath', $readyPath, '-TranscriptPath', $transcriptPath
+    )
+    try {
+        $readyDeadline = [DateTime]::UtcNow.AddSeconds(5)
+        $parsedPort = 0
+        while ($parsedPort -eq 0) {
+            if ($worker.Process.HasExited) { throw 'Fake peer exited before readiness.' }
+            if ([DateTime]::UtcNow -gt $readyDeadline) { throw 'Fake peer readiness deadline exceeded.' }
+            if (Test-Path -LiteralPath $readyPath) {
+                $portText = [IO.File]::ReadAllText($readyPath)
+                $candidatePort = 0
+                if ([int]::TryParse($portText, [ref]$candidatePort) -and $candidatePort -ge 1 -and $candidatePort -le 65535) {
+                    $parsedPort = $candidatePort
+                    break
+                }
+            }
+            Start-Sleep -Milliseconds 10
+        }
+        $base = $namespace + '__peer'
+        # No PID or ownership marker: this is a synthetic registry, not a server.
+        [IO.File]::WriteAllText((Join-Path $dataDir ($base + '.key')), 'audit-synthetic-key')
+        [IO.File]::WriteAllText((Join-Path $dataDir ($base + '.port')), $parsedPort.ToString())
+        $cliArguments = @('-L', $namespace, 'list-sessions')
+        if ($Formatted) { $cliArguments += @('-F', '#{session_name}') }
+        $observed = Invoke-Listing $cliArguments
+        $observed | ConvertTo-Json -Depth 4 | Set-Content -LiteralPath (Join-Path $dataDir 'observed.json') -Encoding utf8
+        if (-not $worker.Process.WaitForExit(4000)) { throw 'Fake peer did not finish its bounded protocol.' }
+        if ($worker.Process.ExitCode -ne 0) { throw ('Fake peer failed: ' + $worker.Stderr.GetAwaiter().GetResult()) }
+        $trace = @(Get-Content -LiteralPath $transcriptPath -Raw | ConvertFrom-Json)
+        if (@($trace | Where-Object Stage -EQ 'listing').Count -ne 1) { throw 'Listing was not observed by the fake peer.' }
+        $registryRetained = (Test-Path -LiteralPath (Join-Path $dataDir ($base + '.port'))) -and
+            (Test-Path -LiteralPath (Join-Path $dataDir ($base + '.key')))
+        if (-not $registryRetained) { throw 'The synthetic live registry was unexpectedly removed.' }
+        $classification = 'unexpected-result'
+        switch ($Mode) {
+            'Healthy' {
+                if ($observed.ExitCode -eq 0 -and $observed.Stdout.Trim() -eq 'audit-peer: 1 windows' -and
+                    [string]::IsNullOrWhiteSpace($observed.Stderr)) { $classification = 'correct-behavior' }
+            }
+            'InvalidAuth' {
+                if ($observed.ExitCode -eq 0 -and $observed.Stdout.Contains('ERROR: Invalid session key')) {
+                    $classification = 'known-defect-observed'
+                } elseif ($observed.ExitCode -ne 0 -and [string]::IsNullOrWhiteSpace($observed.Stdout)) {
+                    $classification = 'defect-not-observed-error-reported'
+                }
+            }
+            'SlowPayload' {
+                if ($observed.ExitCode -eq 0 -and $observed.Stdout.Length -gt 0 -and
+                    [string]::IsNullOrWhiteSpace($observed.Stdout)) {
+                    $classification = 'known-defect-observed'
+                } elseif ($observed.ExitCode -ne 0 -and [string]::IsNullOrWhiteSpace($observed.Stdout)) {
+                    $classification = 'defect-not-observed-timeout-reported'
+                } elseif ($observed.ExitCode -eq 0 -and $observed.Stdout.Trim() -eq 'audit-peer: 1 windows') {
+                    $classification = 'defect-not-observed-response-awaited'
+                }
+            }
+        }
+        $results.Add([pscustomobject]@{
+            Case = $Case; Classification = $classification; Observed = $observed
+            RegistryRetained = $registryRetained; PeerTranscript = $transcriptPath
+        })
+        if ($classification -in @('unexpected-result','known-defect-observed')) { throw "Unexpected protocol result in $Case; inspect results.json." }
+    } finally {
+        Stop-OwnedProcess $worker
+    }
+}
+
+$before = Get-RealSnapshot
+$before | ConvertTo-Json -Depth 6 | Set-Content -LiteralPath (Join-Path $runRoot 'real-before.json') -Encoding utf8
+try {
+    foreach ($name in $managedEnvironment) { [Environment]::SetEnvironmentVariable($name, $null, 'Process') }
+    [Environment]::SetEnvironmentVariable('PSMUX_NO_WARM', '1', 'Process')
+    $emptyDir = Join-Path $runRoot 'empty'
+    New-Item -ItemType Directory -Path $emptyDir | Out-Null
+    [Environment]::SetEnvironmentVariable('PSMUX_DATA_DIR', $emptyDir, 'Process')
+    $empty = Invoke-Listing @('-L', $namespace, 'list-sessions')
+    $emptyOk = $empty.ExitCode -eq 1 -and [string]::IsNullOrWhiteSpace($empty.Stdout) -and
+        $empty.Stderr.Contains('no server running')
+    $results.Add([pscustomobject]@{
+        Case = 'empty-namespace'; Classification = $(if ($emptyOk) { 'correct-behavior' } else { 'unexpected-result' })
+        Observed = $empty
+    })
+    if (-not $emptyOk) { throw 'Empty namespace did not produce the reviewed upstream error behavior.' }
+    Invoke-PeerCase 'healthy-control' 'Healthy' $false
+    Invoke-PeerCase 'invalid-auth' 'InvalidAuth' $false
+    Invoke-PeerCase 'formatted-timeout' 'SlowPayload' $true
+} catch {
+    $failures.Add($_.Exception.Message)
+} finally {
+    foreach ($child in $children) {
+        try { Stop-OwnedProcess $child } catch { $failures.Add($_.Exception.Message) }
+    }
+    foreach ($name in $managedEnvironment) {
+        [Environment]::SetEnvironmentVariable($name, $savedEnvironment[$name], 'Process')
+    }
+    $after = Get-RealSnapshot
+    $after | ConvertTo-Json -Depth 6 | Set-Content -LiteralPath (Join-Path $runRoot 'real-after.json') -Encoding utf8
+    $afterIdentities = @($after.Processes | ForEach-Object { "$($_.Id)/$($_.StartTimeUtc)" })
+    $lostProcesses = @($before.Processes | Where-Object { "$($_.Id)/$($_.StartTimeUtc)" -notin $afterIdentities })
+    $changedRegistry = [Collections.Generic.List[string]]::new()
+    $afterFiles = @{}
+    foreach ($file in $after.Files) { $afterFiles[$file.Name] = $file }
+    foreach ($file in $before.Files) {
+        # .act records typing and may change during normal concurrent use.
+        if ([IO.Path]::GetExtension($file.Name) -eq '.act') { continue }
+        if (-not $afterFiles.ContainsKey($file.Name)) { $changedRegistry.Add($file.Name); continue }
+        $other = $afterFiles[$file.Name]
+        if ($file.PSObject.Properties.Name -contains 'Sha256' -and $other.PSObject.Properties.Name -contains 'Sha256') {
+            if ($file.Sha256 -ne $other.Sha256) { $changedRegistry.Add($file.Name) }
+        } else { $changedRegistry.Add($file.Name) }
+    }
+    if ($lostProcesses.Count -gt 0 -or $changedRegistry.Count -gt 0) {
+        $failures.Add('Real process/registry snapshots changed. This may be concurrent activity; inspect before/after evidence before attributing cause.')
+    }
+    $summary = [pscustomobject]@{
+        Binary = $exePath; Sha256 = $actualHash; Namespace = $namespace; EvidenceDirectory = $runRoot
+        NoPsmuxServersSpawned = $true; Cases = $results.ToArray()
+        LostExistingProcesses = $lostProcesses; ChangedExistingRegistryFiles = $changedRegistry.ToArray()
+        Failures = $failures.ToArray(); HarnessPassed = ($failures.Count -eq 0)
+    }
+    $summary | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath (Join-Path $runRoot 'results.json') -Encoding utf8
+    foreach ($result in $results) { Write-Host ("{0}: {1}" -f $result.Case, $result.Classification) }
+    Write-Host "Evidence: $runRoot"
+    foreach ($failure in $failures) { Write-Warning $failure }
+    foreach ($child in $children) { $child.Process.Dispose() }
+}
+if ($failures.Count -gt 0) { exit 1 }
+exit 0

--- a/tests/audit_lifecycle_faults.ps1
+++ b/tests/audit_lifecycle_faults.ps1
@@ -1,0 +1,397 @@
+#requires -Version 7.0
+<#
+.SYNOPSIS
+Bounded, private lifecycle audit against one explicitly identified new build.
+.DESCRIPTION
+Creates one disposable server in target/audit with its own data directory,
+namespace, and config. USERPROFILE and HOME are unchanged. Never resolves an
+installed psmux, runs a global kill command, or deletes evidence. A successful
+audit requires rejected commands to preserve the server and its original panes.
+Only the supplied executable is ever invoked.
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)][string]$PsmuxExe,
+    [Parameter(Mandatory)][ValidatePattern('^[0-9a-fA-F]{64}$')][string]$ExpectedSha256
+)
+$ErrorActionPreference = 'Stop'
+$repoRoot = [IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..'))
+$PsmuxExe = (Get-Item -LiteralPath $PsmuxExe -ErrorAction Stop).FullName
+if ([IO.Path]::GetFileName($PsmuxExe) -ne 'psmux.exe') { throw 'Use the canonical new psmux.exe, not an installed alias or renamed executable.' }
+$actualHash = (Get-FileHash -LiteralPath $PsmuxExe -Algorithm SHA256).Hash
+if ($actualHash -ne $ExpectedSha256) { throw 'Executable SHA256 does not match the explicitly supplied new build.' }
+
+# Hold native handles from identity capture through cleanup. Termination uses
+# that SAME handle, never a fresh lookup of a potentially recycled process ID.
+if (-not ('PsmuxLifecycleAuditHandleV1' -as [type])) {
+    Add-Type -TypeDefinition @'
+using System;
+using System.Runtime.InteropServices;
+public sealed class PsmuxLifecycleAuditHandleV1 : IDisposable {
+    [DllImport("kernel32.dll", SetLastError=true)] static extern IntPtr OpenProcess(uint access, bool inherit, uint pid);
+    [DllImport("kernel32.dll", SetLastError=true)] static extern bool GetProcessTimes(IntPtr h, out long created, out long exited, out long kernel, out long user);
+    [DllImport("kernel32.dll", SetLastError=true)] static extern bool TerminateProcess(IntPtr h, uint exitCode);
+    [DllImport("kernel32.dll")] static extern uint WaitForSingleObject(IntPtr h, uint milliseconds);
+    [DllImport("kernel32.dll")] static extern bool CloseHandle(IntPtr h);
+    IntPtr handle;
+    public uint Pid { get; private set; }
+    public long CreatedFileTime { get; private set; }
+    public bool IsAlive { get { return handle != IntPtr.Zero && WaitForSingleObject(handle, 0) == 258; } }
+    public static PsmuxLifecycleAuditHandleV1 Open(uint pid) {
+        // SYNCHRONIZE | QUERY_LIMITED_INFORMATION | TERMINATE, without inheritance.
+        IntPtr h = OpenProcess(0x00101001, false, pid);
+        if (h == IntPtr.Zero) return null;
+        long c, e, k, u;
+        if (!GetProcessTimes(h, out c, out e, out k, out u)) { CloseHandle(h); return null; }
+        return new PsmuxLifecycleAuditHandleV1 { handle = h, Pid = pid, CreatedFileTime = c };
+    }
+    public bool Stop() { return !IsAlive || TerminateProcess(handle, 233); }
+    public bool WaitForExit(uint milliseconds) { return handle != IntPtr.Zero && WaitForSingleObject(handle, milliseconds) == 0; }
+    public void Dispose() { if (handle != IntPtr.Zero) { CloseHandle(handle); handle = IntPtr.Zero; } }
+}
+'@
+}
+
+$runToken = (Get-Date -Format 'yyyyMMdd-HHmmss') + '-' + [Guid]::NewGuid().ToString('N').Substring(0,12)
+$auditParent = [IO.Path]::GetFullPath((Join-Path $repoRoot 'target/audit'))
+$evidenceDir = [IO.Path]::GetFullPath((Join-Path $auditParent ('lifecycle-' + $runToken)))
+if (-not $evidenceDir.StartsWith($auditParent + [IO.Path]::DirectorySeparatorChar, [StringComparison]::OrdinalIgnoreCase)) { throw 'Audit path escaped target/audit.' }
+if (Test-Path -LiteralPath $evidenceDir) { throw 'Refusing to reuse an audit directory.' }
+New-Item -ItemType Directory -Path $evidenceDir | Out-Null
+$dataDir = Join-Path $evidenceDir 'data'
+New-Item -ItemType Directory -Path $dataDir | Out-Null
+$namespace = 'audit_lifecycle_' + [Guid]::NewGuid().ToString('N').Substring(0,12)
+$sessionName = 'audit-session'
+$configPath = Join-Path $evidenceDir 'audit.conf'
+$cmdExe = Join-Path $env:SystemRoot 'System32/cmd.exe'
+if (-not (Test-Path -LiteralPath $cmdExe -PathType Leaf)) { throw 'cmd.exe unavailable; refusing to substitute a profile-loading shell.' }
+[IO.File]::WriteAllText($configPath, "set -g warm off`nset -g default-shell `"$($cmdExe.Replace('\','/'))`"`nset -g base-index 0`nset -g pane-base-index 0`n", [Text.UTF8Encoding]::new($false))
+$events = [Collections.Generic.List[object]]::new()
+$owned = [Collections.Generic.List[object]]::new()
+$server = $null
+$before = [pscustomobject]@{ Registries=@(); Processes=@() }
+$status = 'not-started'
+$auditError = $null
+$serverExitCode = $null
+$counter = 0
+$realRoots = @((Join-Path $env:USERPROFILE '.psmux'))
+if ($env:HOME) { $realRoots += Join-Path $env:HOME '.psmux' }
+if ($env:PSMUX_DATA_DIR) { $realRoots += [IO.Path]::GetFullPath($env:PSMUX_DATA_DIR) }
+$realRoots = @($realRoots | ForEach-Object { [IO.Path]::GetFullPath($_) } | Sort-Object -Unique)
+
+function Save-Json([string]$Name, $Value) {
+    $Value | ConvertTo-Json -Depth 12 | Set-Content -LiteralPath (Join-Path $evidenceDir $Name) -Encoding utf8NoBOM
+}
+
+function Get-ObservedSnapshot([string[]]$Roots) {
+    $errors = [Collections.Generic.List[string]]::new()
+    $registries = @(foreach ($root in $Roots) {
+        try {
+            $entries = if (Test-Path -LiteralPath $root) { @(Get-ChildItem -LiteralPath $root -File) } else { @() }
+            $records = @(foreach ($entry in $entries) {
+                if ($entry.Extension -notin '.port','.pid','.sid','.key','.act','.spawnlock','.instance' -and -not $entry.Name.EndsWith('.registry.json')) { continue }
+                try {
+                    [pscustomobject]@{ Name=$entry.Name; Length=$entry.Length; ModifiedUtc=$entry.LastWriteTimeUtc; SHA256=(Get-FileHash -LiteralPath $entry.FullName).Hash }
+                } catch { $errors.Add("Snapshot file ($($entry.FullName)): " + $_.Exception.Message) }
+            })
+            [pscustomobject]@{ Root=$root; Files=@($records | Sort-Object Name) }
+        } catch { $errors.Add("Snapshot root ($root): " + $_.Exception.Message) }
+    })
+    try {
+        $processes = @(Get-CimInstance Win32_Process -OperationTimeoutSec 10 | Where-Object Name -match '^(psmux|tmux|pmux)\.exe$' |
+            Select-Object ProcessId,ParentProcessId,Name,ExecutablePath,CreationDate | Sort-Object ProcessId)
+    } catch { $processes=@(); $errors.Add('Snapshot processes: ' + $_.Exception.Message) }
+    [pscustomobject]@{ AtUtc=[DateTime]::UtcNow.ToString('o'); Registries=$registries; Processes=$processes; Errors=$errors.ToArray() }
+}
+
+function Start-OwnedMux([string[]]$MuxArgs, [string]$Label, [switch]$InheritNamespace) {
+    # Re-check before every launch so replacing the file mid-audit cannot invoke
+    # an unexpected or old binary under the isolated directory.
+    if ((Get-FileHash -LiteralPath $PsmuxExe).Hash -ne $ExpectedSha256) { throw 'Executable changed during audit.' }
+    $start = [Diagnostics.ProcessStartInfo]::new()
+    $start.FileName = $PsmuxExe
+    $start.UseShellExecute = $false
+    $start.CreateNoWindow = $true
+    $start.RedirectStandardOutput = $true
+    $start.RedirectStandardError = $true
+    $start.WorkingDirectory = $evidenceDir
+    foreach ($name in @($start.Environment.Keys)) {
+        if ($name -like 'PSMUX_*' -or $name -eq 'TMUX' -or $name -eq 'TMUX_PANE') { [void]$start.Environment.Remove($name) }
+    }
+    $start.Environment['PSMUX_DATA_DIR'] = $dataDir
+    $start.Environment['PSMUX_NO_WARM'] = '1'
+    $start.Environment['PSMUX_CONFIG_FILE'] = $configPath
+    $routing = @('-L',$namespace)
+    if ($InheritNamespace) { $routing = @(); $start.Environment['PSMUX_SOCKET_NAME'] = $namespace }
+    foreach ($arg in $routing + @('-f',$configPath) + $MuxArgs) { $start.ArgumentList.Add($arg) }
+    $process = [Diagnostics.Process]::new()
+    $process.StartInfo = $start
+    [void]$process.Start()
+    $record = [pscustomobject]@{ Label=$Label; Process=$process; Stdout=$process.StandardOutput.ReadToEndAsync(); Stderr=$process.StandardError.ReadToEndAsync(); Handle=$null }
+    $record.Handle = [PsmuxLifecycleAuditHandleV1]::Open([uint32]$process.Id)
+    if (-not $record.Handle -and -not $process.HasExited) {
+        # This object came directly from Process.Start, so its retained OS
+        # handle still names this exact child. Do not leave it behind when
+        # duplicate ownership capture fails.
+        $process.Kill(); [void]$process.WaitForExit(2000); $process.Dispose()
+        throw 'Could not capture a live newly started child; stopped that exact child.'
+    }
+    if ($record.Handle -and $record.Handle.CreatedFileTime -ne $process.StartTime.ToUniversalTime().ToFileTimeUtc()) {
+        $record.Handle.Dispose(); $record.Handle=$null; throw 'New process identity changed before ownership capture.'
+    }
+    return $record
+}
+
+function Read-ProcessText($Task) {
+    if ($Task.Wait(1000)) { return [string]$Task.Result }
+    return '[output capture incomplete after deadline]'
+}
+
+function Invoke-BoundedMux([string]$Label, [string[]]$MuxArgs, [int]$TimeoutMs=7000, [switch]$InheritNamespace) {
+    $script:counter++
+    $record = Start-OwnedMux $MuxArgs $Label -InheritNamespace:$InheritNamespace
+    $timer = [Diagnostics.Stopwatch]::StartNew()
+    $timedOut = $false
+    try {
+        if (-not $record.Process.WaitForExit($TimeoutMs)) {
+            $timedOut=$true
+            if ($record.Handle) { [void]$record.Handle.Stop() }
+            else { throw 'Client timeout without an owned termination handle.' }
+            [void]$record.Process.WaitForExit(2000)
+        }
+        $result = [pscustomobject]@{
+            Label=$Label; Arguments=$MuxArgs; Pid=$record.Process.Id; TimedOut=$timedOut
+            ExitCode=$(if ($record.Process.HasExited) { $record.Process.ExitCode } else { $null })
+            Stdout=(Read-ProcessText $record.Stdout); Stderr=(Read-ProcessText $record.Stderr); ElapsedMs=$timer.ElapsedMilliseconds
+        }
+        $events.Add($result)
+        Save-Json ('client-{0:D2}-{1}.json' -f $script:counter,$Label) $result
+        return $result
+    } finally {
+        if ($record.Handle) { $record.Handle.Dispose() }
+        $record.Process.Dispose()
+    }
+}
+
+function Require-Healthy($Result, [string]$Contains='') {
+    if ($Result.TimedOut -or $Result.ExitCode -ne 0 -or ($Contains -and -not $Result.Stdout.Contains($Contains))) {
+        throw "Healthy precondition failed: $($Result.Label); inspect client evidence."
+    }
+    if ($server.Process.HasExited) { throw "Server exited during healthy precondition: $($Result.Label)" }
+}
+
+function Test-Ready {
+    $portPath = Join-Path $dataDir ($namespace + '__' + $sessionName + '.port')
+    $keyPath = [IO.Path]::ChangeExtension($portPath,'.key')
+    $tcp=$null
+    try {
+        $port=[int][IO.File]::ReadAllText($portPath).Trim()
+        $key=[IO.File]::ReadAllText($keyPath).Trim()
+        if (-not $key -or $key -match '[\r\n\x00]') { return $false }
+        $tcp=[Net.Sockets.TcpClient]::new()
+        if (-not $tcp.ConnectAsync('127.0.0.1',$port).Wait(500)) { return $false }
+        $stream=$tcp.GetStream(); $stream.ReadTimeout=500; $stream.WriteTimeout=500
+        $bytes=[Text.Encoding]::UTF8.GetBytes("AUTH $key`nsession-info`n")
+        $stream.Write($bytes,0,$bytes.Length)
+        $reader=[IO.StreamReader]::new($stream)
+        if ($reader.ReadLine() -ne 'OK') { return $false }
+        $line=$reader.ReadLine()
+        return ($line -and $line.StartsWith($sessionName + ': '))
+    } catch { return $false }
+    finally { $key=$null; if ($tcp) { $tcp.Dispose() } }
+}
+
+function Capture-OwnedDescendants {
+    # Once the server has exited, its numeric PID can be reused. Keep the
+    # handles captured before the fault; never discover a new tree from that
+    # stale parent ID during cleanup.
+    if (-not $server -or -not $server.Handle -or -not $server.Handle.IsAlive) { return }
+    $snapshot=@(Get-CimInstance Win32_Process -OperationTimeoutSec 10)
+    $queue=[Collections.Generic.Queue[uint32]]::new(); $queue.Enqueue([uint32]$server.Process.Id)
+    $visited=[Collections.Generic.HashSet[uint32]]::new()
+    while ($queue.Count -gt 0) {
+        $parent=$queue.Dequeue()
+        if (-not $visited.Add($parent)) { continue }
+        foreach ($child in @($snapshot | Where-Object ParentProcessId -eq $parent)) {
+            $childPid=[uint32]$child.ProcessId
+            if ($childPid -eq $PID -or $child.CreationDate.ToUniversalTime().ToFileTimeUtc() -lt $server.Handle.CreatedFileTime) { continue }
+            if (@($owned | Where-Object Pid -eq $childPid).Count -gt 0) { $queue.Enqueue($childPid); continue }
+            $handle=[PsmuxLifecycleAuditHandleV1]::Open($childPid)
+            if (-not $handle) { continue }
+            # CIM timestamps have microsecond precision, FILETIME has 100ns.
+            $expected=$child.CreationDate.ToUniversalTime().ToFileTimeUtc()
+            if ([Math]::Abs($handle.CreatedFileTime-$expected) -ge 10) { $handle.Dispose(); continue }
+            $owned.Add([pscustomobject]@{ Pid=$childPid; ParentPid=$parent; Name=$child.Name; CreatedFileTime=$handle.CreatedFileTime; Handle=$handle })
+            $queue.Enqueue($childPid)
+        }
+    }
+    Save-Json 'owned-descendants.json' @($owned | Select-Object Pid,ParentPid,Name,CreatedFileTime)
+}
+
+try {
+    Write-Output "Audit evidence: $evidenceDir"
+    Save-Json 'invocation.json' ([ordered]@{ Executable=$PsmuxExe; SHA256=$actualHash; DataDir=$dataDir; Namespace=$namespace; Config=$configPath; UserProfile=$env:USERPROFILE; Home=$env:HOME; Command='Direct isolated server; healthy queries; respawn-pane without -k'; StartedUtc=[DateTime]::UtcNow.ToString('o') })
+    $before=Get-ObservedSnapshot $realRoots
+    Save-Json 'real-before.json' $before
+    $server=Start-OwnedMux @('server','-s',$sessionName,'-x','80','-y','24') 'server'
+    if (-not $server.Handle) { throw 'Could not retain the exact server process handle.' }
+    Save-Json 'server-identity.json' ([ordered]@{ Pid=$server.Process.Id; CreatedFileTime=$server.Handle.CreatedFileTime; Executable=$PsmuxExe; SHA256=$actualHash })
+    $readyTimer=[Diagnostics.Stopwatch]::StartNew()
+    $ready=$false
+    while ($readyTimer.ElapsedMilliseconds -lt 20000 -and -not $server.Process.HasExited) {
+        if (Test-Ready) { $ready=$true; break }
+        Start-Sleep -Milliseconds 100
+    }
+    if (-not $ready) { throw 'Direct server did not authenticate and report its session within 20 seconds.' }
+    Capture-OwnedDescendants
+    Require-Healthy (Invoke-BoundedMux 'list-sessions' @('list-sessions')) ($sessionName + ': ')
+    Require-Healthy (Invoke-BoundedMux 'has-session' @('has-session','-t',$sessionName))
+    Require-Healthy (Invoke-BoundedMux 'new-window' @('new-window','-d','-t',$sessionName,'-n','audit-second'))
+    Require-Healthy (Invoke-BoundedMux 'list-windows' @('list-windows','-t',$sessionName,'-F','#{window_index}|#{window_name}|#{window_panes}')) '1|audit-second|1'
+    Require-Healthy (Invoke-BoundedMux 'rename-window' @('rename-window','-t',($sessionName + ':1'),'audit-renamed'))
+    Require-Healthy (Invoke-BoundedMux 'list-renamed-window' @('list-windows','-t',$sessionName,'-F','#{window_index}|#{window_name}|#{window_panes}')) '1|audit-renamed|1'
+    Capture-OwnedDescendants
+    Save-Json 'isolated-before-fault.json' (Get-ObservedSnapshot @($dataDir))
+    $fault=Invoke-BoundedMux 'respawn-live-pane' @('respawn-pane','-t',($sessionName + ':0'))
+    $serverDied=$server.Process.WaitForExit(5000)
+    if ($serverDied) {
+        $serverExitCode=$server.Process.ExitCode
+        $stderr=Read-ProcessText $server.Stderr
+        if ($stderr.Contains('pane still active')) { $status='regression-server-died'; throw 'Invalid respawn terminated the server.' }
+        else { $status='unexpected-server-exit'; throw 'Server exited without expected pane-still-active evidence.' }
+    } else {
+        Require-Healthy (Invoke-BoundedMux 'survivor-has-session' @('has-session','-t',$sessionName))
+        Require-Healthy (Invoke-BoundedMux 'survivor-list-windows' @('list-windows','-t',$sessionName,'-F','#{window_index}|#{window_name}|#{window_panes}')) '1|audit-renamed|1'
+        if (-not $fault.TimedOut -and $fault.ExitCode -ne 0) { $status='fixed-rejection-survivor' }
+        else { $status='unexpected-success-survivor'; throw 'Server survived, but the invalid command did not return a bounded nonzero rejection.' }
+    }
+    # A failed replacement must not destroy the original child, even with -k.
+    $originalPanes = Invoke-BoundedMux 'original-pane-pids' @('list-panes','-t',($sessionName + ':0'),'-F','#{pane_id}|#{pane_pid}')
+    Require-Healthy $originalPanes
+    $badDirectory = Join-Path $evidenceDir 'directory-that-does-not-exist'
+    foreach ($verb in @('respawn-pane','respawn-window')) {
+        $rejected = Invoke-BoundedMux ($verb + '-live-rejected') @($verb,'-t',($sessionName + ':0'))
+        if ($rejected.TimedOut -or $rejected.ExitCode -eq 0 -or -not $rejected.Stderr) { throw "$verb did not reject an active target" }
+        $rejected = Invoke-BoundedMux ($verb + '-replacement-failed') @($verb,'-k','-t',($sessionName + ':0'),'-c',$badDirectory)
+        if ($rejected.TimedOut -or $rejected.ExitCode -eq 0 -or -not $rejected.Stderr) { throw "$verb accepted an invalid replacement directory" }
+        $survivors = Invoke-BoundedMux ($verb + '-original-still-live') @('list-panes','-t',($sessionName + ':0'),'-F','#{pane_id}|#{pane_pid}')
+        Require-Healthy $survivors
+        if ($survivors.Stdout -ne $originalPanes.Stdout) { throw "$verb changed the original pane after failed replacement" }
+    }
+
+    # A foreign live PID is deliberately not a canonical psmux image. A name
+    # collision must still preserve that registration byte-for-byte.
+    $foreignBase = $namespace + '__foreign'
+    $selfIdentity = [PsmuxLifecycleAuditHandleV1]::Open([uint32]$PID)
+    try {
+        $foreign = [ordered]@{ pid=$PID; creation_time=$selfIdentity.CreatedFileTime; generation='synthetic-live-owner'; port=65531; key='synthetic-key'; sid=999999 }
+    } finally { $selfIdentity.Dispose() }
+    $records = [ordered]@{ 'port'='65531'; 'key'='synthetic-key'; 'sid'='999999'; 'pid'=([string]$foreign.pid + ':' + [string]$foreign.creation_time); 'registry.json'=($foreign | ConvertTo-Json -Compress) }
+    foreach ($extension in $records.Keys) { [IO.File]::WriteAllText((Join-Path $dataDir ($foreignBase + '.' + $extension)), $records[$extension]) }
+    $rejected = Invoke-BoundedMux 'rename-live-collision' @('rename-session','-t',$sessionName,'foreign')
+    if ($rejected.TimedOut -or $rejected.ExitCode -eq 0) { throw 'Rename overwrote or hung on a live destination' }
+    foreach ($extension in $records.Keys) {
+        $path = Join-Path $dataDir ($foreignBase + '.' + $extension)
+        if ([IO.File]::ReadAllText($path) -ne $records[$extension]) { throw 'Rename modified foreign registry bytes' }
+        Remove-Item -LiteralPath $path
+    }
+    Require-Healthy (Invoke-BoundedMux 'after-collision-has' @('has-session','-t',$sessionName))
+    Require-Healthy (Invoke-BoundedMux 'inherited-namespace-list' @('list-sessions') -InheritNamespace) ($sessionName + ': ')
+
+    # The new encoding must be usable on the real command route, not only by
+    # standalone filename helper tests.
+    $newName = 'audit__renamed'
+    Require-Healthy (Invoke-BoundedMux 'rename-delimited-name' @('rename-session','-t',$sessionName,$newName))
+    $sessionName = $newName
+    Require-Healthy (Invoke-BoundedMux 'renamed-has' @('has-session','-t',$sessionName))
+    Require-Healthy (Invoke-BoundedMux 'renamed-list' @('list-sessions','-F','#{session_name}')) $sessionName
+    Require-Healthy (Invoke-BoundedMux 'renamed-new-window' @('new-window','-d','-t',$sessionName,'-n','post-rename'))
+    Require-Healthy (Invoke-BoundedMux 'renamed-list-windows' @('list-windows','-t',$sessionName,'-F','#{window_name}')) 'post-rename'
+    Require-Healthy (Invoke-BoundedMux 'enable-warm-panes' @('set-option','-g','warm','on'))
+    for ($i=0; $i -lt 4; $i++) {
+        $created = Invoke-BoundedMux ('warm-window-' + $i) @('new-window','-d','-t',$sessionName,'-n',('warm-' + $i))
+        Require-Healthy $created
+        if ($created.ElapsedMs -gt 2500) { throw 'Warm replenishment blocked window creation' }
+        Require-Healthy (Invoke-BoundedMux ('warm-probe-' + $i) @('has-session','-t',$sessionName))
+    }
+    Require-Healthy (Invoke-BoundedMux 'disable-warm-panes' @('set-option','-g','warm','off'))
+    Capture-OwnedDescendants
+
+    # A sink that never reads stdin must not hold the control loop hostage.
+    $sinkCommand = 'pwsh -NoLogo -NoProfile -NonInteractive -Command "Start-Sleep -Seconds 20"'
+    Require-Healthy (Invoke-BoundedMux 'start-nonreading-sink' @('pipe-pane','-O','-t',($sessionName + ':1'),$sinkCommand))
+    Capture-OwnedDescendants
+    $flood = 'for /L %i in (1,1,60000) do @echo psmux-audit-output-012345678901234567890123456789012345678901234567890123456789'
+    Require-Healthy (Invoke-BoundedMux 'start-output-flood' @('send-keys','-t',($sessionName + ':1'),$flood,'Enter'))
+    $rssBefore = $server.Process.WorkingSet64
+    $peakRss = $rssBefore
+    for ($i=0; $i -lt 15; $i++) {
+        $probe = Invoke-BoundedMux ('load-has-' + $i) @('has-session','-t',$sessionName)
+        Require-Healthy $probe
+        if ($probe.ElapsedMs -gt 2500) { throw 'Control request exceeded 2.5 seconds during output load' }
+        $server.Process.Refresh()
+        $peakRss = [Math]::Max($peakRss,$server.Process.WorkingSet64)
+        Start-Sleep -Milliseconds 100
+    }
+    Require-Healthy (Invoke-BoundedMux 'cancel-nonreading-sink' @('pipe-pane','-t',($sessionName + ':1')))
+    Require-Healthy (Invoke-BoundedMux 'stop-output-flood' @('send-keys','-t',($sessionName + ':1'),'C-c'))
+    $floodCapture = Invoke-BoundedMux 'verify-output-flood' @('capture-pane','-p','-t',($sessionName + ':1'))
+    Require-Healthy $floodCapture 'psmux-audit-output-'
+    if ([regex]::Matches($floodCapture.Stdout, 'psmux-audit-output-').Count -lt 3) { throw 'Output flood did not produce the expected repeated pane output' }
+    Require-Healthy (Invoke-BoundedMux 'post-load-list' @('list-sessions')) $sessionName
+    Save-Json 'load-memory.json' ([ordered]@{ BeforeBytes=$rssBefore; PeakBytes=$peakRss; IncreaseBytes=($peakRss-$rssBefore); Samples=15 })
+    if ($peakRss -gt $rssBefore + 128MB) { throw 'Resident memory grew more than 128 MiB during the bounded load probe' }
+    Capture-OwnedDescendants
+    $status = 'fixed-rejections-transactions-namespace-and-load-survivor'
+    Save-Json 'isolated-after-fault.json' (Get-ObservedSnapshot @($dataDir))
+} catch {
+    $auditError=$_.Exception.Message
+    if ($status -eq 'not-started') { $status='precondition-failed' }
+} finally {
+    $cleanup=[Collections.Generic.List[object]]::new()
+    if ($server) {
+        try { Capture-OwnedDescendants } catch { $cleanup.Add([pscustomobject]@{ Stage='capture'; Error=$_.Exception.Message }) }
+        if ($server.Handle) {
+            $cleanup.Add([pscustomobject]@{ Pid=$server.Handle.Pid; CreatedFileTime=$server.Handle.CreatedFileTime; Kind='server'; WasAlive=$server.Handle.IsAlive; StopSucceeded=$server.Handle.Stop() })
+        }
+        foreach ($entry in $owned) {
+            $cleanup.Add([pscustomobject]@{ Pid=$entry.Pid; CreatedFileTime=$entry.CreatedFileTime; Kind=$entry.Name; WasAlive=$entry.Handle.IsAlive; StopSucceeded=$entry.Handle.Stop() })
+        }
+        foreach ($entry in $owned) {
+            if (-not $entry.Handle.WaitForExit(2000)) {
+                $cleanup.Add([pscustomobject]@{ Pid=$entry.Pid; Kind=$entry.Name; Error='Owned process remained after cleanup deadline' })
+                $auditError='An owned process did not stop within the cleanup deadline; inspect cleanup.json.'
+            }
+        }
+        if (-not $server.Process.WaitForExit(3000)) {
+            $cleanup.Add([pscustomobject]@{ Pid=$server.Process.Id; Kind='server'; Error='Owned server remained after cleanup deadline' })
+            $auditError='Owned server did not stop within the cleanup deadline.'
+        }
+        [IO.File]::WriteAllText((Join-Path $evidenceDir 'server.stdout.txt'),(Read-ProcessText $server.Stdout))
+        [IO.File]::WriteAllText((Join-Path $evidenceDir 'server.stderr.txt'),(Read-ProcessText $server.Stderr))
+        foreach ($entry in $owned) { $entry.Handle.Dispose() }
+        if ($server.Handle) { $server.Handle.Dispose() }
+        $server.Process.Dispose()
+    }
+    Save-Json 'cleanup.json' $cleanup.ToArray()
+    $after=Get-ObservedSnapshot $realRoots
+    Save-Json 'real-after.json' $after
+    $realChanges=@(foreach ($oldRoot in @($before.Registries)) {
+        $newRoot=@($after.Registries | Where-Object Root -eq $oldRoot.Root) | Select-Object -First 1
+        $oldRecords=@($oldRoot.Files | ForEach-Object { $_.Name + '|' + $_.SHA256 })
+        $newRecords=@($newRoot.Files | ForEach-Object { $_.Name + '|' + $_.SHA256 })
+        foreach ($oldRecord in $oldRecords) { if ($newRecords -notcontains $oldRecord) { [pscustomobject]@{ Root=$oldRoot.Root; Record=$oldRecord; Side='<=' } } }
+        foreach ($newRecord in $newRecords) { if ($oldRecords -notcontains $newRecord) { [pscustomobject]@{ Root=$oldRoot.Root; Record=$newRecord; Side='=>' } } }
+    })
+    Save-Json 'real-registry-changes.json' $realChanges
+    $lostProcesses=@(foreach ($prior in @($before.Processes)) {
+        if (@($after.Processes | Where-Object { $_.ProcessId -eq $prior.ProcessId -and $_.CreationDate -eq $prior.CreationDate }).Count -eq 0) { $prior }
+    })
+    if ($realChanges.Count -gt 0 -or $lostProcesses.Count -gt 0) { $auditError='Real registry/process baseline changed; treat this run as failed and inspect before/after evidence.' }
+    if (@($cleanup | Where-Object { $_.Error -or ($_.PSObject.Properties.Name -contains 'StopSucceeded' -and -not $_.StopSucceeded) }).Count -gt 0) { $auditError='Owned-process cleanup reported a failure; inspect cleanup.json.' }
+    $summary=[ordered]@{ Status=$status; Error=$auditError; EvidenceDirectory=$evidenceDir; ServerFaultExitCode=$serverExitCode; RealRegistryChangeCount=$realChanges.Count; BaselineMuxProcessesAbsentAfter=$lostProcesses; Commands=$events.ToArray(); Cleanup=$cleanup.ToArray(); CompletedUtc=[DateTime]::UtcNow.ToString('o'); Note='Real-state changes may be concurrent user activity; inspect snapshots. No installed executable or global kill command was invoked.' }
+    Save-Json 'summary.json' $summary
+    Write-Output ($summary | ConvertTo-Json -Depth 7)
+}
+if ($auditError) { throw $auditError }
+exit 0

--- a/tests/audit_reliability_units.ps1
+++ b/tests/audit_reliability_units.ps1
@@ -1,0 +1,77 @@
+#requires -Version 7.0
+# Execute only reviewed unit modules; never pass an installed psmux executable.
+[CmdletBinding()]
+param([Parameter(Mandatory)][string]$TestExecutable)
+$ErrorActionPreference = 'Stop'
+$repoRoot = [IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..'))
+$testExe = (Get-Item -LiteralPath $TestExecutable).FullName
+if ([IO.Path]::GetFileName($testExe) -notmatch '^psmux-[0-9a-f]+\.exe$' -or
+    [IO.Path]::GetFileName([IO.Path]::GetDirectoryName($testExe)) -ne 'deps') {
+    throw 'Supply the Cargo-built psmux unit-test executable from a deps directory, never an installed CLI.'
+}
+$runDir = Join-Path $repoRoot ('target/audit/units-' + (Get-Date -Format 'yyyyMMdd-HHmmss') + '-' + [Guid]::NewGuid().ToString('N').Substring(0,6))
+New-Item -ItemType Directory -Path $runDir | Out-Null
+$filters = @(
+    'types::request_queue::tests::',
+    'paths::registry_encoding_tests::',
+    'registry::reliability_registry_tests::',
+    'server::connection::bounded_wire_tests::',
+    'server::connection::new_session_destination_tests::',
+    'server::connection::session_command_routing_tests::',
+    'input::tests_audit_input_errors::',
+    'pane::io_queue::tests::',
+    'pane::staging::tests::',
+    'pane::pipe::tests::',
+    'pane::tests_pane_writer_queue::',
+    'pane::tests_pane_writer_transient_error::',
+    'session::tests_session_id_alloc_race::',
+    'server::panic_registration_tests::',
+    'session::tests_reliability_discovery::',
+    'session::tests::',
+    'session::tests_issue448_orphan_reaper::',
+    'session::tests_issue510_reaper_attribution::',
+    'session::tests_issue509_namespace_instance::',
+    'session::tests_picker_namespace_filter::',
+    'session::tests_l_socket_tmux_precedence::',
+    'platform::tests_issue599_data_root_mutex::',
+    'server::tests_issue505_rename_session_guard::',
+    'server::tests_issue574_rename_loop_guard::',
+    'server::test_issue459_warm_single_instance::',
+    'server::connection::tests_pane_border_indicator_control::',
+    'server::connection::tests_refresh_client_flags::'
+)
+$results = [Collections.Generic.List[object]]::new()
+foreach ($filter in $filters) {
+    $tag = $filter.TrimEnd(':').Replace('::','-')
+    $psi = [Diagnostics.ProcessStartInfo]::new($testExe)
+    $psi.UseShellExecute = $false
+    $psi.CreateNoWindow = $true
+    $psi.RedirectStandardOutput = $true
+    $psi.RedirectStandardError = $true
+    $psi.ArgumentList.Add($filter)
+    $psi.ArgumentList.Add('--test-threads=1')
+    foreach ($key in @($psi.Environment.Keys)) {
+        if ($key -match '^TMUX' -or $key -match '^PSMUX_') { $null = $psi.Environment.Remove($key) }
+    }
+    $psi.Environment['PSMUX_DATA_DIR'] = Join-Path $runDir 'isolated-data'
+    $psi.Environment['PSMUX_NO_WARM'] = '1'
+    $process = [Diagnostics.Process]::Start($psi)
+    $stdout = $process.StandardOutput.ReadToEndAsync()
+    $stderr = $process.StandardError.ReadToEndAsync()
+    $finished = $process.WaitForExit(45000)
+    if (-not $finished) { $process.Kill(); $process.WaitForExit(3000) | Out-Null }
+    $out = $stdout.GetAwaiter().GetResult()
+    $err = $stderr.GetAwaiter().GetResult()
+    [IO.File]::WriteAllText((Join-Path $runDir ($tag + '.stdout.txt')), $out)
+    [IO.File]::WriteAllText((Join-Path $runDir ($tag + '.stderr.txt')), $err)
+    $count = if ($out -match 'test result: ok\. (\d+) passed;') { [int]$Matches[1] } else { 0 }
+    $result = [pscustomobject]@{ Filter=$filter; ExitCode=$process.ExitCode; Passed=$count; TimedOut=(-not $finished) }
+    $results.Add($result)
+    $process.Dispose()
+    Write-Output ($result | ConvertTo-Json -Compress)
+    $results | ConvertTo-Json | Set-Content -LiteralPath (Join-Path $runDir 'results.json')
+    if (-not $finished -or $result.ExitCode -ne 0 -or $count -eq 0) { throw "Unit filter failed: $filter. Evidence: $runDir" }
+}
+Write-Output "Unit evidence: $runDir"
+Write-Output "Total passed: $(($results.Passed | Measure-Object -Sum).Sum)"
+exit 0


### PR DESCRIPTION
## Problem

Several independent failures can look like a psmux crash:

- A delayed discovery response can remove a live session's registration, followed by automatic orphan termination.
- A normal rejection such as `respawn-pane` without `-k` on a live pane can escape the server loop, terminate the server, and still leave the CLI reporting success.
- Failed AUTH or missing formatted output can appear as a blank successful `ls`.
- Rename/warm-claim races can overwrite another live owner's registration.
- A nonreading `pipe-pane` sink can block cancellation and the control loop; unbounded queues amplify latency and memory use.

The respawn failure was reproduced against the unmodified upstream runtime: client exit 0, server exit 1 with `pane still active`.

## Fix

- **Discovery and ownership:** keep observation read-only; preserve uncertain live registrations; identify processes by PID and creation time rather than executable basename. Reserve destination ownership before creation/rename/claim. Publish an atomic coherent manifest and clean up only the owning generation.
- **Command results:** require exact AUTH and complete bounded response frames. Incomplete listings retain healthy rows but return stderr/nonzero status. Keep command errors inside the event loop and attach them to their originating requests. Prepare respawn replacements before retiring the original pane.
- **Namespace routing:** resolve inherited and explicit namespaces consistently and encode ambiguous/path-unsafe storage names. An unresolved explicit shutdown target cannot kill the current session.
- **I/O and fairness:** bound allocated input, output staging, request admission/batches, handlers, and persistent/control queues. Give each sink an independent cancellable writer; move warm-pane refill and internal self-directed commands off the event loop. Propagate admission and permanent writer failures, including atomic paste rejection.
- **Lifecycle diagnostics:** append panic diagnostics without unregistering sessions; allocate session IDs under verified lock ownership with checked, atomic counter persistence.

The shared request/ack, registry, and writer APIs are included together so the change has one compilable transition. The build-provenance change is submitted independently as #636. The upgrade follow-up requires a coherent manifest before claiming a warm server, so legacy named sessions remain connectable while new sessions cold-start instead of adopting an old standby; four scratch-registry tests cover this path.

## Validation

- `cargo check --locked --all-targets` and compilation of the `psmux` unit-test harness passed.
- **200 targeted tests across 27 reviewed modules** passed, including fake AUTH peers, ownership rollback, renamed-executable identity, counter contention, panic-hook behavior, byte bounds/FIFO, partial writes, permanent failures, native Windows blocked-pipe cancellation, and control protocol regressions.
- A locked optimized Windows build passed **four discovery fault cases** and **55 lifecycle/load commands** in isolated data roots/namespaces. The latter includes failed respawn survival with original pane PIDs, foreign-live-owner collision, inherited/encoded routing, warm creation, output flood, nonreading sink cancellation, and capture verification. Slowest command in the final versioned-build probe: 204 ms.
- Existing user registrations/process identities were unchanged and all owned test processes were cleaned up. The full upstream suite was not run on the work machine because some tests can create default-namespace sessions or kill processes by image name; CI/disposable Windows remains the place for that suite.

Reproduction tools are `tests/audit_reliability_units.ps1`, `tests/audit_discovery_faults.ps1`, and `tests/audit_lifecycle_faults.ps1`. The runtime tools require an explicit executable SHA-256 and verify that the real baseline is unchanged.

## Tradeoffs and related work

- Overload returns a visible error or disconnects a slow consumer. A timed-out command has an unknown outcome; non-idempotent operations should not be blindly retried. Queue bounds do not cap total terminal-history/application memory.
- Legacy names already ambiguous under the old delimiter scheme are not silently migrated. A live process with missing/unreadable metadata is not automatically terminated. Existing old-code servers remain old code until restarted.
- A sink that exceeds its budget stops with an observable failure, so its transcript can be incomplete. Direct-file sink opening is asynchronous; delayed open failures reach pane diagnostics.
- This overlaps #541's discovery/reaping work: here even connection refusal is insufficient to reap a positively live server. It also overlaps #542's control buffering/ack work: this proposal disconnects slow consumers rather than silently shedding output. #635 overlaps command-ingress files. These are competing/overlapping changes, not a claim that the branches can be combined unchanged.

Long interactive/cross-version and overnight-load testing remain broader acceptance work; the bounded regressions are not a claim of exhaustive correctness.
