### PR TITLE
fix(#651): bind prefix + . to a move-window prompt, and stop command-prompt leaking a flag's value

### DIFF
--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -88,6 +88,7 @@ rebind the prefix, the new key is bound to `send-prefix` for you.
 | `Prefix + &` | Kill current window (with confirmation) |
 | `Prefix + ,` | Rename current window |
 | `Prefix + '` | Prompt for window index (jump to any window) |
+| `Prefix + .` | Prompt for an index and move the current window there (`move-window`) |
 | `Prefix + 0-9` | Select window by number |
 
 **Gotcha: `select-window-index` is not a real command.** `Prefix + '` is bound to

--- a/docs/tmux_args_reference.md
+++ b/docs/tmux_args_reference.md
@@ -511,6 +511,7 @@ A psmux extension that creates a pane floating above the tiled layout.
 - Boolean: `-N` (numeric input only), `-W` (word input only)
 - Value: `-I` (initial value), `-p` (prompt list), `-T` (prompt type), `-t` (target)
 - Not accepted: `-1`, `-b`, `-e`, `-F`, `-i`, `-k`, `-l`
+- `-T` is parsed and its value consumed, but the prompt type itself is ignored: psmux has no target completion. `-t` is consumed and ignored the same way. The flags end at the first argument that is not a flag, so a template given unquoted (`command-prompt move-window -t %%`) keeps its own flags.
 
 **choose-tree**, **choose-window**, **choose-session**, **choose-client**, **choose-buffer**, **customize-mode**, **clock-mode**
 - No flags. These open client side overlays. While an overlay is open its keys are handled before any key table, so a bound key does not reach the tables until the overlay closes.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -316,6 +316,23 @@ pub fn validate_command_line_flags<S: AsRef<str>>(tokens: &[S]) -> Result<(), St
     validate_flag_arguments(command.as_ref(), &tokens[1..])
 }
 
+/// True when `-<flag>` takes a value for `command`, per [`ARGS_TEMPLATES`].
+///
+/// Same classification [`validate_flag_arguments`] applies, exposed so a parser
+/// that has to step OVER a flag's value cannot drift from the one flag table.
+/// Without it a hand-written parser has to keep its own list of value-taking
+/// flags, and the flag it forgets turns its value into a positional argument.
+pub fn flag_takes_value(command: &str, flag: char) -> bool {
+    let Some(template) = args_template(command) else {
+        return false;
+    };
+    let kind = match flag_value_kind(template, flag) {
+        FlagValue::None => flag_value_kind(psmux_extra_flags(command), flag),
+        kind => kind,
+    };
+    kind != FlagValue::None
+}
+
 /// Normalize `-x=VALUE` short-flag forms into `["-x", "VALUE"]`.
 ///
 /// tmux accepts both `-t VALUE` (space) and `-t=VALUE` (equals) for

--- a/src/client.rs
+++ b/src/client.rs
@@ -179,6 +179,73 @@ fn extract_confirm_command(args: &str) -> String {
     args.to_string()
 }
 
+/// What a `command-prompt` binding's flags asked the client to do: the text the
+/// prompt opens with (`-I`), the overlay heading (`-p`), and the command to run
+/// with `%%` replaced by whatever the user typed. A bare `command-prompt`
+/// leaves all three empty and the typed line is itself the command.
+#[derive(Debug, Default, PartialEq, Eq)]
+struct CommandPromptSpec {
+    initial: String,
+    label: Option<String>,
+    template: Option<String>,
+}
+
+/// Parse the arguments of a `command-prompt` binding — everything after the
+/// command name.
+///
+/// A value-taking flag consumes the token after it, classified through the one
+/// flag table in cli.rs (`cli::flag_takes_value`) rather than a list kept here.
+/// tmux's own `bind . command-prompt -T target "move-window -t '%%'"` is the
+/// case that needs it: skipping the flag but not its value left `target` as the
+/// first word of the template, so Enter ran `target move-window -t '3'`.
+///
+/// A value glued to its flag (`-pindex`) satisfies the flag on its own, the way
+/// tmux's `args_parse_flags` treats a template letter it finds a character
+/// after. `--` ends the flags, as it does there.
+fn parse_command_prompt_args(args: &str) -> CommandPromptSpec {
+    let tokens = crate::config::shell_words(args);
+    let mut spec = CommandPromptSpec::default();
+    let mut positional: Vec<String> = Vec::new();
+    let mut i = 0;
+    while i < tokens.len() {
+        let token = tokens[i].clone();
+        if token == "--" {
+            positional.extend(tokens[i + 1..].iter().cloned());
+            break;
+        }
+        // A bare `-`, and anything not starting with `-`, is a positional.
+        let flag = token.strip_prefix('-').and_then(|rest| {
+            let mut chars = rest.chars();
+            chars.next().map(|f| (f, chars.as_str().to_string()))
+        });
+        let Some((flag, glued)) = flag else {
+            positional.push(token);
+            i += 1;
+            continue;
+        };
+        let value = if !crate::cli::flag_takes_value("command-prompt", flag) {
+            None
+        } else if !glued.is_empty() {
+            Some(glued)
+        } else {
+            i += 1;
+            tokens.get(i).cloned()
+        };
+        match flag {
+            'I' => spec.initial = value.unwrap_or_default(),
+            'p' => spec.label = value,
+            // -t (target) and -T (prompt type) are consumed and dropped: psmux
+            // has no per-client prompt routing and no prompt-type completion.
+            _ => {}
+        }
+        i += 1;
+    }
+    if !positional.is_empty() {
+        spec.template = Some(positional.join(" "));
+    }
+    spec
+}
+
 /// One row of the choose-tree model: `(is_win, win_id, pane_id, label, session)`.
 /// A session header is `is_win == true` with `win_id == usize::MAX`.
 pub(crate) type TreeRow = (bool, usize, usize, String, String);
@@ -3639,52 +3706,22 @@ pub fn run_remote(terminal: &mut Terminal<crate::platform::PsmuxBackend>, input:
                                     renaming = true; rename_buf.clear(); session_renaming = true;
                                 } else if cmd == "command-prompt" || cmd.starts_with("command-prompt ") {
                                     command_input = true;
-                                    command_cursor = 0;
                                     command_history_idx = command_history.len();
-                                    command_template = None;
-                                    command_prompt_label = None;
-                                    if cmd.starts_with("command-prompt ") {
-                                        // Parse -I initial_text, -p prompt, and template argument
-                                        let cp_args = &cmd["command-prompt ".len()..];
-                                        let tokens = crate::config::shell_words(cp_args);
-                                        let mut initial = String::new();
-                                        let mut prompt_text: Option<String> = None;
-                                        let mut positional: Vec<String> = Vec::new();
-                                        let mut i = 0;
-                                        while i < tokens.len() {
-                                            if tokens[i] == "-I" && i + 1 < tokens.len() {
-                                                initial = tokens[i + 1].clone();
-                                                i += 2;
-                                            } else if tokens[i] == "-p" && i + 1 < tokens.len() {
-                                                prompt_text = Some(tokens[i + 1].clone());
-                                                i += 2;
-                                            } else if tokens[i] == "-1" || tokens[i] == "-N" || tokens[i] == "-W" {
-                                                i += 1; // skip flags
-                                            } else if tokens[i].starts_with('-') {
-                                                i += 1; // skip unknown flags
-                                            } else {
-                                                positional.push(tokens[i].clone());
-                                                i += 1;
-                                            }
-                                        }
-                                        // Expand format variables in initial text
-                                        let initial = initial
-                                            .replace("#W", &active_window_name)
-                                            .replace("#{window_name}", &active_window_name)
-                                            .replace("#S", &current_session)
-                                            .replace("#{session_name}", &current_session);
-                                        command_buf = initial.clone();
-                                        command_cursor = command_buf.len();
-                                        // Join all positional args to form the template
-                                        // e.g. 'rename-window "%%"' → single arg, or
-                                        //       rename-window %%    → two args joined
-                                        if !positional.is_empty() {
-                                            command_template = Some(positional.join(" "));
-                                        }
-                                        command_prompt_label = prompt_text;
-                                    } else {
-                                        command_buf.clear();
-                                    }
+                                    let spec = parse_command_prompt_args(
+                                        cmd.strip_prefix("command-prompt")
+                                            .unwrap_or("")
+                                            .trim_start(),
+                                    );
+                                    // Expand format variables in initial text
+                                    command_buf = spec
+                                        .initial
+                                        .replace("#W", &active_window_name)
+                                        .replace("#{window_name}", &active_window_name)
+                                        .replace("#S", &current_session)
+                                        .replace("#{session_name}", &current_session);
+                                    command_cursor = command_buf.len();
+                                    command_template = spec.template;
+                                    command_prompt_label = spec.label;
                                 } else if cmd == "list-keys" {
                                     keys_viewer_scroll = 0;
                                     let user_binds: Vec<(bool, String, String, String)> = synced_bindings

--- a/src/client.rs
+++ b/src/client.rs
@@ -239,7 +239,18 @@ fn parse_command_prompt_args(args: &str) -> CommandPromptSpec {
         i += 1;
     }
     if i < tokens.len() {
-        spec.template = Some(tokens[i..].join(" "));
+        let template = tokens[i..].join(" ");
+        if spec.label.is_none() {
+            // With no -p, tmux's prompt names the command it is about to run
+            // (cmd-command-prompt.c):
+            //     tmp = xstrndup(cdata->template, strcspn(cdata->template, " ,"));
+            //     xasprintf(&new_prompt, "(%s) ", tmp);
+            let head = template.split(|c| c == ' ' || c == ',').next().unwrap_or("");
+            if !head.is_empty() {
+                spec.label = Some(format!("({})", head));
+            }
+        }
+        spec.template = Some(template);
     }
     spec
 }
@@ -3836,6 +3847,7 @@ pub fn run_remote(terminal: &mut Terminal<crate::platform::PsmuxBackend>, input:
                                     command_cursor = 0;
                                     command_history_idx = command_history.len();
                                     command_template = Some("move-window -t '%%'".into());
+                                    command_prompt_label = Some("(move-window)".into());
                                 }
                                 KeyCode::Char('w') => { do_choose_tree = true; }
                                 KeyCode::Char('s') => { do_choose_session = true; }

--- a/src/client.rs
+++ b/src/client.rs
@@ -199,29 +199,27 @@ struct CommandPromptSpec {
 /// case that needs it: skipping the flag but not its value left `target` as the
 /// first word of the template, so Enter ran `target move-window -t '3'`.
 ///
-/// A value glued to its flag (`-pindex`) satisfies the flag on its own, the way
-/// tmux's `args_parse_flags` treats a template letter it finds a character
-/// after. `--` ends the flags, as it does there.
+/// Three more shapes follow tmux's `args_parse_flags`: the flags end at the
+/// first token that is not one (so a `-t` inside an unquoted template stays in
+/// the template), `--` ends them explicitly, and a value glued to its flag
+/// (`-pindex`) satisfies it on its own.
 fn parse_command_prompt_args(args: &str) -> CommandPromptSpec {
     let tokens = crate::config::shell_words(args);
     let mut spec = CommandPromptSpec::default();
-    let mut positional: Vec<String> = Vec::new();
     let mut i = 0;
     while i < tokens.len() {
         let token = tokens[i].clone();
         if token == "--" {
-            positional.extend(tokens[i + 1..].iter().cloned());
+            i += 1;
             break;
         }
-        // A bare `-`, and anything not starting with `-`, is a positional.
-        let flag = token.strip_prefix('-').and_then(|rest| {
+        // A bare `-`, and anything not starting with `-`, ends the flags: what
+        // is left is the template.
+        let Some((flag, glued)) = token.strip_prefix('-').and_then(|rest| {
             let mut chars = rest.chars();
             chars.next().map(|f| (f, chars.as_str().to_string()))
-        });
-        let Some((flag, glued)) = flag else {
-            positional.push(token);
-            i += 1;
-            continue;
+        }) else {
+            break;
         };
         let value = if !crate::cli::flag_takes_value("command-prompt", flag) {
             None
@@ -240,8 +238,8 @@ fn parse_command_prompt_args(args: &str) -> CommandPromptSpec {
         }
         i += 1;
     }
-    if !positional.is_empty() {
-        spec.template = Some(positional.join(" "));
+    if i < tokens.len() {
+        spec.template = Some(tokens[i..].join(" "));
     }
     spec
 }
@@ -3558,6 +3556,8 @@ pub fn run_remote(terminal: &mut Terminal<crate::platform::PsmuxBackend>, input:
                             } else {
                                 command_input = false;
                                 command_cursor = 0;
+                                command_template = None;
+                                command_prompt_label = None;
                                 renaming = false;
                                 pane_renaming = false;
                                 tree_chooser = false;
@@ -3827,6 +3827,16 @@ pub fn run_remote(terminal: &mut Terminal<crate::platform::PsmuxBackend>, input:
                                 KeyCode::Char('#') => { cmd_batch.push("list-buffers\n".into()); }
                                 KeyCode::Char(':') => { command_input = true; command_buf.clear(); command_cursor = 0; command_history_idx = command_history.len(); }
                                 KeyCode::Char('\'') => { window_idx_input = true; window_idx_buf.clear(); }
+                                // Same command as the PREFIX_DEFAULTS entry for
+                                // `.`, so the key is not dead for the moment
+                                // before the first state sync arrives.
+                                KeyCode::Char('.') => {
+                                    command_input = true;
+                                    command_buf.clear();
+                                    command_cursor = 0;
+                                    command_history_idx = command_history.len();
+                                    command_template = Some("move-window -t '%%'".into());
+                                }
                                 KeyCode::Char('w') => { do_choose_tree = true; }
                                 KeyCode::Char('s') => { do_choose_session = true; }
                                 KeyCode::Char('q') => { cmd_batch.push("display-panes\n".into()); }
@@ -4727,11 +4737,13 @@ pub fn run_remote(terminal: &mut Terminal<crate::platform::PsmuxBackend>, input:
                                     }
                                     command_input = false;
                                     command_cursor = 0;
+                                    command_template = None;
+                                    command_prompt_label = None;
                                 }
                                 KeyCode::Esc if renaming => { renaming = false; session_renaming = false; }
                                 KeyCode::Esc if pane_renaming => { pane_renaming = false; }
                                 KeyCode::Esc if window_idx_input => { window_idx_input = false; }
-                                KeyCode::Esc if command_input => { command_input = false; command_cursor = 0; }
+                                KeyCode::Esc if command_input => { command_input = false; command_cursor = 0; command_template = None; command_prompt_label = None; }
 
                                 // Command prompt: cursor movement, history, and editing keys
                                 KeyCode::Left if command_input => {
@@ -8086,3 +8098,7 @@ mod test_issue640_sticky_key_table;
 #[cfg(test)]
 #[path = "../tests-rs/test_switch_client_target_routing.rs"]
 mod test_switch_client_target_routing;
+
+#[cfg(test)]
+#[path = "../tests-rs/test_prefix_dot_move_window.rs"]
+mod test_prefix_dot_move_window;

--- a/src/help.rs
+++ b/src/help.rs
@@ -35,6 +35,13 @@ pub const PREFIX_DEFAULTS: &[(&str, &str)] = &[
     ("&",       "confirm-before -p 'kill-window #W? (y/n)' kill-window"),
     (",",       "rename-window"),
     ("'",       "select-window-index"),
+    // tmux binds `.` by default: prompt for an index and move the current
+    // window there. Measured on tmux 3.6a, `list-keys -T prefix` renders it as
+    //     command-prompt -T target { move-window -t "%%" }
+    // psmux has no `{}` command blocks, so the same command is written in the
+    // quoting form psmux's parser reads. parse_command_line strips the quotes
+    // again before move-window sees the index, so the two are equivalent.
+    (".",       "command-prompt -T target \"move-window -t '%%'\""),
     ("0",       "select-window -t :0"),
     ("1",       "select-window -t :1"),
     ("2",       "select-window -t :2"),

--- a/tests-rs/test_prefix_dot_move_window.rs
+++ b/tests-rs/test_prefix_dot_move_window.rs
@@ -141,7 +141,40 @@ fn a_value_glued_to_its_flag_satisfies_it() {
 fn double_dash_ends_the_flags() {
     let spec = parse_command_prompt_args("-- -N");
     assert_eq!(spec.template.as_deref(), Some("-N"));
-    assert_eq!(spec.label, None);
+}
+
+// ---------------------------------------------------------------------------
+// The heading: with no -p, tmux names the command the prompt will run
+// ---------------------------------------------------------------------------
+
+#[test]
+fn the_prompt_names_the_command_it_will_run() {
+    assert_eq!(spec_of(TMUX_DOT).label.as_deref(), Some("(move-window)"));
+}
+
+#[test]
+fn an_explicit_prompt_wins_over_the_derived_one() {
+    let spec = parse_command_prompt_args("-p index \"move-window -t '%%'\"");
+    assert_eq!(spec.label.as_deref(), Some("index"));
+}
+
+#[test]
+fn the_heading_stops_at_a_space_or_a_comma() {
+    // tmux: strcspn(template, " ,").
+    assert_eq!(
+        parse_command_prompt_args("'rename-window \"%%\"'").label.as_deref(),
+        Some("(rename-window)"),
+    );
+    assert_eq!(
+        parse_command_prompt_args("'new-window,split-window'").label.as_deref(),
+        Some("(new-window)"),
+    );
+}
+
+#[test]
+fn a_bare_command_prompt_has_no_heading() {
+    // prefix + `:` has no template, so there is no command to name.
+    assert_eq!(parse_command_prompt_args("").label, None);
 }
 
 #[test]

--- a/tests-rs/test_prefix_dot_move_window.rs
+++ b/tests-rs/test_prefix_dot_move_window.rs
@@ -1,0 +1,230 @@
+// prefix + `.` — prompt for an index and move the current window there.
+//
+// tmux binds it by default. Measured on tmux 3.6a, `list-keys -T prefix`:
+//
+//     bind-key -T prefix . command-prompt -T target { move-window -t "%%" }
+//
+// psmux has no `{}` command blocks, so the binding below spells the same
+// command the way psmux's parser reads it; parse_command_line strips the quotes
+// before move-window sees the index. What is load bearing is `-T target` plus
+// the `move-window -t %%` template, and those are asserted piece by piece.
+//
+// psmux had no `.` binding at all, so the key did nothing. Adding the line was
+// not enough on its own: the client's command-prompt parser skipped an unknown
+// flag WITHOUT its value, so `-T target` left `target` as the first positional
+// and the template became `target move-window -t '%%'`. Enter then sent
+// `target move-window -t '3'`, which is not a command.
+//
+// What move-window itself does with the resolved target is pinned by
+// tests-rs/test_issue601_602_move_swap_window.rs (unit) and
+// tests/test_issue601_602_move_swap_window.ps1 (end to end). This file pins the
+// path from the key to the command line those already cover: the default
+// binding, the flag parse, and the substituted line.
+
+use super::*;
+
+/// The default binding: tmux's command, in the quoting form psmux's parser
+/// reads (tmux 3.6a prints its own as `-T target { move-window -t "%%" }`).
+const TMUX_DOT: &str = "command-prompt -T target \"move-window -t '%%'\"";
+
+/// Parse a whole `command-prompt ...` binding the way the key dispatcher does.
+fn spec_of(binding: &str) -> CommandPromptSpec {
+    parse_command_prompt_args(
+        binding
+            .strip_prefix("command-prompt")
+            .expect("not a command-prompt binding")
+            .trim_start(),
+    )
+}
+
+fn default_for(key: &str) -> Option<&'static str> {
+    crate::help::PREFIX_DEFAULTS
+        .iter()
+        .find(|(k, _)| *k == key)
+        .map(|(_, cmd)| *cmd)
+}
+
+// ---------------------------------------------------------------------------
+// The binding exists, and reaches the live key table
+// ---------------------------------------------------------------------------
+
+#[test]
+fn prefix_dot_prompts_for_a_target_and_moves_the_window() {
+    let cmd = default_for(".").expect("'.' missing from PREFIX_DEFAULTS");
+    assert_eq!(cmd, TMUX_DOT);
+    // The three parts that have to match tmux, whatever the quoting:
+    assert!(cmd.starts_with("command-prompt "), "{}", cmd);
+    assert!(cmd.contains("-T target"), "{}", cmd);
+    let template = spec_of(cmd).template.expect("no template");
+    assert_eq!(template.replace("'", "\""), "move-window -t \"%%\"");
+}
+
+#[test]
+fn dot_is_a_bindable_key_name() {
+    assert_eq!(
+        crate::config::parse_key_name("."),
+        Some((
+            crossterm::event::KeyCode::Char('.'),
+            crossterm::event::KeyModifiers::NONE
+        )),
+    );
+}
+
+#[test]
+fn the_dot_default_lands_in_the_prefix_table() {
+    // populate_default_bindings silently drops a default whose command
+    // parse_command_to_action does not recognise. Prove this one survives.
+    let mut app = crate::types::AppState::new("t-dot".to_string());
+    crate::config::populate_default_bindings(&mut app);
+    let table = app.key_tables.get("prefix").expect("no prefix table");
+    let bind = table
+        .iter()
+        .find(|b| {
+            b.key
+                == (
+                    crossterm::event::KeyCode::Char('.'),
+                    crossterm::event::KeyModifiers::NONE,
+                )
+        })
+        .expect("'.' did not reach the prefix key table");
+    match &bind.action {
+        crate::types::Action::Command(cmd) => assert_eq!(cmd, TMUX_DOT),
+        other => panic!(
+            "'.' became {}, not a command string",
+            crate::commands::format_action(other)
+        ),
+    }
+    assert!(!bind.repeat, "'.' is not a repeat binding in tmux");
+}
+
+// ---------------------------------------------------------------------------
+// The flag parse: a value-taking flag consumes its value
+// ---------------------------------------------------------------------------
+
+#[test]
+fn the_prompt_type_stays_out_of_the_template() {
+    let spec = spec_of(TMUX_DOT);
+    assert_eq!(spec.template.as_deref(), Some("move-window -t '%%'"));
+    assert_eq!(spec.initial, "");
+}
+
+#[test]
+fn a_target_flag_value_stays_out_of_the_template() {
+    // -t is command-prompt's other value-taking flag.
+    let spec = parse_command_prompt_args("-t %3 \"move-window -t '%%'\"");
+    assert_eq!(spec.template.as_deref(), Some("move-window -t '%%'"));
+}
+
+#[test]
+fn boolean_flags_do_not_eat_the_template() {
+    for flags in ["-1", "-N", "-W", "-1 -N"] {
+        let spec = parse_command_prompt_args(&format!("{} \"move-window -t '%%'\"", flags));
+        assert_eq!(
+            spec.template.as_deref(),
+            Some("move-window -t '%%'"),
+            "{} consumed the template",
+            flags
+        );
+    }
+}
+
+#[test]
+fn a_value_glued_to_its_flag_satisfies_it() {
+    // tmux's args_parse_flags: a template letter with a character after it is
+    // already satisfied, so the next token is not its value.
+    let spec = parse_command_prompt_args("-pindex \"move-window -t '%%'\"");
+    assert_eq!(spec.label.as_deref(), Some("index"));
+    assert_eq!(spec.template.as_deref(), Some("move-window -t '%%'"));
+}
+
+#[test]
+fn double_dash_ends_the_flags() {
+    let spec = parse_command_prompt_args("-- -N");
+    assert_eq!(spec.template.as_deref(), Some("-N"));
+    assert_eq!(spec.label, None);
+}
+
+#[test]
+fn an_initial_value_and_a_prompt_still_parse() {
+    // The shape a user's config uses for a rename binding, unchanged.
+    let spec = parse_command_prompt_args("-p 'new name:' -I '#W' 'rename-window \"%%\"'");
+    assert_eq!(spec.initial, "#W");
+    assert_eq!(spec.label.as_deref(), Some("new name:"));
+    assert_eq!(spec.template.as_deref(), Some("rename-window \"%%\""));
+}
+
+#[test]
+fn a_bare_command_prompt_has_no_template() {
+    // prefix + `:` — whatever is typed is the whole command.
+    assert_eq!(default_for(":"), Some("command-prompt"));
+    assert_eq!(parse_command_prompt_args(""), CommandPromptSpec::default());
+}
+
+#[test]
+fn several_positionals_join_into_one_template() {
+    let spec = parse_command_prompt_args("-T target move-window -t %%");
+    assert_eq!(spec.template.as_deref(), Some("move-window -t %%"));
+}
+
+// ---------------------------------------------------------------------------
+// What Enter sends
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_typed_index_reaches_move_window_as_one_argument() {
+    let template = spec_of(TMUX_DOT).template.expect("no template");
+    let line = template.replace("%%", "3");
+    assert_eq!(line, "move-window -t '3'");
+    // The server tokenizes with parse_command_line, which strips the quotes
+    // tmux's binding puts around the index.
+    assert_eq!(
+        crate::commands::parse_command_line(&line),
+        vec![
+            "move-window".to_string(),
+            "-t".to_string(),
+            "3".to_string()
+        ],
+    );
+}
+
+#[test]
+fn a_symbolic_target_survives_the_substitution() {
+    // resolve_window_spec accepts +N / {end} / a name; the prompt must not
+    // mangle them on the way.
+    let template = spec_of(TMUX_DOT).template.expect("no template");
+    for typed in ["+1", "-1", "{end}", "$"] {
+        assert_eq!(
+            crate::commands::parse_command_line(&template.replace("%%", typed)),
+            vec![
+                "move-window".to_string(),
+                "-t".to_string(),
+                typed.to_string()
+            ],
+            "typed {}",
+            typed
+        );
+    }
+}
+
+#[test]
+fn the_generated_line_passes_the_flag_validator() {
+    // Every command ingress runs validate_command_line_flags (#635) before
+    // dispatch; a line it rejects never reaches move-window.
+    let template = spec_of(TMUX_DOT).template.expect("no template");
+    let tokens = crate::commands::parse_command_line(&template.replace("%%", "3"));
+    assert_eq!(crate::cli::validate_command_line_flags(&tokens), Ok(()));
+}
+
+#[test]
+fn the_flag_table_is_what_the_parser_asks() {
+    // The parser reads ARGS_TEMPLATES rather than keeping its own list, so pin
+    // the answers it depends on.
+    assert!(crate::cli::flag_takes_value("command-prompt", 'T'));
+    assert!(crate::cli::flag_takes_value("command-prompt", 't'));
+    assert!(crate::cli::flag_takes_value("command-prompt", 'I'));
+    assert!(crate::cli::flag_takes_value("command-prompt", 'p'));
+    assert!(!crate::cli::flag_takes_value("command-prompt", 'N'));
+    assert!(!crate::cli::flag_takes_value("command-prompt", '1'));
+    // 'W' is not in tmux's template at all, so it is not ours to police.
+    assert!(!crate::cli::flag_takes_value("command-prompt", 'W'));
+}


### PR DESCRIPTION
Fixes #651.

Fixes the two things that sit between the keyboard and `move-window`: tmux's default binding for `.` was missing, and the binding could not have worked anyway because the client's `command-prompt` parser dropped a value-taking flag's value into the template.

tmux 3.6a renders its own binding as

```
bind-key -T prefix . command-prompt -T target { move-window -t "%%" }
```

psmux has no `{}` command blocks, so `PREFIX_DEFAULTS` spells the same command the way psmux's parser reads it:

```
command-prompt -T target "move-window -t '%%'"
```

`parse_command_line` strips the quotes again before `move-window` sees the index, so the two are equivalent — `list-keys` prints the quoted form rather than tmux's braces.

## Why the binding alone was not enough

The parser consumed a value for `-I` and `-p`, skipped `-1`/`-N`/`-W` as booleans, and for every other flag skipped **the flag but not its value**. So `-T target "move-window -t '%%'"` built the template `target move-window -t '%%'`, and Enter sent `target move-window -t '3'` — not a command. `-t` was in the same hole.

This was not only about the missing default: a user's own `bind . command-prompt -T target "move-window -t '%%'"` hit the same parser, since the dispatcher takes the command string out of the synced binding table without caring where it came from. Measured on `ddd38bc` with nested psmux (outer pane hosting an attached inner psmux, `send-keys` as real key input, the inner window list as witness): the binding is stored and listed, the prompt opens, `5` + Enter moves nothing. The same config on this branch moves the window to 5. Written without `-T` (`-p index` instead) it worked on master too, which was the only workaround.

psmux already knows the shape of every flag: `ARGS_TEMPLATES` in `cli.rs` carries `command-prompt`'s `1CbeFiklI:NPp:t:T:` transcribed from tmux's `cmd_entry`, and one validator reads it (#635). The parser was not asking. `cli::flag_takes_value` exposes that same classification so a parser that has to step over a value cannot drift from the table, and the parse moves out of the event loop into `parse_command_prompt_args`, where it is testable.

Three shapes now follow tmux's `args_parse_flags` rather than the old code: the flags end at the first token that is not one (so a `-t` inside an unquoted template stays in the template), `--` ends them, and a value glued to its flag (`-pindex`) satisfies it. `-T` and `-t` are consumed and dropped — psmux has neither prompt-type completion nor per-client prompt routing.

## Not a change to move-window (re #601, #602)

`move-window` is untouched: no diff in `types.rs`, `server/`, `main.rs` or `commands.rs`. Its target resolution and state invalidation already landed in master as `f497d7b` (#602) and `8986564` (#601), and this change builds on them — because `resolve_window_spec` is complete, `+1`, `-1`, `$` and `{end}` typed at the prompt all work, and an occupied index is refused with `index in use: N` instead of silently swapping.

## Commits

1. **`fix(command-prompt): a value-taking flag consumes its value instead of leaking it into the template`** — `cli::flag_takes_value`, and the parse extracted into `parse_command_prompt_args`. No default binding uses `-T`/`-t` before this PR, so nothing changes for `:` or for a user's `command-prompt -I ... 'cmd "%%"'`.
2. **`feat(keys): bind prefix + . to move the current window to a typed index`** — the default binding, the same entry in the pre-sync fallback table (where `:` and `'` already live, so `.` is not dead for the moment before the first state dump), tests and docs. The fallback entry exposed a latent leak: the prompt's template was never cleared when the prompt closed, only overwritten by the next `command-prompt` binding, so a following `:` in that window would have inherited `move-window -t '%%'`. It is now cleared at all three close sites.
3. **`fix(command-prompt): with no -p, the prompt names the command it will run`** — tmux fills the prompt in from the template when the binding gives no `-p` (`cmd-command-prompt.c`: `xstrndup(template, strcspn(template, " ,"))` → `"(%s) "`). Measured rather than read off the source: tmux 3.6a nested inside tmux, `prefix .` on the inner server, the outer server capturing the pane — the inner status line reads `(move-window)`. psmux said `command` for every templated prompt, so `.` and `:` looked identical while one was about to renumber a window. The heading now reads `(move-window)`; a `-p` still wins. **Separate commit because it also changes the heading of a user's own templated `command-prompt` binding** (towards what tmux shows there) — drop it if you would rather not.

## Tests

`tests-rs/test_prefix_dot_move_window.rs`, 19 unit tests, no server started. They cover the binding surviving `populate_default_bindings` into the live prefix table; the `-T`/`-t` regression; booleans, `--`, glued values and unquoted templates; the unchanged `-I '#W' 'rename-window "%%"'` shape; the derived heading; and the substituted line all the way to the argv `parse_command_line` produces, including that it passes `validate_command_line_flags`. `move-window`'s own behaviour stays pinned by `test_issue601_602_move_swap_window.{rs,ps1}`.

Existing suites re-run green: `client::test_issue345_command_prompt_utf8`, `client::tests::paste_`, `commands::tests_flag_parity::command_prompt`, `types::tests_issue601_602_move_swap_window`, `commands::tests_issue210_gastown_fixes`, `config::tests_issue198`, `config::tests_issue209` (78 tests).

## Verified

Windows 11 Pro 26200, Intel Core Ultra 5 225U, psmux built from this branch on top of `ddd38bc`, isolated `-L` namespace.

Headless:

| | result |
|---|---|
| `list-keys` | `bind-key -T prefix . command-prompt -T target "move-window -t '%%'"` (tmux's command, psmux's quoting) |
| `move-window -t 5` on `1 2 3*` | `1 2 5*`, rc 0 |
| `move-window -t 1` (occupied) | `ERROR: index in use: 1`, nothing moved, rc 1 |
| `move-window -t +3` from `0*` | `1 2 3*`, rc 0 |

Attached, by hand: `prefix .` opens a prompt headed `(move-window)`; a typed index moves the current window and the status line follows it; an occupied index does nothing; Escape closes without running anything; `prefix '`, `prefix :` and `prefix ,` are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NEBUMwTtA5BFQGZNkHmsCg
