### PR TITLE
fix(#654): support CSI u extended keys on input

### DIFF
--- a/examples/csi_u_diag.rs
+++ b/examples/csi_u_diag.rs
@@ -1,0 +1,166 @@
+//! Ground truth for what a console delivers when a terminal sends an extended
+//! key (`CSI 13;2u`, the Shift+Enter of `set -s extended-keys`).
+//!
+//! `key_diag` shows what crossterm MADE of the input; this shows what arrived,
+//! one `INPUT_RECORD` at a time, with the fields crossterm decides on:
+//! `wVirtualKeyCode`, `UnicodeChar` and `dwControlKeyState`.  The distinction
+//! matters because crossterm can drop a record entirely — a record whose
+//! virtual key code is not one it names and whose `UnicodeChar` is a control
+//! code goes to `ToUnicodeEx`, which answers nothing for a synthesised record,
+//! and the event is discarded (crossterm 0.29 `event/sys/windows/parse.rs`).
+//!
+//! Run it in the terminal under test, NOT inside psmux, then press the key:
+//!
+//! ```text
+//!   cargo run --example csi_u_diag
+//! ```
+//!
+//! Press `q` (or Ctrl+C) to quit.  Lines also go to `$TEMP/psmux_csi_u_diag.log`.
+#![cfg(windows)]
+
+use std::ffi::c_void;
+use std::io::Write;
+use std::path::PathBuf;
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+struct KeyEventRecord {
+    key_down: i32,
+    repeat_count: u16,
+    virtual_key_code: u16,
+    virtual_scan_code: u16,
+    u_char: u16,
+    control_key_state: u32,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+struct InputRecord {
+    event_type: u16,
+    _pad: u16,
+    data: [u8; 16],
+}
+
+#[link(name = "kernel32")]
+extern "system" {
+    fn GetStdHandle(n: u32) -> *mut c_void;
+    fn GetConsoleMode(h: *mut c_void, mode: *mut u32) -> i32;
+    fn SetConsoleMode(h: *mut c_void, mode: u32) -> i32;
+    fn ReadConsoleInputW(h: *mut c_void, buf: *mut c_void, len: u32, read: *mut u32) -> i32;
+}
+
+const STD_INPUT_HANDLE: u32 = -10i32 as u32;
+const KEY_EVENT: u16 = 0x0001;
+const ENABLE_PROCESSED_INPUT: u32 = 0x0001;
+const ENABLE_LINE_INPUT: u32 = 0x0002;
+const ENABLE_ECHO_INPUT: u32 = 0x0004;
+const ENABLE_WINDOW_INPUT: u32 = 0x0008;
+const ENABLE_VIRTUAL_TERMINAL_INPUT: u32 = 0x0200;
+
+fn log_path() -> PathBuf {
+    let dir = std::env::var("TEMP")
+        .or_else(|_| std::env::var("TMP"))
+        .unwrap_or_else(|_| ".".into());
+    PathBuf::from(dir).join("psmux_csi_u_diag.log")
+}
+
+fn emit(line: &str) {
+    print!("{}\r\n", line);
+    let _ = std::io::stdout().flush();
+    if let Ok(mut f) = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(log_path())
+    {
+        let _ = writeln!(f, "{}", line);
+    }
+}
+
+/// How crossterm 0.29 resolves this record, so the log says outright whether
+/// the key survives the trip.  Mirrors `parse_key_event_record`: the named
+/// virtual key codes win, and everything else falls back to `UnicodeChar` —
+/// where a control code is handed to `ToUnicodeEx` and, for a record conhost
+/// synthesised while flushing a sequence it did not recognise, comes back
+/// empty.
+fn crossterm_verdict(k: &KeyEventRecord) -> &'static str {
+    match k.virtual_key_code {
+        0x10..=0x12 => "dropped (bare modifier)",
+        0x08 => "KeyCode::Backspace",
+        0x1b => "KeyCode::Esc",
+        0x0d => "KeyCode::Enter",
+        0x09 => "KeyCode::Tab",
+        0x25..=0x28 => "an arrow KeyCode",
+        _ => match k.u_char {
+            0x00..=0x1f => "ToUnicodeEx fallback -> DROPPED unless the layout answers",
+            _ => "KeyCode::Char(u_char)",
+        },
+    }
+}
+
+fn main() {
+    let _ = std::fs::write(log_path(), "");
+    let h = unsafe { GetStdHandle(STD_INPUT_HANDLE) };
+    let mut original: u32 = 0;
+    if unsafe { GetConsoleMode(h, &mut original) } == 0 {
+        eprintln!("stdin is not a console");
+        return;
+    }
+    // Raw, and with VTI on: the mode psmux's client runs its console in.
+    let raw = (original & !(ENABLE_PROCESSED_INPUT | ENABLE_LINE_INPUT | ENABLE_ECHO_INPUT))
+        | ENABLE_WINDOW_INPUT
+        | ENABLE_VIRTUAL_TERMINAL_INPUT;
+    unsafe { SetConsoleMode(h, raw) };
+
+    emit(&format!(
+        "=== csi_u_diag: console mode {:#06x} -> {:#06x} (VTI {}), log {:?} ===",
+        original,
+        raw,
+        if raw & ENABLE_VIRTUAL_TERMINAL_INPUT != 0 { "on" } else { "off" },
+        log_path()
+    ));
+    emit("Press the key under test (Shift+Enter). Press q to quit.");
+
+    let mut buf = [InputRecord { event_type: 0, _pad: 0, data: [0u8; 16] }; 32];
+    loop {
+        let mut read: u32 = 0;
+        let ok = unsafe {
+            ReadConsoleInputW(h, buf.as_mut_ptr() as *mut c_void, buf.len() as u32, &mut read)
+        };
+        if ok == 0 {
+            emit("ReadConsoleInputW failed");
+            break;
+        }
+        let mut quit = false;
+        emit(&format!("--- batch of {} record(s) ---", read));
+        for rec in buf.iter().take(read as usize) {
+            if rec.event_type != KEY_EVENT {
+                emit(&format!("  other event type {:#06x}", rec.event_type));
+                continue;
+            }
+            let k: KeyEventRecord = unsafe { std::ptr::read(rec.data.as_ptr() as *const _) };
+            let ch = char::from_u32(k.u_char as u32)
+                .filter(|c| !c.is_control())
+                .map(|c| format!("{:?}", c))
+                .unwrap_or_else(|| "-".into());
+            emit(&format!(
+                "  {} vk={:#04x} scan={:#04x} uChar={:#06x} {:>4} ctrl={:#06x}  crossterm: {}",
+                if k.key_down != 0 { "DOWN" } else { "UP  " },
+                k.virtual_key_code,
+                k.virtual_scan_code,
+                k.u_char,
+                ch,
+                k.control_key_state,
+                crossterm_verdict(&k),
+            ));
+            if k.key_down != 0 && (k.u_char == b'q' as u16 || k.u_char == 0x03) {
+                quit = true;
+            }
+        }
+        if quit {
+            break;
+        }
+    }
+
+    unsafe { SetConsoleMode(h, original) };
+    emit("=== csi_u_diag done ===");
+}

--- a/src/ssh_input.rs
+++ b/src/ssh_input.rs
@@ -548,6 +548,11 @@ pub fn keepalive_reasserts_mouse_input() -> bool {
 /// has used since #397.
 pub(crate) const ESC_COALESCE_MS: u64 = 50;
 
+/// Ceiling on the parameter bytes collected for one `CSI` sequence.  A real
+/// key sequence is a handful of bytes; anything longer is a stream that merely
+/// starts like one, and must not keep the held Escape alive indefinitely.
+pub(crate) const CSI_MAX_PARAM_LEN: usize = 32;
+
 /// Folds a bare Escape that is immediately followed by Enter into one
 /// `Alt+Enter` event (issue #611).
 ///
@@ -565,6 +570,47 @@ pub(crate) const ESC_COALESCE_MS: u64 = 50;
 /// `input_key_write` then emits the `\033` prefix and the key's own bytes back
 /// to back.  `encode_key_event` already turns `Alt+Enter` into a single
 /// `\x1b\r`, so producing one merged event is all that is needed here.
+///
+/// It is also where an EXTENDED KEY is put back together, for a related but
+/// distinct reason.  A terminal that encodes Shift+Enter as `CSI 13;2u` — the
+/// modifyOtherKeys / fixterms "CSI u" form, which is what `set -s
+/// extended-keys` asks a terminal for and what a Windows Terminal `sendInput`
+/// keybinding writes — hands psmux nothing but literal characters: conhost's
+/// input parser does not know `CSI u`, so it flushes the unrecognised sequence
+/// into the console input buffer one `KEY_EVENT` per byte.  Measured under
+/// Windows Terminal on Windows 11 26200 with `examples/csi_u_diag.rs`, which
+/// reads the records straight from the console, one press of Shift+Enter
+/// delivers seven of them in a single `ReadConsoleInputW`:
+///
+/// ```text
+///   DOWN vk=0x00 scan=0x00 uChar=0x001b        <- ESC
+///   DOWN vk=0x00 scan=0x00 uChar=0x005b  '['
+///   DOWN vk=0x00 scan=0x00 uChar=0x0031  '1'
+///   DOWN vk=0x00 scan=0x00 uChar=0x0033  '3'
+///   DOWN vk=0x00 scan=0x00 uChar=0x003b  ';'
+///   DOWN vk=0x00 scan=0x00 uChar=0x0032  '2'
+///   DOWN vk=0x00 scan=0x00 uChar=0x0075  'u'
+/// ```
+///
+/// and the ESC does not survive the trip: with no virtual key code to name it
+/// and a `uChar` inside the control range, crossterm sends that record to
+/// `ToUnicodeEx`, which answers nothing for a synthesised record, and the event
+/// is discarded (`event/sys/windows/parse.rs`).  So psmux is handed six bare
+/// characters, its paste heuristic sees three or more ASCII characters inside
+/// 20 ms and bundles them into a bracketed paste, and the child application
+/// receives the TEXT `[13;2u` instead of a newline.
+///
+/// The `[` is therefore the only introducer left to work with, and the batch is
+/// what makes that safe: every byte of the sequence is ALREADY in the queue
+/// when the `[` is handed over, so [`recover_csi_u`] pulls without ever
+/// waiting.  A `[` a person typed has nothing behind it, the pull comes back
+/// empty on the first try, and the character goes straight through — no hold,
+/// no added latency on a character that is ordinary in every editor.
+///
+/// tmux never has this problem, because it reads its client tty as bytes and
+/// parses the sequence itself in `tty-keys.c`.  Reassembly is unconditional
+/// there and here: `extended-keys` governs what tmux WRITES to a pane, never
+/// what it accepts from the terminal.
 pub struct EscCoalesce {
     /// When the held Escape arrived.  `None` when nothing is held.
     pending: Option<Instant>,
@@ -593,57 +639,110 @@ impl EscCoalesce {
         make_key(KeyCode::Esc, KeyModifiers::empty())
     }
 
-    /// Feed one event straight from the terminal.
+    /// Feed one event straight from the terminal, with no way to look ahead.
+    ///
+    /// Extended keys cannot be recovered through this entry point — see
+    /// [`EscCoalesce::feed_with`], which is what the live input source calls.
+    pub fn feed(&mut self, ev: Event, now: Instant) -> Option<Event> {
+        self.feed_with(ev, now, || None)
+    }
+
+    /// Feed one event, with `pull` offering whatever the terminal has ALREADY
+    /// delivered.
+    ///
+    /// `pull` must never wait: it returns the next event if one is queued and
+    /// `None` the moment nothing is, which is what lets a `[` that opens an
+    /// extended key be told apart from a `[` a person typed without holding
+    /// either of them back.
     ///
     /// Returns the event the client should see, or `None` when the event was
-    /// absorbed: either a bare Escape that is now being held, or the key
-    /// release belonging to one.
-    pub fn feed(&mut self, ev: Event, now: Instant) -> Option<Event> {
+    /// absorbed: a bare Escape now being held, the key release belonging to
+    /// one, or a whole sequence that resolved to nothing.
+    pub fn feed_with<F>(&mut self, ev: Event, now: Instant, pull: F) -> Option<Event>
+    where
+        F: FnMut() -> Option<Event>,
+    {
         if !self.enabled {
             return Some(ev);
         }
+        // The release of the very Escape being held is not "another key" and
+        // must not close the window.
         if self.pending.is_some() {
-            match ev {
-                // ESC then Enter: the pair every terminal that cannot encode a
-                // modified Enter falls back to.  Merge into one Alt+Enter, the
-                // way tmux merges `\033` + byte into a META key.  Ctrl+Enter is
-                // left alone because it has its own byte (0x0a) and must not
-                // gain a spurious Alt.
-                Event::Key(k)
-                    if matches!(k.code, KeyCode::Enter)
-                        && matches!(k.kind, KeyEventKind::Press | KeyEventKind::Repeat)
-                        && !k.modifiers.contains(KeyModifiers::CONTROL) =>
-                {
-                    self.pending = None;
-                    let mut merged = k;
-                    merged.modifiers.insert(KeyModifiers::ALT);
-                    merged.kind = KeyEventKind::Press;
-                    Some(Event::Key(merged))
-                }
-                // The release of the very Escape being held is not "another
-                // key" and must not close the window.
-                Event::Key(k)
-                    if k.kind == KeyEventKind::Release && matches!(k.code, KeyCode::Esc) =>
-                {
-                    None
-                }
-                other => {
-                    self.pending = None;
-                    self.queue.push_back(other);
-                    Some(Self::escape_event())
+            if let Event::Key(k) = &ev {
+                if k.kind == KeyEventKind::Release && matches!(k.code, KeyCode::Esc) {
+                    return None;
                 }
             }
-        } else {
-            match ev {
-                Event::Key(k)
-                    if matches!(k.code, KeyCode::Esc)
-                        && k.modifiers.is_empty()
-                        && matches!(k.kind, KeyEventKind::Press | KeyEventKind::Repeat) =>
-                {
-                    self.pending = Some(now);
-                    None
+        }
+        match ev {
+            // `[` may be the second byte of an extended key whose ESC the
+            // console dropped.  Everything else of the sequence is already in
+            // the queue, so this decides itself immediately.
+            Event::Key(k)
+                if matches!(k.code, KeyCode::Char('['))
+                    && !k
+                        .modifiers
+                        .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT)
+                    && matches!(k.kind, KeyEventKind::Press | KeyEventKind::Repeat) =>
+            {
+                match recover_csi_u(pull) {
+                    // The sequence was real, so a held Escape was its
+                    // introducer and goes with it.
+                    Recovered::Key(out) => {
+                        self.pending = None;
+                        Some(out)
+                    }
+                    Recovered::Consumed => {
+                        self.pending = None;
+                        None
+                    }
+                    // Not a sequence.  Hand back the `[`, everything pulled
+                    // behind it and any held Escape, in arrival order.
+                    Recovered::Raw(rest) => {
+                        let had_escape = self.pending.take().is_some();
+                        self.queue.push_back(Event::Key(k));
+                        self.queue.extend(rest);
+                        if had_escape {
+                            Some(Self::escape_event())
+                        } else {
+                            self.queue.pop_front()
+                        }
+                    }
                 }
-                other => Some(other),
+            }
+            // ESC then Enter: the pair every terminal that cannot encode a
+            // modified Enter falls back to.  Merge into one Alt+Enter, the
+            // way tmux merges `\033` + byte into a META key.  Ctrl+Enter is
+            // left alone because it has its own byte (0x0a) and must not
+            // gain a spurious Alt.
+            Event::Key(k)
+                if self.pending.is_some()
+                    && matches!(k.code, KeyCode::Enter)
+                    && matches!(k.kind, KeyEventKind::Press | KeyEventKind::Repeat)
+                    && !k.modifiers.contains(KeyModifiers::CONTROL) =>
+            {
+                self.pending = None;
+                let mut merged = k;
+                merged.modifiers.insert(KeyModifiers::ALT);
+                merged.kind = KeyEventKind::Press;
+                Some(Event::Key(merged))
+            }
+            Event::Key(k)
+                if self.pending.is_none()
+                    && matches!(k.code, KeyCode::Esc)
+                    && k.modifiers.is_empty()
+                    && matches!(k.kind, KeyEventKind::Press | KeyEventKind::Repeat) =>
+            {
+                self.pending = Some(now);
+                None
+            }
+            other => {
+                if self.pending.take().is_some() {
+                    self.queue.push_back(other);
+                    Some(Self::escape_event())
+                } else {
+                    Some(other)
+                }
             }
         }
     }
@@ -916,7 +1015,7 @@ impl InputSource {
                     };
                     if ready {
                         let ev = crossterm::event::read()?;
-                        if let Some(out) = esc.feed(ev, Instant::now()) {
+                        if let Some(out) = esc.feed_with(ev, Instant::now(), pull_queued) {
                             return Ok(Some(out));
                         }
                     }
@@ -958,7 +1057,7 @@ impl InputSource {
                 loop {
                     if crossterm::event::poll(Duration::ZERO)? {
                         let ev = crossterm::event::read()?;
-                        if let Some(out) = esc.feed(ev, Instant::now()) {
+                        if let Some(out) = esc.feed_with(ev, Instant::now(), pull_queued) {
                             return Ok(Some(out));
                         }
                         continue;
@@ -976,6 +1075,19 @@ impl InputSource {
 }
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/// The look-ahead [`EscCoalesce::feed_with`] runs on: one event if the terminal
+/// has already delivered it, `None` the instant it has not.
+///
+/// A read error is reported as "nothing queued" rather than swallowed for good:
+/// the very next `poll`/`read` in the loop above hits the same broken stdin and
+/// surfaces it as the `io::Error` the caller expects.
+fn pull_queued() -> Option<Event> {
+    match crossterm::event::poll(Duration::ZERO) {
+        Ok(true) => crossterm::event::read().ok(),
+        _ => None,
+    }
+}
 
 /// Construct a press `Event::Key` with the given code and modifiers.
 #[inline(always)]
@@ -1003,6 +1115,169 @@ fn decode_modifiers(n: u16) -> KeyModifiers {
         mods |= KeyModifiers::CONTROL;
     }
     mods
+}
+
+/// What the characters behind a `[` turned out to be.
+pub(crate) enum Recovered {
+    /// A complete extended key.  Everything pulled belonged to it.
+    Key(Event),
+    /// A complete key report that carries nothing for the client (a Kitty
+    /// protocol RELEASE).  Everything pulled belonged to it and none of it is
+    /// forwarded.
+    Consumed,
+    /// No sequence.  These are the events pulled, in arrival order; the caller
+    /// owes every one of them to the client, behind the `[` itself.
+    Raw(Vec<Event>),
+}
+
+/// Pull the characters sitting behind a `[` and decide whether they are an
+/// extended key.
+///
+/// `pull` returns only what the terminal has ALREADY delivered and `None` the
+/// instant it has nothing, so a `[` a person typed costs exactly one empty pull
+/// and is handed straight back — no hold, no guess about typing speed.  A `[`
+/// that opens a sequence the console could not parse is a different case
+/// entirely: conhost flushes the whole thing in one `ReadConsoleInputW`, so
+/// every remaining byte is already queued and the pulls all succeed.
+///
+/// Nothing pulled is ever dropped on the way out: [`Recovered::Raw`] carries
+/// the events back in the order they arrived, releases included, because the
+/// caller cannot re-read what this function has consumed.
+pub(crate) fn recover_csi_u<F>(mut pull: F) -> Recovered
+where
+    F: FnMut() -> Option<Event>,
+{
+    let mut pulled: Vec<Event> = Vec::new();
+    let mut params = String::new();
+    loop {
+        let Some(ev) = pull() else {
+            return Recovered::Raw(pulled);
+        };
+        pulled.push(ev.clone());
+        let Event::Key(k) = ev else {
+            return Recovered::Raw(pulled);
+        };
+        // Releases are not sequence content.  A console that reports them
+        // interleaved with the presses must not break the sequence apart.
+        if k.kind == KeyEventKind::Release {
+            continue;
+        }
+        if k.modifiers
+            .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT)
+        {
+            return Recovered::Raw(pulled);
+        }
+        let KeyCode::Char(c) = k.code else {
+            return Recovered::Raw(pulled);
+        };
+        match c as u32 {
+            // Parameter and intermediate bytes.
+            0x20..=0x3f if params.len() < CSI_MAX_PARAM_LEN => params.push(c),
+            // Final byte: the sequence is complete, for better or worse.
+            0x40..=0x7e => {
+                return match csi_key(&params, c) {
+                    CsiKey::Key(out) => Recovered::Key(out),
+                    CsiKey::Absorbed => Recovered::Consumed,
+                    CsiKey::NotAKey => Recovered::Raw(pulled),
+                }
+            }
+            _ => return Recovered::Raw(pulled),
+        }
+    }
+}
+
+/// What a reassembled `CSI … <final>` turned out to be.
+pub(crate) enum CsiKey {
+    /// A key the client should see.
+    Key(Event),
+    /// A well formed key report that carries nothing for the client: a key
+    /// RELEASE from a terminal running the Kitty protocol.  Dropping it is not
+    /// a loss — psmux never asks for release reporting — and it must not be
+    /// forwarded, because a release of Enter is exactly what the client's
+    /// WezTerm workaround promotes back into a press.
+    Absorbed,
+    /// Not a key sequence; the caller hands the raw bytes back.
+    NotAKey,
+}
+
+/// Decode a `CSI <code> ; <modifiers> u` key sequence — the modifyOtherKeys /
+/// fixterms encoding, which xterm, Kitty, WezTerm, Windows Terminal and tmux's
+/// own `extended-keys` all speak, and the only reason a terminal can report
+/// Shift+Enter at all (legacy VT has no encoding for it: CR is CR whether or
+/// not Shift is down).
+///
+/// `<code>` is the unicode code point of the unmodified key, so Shift+Enter is
+/// `CSI 13;2u`.  Kitty's extra sub-parameters are tolerated: `code:shifted:base`
+/// keeps only the first, and `modifiers:event` uses the event type to tell a
+/// press from a release.
+///
+/// Every other final byte returns [`CsiKey::NotAKey`], including the ones the
+/// console DOES understand (`A`-`D`, `~`, …).  Those never arrive here as loose
+/// characters — conhost translates them into virtual-key records long before
+/// psmux sees them — so recognising them would add a second, divergent decoder
+/// for sequences that cannot reach it.
+pub(crate) fn csi_key(params: &str, final_byte: char) -> CsiKey {
+    if final_byte != 'u' {
+        return CsiKey::NotAKey;
+    }
+    // `CSI ? … u`, `CSI > … u` and friends are terminal queries and replies,
+    // never keys.
+    if params.starts_with(['?', '<', '=', '>']) {
+        return CsiKey::NotAKey;
+    }
+    let mut fields = params.split(';');
+    let Some(code) = fields
+        .next()
+        .and_then(|f| f.split(':').next())
+        .and_then(|f| f.parse::<u32>().ok())
+    else {
+        return CsiKey::NotAKey;
+    };
+    let mut modifier_field = fields.next().unwrap_or("1").split(':');
+    let mods = match modifier_field.next() {
+        // `CSI 13u` and `CSI 13;u` both mean "no modifiers".
+        None | Some("") => KeyModifiers::empty(),
+        Some(f) => match f.parse::<u16>() {
+            Ok(n) => decode_modifiers(n),
+            Err(_) => return CsiKey::NotAKey,
+        },
+    };
+    // Kitty event types: 1 press, 2 repeat, 3 release.
+    let kind = match modifier_field.next() {
+        Some("3") => return CsiKey::Absorbed,
+        Some("2") => KeyEventKind::Repeat,
+        _ => KeyEventKind::Press,
+    };
+    let Some(code) = csi_u_key_code(code) else {
+        return CsiKey::NotAKey;
+    };
+    CsiKey::Key(Event::Key(KeyEvent {
+        code,
+        modifiers: mods,
+        kind,
+        state: crossterm::event::KeyEventState::empty(),
+    }))
+}
+
+/// Map the code point in a `CSI u` sequence onto the key it names.
+///
+/// The named keys are spelled out because `KeyCode::Char('\r')` is not the
+/// Enter key to anything downstream: the client's key tables, its paste
+/// heuristic and `encode_key_event` all match on `KeyCode::Enter`.
+fn csi_u_key_code(code: u32) -> Option<KeyCode> {
+    Some(match code {
+        8 | 127 => KeyCode::Backspace,
+        9 => KeyCode::Tab,
+        13 => KeyCode::Enter,
+        27 => KeyCode::Esc,
+        c => {
+            let ch = char::from_u32(c)?;
+            if ch.is_control() {
+                return None;
+            }
+            KeyCode::Char(ch)
+        }
+    })
 }
 
 /// Decode a UTF-16 code unit, combining surrogate pairs.
@@ -1512,6 +1787,18 @@ impl VtParser {
                 let cols = self.params[2];
                 if rows > 0 && cols > 0 {
                     emit(Event::Resize(cols, rows));
+                }
+            }
+            // `CSI <code> ; <modifiers> u` — the modifyOtherKeys / fixterms
+            // extended key.  This parser reads real bytes, so unlike the
+            // console path it has the whole sequence in hand; without an arm
+            // here it fell through to the discard below and the key vanished
+            // outright, which is how a terminal-side Shift+Enter binding
+            // silently did nothing over SSH.  See [`csi_u_key_code`] for why
+            // the code point becomes a named `KeyCode`.
+            'u' => {
+                if let Some(code) = csi_u_key_code(self.params[0] as u32) {
+                    emit(make_key(code, mods));
                 }
             }
             '~' => self.dispatch_tilde(mods, emit),
@@ -2469,6 +2756,10 @@ mod tests_issue508_wezterm_vt_cspace;
 #[cfg(test)]
 #[path = "../tests-rs/test_issue611_shift_enter_event_modifiers.rs"]
 mod tests_issue611_shift_enter_event_modifiers;
+
+#[cfg(test)]
+#[path = "../tests-rs/test_extended_keys_csi_u.rs"]
+mod tests_extended_keys_csi_u;
 
 // ─── Raw VT pipe client input — issue #474 / Windows 10 SSH ────────────────
 //

--- a/tests-rs/test_extended_keys_csi_u.rs
+++ b/tests-rs/test_extended_keys_csi_u.rs
@@ -1,0 +1,556 @@
+//! Extended keys (`CSI u`) never reached a pane; their bytes did, as text.
+//!
+//! A terminal cannot report Shift+Enter in legacy VT — CR is CR whether or not
+//! Shift is down — so every terminal that can report it uses the
+//! modifyOtherKeys / fixterms form `CSI 13;2u`.  That is what `set -s
+//! extended-keys always` asks a terminal for, and what a Windows Terminal
+//! `sendInput` keybinding writes.
+//!
+//! Windows never delivered it.  psmux's local input source reads console
+//! KEY_EVENT records, not bytes, and conhost's input parser does not know
+//! `CSI u`: it flushes the unrecognised sequence into the input buffer one
+//! record per byte.  Measured with `examples/csi_u_diag.rs` under Windows
+//! Terminal on Windows 11 26200, one press of Shift+Enter delivers seven
+//! records in a SINGLE `ReadConsoleInputW`:
+//!
+//! ```text
+//!   DOWN vk=0x00 scan=0x00 uChar=0x001b        <- ESC
+//!   DOWN vk=0x00 scan=0x00 uChar=0x005b  '['
+//!   DOWN vk=0x00 scan=0x00 uChar=0x0031  '1'
+//!   DOWN vk=0x00 scan=0x00 uChar=0x0033  '3'
+//!   DOWN vk=0x00 scan=0x00 uChar=0x003b  ';'
+//!   DOWN vk=0x00 scan=0x00 uChar=0x0032  '2'
+//!   DOWN vk=0x00 scan=0x00 uChar=0x0075  'u'
+//! ```
+//!
+//! Two facts in there decide the whole design.
+//!
+//! 1. The ESC does not survive.  It has no virtual key code and a `uChar`
+//!    inside the control range, so crossterm hands that record to
+//!    `ToUnicodeEx`, which answers nothing for a synthesised record, and drops
+//!    the event (`event/sys/windows/parse.rs`).  psmux is handed six bare
+//!    characters; its paste heuristic sees three or more ASCII characters
+//!    inside 20 ms, calls it a paste, and the child application receives the
+//!    TEXT `[13;2u` instead of a newline.  So the `[` is the only introducer
+//!    left to key off.
+//!
+//! 2. They arrive in one batch.  Every byte behind the `[` is ALREADY queued
+//!    when the `[` is handed over, so the decision needs no timer and no guess
+//!    about typing speed: pull what is there, and a `[` a person typed comes
+//!    back empty on the first pull and goes straight through.
+//!
+//! tmux does not have this problem because `tty-keys.c` parses its client tty
+//! as bytes.  Reassembly is unconditional there and here: `extended-keys`
+//! governs what tmux WRITES to a pane, never what it accepts from a terminal.
+
+use crossterm::event::{Event, KeyCode, KeyEvent, KeyEventKind, KeyEventState, KeyModifiers};
+use std::collections::VecDeque;
+use std::time::{Duration, Instant};
+
+use super::{EscCoalesce, ESC_COALESCE_MS};
+
+fn press(code: KeyCode, mods: KeyModifiers) -> Event {
+    Event::Key(KeyEvent {
+        code,
+        modifiers: mods,
+        kind: KeyEventKind::Press,
+        state: KeyEventState::empty(),
+    })
+}
+
+fn release(code: KeyCode, mods: KeyModifiers) -> Event {
+    Event::Key(KeyEvent {
+        code,
+        modifiers: mods,
+        kind: KeyEventKind::Release,
+        state: KeyEventState::empty(),
+    })
+}
+
+fn key_of(ev: &Event) -> KeyEvent {
+    match ev {
+        Event::Key(k) => *k,
+        other => panic!("expected a key event, got {:?}", other),
+    }
+}
+
+/// A console batch: the events the terminal has already delivered.  Feeding the
+/// first one and letting the coalescer pull the rest is exactly what the live
+/// input source does.
+struct Batch(VecDeque<Event>);
+
+impl Batch {
+    /// Build the batch a console produces for `seq`, minus the leading ESC that
+    /// crossterm drops.
+    fn from_sequence(seq: &str) -> Self {
+        let mut q = VecDeque::new();
+        let mut chars = seq.chars();
+        assert_eq!(chars.next(), Some('\u{1b}'), "a CSI sequence starts with ESC");
+        for ch in chars {
+            q.push_back(press(KeyCode::Char(ch), KeyModifiers::NONE));
+        }
+        Batch(q)
+    }
+
+    fn of(events: Vec<Event>) -> Self {
+        Batch(events.into())
+    }
+
+    /// Feed the batch's first event to `c`, with the remainder available to
+    /// pull, and return what came out.
+    fn feed_into(&mut self, c: &mut EscCoalesce, now: Instant) -> Option<Event> {
+        let first = self.0.pop_front().expect("a batch is never empty");
+        let rest = &mut self.0;
+        c.feed_with(first, now, || rest.pop_front())
+    }
+
+    fn is_drained(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
+/// Everything `c` will hand the client, in order, after `first` is fed with
+/// `rest` available to pull — and whatever was left unpulled.
+///
+/// The leftover is not a loss: those events are still sitting in the terminal's
+/// own queue and the input loop reads them on its next turn.  What must never
+/// happen is an event being pulled and then not handed on, because THAT one the
+/// caller can no longer re-read.
+fn drain(
+    c: &mut EscCoalesce,
+    first: Event,
+    rest: Vec<Event>,
+    now: Instant,
+) -> (Vec<Event>, Vec<Event>) {
+    let mut queued: VecDeque<Event> = rest.into();
+    let mut out = Vec::new();
+    if let Some(ev) = c.feed_with(first, now, || queued.pop_front()) {
+        out.push(ev);
+    }
+    while let Some(ev) = c.pop() {
+        out.push(ev);
+    }
+    (out, queued.into_iter().collect())
+}
+
+fn codes(events: &[Event]) -> Vec<KeyCode> {
+    events.iter().map(|e| key_of(e).code).collect()
+}
+
+/// Run a byte sequence through the VT parser — the input path SSH, WezTerm and
+/// the JetBrains terminals use, where psmux reads real bytes instead of console
+/// records.
+fn parse_vt(seq: &str) -> Vec<Event> {
+    let mut p = super::VtParser::new();
+    let mut events = Vec::new();
+    for ch in seq.chars() {
+        p.feed(ch, &mut |evt| events.push(evt));
+    }
+    events
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// The reported key
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn csi_13_2_u_becomes_one_shift_enter() {
+    let mut c = EscCoalesce::new(true);
+    let t0 = Instant::now();
+
+    let mut batch = Batch::from_sequence("\x1b[13;2u");
+    let out = batch
+        .feed_into(&mut c, t0)
+        .expect("the sequence must produce a key");
+
+    let k = key_of(&out);
+    assert_eq!(k.code, KeyCode::Enter);
+    assert_eq!(k.modifiers, KeyModifiers::SHIFT);
+    assert_eq!(k.kind, KeyEventKind::Press);
+
+    assert!(batch.is_drained(), "the whole sequence must be consumed");
+    assert!(c.pop().is_none(), "nothing may be left over");
+    assert!(c.expire(t0 + Duration::from_secs(1)).is_none());
+}
+
+/// The whole point of the exercise: the key the reporter's terminal sends has
+/// to leave psmux as the two bytes the pane needs.  `\x1b\r` is what psmux
+/// already writes for a Shift+Enter it recognises, and what Claude Code reads
+/// as "insert a newline" — a real Alt+Enter produces a newline there too.
+#[cfg(windows)]
+#[test]
+fn the_reassembled_key_encodes_to_esc_cr() {
+    let mut c = EscCoalesce::new(true);
+    let out = Batch::from_sequence("\x1b[13;2u")
+        .feed_into(&mut c, Instant::now())
+        .unwrap();
+    let bytes = crate::input::encode_key_event(&key_of(&out)).expect("Enter must encode");
+    assert_eq!(bytes, b"\x1b\r".to_vec(), "got {:02x?}", bytes);
+}
+
+/// A console that DOES deliver the ESC must not end up sending it on ahead of
+/// the key: the held Escape is the sequence's introducer and goes with it.
+#[test]
+fn a_surviving_escape_is_consumed_by_the_sequence() {
+    let mut c = EscCoalesce::new(true);
+    let t0 = Instant::now();
+
+    assert!(c.feed(press(KeyCode::Esc, KeyModifiers::NONE), t0).is_none());
+
+    let mut batch = Batch::from_sequence("\x1b[13;2u");
+    let out = batch.feed_into(&mut c, t0).expect("must produce a key");
+    assert_eq!(key_of(&out).code, KeyCode::Enter);
+    assert_eq!(key_of(&out).modifiers, KeyModifiers::SHIFT);
+
+    assert!(c.pop().is_none(), "the Escape must not follow the key out");
+    assert!(c.expire(t0 + Duration::from_secs(1)).is_none());
+    assert!(c.deadline_ms(t0).is_none());
+}
+
+/// Every modifier combination the parameter can carry, so the decode is not
+/// just "2 happens to mean Shift".
+#[test]
+fn the_modifier_parameter_is_decoded() {
+    for (param, want) in [
+        (1u8, KeyModifiers::NONE),
+        (2, KeyModifiers::SHIFT),
+        (3, KeyModifiers::ALT),
+        (5, KeyModifiers::CONTROL),
+        (6, KeyModifiers::CONTROL | KeyModifiers::SHIFT),
+        (7, KeyModifiers::CONTROL | KeyModifiers::ALT),
+        (
+            8,
+            KeyModifiers::CONTROL | KeyModifiers::ALT | KeyModifiers::SHIFT,
+        ),
+    ] {
+        let mut c = EscCoalesce::new(true);
+        let out = Batch::from_sequence(&format!("\x1b[13;{}u", param))
+            .feed_into(&mut c, Instant::now())
+            .expect("must produce a key");
+        assert_eq!(key_of(&out).modifiers, want, "parameter {}", param);
+        assert_eq!(key_of(&out).code, KeyCode::Enter);
+    }
+}
+
+/// A code point with no modifier parameter at all is still a key.
+#[test]
+fn a_bare_code_point_needs_no_modifier_parameter() {
+    let mut c = EscCoalesce::new(true);
+    let out = Batch::from_sequence("\x1b[13u")
+        .feed_into(&mut c, Instant::now())
+        .expect("must produce a key");
+    assert_eq!(key_of(&out).code, KeyCode::Enter);
+    assert_eq!(key_of(&out).modifiers, KeyModifiers::NONE);
+}
+
+/// The named keys must arrive as their `KeyCode`, not as a `Char` holding the
+/// same code point: the client's key tables, its paste heuristic and
+/// `encode_key_event` all match on `KeyCode::Enter`, `Tab`, `Backspace`.
+#[test]
+fn control_code_points_map_to_named_keys() {
+    for (code, want) in [
+        (8u32, KeyCode::Backspace),
+        (9, KeyCode::Tab),
+        (13, KeyCode::Enter),
+        (27, KeyCode::Esc),
+        (127, KeyCode::Backspace),
+        (32, KeyCode::Char(' ')),
+        (97, KeyCode::Char('a')),
+    ] {
+        let mut c = EscCoalesce::new(true);
+        let out = Batch::from_sequence(&format!("\x1b[{};5u", code))
+            .feed_into(&mut c, Instant::now())
+            .expect("must produce a key");
+        assert_eq!(key_of(&out).code, want, "code point {}", code);
+    }
+}
+
+/// The release records a console may interleave with the presses must not break
+/// the sequence apart.
+#[test]
+fn key_releases_inside_a_sequence_are_ignored() {
+    let mut events = Vec::new();
+    for ch in ['[', '1', '3', ';', '2', 'u'] {
+        events.push(press(KeyCode::Char(ch), KeyModifiers::NONE));
+        events.push(release(KeyCode::Char(ch), KeyModifiers::NONE));
+    }
+    let mut c = EscCoalesce::new(true);
+    let out = Batch::of(events)
+        .feed_into(&mut c, Instant::now())
+        .expect("the sequence must still complete");
+    assert_eq!(key_of(&out).code, KeyCode::Enter);
+    assert_eq!(key_of(&out).modifiers, KeyModifiers::SHIFT);
+}
+
+/// A Kitty protocol RELEASE report is dropped rather than forwarded.  psmux
+/// never asks a terminal for release reporting, and forwarding one would be
+/// worse than dropping it: a release of Enter is exactly what the client's
+/// WezTerm workaround promotes back into a press, which would double the key.
+#[test]
+fn a_kitty_release_report_is_dropped() {
+    let mut c = EscCoalesce::new(true);
+    let t0 = Instant::now();
+    let mut batch = Batch::from_sequence("\x1b[13;2:3u");
+    assert!(batch.feed_into(&mut c, t0).is_none());
+    assert!(batch.is_drained());
+    assert!(c.pop().is_none());
+    assert!(c.deadline_ms(t0).is_none(), "nothing may still be held");
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Everything that is NOT an extended key still behaves exactly as before
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// The regression this design exists to avoid: `[` is an ordinary character in
+/// every editor, and typing one must cost nothing.  With an empty queue behind
+/// it the pull comes back empty at once and the character goes straight out —
+/// no hold, nothing queued, no deadline armed.
+#[test]
+fn a_typed_bracket_passes_straight_through() {
+    let mut c = EscCoalesce::new(true);
+    let t0 = Instant::now();
+
+    let (out, left) = drain(&mut c, press(KeyCode::Char('['), KeyModifiers::NONE), vec![], t0);
+    assert_eq!(codes(&out), vec![KeyCode::Char('[')]);
+    assert!(left.is_empty());
+    assert!(c.deadline_ms(t0).is_none(), "nothing may be held");
+}
+
+/// `[` followed by ordinary typing keeps every character, in order.
+///
+/// The recovery stops pulling the moment the characters cannot be a sequence,
+/// so `b` is still in the terminal's queue and the input loop reads it next
+/// turn.  `a` was pulled, and therefore had to come back out here.
+#[test]
+fn a_bracket_followed_by_typing_keeps_every_character() {
+    let mut c = EscCoalesce::new(true);
+    let (out, left) = drain(
+        &mut c,
+        press(KeyCode::Char('['), KeyModifiers::NONE),
+        vec![
+            press(KeyCode::Char('a'), KeyModifiers::NONE),
+            press(KeyCode::Char('b'), KeyModifiers::NONE),
+        ],
+        Instant::now(),
+    );
+    assert_eq!(codes(&out), vec![KeyCode::Char('['), KeyCode::Char('a')]);
+    assert_eq!(codes(&left), vec![KeyCode::Char('b')], "still readable");
+}
+
+/// A sequence psmux does not decode is handed back byte for byte, in order.
+/// `CSI 1;5A` is Ctrl+Up — conhost translates that one itself, so it never
+/// arrives as loose characters, and recognising it here would only add a second
+/// decoder for input that cannot reach this code.
+#[test]
+fn an_undecoded_final_byte_replays_every_character() {
+    let mut c = EscCoalesce::new(true);
+    let mut batch = Batch::from_sequence("\x1b[1;5A");
+    let first = batch
+        .feed_into(&mut c, Instant::now())
+        .expect("the abandoned sequence must start coming out");
+    let mut out = vec![first];
+    while let Some(ev) = c.pop() {
+        out.push(ev);
+    }
+    assert_eq!(
+        codes(&out),
+        vec![
+            KeyCode::Char('['),
+            KeyCode::Char('1'),
+            KeyCode::Char(';'),
+            KeyCode::Char('5'),
+            KeyCode::Char('A'),
+        ]
+    );
+}
+
+/// A held Escape in front of an abandoned sequence still comes out first.
+#[test]
+fn a_held_escape_precedes_an_abandoned_sequence() {
+    let mut c = EscCoalesce::new(true);
+    let t0 = Instant::now();
+    assert!(c.feed(press(KeyCode::Esc, KeyModifiers::NONE), t0).is_none());
+
+    let (out, left) = drain(
+        &mut c,
+        press(KeyCode::Char('['), KeyModifiers::NONE),
+        vec![press(KeyCode::Char('a'), KeyModifiers::NONE)],
+        t0,
+    );
+    assert_eq!(
+        codes(&out),
+        vec![KeyCode::Esc, KeyCode::Char('['), KeyCode::Char('a')]
+    );
+    assert!(left.is_empty());
+    assert!(c.deadline_ms(t0).is_none(), "the Escape is no longer held");
+}
+
+/// A non-character event inside a sequence abandons it, and nothing is lost.
+#[test]
+fn a_foreign_event_inside_a_sequence_replays_it() {
+    let mut c = EscCoalesce::new(true);
+    let (out, left) = drain(
+        &mut c,
+        press(KeyCode::Char('['), KeyModifiers::NONE),
+        vec![
+            press(KeyCode::Char('1'), KeyModifiers::NONE),
+            Event::Resize(80, 24),
+        ],
+        Instant::now(),
+    );
+    assert_eq!(out.len(), 3);
+    assert_eq!(key_of(&out[0]).code, KeyCode::Char('['));
+    assert_eq!(key_of(&out[1]).code, KeyCode::Char('1'));
+    assert!(matches!(out[2], Event::Resize(80, 24)));
+    assert!(left.is_empty());
+}
+
+/// A run of characters long enough to be a stream rather than a key is
+/// abandoned rather than collected forever, and nothing that was pulled to
+/// reach that conclusion is lost.
+#[test]
+fn an_overlong_parameter_run_is_abandoned() {
+    const SENT: usize = 64;
+    let mut c = EscCoalesce::new(true);
+    let rest: Vec<Event> = (0..SENT)
+        .map(|_| press(KeyCode::Char('1'), KeyModifiers::NONE))
+        .collect();
+    let (out, left) = drain(
+        &mut c,
+        press(KeyCode::Char('['), KeyModifiers::NONE),
+        rest,
+        Instant::now(),
+    );
+    assert!(
+        out.len() < SENT,
+        "the run must be abandoned, not collected whole"
+    );
+    assert_eq!(
+        out.len() + left.len(),
+        SENT + 1,
+        "the `[` plus every character sent, split between handed on and still readable"
+    );
+    assert_eq!(key_of(&out[0]).code, KeyCode::Char('['));
+    assert!(c.deadline_ms(Instant::now()).is_none());
+}
+
+/// A terminal query reply (`CSI ? … u`) is not a key.
+#[test]
+fn a_private_parameter_sequence_is_not_a_key() {
+    let mut c = EscCoalesce::new(true);
+    let mut batch = Batch::from_sequence("\x1b[?1u");
+    let first = batch.feed_into(&mut c, Instant::now()).expect("replayed");
+    let mut out = vec![first];
+    while let Some(ev) = c.pop() {
+        out.push(ev);
+    }
+    assert_eq!(
+        codes(&out),
+        vec![
+            KeyCode::Char('['),
+            KeyCode::Char('?'),
+            KeyCode::Char('1'),
+            KeyCode::Char('u'),
+        ]
+    );
+}
+
+/// A `[` that carries Ctrl or Alt is a key in its own right (Ctrl+[ IS Escape
+/// on a real keyboard) and must never open a sequence.
+#[test]
+fn a_modified_bracket_opens_nothing() {
+    let mut c = EscCoalesce::new(true);
+    let t0 = Instant::now();
+    for mods in [KeyModifiers::CONTROL, KeyModifiers::ALT] {
+        let out = c
+            .feed_with(press(KeyCode::Char('['), mods), t0, || {
+                panic!("a modified `[` must not pull")
+            })
+            .expect("must pass straight through");
+        assert_eq!(key_of(&out).modifiers, mods);
+        assert_eq!(key_of(&out).code, KeyCode::Char('['));
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// The Escape behaviour this shares its state with (#611) is unchanged
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn esc_then_enter_still_merges() {
+    let mut c = EscCoalesce::new(true);
+    let t0 = Instant::now();
+    assert!(c.feed(press(KeyCode::Esc, KeyModifiers::NONE), t0).is_none());
+    let out = c
+        .feed(press(KeyCode::Enter, KeyModifiers::NONE), t0)
+        .expect("the pair must produce one event");
+    assert!(key_of(&out).modifiers.contains(KeyModifiers::ALT));
+    assert_eq!(key_of(&out).code, KeyCode::Enter);
+}
+
+#[test]
+fn a_lone_escape_still_comes_out_after_the_window() {
+    let mut c = EscCoalesce::new(true);
+    let t0 = Instant::now();
+    assert!(c.feed(press(KeyCode::Esc, KeyModifiers::NONE), t0).is_none());
+    assert!(c
+        .expire(t0 + Duration::from_millis(ESC_COALESCE_MS - 1))
+        .is_none());
+    let out = c
+        .expire(t0 + Duration::from_millis(ESC_COALESCE_MS))
+        .expect("the window has run out");
+    assert_eq!(key_of(&out).code, KeyCode::Esc);
+    assert!(c.expire(t0 + Duration::from_secs(1)).is_none());
+}
+
+/// Disabled (the Unix build, where crossterm's own VT parser decodes `CSI u`
+/// before psmux ever sees it), nothing is held or reassembled.
+#[test]
+fn disabled_coalescer_does_not_reassemble() {
+    let mut c = EscCoalesce::new(false);
+    let t0 = Instant::now();
+    let out = c.feed(press(KeyCode::Esc, KeyModifiers::NONE), t0).unwrap();
+    assert_eq!(key_of(&out).code, KeyCode::Esc);
+    let out = c
+        .feed_with(press(KeyCode::Char('['), KeyModifiers::NONE), t0, || {
+            panic!("a disabled coalescer must not pull")
+        })
+        .unwrap();
+    assert_eq!(key_of(&out).code, KeyCode::Char('['));
+    assert!(c.deadline_ms(t0).is_none());
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// The SSH / VT input path had the same gap, with a worse symptom
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Over SSH — and under WezTerm and the JetBrains terminals, which
+/// `needs_vt_input()` routes the same way — psmux reads real bytes and runs its
+/// own VT parser.  That parser knew every CSI final byte except `u`, so an
+/// extended key fell through to its `_ => {}` discard and the keystroke was
+/// lost outright: a terminal-side Shift+Enter binding did nothing at all, with
+/// not even stray text to show for it.
+#[test]
+fn the_vt_parser_decodes_csi_u_too() {
+    let out = parse_vt("\x1b[13;2u");
+    assert_eq!(out.len(), 1, "one key, got {:?}", out);
+    assert_eq!(key_of(&out[0]).code, KeyCode::Enter);
+    assert_eq!(key_of(&out[0]).modifiers, KeyModifiers::SHIFT);
+}
+
+/// The same named-key mapping as the console path, so the two never disagree
+/// about what `CSI 9;5u` is.
+#[test]
+fn the_vt_parser_agrees_on_named_keys() {
+    for (seq, want, mods) in [
+        ("\x1b[9;5u", KeyCode::Tab, KeyModifiers::CONTROL),
+        ("\x1b[127;5u", KeyCode::Backspace, KeyModifiers::CONTROL),
+        ("\x1b[13u", KeyCode::Enter, KeyModifiers::NONE),
+        ("\x1b[97;5u", KeyCode::Char('a'), KeyModifiers::CONTROL),
+    ] {
+        let out = parse_vt(seq);
+        assert_eq!(out.len(), 1, "{:?} produced {:?}", seq, out);
+        assert_eq!(key_of(&out[0]).code, want, "{:?}", seq);
+        assert_eq!(key_of(&out[0]).modifiers, mods, "{:?}", seq);
+    }
+}


### PR DESCRIPTION
Fixes #654.

## What

psmux does not understand `CSI u` key sequences on input. Both of its input paths mishandle them, in opposite directions:

| Path | Terminals | Symptom today |
|---|---|---|
| Console records | Windows Terminal, conhost, VS Code | the sequence is delivered to the pane **as literal text** |
| VT bytes | SSH, WezTerm, JetBrains | the key is **silently discarded** |

Neither is a missing feature — one types characters the user never pressed, the other swallows a key that was pressed. psmux never asks a terminal for this encoding, so a `CSI u` sequence only ever arrives because the user deliberately configured their terminal to send it.

## Why it matters

`CSI <code> ; <modifiers> u` (modifyOtherKeys / fixterms) is the only way a terminal can report keys that legacy VT cannot encode. CR is CR whether or not Shift is down, and C0 collapses whole families of Ctrl combinations onto the same byte. These keys have no other representation:

- `S-Enter`, `C-Enter`, `C-S-Enter`
- `C-Tab`, `C-S-Tab` — a common want for window switching
- `C-i` distinct from `Tab`, `C-m` distinct from `Enter` (both `0x09` / `0x0d` otherwise)
- `C-;`, `C-'`, `C-,`, `C-.` — psmux already carries a tmux-parity remap table (`ctrl_char_send_keys_byte`) precisely because these collide in C0
- `C-S-<letter>` distinct from `C-<letter>`

Once these arrive as real key events they can also be reached by `bind-key`, which today they cannot.

This is tmux parity: `tty-keys.c` has parsed `CSI u` since 3.2. Note that in tmux `extended-keys` governs what tmux **writes** to a pane, never what it accepts from the terminal — parsing is unconditional there, and is unconditional here. **No new option is added.**

## The measurement

conhost's input parser does not know `CSI u`, so it flushes the unrecognised sequence into the console input buffer one record per byte. Reading `INPUT_RECORD`s directly under Windows Terminal on Windows 11 26200, one press of Shift+Enter delivers seven records in a **single** `ReadConsoleInputW`:

```text
DOWN vk=0x00 scan=0x00 uChar=0x001b        the ESC
DOWN vk=0x00 scan=0x00 uChar=0x005b  '['
DOWN vk=0x00 scan=0x00 uChar=0x0031  '1'
DOWN vk=0x00 scan=0x00 uChar=0x0033  '3'
DOWN vk=0x00 scan=0x00 uChar=0x003b  ';'
DOWN vk=0x00 scan=0x00 uChar=0x0032  '2'
DOWN vk=0x00 scan=0x00 uChar=0x0075  'u'
```

Two facts in there decide the design.

**The ESC does not survive.** With no virtual key code to name it and a `uChar` inside the control range, crossterm hands that record to `ToUnicodeEx`, which answers nothing for a synthesised record, and drops the event (`event/sys/windows/parse.rs`). psmux is left with six bare characters; the paste heuristic sees three or more ASCII characters inside 20 ms, calls it a paste, and the child receives the text `[13;2u`. So `[` is the only introducer left.

**They arrive in one batch.** Every byte is already queued when the `[` is handed over, which is what makes keying off `[` safe.

## The change

`EscCoalesce` — which already holds a bare Escape for this class of reason (#611) — gains a look-ahead. `feed_with(ev, now, pull)` takes a `pull` that returns only what the terminal has **already** delivered and `None` the instant it has not.

- A `[` that opens a sequence: every remaining byte is queued, the pulls succeed, `recover_csi_u` decodes the key.
- A `[` a person typed: nothing behind it, the first pull comes back empty, the character goes straight out. **No hold, no added latency** on a character that opens every array subscript. A timer-based approach was tried first and rejected for exactly this reason.
- `Ctrl+[` / `Alt+[` never open a sequence — `Ctrl+[` *is* Escape on a real keyboard.

Nothing pulled is ever dropped: a run that turns out not to be a sequence is handed back in arrival order, because the caller cannot re-read what the pull consumed. The tests fix that contract.

The VT path needed twelve lines: it already assembled the sequence correctly and only lacked a `'u'` arm in `dispatch_csi`. Both paths share one decoder, so they cannot disagree about what `CSI 9;5u` is.

A Kitty protocol release report (`CSI 13;2:3u`) is consumed rather than forwarded, because a release of Enter is what the client's WezTerm workaround promotes back into a press.

`feed()` is kept as a thin `feed_with(.., || None)` wrapper, so the existing #611 tests are unchanged.

## Verification

### Real terminals, real application: before and after

Windows 11 26200. **F10** was bound to send `ESC [13;2u` (the Shift+Enter sequence) in both Windows Terminal and WezTerm, then Claude Code was started inside psmux and F10 was pressed in its prompt.

Windows Terminal, `settings.json`:

```json
"actions": [
    { "command": { "action": "sendInput", "input": "\u001b[13;2u" }, "id": "User.sendInput.999999" }
],
"keybindings": [
    { "id": "User.sendInput.999999", "keys": "f10" }
]
```

WezTerm, `~/.wezterm.lua`:

```lua
config.keys = {
  { key = 'F10', action = wezterm.action.SendString '\x1b[13;2u' },
}
```

| Terminal | Input path | Released psmux | This branch |
|---|---|---|---|
| Windows Terminal | console records | the text `[13;2u` is typed into the prompt | newline inserted, prompt **not** submitted |
| WezTerm | VT bytes | nothing happens | newline inserted, prompt **not** submitted |

Two details make this result conclusive:

- **F10 has no newline of its own.** Nothing but the bound sequence can produce one, so any newline must come from psmux decoding `CSI u`. A binding on Shift+Enter itself could not rule out a plain Enter getting through some other way.
- **The prompt was not submitted.** In Claude Code, Enter submits and Shift+Enter inserts a newline. A newline without submission means the Shift modifier survived all the way to the application. psmux delivered Shift+Enter, not a stripped Enter.

The "before" column reproduces, in a real terminal with a real application, each of the two failures described above, one per input path. The "after" column shows both fixed.

### Other checks

- **VT path under Windows Terminal**, with `{ "keys": "shift+enter", "command": { "action": "sendInput", "input": "\u001b[13;2u" } }` and `TERM_PROGRAM=WezTerm` (the variable `needs_vt_input()` checks). `PSMUX_SSH_DEBUG=1` confirmed the VT reader was the active path. Shift+Enter inserts a newline in the pane's child.
- Ordinary `[`, Escape, and Ctrl+V paste unchanged; mouse unchanged on the VT path.

21 new tests in `tests-rs/test_extended_keys_csi_u.rs`, covering both paths, the replay ordering, and the no-latency contract for a typed `[`. `cargo clippy` clean on the changed code.

**Not verified:** the JetBrains terminals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V72ESMLHrKbNUW5p6foW9A
